### PR TITLE
feat(cli): add roster invite --file for bulk email invites

### DIFF
--- a/cli/gh-teacher/internal/cliutil/httpstatus.go
+++ b/cli/gh-teacher/internal/cliutil/httpstatus.go
@@ -1,6 +1,10 @@
 package cliutil
 
-import "github.com/foundation50/classroom50-cli-shared/ghutil"
+import (
+	"time"
+
+	"github.com/foundation50/classroom50-cli-shared/ghutil"
+)
 
 // IsHTTPStatus reports whether err is a *api.HTTPError with the given status.
 // Thin wrapper over the shared ghutil helper so domain packages don't import
@@ -14,4 +18,11 @@ func IsHTTPStatus(err error, code int) bool {
 // shared ghutil helper.
 func IsRateLimited(err error) bool {
 	return ghutil.IsRateLimited(err)
+}
+
+// RetryAfter reports the wait GitHub's `Retry-After` header asked for (capped),
+// or 0 when the error carries no usable hint. Thin wrapper over the shared
+// ghutil helper.
+func RetryAfter(err error) time.Duration {
+	return ghutil.RetryAfter(err)
 }

--- a/cli/gh-teacher/internal/configrepo/students_csv.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv.go
@@ -285,10 +285,14 @@ func ParseImportCSV(data []byte) ([]RosterRow, error) {
 			rowErrs = append(rowErrs, err)
 			continue
 		}
-		if err := ValidateRosterEmail(row.Email); err != nil {
+		// Canonicalize rather than only validate: the parsed address is what a
+		// later invite, join, or team-name hash uses.
+		canonical, err := CanonicalRosterEmail(row.Email)
+		if err != nil {
 			rowErrs = append(rowErrs, fmt.Errorf("line %d: %w", line, err))
 			continue
 		}
+		row.Email = canonical
 		row.Line = line
 		rows = append(rows, row)
 	}
@@ -696,20 +700,19 @@ func BackfillRosterGitHubID(rows []RosterRow, username string, githubID int64) (
 	return rows, false
 }
 
-// ValidateRosterEmail: empty is valid. Non-empty must parse as bare
-// `local@domain`; the display-name form is rejected so name metadata doesn't
-// sneak into the email column. No TLD requirement, no DNS check.
-func ValidateRosterEmail(email string) error {
-	_, err := CanonicalRosterEmail(email)
-	return err
-}
-
-// CanonicalRosterEmail validates like ValidateRosterEmail and returns the
-// address mail.ParseAddress actually parsed, normalized. Callers that go on to
-// USE the value need this rather than the raw input: `<a@b.edu>` and
-// `a@b.edu <a@b.edu>`-adjacent forms validate but normalize to something GitHub
-// rejects, so a raw-input caller would send an unusable address and read the
-// resulting 422 as "already invited".
+// CanonicalRosterEmail validates a roster email and returns the address
+// mail.ParseAddress actually parsed, normalized (trim + lowercase). Empty is
+// valid and returns empty — the column is optional per row. Non-empty must
+// parse as bare `local@domain`; the display-name form is rejected so name
+// metadata doesn't sneak into the email column. No TLD requirement, no DNS
+// check.
+//
+// It deliberately returns the parsed value rather than only an error, and there
+// is no validate-only variant: a caller that validated and then used its RAW
+// input silently kept forms mail.ParseAddress accepts but GitHub does not
+// (`<a@b.edu>`), which surfaced later as a roster join that never matches or an
+// invitation GitHub 422s — read as "already invited". Returning the canonical
+// form is what forecloses that.
 func CanonicalRosterEmail(email string) (string, error) {
 	if email == "" {
 		return "", nil

--- a/cli/gh-teacher/internal/configrepo/students_csv.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv.go
@@ -52,6 +52,13 @@ const maxSafeGitHubID = 1<<53 - 1
 // and the header check fails on two identical-looking slices.
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
+// TrimUTF8BOM drops the byte-order mark Excel and Notepad prepend when saving
+// UTF-8. Every reader of a teacher-supplied file needs it: the BOM is invisible
+// in an editor but makes the first line of the file unparseable.
+func TrimUTF8BOM(data []byte) []byte {
+	return bytes.TrimPrefix(data, utf8BOM)
+}
+
 // RosterRow is one student in the roster. GitHubID == 0 means unresolved (a
 // 5-column import row before GET /users/{username}, or a cell we couldn't use).
 type RosterRow struct {
@@ -130,7 +137,7 @@ func ParseRosterLenient(data []byte) ([]RosterRow, error) {
 // parseRoster is the shared core; lenient preserves a bad row as raw rather
 // than erroring (see ParseRoster / ParseRosterLenient).
 func parseRoster(data []byte, lenient bool) ([]RosterRow, error) {
-	data = bytes.TrimPrefix(data, utf8BOM)
+	data = TrimUTF8BOM(data)
 	r := csv.NewReader(bytes.NewReader(data))
 	// Read header without field-count enforcement so a renamed/short header
 	// gets our message, not csv's generic "wrong number of fields".
@@ -232,7 +239,7 @@ func parseRoster(data []byte, lenient bool) ([]RosterRow, error) {
 // can add its own per-row failures (a username that resolves to no account) to
 // them and refuse once with every unusable line named.
 func ParseImportCSV(data []byte) ([]RosterRow, error) {
-	data = bytes.TrimPrefix(data, utf8BOM)
+	data = TrimUTF8BOM(data)
 	r := csv.NewReader(bytes.NewReader(data))
 	r.FieldsPerRecord = -1
 

--- a/cli/gh-teacher/internal/configrepo/students_csv.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv.go
@@ -693,17 +693,28 @@ func BackfillRosterGitHubID(rows []RosterRow, username string, githubID int64) (
 // `local@domain`; the display-name form is rejected so name metadata doesn't
 // sneak into the email column. No TLD requirement, no DNS check.
 func ValidateRosterEmail(email string) error {
+	_, err := CanonicalRosterEmail(email)
+	return err
+}
+
+// CanonicalRosterEmail validates like ValidateRosterEmail and returns the
+// address mail.ParseAddress actually parsed, normalized. Callers that go on to
+// USE the value need this rather than the raw input: `<a@b.edu>` and
+// `a@b.edu <a@b.edu>`-adjacent forms validate but normalize to something GitHub
+// rejects, so a raw-input caller would send an unusable address and read the
+// resulting 422 as "already invited".
+func CanonicalRosterEmail(email string) (string, error) {
 	if email == "" {
-		return nil
+		return "", nil
 	}
 	parsed, err := mail.ParseAddress(email)
 	if err != nil {
-		return fmt.Errorf("invalid email %q: %w", email, err)
+		return "", fmt.Errorf("invalid email %q: %w", email, err)
 	}
 	if parsed.Name != "" {
-		return fmt.Errorf("invalid email %q: include only the address (e.g., alice@example.edu), not a display name", email)
+		return "", fmt.Errorf("invalid email %q: include only the address (e.g., alice@example.edu), not a display name", email)
 	}
-	return nil
+	return NormalizeInviteEmail(parsed.Address), nil
 }
 
 // checkFieldLengths rejects cells over maxFieldBytes. Errors name the column

--- a/cli/gh-teacher/internal/configrepo/students_csv_test.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv_test.go
@@ -805,6 +805,42 @@ func TestUpdateRosterRow(t *testing.T) {
 	})
 }
 
+// CanonicalRosterEmail accepts exactly what ValidateRosterEmail does, but
+// returns the address mail.ParseAddress parsed rather than the raw input. A
+// caller that goes on to USE the value needs that: `<a@b.edu>` validates, and
+// sending the raw form to GitHub would 422 and read as "already invited".
+func TestCanonicalRosterEmail(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "", false},
+		{"alice@example.edu", "alice@example.edu", false},
+		{"<alice@example.edu>", "alice@example.edu", false},
+		{"  Alice@Example.EDU  ", "alice@example.edu", false},
+		{"Alice <alice@example.edu>", "", true},
+		{"alice", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := CanonicalRosterEmail(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("CanonicalRosterEmail(%q) = %q, want an error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CanonicalRosterEmail(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("CanonicalRosterEmail(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestValidateRosterEmail(t *testing.T) {
 	cases := []struct {
 		in      string

--- a/cli/gh-teacher/internal/configrepo/students_csv_test.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv_test.go
@@ -805,22 +805,47 @@ func TestUpdateRosterRow(t *testing.T) {
 	})
 }
 
-// CanonicalRosterEmail accepts exactly what ValidateRosterEmail does, but
-// returns the address mail.ParseAddress parsed rather than the raw input. A
-// caller that goes on to USE the value needs that: `<a@b.edu>` validates, and
-// sending the raw form to GitHub would 422 and read as "already invited".
-func TestCanonicalRosterEmail(t *testing.T) {
+// The accepted/rejected forms are the roster email contract. Every case also
+// asserts what the value CANONICALIZES to, since that parsed form — not the raw
+// input — is what a later invite, roster join, or invite-team hash uses.
+func TestCanonicalRosterEmailForms(t *testing.T) {
 	cases := []struct {
 		in      string
 		want    string
 		wantErr bool
 	}{
-		{"", "", false},
-		{"alice@example.edu", "alice@example.edu", false},
-		{"<alice@example.edu>", "alice@example.edu", false},
-		{"  Alice@Example.EDU  ", "alice@example.edu", false},
-		{"Alice <alice@example.edu>", "", true},
-		{"alice", "", true},
+		// Email is optional per row.
+		{in: "", want: ""},
+
+		// Bare local@domain shapes teachers actually use.
+		{in: "alice@example.edu", want: "alice@example.edu"},
+		{in: "alice.smith@example.com", want: "alice.smith@example.com"},
+		{in: "alice+section1@example.com", want: "alice+section1@example.com"},
+		{in: "12345@example.com", want: "12345@example.com"},
+		{in: "a@b.c", want: "a@b.c"},
+		{in: "alice@school.local", want: "alice@school.local"},
+		{in: "Alice@Example.EDU", want: "alice@example.edu"},
+		{in: "alice@xn--bcher-kva.example", want: "alice@xn--bcher-kva.example"},
+		{in: "alice@[192.0.2.1]", want: "alice@[192.0.2.1]"},
+
+		// Accepted, but the angle brackets are stripped — sending the raw form
+		// to GitHub is the bug this function exists to prevent.
+		{in: "<alice@example.edu>", want: "alice@example.edu"},
+		{in: "  <Alice@Example.EDU>  ", want: "alice@example.edu"},
+
+		// Display-name forms reject — name metadata belongs in
+		// first_name/last_name, not the email column.
+		{in: "Alice <alice@example.edu>", wantErr: true},
+		{in: "alice <alice@example.edu>", wantErr: true},
+		{in: "Alice Andersson <alice@example.edu>", wantErr: true},
+
+		// Malformed.
+		{in: "alice", wantErr: true},
+		{in: "alice@", wantErr: true},
+		{in: "@example.com", wantErr: true},
+		{in: "alice example.com", wantErr: true},
+		{in: "alice@@example.com", wantErr: true},
+		{in: "alice@example.com, bob@example.com", wantErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.in, func(t *testing.T) {
@@ -832,57 +857,10 @@ func TestCanonicalRosterEmail(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Fatalf("CanonicalRosterEmail(%q): %v", tc.in, err)
+				t.Fatalf("CanonicalRosterEmail(%q) = %v, want nil", tc.in, err)
 			}
 			if got != tc.want {
 				t.Errorf("CanonicalRosterEmail(%q) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestValidateRosterEmail(t *testing.T) {
-	cases := []struct {
-		in      string
-		wantErr bool
-	}{
-		// Email is optional per row.
-		{"", false},
-
-		// Bare local@domain shapes teachers actually use.
-		{"alice@example.edu", false},
-		{"alice.smith@example.com", false},
-		{"alice+section1@example.com", false},
-		{"12345@example.com", false},
-		{"a@b.c", false},
-		{"alice@school.local", false},
-		{"Alice@Example.EDU", false},
-		{"<alice@example.edu>", false},
-		{"alice@xn--bcher-kva.example", false},
-		{"alice@[192.0.2.1]", false},
-
-		// Display-name forms reject — name metadata belongs in
-		// first_name/last_name, not the email column.
-		{"Alice <alice@example.edu>", true},
-		{"alice <alice@example.edu>", true},
-		{"Alice Andersson <alice@example.edu>", true},
-
-		// Malformed.
-		{"alice", true},
-		{"alice@", true},
-		{"@example.com", true},
-		{"alice example.com", true},
-		{"alice@@example.com", true},
-		{"alice@example.com, bob@example.com", true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.in, func(t *testing.T) {
-			err := ValidateRosterEmail(tc.in)
-			if tc.wantErr && err == nil {
-				t.Fatalf("ValidateRosterEmail(%q) = nil, want error", tc.in)
-			}
-			if !tc.wantErr && err != nil {
-				t.Fatalf("ValidateRosterEmail(%q) = %v, want nil", tc.in, err)
 			}
 		})
 	}

--- a/cli/gh-teacher/internal/roster/cancel_invite_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/cancel_invite_cmd_test.go
@@ -462,6 +462,23 @@ func TestRosterCancelInviteCmd(t *testing.T) {
 		}
 	})
 
+	// A bracketed address is accepted, and must be CANONICALIZED: cancel-invite
+	// recomputes the invite-team hash from this value, so keeping the raw
+	// `<ada@uni.edu>` would hash to a team that does not exist and silently
+	// tear down nothing.
+	t.Run("bracketed address canonicalizes to the bare address", func(t *testing.T) {
+		_, _, email, err := parseEmailArgs([]string{"o", "cs-principles", "<" + inviteTestEmail + ">"})
+		if err != nil {
+			t.Fatalf("parseEmailArgs: %v", err)
+		}
+		if email != inviteTestEmail {
+			t.Fatalf("email = %q, want the bare %q", email, inviteTestEmail)
+		}
+		if got := configrepo.InviteTeamName(inviteTestClassroom, email); got != configrepo.InviteTeamName(inviteTestClassroom, inviteTestEmail) {
+			t.Errorf("invite-team slug %q does not match the address's own team", got)
+		}
+	})
+
 	// No --force: forcing teardown without a pending invitation would delete the
 	// only record of the address (see runRosterCancelInvite).
 	t.Run("has no --force flag", func(t *testing.T) {

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -71,12 +71,87 @@ func rosterInviteCmd() *cobra.Command {
 	return cmd
 }
 
+// emailInviteOutcome classifies what sendOneEmailInvite did with one address,
+// so both the single and bulk callers can react without re-reading the API
+// result. Exactly one is returned per address.
+type emailInviteOutcome int
+
+const (
+	// outcomeInvited: a fresh invitation was sent; the caller should append a
+	// pending row for the address.
+	outcomeInvited emailInviteOutcome = iota
+	// outcomeSkippedAlready: GitHub's 422 — already a member or already invited.
+	// No row; a team this run created has already been torn down.
+	outcomeSkippedAlready
+	// outcomePendingBlocked: the stored roster already lists this address as a
+	// pending email invite, so nothing was sent (no API call was made).
+	outcomePendingBlocked
+	// outcomeRateLimited: the invitation hit a secondary rate limit. Nothing was
+	// torn down (a retry re-adopts the team); the bulk caller stops issuing new
+	// sends, and the single caller surfaces the error.
+	outcomeRateLimited
+	// outcomeFailed: a hard send or team-prep failure; err is set.
+	outcomeFailed
+)
+
+// sendOneEmailInvite runs the per-address invite sequence shared by the single
+// `roster invite` and the bulk `--file` path: pre-check the stored roster,
+// ensure the per-invite metadata team (record written LAST), send the org
+// invitation carrying the classroom and invite team ids, and classify the
+// result. It never writes roster.csv — the caller owns the commit — so a bulk
+// run can append every invited address in one batched commit.
+//
+// The order is load-bearing (mirrors the web's bulkInviteByEmail inviteOne):
+// every read that could refuse the send happens before the first write; the
+// invite team's record is written before the invitation exists, so an accepted
+// invitation always has an address to recover; and a team created THIS run is
+// deleted only on a doomed send (422 or hard failure), never on a rate limit
+// (the retry re-adopts it) and never for an adopted team (it may hold a prior
+// invite's still-unrecovered record).
+func sendOneEmailInvite(client githubapi.Client, errOut io.Writer, org, classroom, email string, classroomTeam configrepo.TeamRef, actor string, rows []configrepo.RosterRow) (emailInviteOutcome, configrepo.TeamRef, error) {
+	holder, pending := rosterEmailClaim(rows, email)
+	if pending {
+		return outcomePendingBlocked, configrepo.TeamRef{}, nil
+	}
+	if holder != "" {
+		_, _ = fmt.Fprintf(errOut, "Note: %s already appears on the %s roster on %s's row. An address can be shared (a parent or a lab contact), so the invitation is still being sent — but no second row is written for it, matching the web app. If that row is the same person, cancel this invite and run `gh teacher roster update %s %s %s` instead.\n",
+			email, classroom, holder, org, classroom, holder)
+	}
+
+	inviteTeam, created, err := configrepo.EnsureInviteTeam(client, org, classroom, email, actor)
+	if err != nil {
+		return outcomeFailed, configrepo.TeamRef{}, err
+	}
+
+	if err := membership.InviteOrgByEmail(client, org, email, []int64{classroomTeam.ID, inviteTeam.ID}); err != nil {
+		// A doomed invitation must not leave a fresh, member-less metadata team
+		// behind for the GC to reap — but an ADOPTED team may hold an earlier
+		// invite's still-unrecovered record, so only delete what this run made.
+		// A rate limit is not doomed: the team stays so a retry adopts it rather
+		// than re-creating one against the same limit (as the web does).
+		if created && !cliutil.IsRateLimited(err) {
+			if delErr := configrepo.DeleteInviteTeam(client, org, inviteTeam.Slug); delErr != nil {
+				warnStrandedInviteTeam(errOut, "nothing was invited, but cleaning up", org, inviteTeam.Slug, delErr)
+			}
+		}
+		if cliutil.IsRateLimited(err) {
+			return outcomeRateLimited, configrepo.TeamRef{}, err
+		}
+		if errors.Is(err, membership.ErrEmailAlreadyInvitedOrMember) {
+			return outcomeSkippedAlready, configrepo.TeamRef{}, nil
+		}
+		return outcomeFailed, configrepo.TeamRef{}, err
+	}
+	return outcomeInvited, inviteTeam, nil
+}
+
 // runRosterInvite sends the email invitation, then records the pending row.
 // The order mirrors the web's bulkInviteByEmail and is load-bearing throughout:
 // every read that could refuse the send happens before the first write, the
 // invite team's record is written before the invitation exists (so an accepted
 // invitation always has an address to recover), and the roster row is appended
-// only once the invitation is real.
+// only once the invitation is real. The per-address work lives in
+// sendOneEmailInvite, shared with the bulk `--file` path.
 func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classroom, email, firstName, lastName, section string) error {
 	email = configrepo.NormalizeInviteEmail(email)
 
@@ -103,15 +178,6 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 	if err != nil {
 		return err
 	}
-	holder, pending := rosterEmailClaim(rows, email)
-	if pending {
-		return fmt.Errorf("%s is already invited to %s — run `gh teacher roster sync %s %s` if they accepted, or `gh teacher roster cancel-invite %s %s %s` to revoke it; nothing was sent",
-			email, classroom, org, classroom, org, classroom, email)
-	}
-	if holder != "" {
-		_, _ = fmt.Fprintf(errOut, "Note: %s already appears on the %s roster on %s's row. An address can be shared (a parent or a lab contact), so the invitation is still being sent — but no second row is written for it, matching the web app. If that row is the same person, cancel this invite and run `gh teacher roster update %s %s %s` instead.\n",
-			email, classroom, holder, org, classroom, holder)
-	}
 
 	// EnsureInviteTeam drops the creator GitHub silently adds, so it needs to
 	// know who that is.
@@ -120,32 +186,19 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 		return fmt.Errorf("resolving your GitHub login (needed to keep the invite team free of teachers): %w", err)
 	}
 
-	// No cleanup on failure here on purpose: EnsureInviteTeam writes the email
-	// LAST, so anything it strands holds no address and no valid record — a
-	// reconcile skips it and the next invite to this address adopts and heals it.
-	inviteTeam, created, err := configrepo.EnsureInviteTeam(client, org, classroom, email, actor)
-	if err != nil {
-		return err
+	outcome, inviteTeam, sendErr := sendOneEmailInvite(client, errOut, org, classroom, email, classroomTeam, actor, rows)
+	switch outcome {
+	case outcomePendingBlocked:
+		return fmt.Errorf("%s is already invited to %s — run `gh teacher roster sync %s %s` if they accepted, or `gh teacher roster cancel-invite %s %s %s` to revoke it; nothing was sent",
+			email, classroom, org, classroom, org, classroom, email)
+	case outcomeSkippedAlready:
+		_, _ = fmt.Fprintf(out, "%s: skipped %s — already a member of the org or already invited\n", org, email)
+		_, _ = fmt.Fprintf(errOut, "If they accepted an earlier invitation, run `gh teacher roster sync %s %s` to record them on the roster.\n", org, classroom)
+		return nil
+	case outcomeRateLimited, outcomeFailed:
+		return sendErr
 	}
-
-	if err := membership.InviteOrgByEmail(client, org, email, []int64{classroomTeam.ID, inviteTeam.ID}); err != nil {
-		// A doomed invitation must not leave a fresh, member-less metadata team
-		// behind for the GC to reap — but an ADOPTED team may hold an earlier
-		// invite's still-unrecovered record, so only delete what this run made.
-		// A rate limit is not doomed: the team stays so a retry adopts it rather
-		// than re-creating one against the same limit (as the web does).
-		if created && !cliutil.IsRateLimited(err) {
-			if delErr := configrepo.DeleteInviteTeam(client, org, inviteTeam.Slug); delErr != nil {
-				warnStrandedInviteTeam(errOut, "nothing was invited, but cleaning up", org, inviteTeam.Slug, delErr)
-			}
-		}
-		if errors.Is(err, membership.ErrEmailAlreadyInvitedOrMember) {
-			_, _ = fmt.Fprintf(out, "%s: skipped %s — already a member of the org or already invited\n", org, email)
-			_, _ = fmt.Fprintf(errOut, "If they accepted an earlier invitation, run `gh teacher roster sync %s %s` to record them on the roster.\n", org, classroom)
-			return nil
-		}
-		return err
-	}
+	// outcomeInvited: the invitation is real; record the pending row.
 	_, _ = fmt.Fprintf(out, "%s: invited %s as direct_member (teams %s, %s)\n",
 		org, email, classroomTeam.Slug, inviteTeam.Slug)
 

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -14,6 +16,7 @@ import (
 	"github.com/foundation50/gh-teacher/internal/configwrite"
 	"github.com/foundation50/gh-teacher/internal/githubapi"
 	"github.com/foundation50/gh-teacher/internal/membership"
+	"github.com/foundation50/gh-teacher/internal/validate"
 )
 
 func rosterInviteCmd() *cobra.Command {
@@ -21,11 +24,12 @@ func rosterInviteCmd() *cobra.Command {
 		firstName string
 		lastName  string
 		section   string
+		file      string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "invite <org> <classroom> <email>",
-		Short: "Invite one student to the classroom by email address",
+		Use:   "invite <org> <classroom> [email]",
+		Short: "Invite one student (or a whole list with --file) by email address",
 		Long: "Send a GitHub organization invitation to <email> and record it as a\n" +
 			"pending row in <org>/classroom50/<classroom>/roster.csv — the same\n" +
 			"three artifacts the web app's email invite creates, so either tool\n" +
@@ -42,33 +46,98 @@ func rosterInviteCmd() *cobra.Command {
 			"can never grant org ownership from a mistyped address.\n\n" +
 			"Once the student accepts, run `gh teacher roster sync` to fill in\n" +
 			"their username and github_id (the web app does this on its own).\n\n" +
+			"Bulk mode: pass --file <path> instead of an email to invite a whole\n" +
+			"list. The file is plaintext, one address per line; blank lines and\n" +
+			"lines starting with `#` are ignored. Every address is validated first,\n" +
+			"and if any line is unusable nothing is sent. Successful invitations are\n" +
+			"retained as pending rows in one commit. --file carries no names or\n" +
+			"sections (fill those later with `roster import` or `roster sync`), and\n" +
+			"the --first-name/--last-name/--section flags apply only to a single\n" +
+			"invite. A run interrupted by a GitHub rate limit reports the remaining\n" +
+			"addresses; re-running is safe (already-invited addresses are skipped).\n\n" +
 			"Returns non-zero on: classroom missing a GitHub team, an address the\n" +
 			"roster already lists as invited, or a failed invitation. An address\n" +
 			"that already belongs to a member (or already has a pending\n" +
 			"invitation) is reported as skipped and exits 0. An address some other\n" +
 			"row already carries is still invited, but gets no second row.",
 		Example: "  gh teacher roster invite cs50-fall-2026 cs-principles ada@example.edu\n" +
-			"  gh teacher roster invite cs50-fall-2026 cs-principles ada@example.edu --first-name Ada --last-name Lovelace --section section-1",
-		Args: cobra.ExactArgs(3),
+			"  gh teacher roster invite cs50-fall-2026 cs-principles ada@example.edu --first-name Ada --last-name Lovelace --section section-1\n" +
+			"  gh teacher roster invite cs50-fall-2026 cs-principles --file ./section-1-emails.txt",
+		Args: func(cmd *cobra.Command, args []string) error {
+			// --file replaces the positional email: <org> <classroom> only.
+			// Without it, the classic <org> <classroom> <email> triple stands.
+			if strings.TrimSpace(file) != "" {
+				if len(args) != 2 {
+					return errors.New("with --file, pass only <org> <classroom> (the addresses come from the file, not the command line)")
+				}
+				return nil
+			}
+			if len(args) != 3 {
+				return errors.New("pass <org> <classroom> <email>, or <org> <classroom> --file <path> to invite a list")
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			org, classroom, email, err := parseEmailArgs(args)
-			if err != nil {
+			org := strings.TrimSpace(args[0])
+			classroom := strings.TrimSpace(args[1])
+			if org == "" || classroom == "" {
+				return errors.New("org and classroom must both be non-empty")
+			}
+			if err := validate.ShortName(classroom, "classroom"); err != nil {
 				return err
+			}
+			// Validate the input BEFORE any auth or network so a typo or an
+			// unreadable file can never reach GitHub.
+			path := strings.TrimSpace(file)
+			var email string
+			if path == "" {
+				email = strings.TrimSpace(args[2])
+				if email == "" {
+					return errors.New("email must be non-empty")
+				}
+				if err := configrepo.ValidateRosterEmail(email); err != nil {
+					return err
+				}
+			}
+			var data []byte
+			if path != "" {
+				var err error
+				if data, err = readInviteFile(path); err != nil {
+					return err
+				}
 			}
 			client, err := githubapi.RequireAuthClient(cmd)
 			if err != nil {
 				return err
+			}
+			if path != "" {
+				return runRosterInviteFile(client, cmd.OutOrStdout(), cmd.ErrOrStderr(), org, classroom, data)
 			}
 			return runRosterInvite(client, cmd.OutOrStdout(), cmd.ErrOrStderr(),
 				org, classroom, email,
 				strings.TrimSpace(firstName), strings.TrimSpace(lastName), strings.TrimSpace(section))
 		},
 	}
-	cmd.Flags().StringVar(&firstName, "first-name", "", "Student's first name (written into the first_name column)")
-	cmd.Flags().StringVar(&lastName, "last-name", "", "Student's last name (written into the last_name column)")
-	cmd.Flags().StringVar(&section, "section", "", "Section identifier (free-form text, written into the section column)")
+	cmd.Flags().StringVar(&firstName, "first-name", "", "Student's first name (single invite only; written into the first_name column)")
+	cmd.Flags().StringVar(&lastName, "last-name", "", "Student's last name (single invite only; written into the last_name column)")
+	cmd.Flags().StringVar(&section, "section", "", "Section identifier (single invite only; free-form text, written into the section column)")
+	cmd.Flags().StringVar(&file, "file", "", "Path to a plaintext list of email addresses (one per line; # comments and blank lines ignored) to invite in bulk")
 	return cmd
+}
+
+// readInviteFile reads the --file address list, resolving the path and turning
+// a read failure into a clear error before any network call.
+func readInviteFile(path string) ([]byte, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve --file path: %w", err)
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", abs, err)
+	}
+	return data, nil
 }
 
 // emailInviteOutcome classifies what sendOneEmailInvite did with one address,

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -51,10 +51,13 @@ func rosterInviteCmd() *cobra.Command {
 			"lines starting with `#` are ignored. Every address is validated first,\n" +
 			"and if any line is unusable nothing is sent. Successful invitations are\n" +
 			"retained as pending rows in one commit. --file carries no names or\n" +
-			"sections (fill those later with `roster import` or `roster sync`), and\n" +
-			"the --first-name/--last-name/--section flags apply only to a single\n" +
-			"invite. A run interrupted by a GitHub rate limit reports the remaining\n" +
-			"addresses; re-running is safe (already-invited addresses are skipped).\n\n" +
+			"sections (fill those later with `roster import` or `roster sync`), so\n" +
+			"the --first-name/--last-name/--section flags are rejected with it.\n" +
+			"Each address is reported as it resolves, then a summary counts them.\n\n" +
+			"Bulk exit codes follow `roster sync`: 0 every address was invited or\n" +
+			"cleanly skipped, 2 nothing failed but a GitHub rate limit left\n" +
+			"addresses uninvited (re-run to continue — already-invited addresses are\n" +
+			"skipped), 1 an address genuinely failed or the roster write failed.\n\n" +
 			"Returns non-zero on: classroom missing a GitHub team, an address the\n" +
 			"roster already lists as invited, or a failed invitation. An address\n" +
 			"that already belongs to a member (or already has a pending\n" +
@@ -69,6 +72,18 @@ func rosterInviteCmd() *cobra.Command {
 			if strings.TrimSpace(file) != "" {
 				if len(args) != 2 {
 					return errors.New("with --file, pass only <org> <classroom> (the addresses come from the file, not the command line)")
+				}
+				// A per-student flag can't apply to a whole list, and silently
+				// dropping it would lose metadata the teacher believes they set.
+				var ignored []string
+				for _, name := range []string{"first-name", "last-name", "section"} {
+					if cmd.Flags().Changed(name) {
+						ignored = append(ignored, "--"+name)
+					}
+				}
+				if len(ignored) > 0 {
+					return fmt.Errorf("%s applies to a single invite, not --file (a list carries no per-student metadata); invite the list, then fill names and sections in with `gh teacher roster import`",
+						strings.Join(ignored, " and "))
 				}
 				return nil
 			}
@@ -92,13 +107,14 @@ func rosterInviteCmd() *cobra.Command {
 			path := strings.TrimSpace(file)
 			var email string
 			if path == "" {
-				email = strings.TrimSpace(args[2])
-				if email == "" {
-					return errors.New("email must be non-empty")
-				}
-				if err := configrepo.ValidateRosterEmail(email); err != nil {
+				canonical, err := configrepo.CanonicalRosterEmail(strings.TrimSpace(args[2]))
+				if err != nil {
 					return err
 				}
+				if canonical == "" {
+					return errors.New("email must be non-empty")
+				}
+				email = canonical
 			}
 			var data []byte
 			if path != "" {
@@ -140,24 +156,39 @@ func readInviteFile(path string) ([]byte, error) {
 	return data, nil
 }
 
+// errClassroomTeamUnusable refuses a send when classroom.json records no usable
+// team. A team-less email invitation is broken, not degraded: the invitee
+// accepts into the org attached to nothing and, with no username to key on,
+// nothing later notices. A recorded team missing its numeric id is just as
+// unusable, since the invitation carries team ids rather than slugs. Shared so
+// the single and bulk paths refuse identically.
+func errClassroomTeamUnusable(org, classroom string) error {
+	return fmt.Errorf("%s: classroom %s has no usable team recorded in classroom.json, so an invitation would enroll nobody — nothing was sent; run `gh teacher classroom add %s %s` to create the team, then retry",
+		org, classroom, org, classroom)
+}
+
 // emailInviteOutcome classifies what sendOneEmailInvite did with one address,
 // so both the single and bulk callers can react without re-reading the API
 // result. Exactly one is returned per address.
 type emailInviteOutcome int
 
 const (
+	// The zero value is deliberately unnamed and unused: an unset outcome must
+	// not read as success, since the callers' success arm appends a roster row
+	// for an address that may never have been invited. Both switches carry a
+	// default arm that rejects it.
+	_ emailInviteOutcome = iota
 	// outcomeInvited: a fresh invitation was sent; the caller should append a
 	// pending row for the address.
-	outcomeInvited emailInviteOutcome = iota
+	outcomeInvited
 	// outcomeSkippedAlready: GitHub's 422 — already a member or already invited.
 	// No row; a team this run created has already been torn down.
 	outcomeSkippedAlready
 	// outcomePendingBlocked: the stored roster already lists this address as a
 	// pending email invite, so nothing was sent (no API call was made).
 	outcomePendingBlocked
-	// outcomeRateLimited: the invitation hit a secondary rate limit. Nothing was
-	// torn down (a retry re-adopts the team); the bulk caller stops issuing new
-	// sends, and the single caller surfaces the error.
+	// outcomeRateLimited: a secondary rate limit; the bulk caller stops issuing
+	// new sends and the single caller surfaces the error.
 	outcomeRateLimited
 	// outcomeFailed: a hard send or team-prep failure; err is set.
 	outcomeFailed
@@ -165,18 +196,15 @@ const (
 
 // sendOneEmailInvite runs the per-address invite sequence shared by the single
 // `roster invite` and the bulk `--file` path: pre-check the stored roster,
-// ensure the per-invite metadata team (record written LAST), send the org
-// invitation carrying the classroom and invite team ids, and classify the
-// result. It never writes roster.csv — the caller owns the commit — so a bulk
-// run can append every invited address in one batched commit.
+// ensure the per-invite metadata team, send the org invitation carrying the
+// classroom and invite team ids, and classify the result. It never writes
+// roster.csv — the caller owns the commit — so a bulk run can append every
+// invited address in one batched commit.
 //
 // The order is load-bearing (mirrors the web's bulkInviteByEmail inviteOne):
-// every read that could refuse the send happens before the first write; the
+// every read that could refuse the send happens before the first write, and the
 // invite team's record is written before the invitation exists, so an accepted
-// invitation always has an address to recover; and a team created THIS run is
-// deleted only on a doomed send (422 or hard failure), never on a rate limit
-// (the retry re-adopts it) and never for an adopted team (it may hold a prior
-// invite's still-unrecovered record).
+// invitation always has an address to recover.
 func sendOneEmailInvite(client githubapi.Client, errOut io.Writer, org, classroom, email string, classroomTeam configrepo.TeamRef, actor string, rows []configrepo.RosterRow) (emailInviteOutcome, configrepo.TeamRef, error) {
 	holder, pending := rosterEmailClaim(rows, email)
 	if pending {
@@ -187,8 +215,17 @@ func sendOneEmailInvite(client githubapi.Client, errOut io.Writer, org, classroo
 			email, classroom, holder, org, classroom, holder)
 	}
 
+	// EnsureInviteTeam mutates (team create, membership drop, description
+	// PATCH), so it can hit the same secondary limit the invitation can. It must
+	// classify as rate-limited too, or a throttled bulk run keeps hammering the
+	// team endpoints instead of deferring the rest. No teardown either way: the
+	// record is written last, so anything stranded holds no address and the next
+	// invite to this address adopts and heals it.
 	inviteTeam, created, err := configrepo.EnsureInviteTeam(client, org, classroom, email, actor)
 	if err != nil {
+		if cliutil.IsRateLimited(err) {
+			return outcomeRateLimited, configrepo.TeamRef{}, err
+		}
 		return outcomeFailed, configrepo.TeamRef{}, err
 	}
 
@@ -214,13 +251,9 @@ func sendOneEmailInvite(client githubapi.Client, errOut io.Writer, org, classroo
 	return outcomeInvited, inviteTeam, nil
 }
 
-// runRosterInvite sends the email invitation, then records the pending row.
-// The order mirrors the web's bulkInviteByEmail and is load-bearing throughout:
-// every read that could refuse the send happens before the first write, the
-// invite team's record is written before the invitation exists (so an accepted
-// invitation always has an address to recover), and the roster row is appended
-// only once the invitation is real. The per-address work lives in
-// sendOneEmailInvite, shared with the bulk `--file` path.
+// runRosterInvite sends one email invitation, then records its pending row. The
+// per-address work lives in sendOneEmailInvite, shared with the bulk `--file`
+// path; the roster row is appended only once the invitation is real.
 func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classroom, email, firstName, lastName, section string) error {
 	email = configrepo.NormalizeInviteEmail(email)
 
@@ -229,23 +262,23 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 		return err
 	}
 
-	// A team-less email invitation is broken, not degraded: the invitee accepts
-	// into the org attached to nothing and, with no username to key on, nothing
-	// later notices. Refuse while nothing has been created or sent. A recorded
-	// team missing its numeric id is just as unusable — the invitation carries
-	// team ids, not slugs.
 	classroomTeam, ok, err := configrepo.ResolveClassroomTeam(client, org, classroom, branch)
 	if err != nil {
 		return err
 	}
 	if !ok || classroomTeam.ID <= 0 {
-		return fmt.Errorf("%s: classroom %s has no usable team recorded in classroom.json, so an invitation would enroll nobody — nothing was sent; run `gh teacher classroom add %s %s` to create the team, then retry",
-			org, classroom, org, classroom)
+		return errClassroomTeamUnusable(org, classroom)
 	}
 
 	rows, err := configrepo.LoadRosterLenient(client, org, classroom, branch)
 	if err != nil {
 		return err
+	}
+	// Refuse before resolving the actor so an already-invited address still
+	// costs zero API calls, as it did before the send was extracted.
+	if _, pending := rosterEmailClaim(rows, email); pending {
+		return fmt.Errorf("%s is already invited to %s — run `gh teacher roster sync %s %s` if they accepted, or `gh teacher roster cancel-invite %s %s %s` to revoke it; nothing was sent",
+			email, classroom, org, classroom, org, classroom, email)
 	}
 
 	// EnsureInviteTeam drops the creator GitHub silently adds, so it needs to
@@ -257,19 +290,22 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 
 	outcome, inviteTeam, sendErr := sendOneEmailInvite(client, errOut, org, classroom, email, classroomTeam, actor, rows)
 	switch outcome {
+	case outcomeInvited:
+		_, _ = fmt.Fprintf(out, "%s: invited %s as direct_member (teams %s, %s)\n",
+			org, email, classroomTeam.Slug, inviteTeam.Slug)
 	case outcomePendingBlocked:
-		return fmt.Errorf("%s is already invited to %s — run `gh teacher roster sync %s %s` if they accepted, or `gh teacher roster cancel-invite %s %s %s` to revoke it; nothing was sent",
-			email, classroom, org, classroom, org, classroom, email)
+		// Unreachable: the pre-check above already refused. Kept so the switch
+		// stays exhaustive.
+		return fmt.Errorf("%s is already invited to %s; nothing was sent", email, classroom)
 	case outcomeSkippedAlready:
 		_, _ = fmt.Fprintf(out, "%s: skipped %s — already a member of the org or already invited\n", org, email)
 		_, _ = fmt.Fprintf(errOut, "If they accepted an earlier invitation, run `gh teacher roster sync %s %s` to record them on the roster.\n", org, classroom)
 		return nil
 	case outcomeRateLimited, outcomeFailed:
 		return sendErr
+	default:
+		return fmt.Errorf("internal error: unhandled invite outcome %d for %s (nothing was recorded)", outcome, email)
 	}
-	// outcomeInvited: the invitation is real; record the pending row.
-	_, _ = fmt.Fprintf(out, "%s: invited %s as direct_member (teams %s, %s)\n",
-		org, email, classroomTeam.Slug, inviteTeam.Slug)
 
 	var appended bool
 	build := func(parentSHA string) (configwrite.CommitChange, error) {

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -119,7 +119,7 @@ func rosterInviteCmd() *cobra.Command {
 			var data []byte
 			if path != "" {
 				var err error
-				if data, err = readInviteFile(path); err != nil {
+				if _, data, err = readTeacherFile(path, "--file path"); err != nil {
 					return err
 				}
 			}
@@ -142,18 +142,20 @@ func rosterInviteCmd() *cobra.Command {
 	return cmd
 }
 
-// readInviteFile reads the --file address list, resolving the path and turning
-// a read failure into a clear error before any network call.
-func readInviteFile(path string) ([]byte, error) {
+// readTeacherFile reads a local file a teacher passed on the command line,
+// returning the resolved absolute path alongside the bytes so callers name the
+// file they actually opened. `what` labels the argument in a resolve error
+// (e.g. "--file path", "import path").
+func readTeacherFile(path, what string) (string, []byte, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
-		return nil, fmt.Errorf("resolve --file path: %w", err)
+		return "", nil, fmt.Errorf("resolve %s: %w", what, err)
 	}
 	data, err := os.ReadFile(abs)
 	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", abs, err)
+		return "", nil, fmt.Errorf("read %s: %w", abs, err)
 	}
-	return data, nil
+	return abs, data, nil
 }
 
 // errClassroomTeamUnusable refuses a send when classroom.json records no usable
@@ -274,8 +276,9 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 	if err != nil {
 		return err
 	}
-	// Refuse before resolving the actor so an already-invited address still
-	// costs zero API calls, as it did before the send was extracted.
+	// Refuse here rather than off outcomePendingBlocked so this path's error can
+	// name the sync/cancel-invite remedies; the helper's own check stays
+	// authoritative for the bulk path.
 	if _, pending := rosterEmailClaim(rows, email); pending {
 		return fmt.Errorf("%s is already invited to %s — run `gh teacher roster sync %s %s` if they accepted, or `gh teacher roster cancel-invite %s %s %s` to revoke it; nothing was sent",
 			email, classroom, org, classroom, org, classroom, email)
@@ -293,10 +296,6 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 	case outcomeInvited:
 		_, _ = fmt.Fprintf(out, "%s: invited %s as direct_member (teams %s, %s)\n",
 			org, email, classroomTeam.Slug, inviteTeam.Slug)
-	case outcomePendingBlocked:
-		// Unreachable: the pre-check above already refused. Kept so the switch
-		// stays exhaustive.
-		return fmt.Errorf("%s is already invited to %s; nothing was sent", email, classroom)
 	case outcomeSkippedAlready:
 		_, _ = fmt.Fprintf(out, "%s: skipped %s — already a member of the org or already invited\n", org, email)
 		_, _ = fmt.Fprintf(errOut, "If they accepted an earlier invitation, run `gh teacher roster sync %s %s` to record them on the roster.\n", org, classroom)
@@ -304,6 +303,8 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 	case outcomeRateLimited, outcomeFailed:
 		return sendErr
 	default:
+		// Includes outcomePendingBlocked, which the pre-check above already
+		// refused with a better message, and the unset zero value.
 		return fmt.Errorf("internal error: unhandled invite outcome %d for %s (nothing was recorded)", outcome, email)
 	}
 

--- a/cli/gh-teacher/internal/roster/invite_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_cmd_test.go
@@ -454,8 +454,7 @@ func TestRosterInviteCmd(t *testing.T) {
 		}
 	})
 
-	// Covers AE2 arg leg / R2: --file with a positional email is rejected before
-	// any network call.
+	// --file with a positional email is rejected before any network call.
 	t.Run("both a positional email and --file is an arg error", func(t *testing.T) {
 		err := run(t, "o", "cs-principles", "ada@uni.edu", "--file", "list.txt")
 		if err == nil || !strings.Contains(err.Error(), "--file") {
@@ -467,6 +466,17 @@ func TestRosterInviteCmd(t *testing.T) {
 		err := run(t, "o", "cs-principles", "--file", "/no/such/list-file.txt")
 		if err == nil || !strings.Contains(err.Error(), "read") {
 			t.Fatalf("err = %v, want a read error", err)
+		}
+	})
+
+	// A per-student flag can't apply to a list; silently dropping it would lose
+	// metadata the teacher believes they set.
+	t.Run("metadata flags are rejected with --file", func(t *testing.T) {
+		for _, flag := range []string{"--first-name", "--last-name", "--section"} {
+			err := run(t, "o", "cs-principles", "--file", "list.txt", flag, "x")
+			if err == nil || !strings.Contains(err.Error(), flag) {
+				t.Errorf("%s with --file: err = %v, want it rejected by name", flag, err)
+			}
 		}
 	})
 }

--- a/cli/gh-teacher/internal/roster/invite_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_cmd_test.go
@@ -447,6 +447,28 @@ func TestRosterInviteCmd(t *testing.T) {
 			t.Error("--role must not exist on `roster invite`")
 		}
 	})
+
+	t.Run("has a --file flag for bulk invites", func(t *testing.T) {
+		if rosterInviteCmd().Flags().Lookup("file") == nil {
+			t.Error("missing --file")
+		}
+	})
+
+	// Covers AE2 arg leg / R2: --file with a positional email is rejected before
+	// any network call.
+	t.Run("both a positional email and --file is an arg error", func(t *testing.T) {
+		err := run(t, "o", "cs-principles", "ada@uni.edu", "--file", "list.txt")
+		if err == nil || !strings.Contains(err.Error(), "--file") {
+			t.Fatalf("err = %v, want an arg error naming --file", err)
+		}
+	})
+
+	t.Run("--file at a nonexistent path errors before network", func(t *testing.T) {
+		err := run(t, "o", "cs-principles", "--file", "/no/such/list-file.txt")
+		if err == nil || !strings.Contains(err.Error(), "read") {
+			t.Fatalf("err = %v, want a read error", err)
+		}
+	})
 }
 
 // The three email-lifecycle subcommands must be reachable and discoverable: a

--- a/cli/gh-teacher/internal/roster/invite_file.go
+++ b/cli/gh-teacher/internal/roster/invite_file.go
@@ -1,0 +1,76 @@
+package roster
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/foundation50/gh-teacher/internal/configrepo"
+)
+
+// addressEntry is one address parsed from a --file list: the normalized email
+// and the file line it first appeared on, so a later skip/failure notice can
+// name the line the teacher would edit.
+type addressEntry struct {
+	email string
+	line  int
+}
+
+// parseInviteFile turns a plaintext address list into an ordered, deduped set of
+// addresses to invite, reporting EVERY unusable line in one pass (never
+// stopping at the first) so a teacher fixes the whole file once. A non-empty
+// failure list means the caller must send nothing — the same fail-closed
+// posture as `roster import`.
+//
+// One address per line. A blank line, or a line whose first non-space rune is
+// `#`, is a comment and ignored, so a teacher can annotate the list. Surviving
+// lines are validated with ValidateRosterEmail (bare local@domain, no display
+// name), normalized (trim + lowercase), and deduped case-insensitively keeping
+// the first occurrence — mirroring dedupePendingByEmail so one file can't queue
+// two invites to the same address.
+func parseInviteFile(data []byte) ([]addressEntry, []error) {
+	var (
+		entries  []addressEntry
+		failures []error
+		seen     = map[string]bool{}
+	)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	// A pathological single line could exceed bufio's default 64KiB token cap;
+	// raise it so a long (if unusual) address file still parses rather than
+	// silently truncating.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	line := 0
+	for scanner.Scan() {
+		line++
+		raw := strings.TrimSpace(scanner.Text())
+		if raw == "" || strings.HasPrefix(raw, "#") {
+			continue
+		}
+		if err := configrepo.ValidateRosterEmail(raw); err != nil {
+			failures = append(failures, fmt.Errorf("line %d (%s): %w", line, raw, err))
+			continue
+		}
+		key := configrepo.NormalizeInviteEmail(raw)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		entries = append(entries, addressEntry{email: key, line: line})
+	}
+	if err := scanner.Err(); err != nil {
+		failures = append(failures, fmt.Errorf("reading address list: %w", err))
+	}
+	return entries, failures
+}
+
+// joinInviteFileFailures collapses the per-line failures into one fail-closed
+// error whose message reports how many lines are unusable before listing them,
+// matching planRosterImport's refusal shape.
+func joinInviteFileFailures(failures []error) error {
+	if len(failures) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%d line(s) can't be invited, so nothing was sent:\n%w", len(failures), errors.Join(failures...))
+}

--- a/cli/gh-teacher/internal/roster/invite_file.go
+++ b/cli/gh-teacher/internal/roster/invite_file.go
@@ -5,9 +5,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
+	"github.com/foundation50/classroom50-cli-shared/contract"
 	"github.com/foundation50/gh-teacher/internal/configrepo"
+	"github.com/foundation50/gh-teacher/internal/configwrite"
+	"github.com/foundation50/gh-teacher/internal/githubapi"
 )
 
 // addressEntry is one address parsed from a --file list: the normalized email
@@ -73,4 +77,150 @@ func joinInviteFileFailures(failures []error) error {
 		return nil
 	}
 	return fmt.Errorf("%d line(s) can't be invited, so nothing was sent:\n%w", len(failures), errors.Join(failures...))
+}
+
+// runRosterInviteFile sends an email invitation to every address in a plaintext
+// list and retains the whole invited batch as pending rows in ONE commit.
+//
+// The lifecycle mirrors the web's bulkInviteByEmail: resolve the classroom team
+// once (a missing team aborts the batch before anything is sent), send each
+// address through the shared sendOneEmailInvite (so the load-bearing order and
+// created-team teardown match the single invite), stop issuing NEW sends once a
+// rate limit appears (hammering a throttled endpoint only extends the window),
+// and append every successfully-invited address in one CommitTreeChange whose
+// closure re-checks the roster under the rebase. A rate-limited or failed run is
+// safe to re-run: an already-invited address 422-skips and an already-rowed one
+// appends nothing.
+func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, classroom string, data []byte) error {
+	entries, failures := parseInviteFile(data)
+	if err := joinInviteFileFailures(failures); err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("no email addresses to invite — the file has only blank or # comment lines")
+	}
+
+	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
+	if err != nil {
+		return err
+	}
+
+	// A team-less email invitation is broken, not degraded (see runRosterInvite):
+	// refuse the whole batch before sending anything.
+	classroomTeam, ok, err := configrepo.ResolveClassroomTeam(client, org, classroom, branch)
+	if err != nil {
+		return err
+	}
+	if !ok || classroomTeam.ID <= 0 {
+		return fmt.Errorf("%s: classroom %s has no usable team recorded in classroom.json, so an invitation would enroll nobody — nothing was sent; run `gh teacher classroom add %s %s` to create the team, then retry",
+			org, classroom, org, classroom)
+	}
+
+	rows, err := configrepo.LoadRosterLenient(client, org, classroom, branch)
+	if err != nil {
+		return err
+	}
+
+	actor, _, err := githubapi.CurrentUser(client)
+	if err != nil {
+		return fmt.Errorf("resolving your GitHub login (needed to keep the invite team free of teachers): %w", err)
+	}
+
+	var (
+		invited        []string
+		skipped        []string
+		pendingBlocked []string
+		deferredList   []string
+		failedList     []string
+		rateLimited    bool
+	)
+	for _, entry := range entries {
+		if rateLimited {
+			// Once throttled, every remaining address is deferred without a call.
+			deferredList = append(deferredList, entry.email)
+			continue
+		}
+		outcome, _, sendErr := sendOneEmailInvite(client, errOut, org, classroom, entry.email, classroomTeam, actor, rows)
+		switch outcome {
+		case outcomeInvited:
+			invited = append(invited, entry.email)
+		case outcomeSkippedAlready:
+			skipped = append(skipped, entry.email)
+		case outcomePendingBlocked:
+			pendingBlocked = append(pendingBlocked, entry.email)
+		case outcomeRateLimited:
+			rateLimited = true
+			deferredList = append(deferredList, entry.email)
+		case outcomeFailed:
+			failedList = append(failedList, fmt.Sprintf("%s (%v)", entry.email, sendErr))
+		}
+	}
+
+	appended, commitErr := commitInvitedRows(client, org, classroom, branch, invited)
+
+	// Report before deciding the exit status so a teacher sees the whole picture.
+	_, _ = fmt.Fprintf(out, "%s/%s/%s: %d invited, %d appended as pending rows, %d already member/invited, %d already on the roster, %d failed, %d deferred (rate limit)\n",
+		org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom),
+		len(invited), appended, len(skipped), len(pendingBlocked), len(failedList), len(deferredList))
+	for _, addr := range pendingBlocked {
+		_, _ = fmt.Fprintf(errOut, "Skipped %s: already a pending invitation on the roster — run `gh teacher roster sync %s %s` if they accepted.\n", addr, org, classroom)
+	}
+	for _, f := range failedList {
+		_, _ = fmt.Fprintf(errOut, "Failed %s\n", f)
+	}
+	if len(deferredList) > 0 {
+		_, _ = fmt.Fprintf(errOut, "Deferred (GitHub rate limit hit): %s\nRe-run the same command once the limit clears; already-invited addresses are skipped automatically.\n",
+			strings.Join(deferredList, ", "))
+	}
+	if len(invited) > 0 {
+		_, _ = fmt.Fprintf(errOut, "Advise the newly-invited students to accept the emailed invitation, then run `gh teacher roster sync %s %s` to record their username and github_id.\n", org, classroom)
+	}
+
+	if commitErr != nil {
+		// Never a rollback: the invitations are the source of truth and each
+		// metadata team retains its address, so `roster sync` heals the rows.
+		_, _ = fmt.Fprintf(errOut, "Warning: %d invitation(s) were sent, but recording them in %s failed; run `gh teacher roster sync %s %s` to add the pending rows (the invitations are unaffected).\n",
+			len(invited), configrepo.RosterFilePath(classroom), org, classroom)
+		return fmt.Errorf("invitations sent, but the roster rows were not written: %w", commitErr)
+	}
+	if len(failedList) > 0 || len(deferredList) > 0 {
+		return fmt.Errorf("%d address(es) were not invited (%d failed, %d deferred); see the report above",
+			len(failedList)+len(deferredList), len(failedList), len(deferredList))
+	}
+	return nil
+}
+
+// commitInvitedRows appends the invited addresses as email-only pending rows in
+// one Tree commit, dropping under the rebase any address a concurrent writer
+// already put on a row (rosterHoldsEmail) — matching the web's single batched
+// appendEmailInviteRows. Returns how many rows were actually appended. An empty
+// invited set writes nothing.
+func commitInvitedRows(client githubapi.Client, org, classroom, branch string, invited []string) (int, error) {
+	if len(invited) == 0 {
+		return 0, nil
+	}
+	var appended int
+	build := func(parentSHA string) (configwrite.CommitChange, error) {
+		appended = 0
+		current, err := configrepo.LoadRosterLenient(client, org, classroom, parentSHA)
+		if err != nil {
+			return configwrite.CommitChange{}, err
+		}
+		for _, email := range invited {
+			if rosterHoldsEmail(current, email) {
+				continue
+			}
+			current = append(current, configrepo.RosterRow{Email: email, Role: rosterRoleStudent})
+			appended++
+		}
+		if appended == 0 {
+			return configwrite.CommitChange{}, nil // every address already held → nothing to write
+		}
+		return configrepo.RosterWriteChange(classroom, current)
+	}
+	message := contract.PrefixCommit(fmt.Sprintf("roster: add %d invited email(s) to %s (gh teacher roster invite --file)", len(invited), classroom))
+	if _, err := configwrite.CommitTreeChange(client, org, configrepo.ConfigRepoName, branch, message, build); err != nil {
+		return 0, err
+	}
+	return appended, nil
 }

--- a/cli/gh-teacher/internal/roster/invite_file.go
+++ b/cli/gh-teacher/internal/roster/invite_file.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/foundation50/classroom50-cli-shared/contract"
+	"github.com/foundation50/gh-teacher/internal/cliutil"
 	"github.com/foundation50/gh-teacher/internal/configrepo"
 	"github.com/foundation50/gh-teacher/internal/configwrite"
 	"github.com/foundation50/gh-teacher/internal/githubapi"
@@ -52,21 +54,40 @@ func parseInviteFile(data []byte) ([]addressEntry, []error) {
 		if raw == "" || strings.HasPrefix(raw, "#") {
 			continue
 		}
-		if err := configrepo.ValidateRosterEmail(raw); err != nil {
-			failures = append(failures, fmt.Errorf("line %d (%s): %w", line, raw, err))
+		// The CANONICAL address is what gets invited: an address that merely
+		// validates (`<ada@uni.edu>` unwraps) must be sent in its parsed form, or
+		// GitHub 422s it and the report misreads that as already-invited.
+		email, err := configrepo.CanonicalRosterEmail(raw)
+		if err != nil {
+			failures = append(failures, inviteLineError(line, raw, err))
 			continue
 		}
-		key := configrepo.NormalizeInviteEmail(raw)
-		if seen[key] {
+		if seen[email] {
 			continue
 		}
-		seen[key] = true
-		entries = append(entries, addressEntry{email: key, line: line})
+		seen[email] = true
+		entries = append(entries, addressEntry{email: email, line: line})
 	}
 	if err := scanner.Err(); err != nil {
 		failures = append(failures, fmt.Errorf("reading address list: %w", err))
 	}
 	return entries, failures
+}
+
+// maxReportedLineBytes caps how much of an unusable line the report echoes. The
+// line number is what a teacher needs to find it; echoing an entire line of a
+// file pointed at --file by mistake would spill its contents.
+const maxReportedLineBytes = 120
+
+// inviteLineError reports an unusable line without echoing more of it than the
+// teacher needs to locate it. An over-long line drops the underlying validator
+// message too, since mail.ParseAddress embeds the whole input in its own error.
+func inviteLineError(line int, raw string, err error) error {
+	if len(raw) <= maxReportedLineBytes {
+		return fmt.Errorf("line %d (%s): %w", line, raw, err)
+	}
+	return fmt.Errorf("line %d (%s... truncated, %d bytes): not a valid email address",
+		line, raw[:maxReportedLineBytes], len(raw))
 }
 
 // joinInviteFileFailures collapses the per-line failures into one fail-closed
@@ -79,25 +100,32 @@ func joinInviteFileFailures(failures []error) error {
 	return fmt.Errorf("%d line(s) can't be invited, so nothing was sent:\n%w", len(failures), errors.Join(failures...))
 }
 
+// inviteFileSleep is the throttle wait, indirected so tests don't actually sleep
+// through a mock's Retry-After.
+var inviteFileSleep = time.Sleep
+
 // runRosterInviteFile sends an email invitation to every address in a plaintext
 // list and retains the whole invited batch as pending rows in ONE commit.
 //
 // The lifecycle mirrors the web's bulkInviteByEmail: resolve the classroom team
 // once (a missing team aborts the batch before anything is sent), send each
-// address through the shared sendOneEmailInvite (so the load-bearing order and
-// created-team teardown match the single invite), stop issuing NEW sends once a
+// address through the shared sendOneEmailInvite, stop issuing NEW sends once a
 // rate limit appears (hammering a throttled endpoint only extends the window),
 // and append every successfully-invited address in one CommitTreeChange whose
 // closure re-checks the roster under the rebase. A rate-limited or failed run is
 // safe to re-run: an already-invited address 422-skips and an already-rowed one
 // appends nothing.
+//
+// Exit codes follow `roster sync`'s convention so a script can tell a retryable
+// partial run from a broken one: 0 all done, 2 nothing failed but addresses
+// remain (deferred), 1 something actually failed.
 func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, classroom string, data []byte) error {
 	entries, failures := parseInviteFile(data)
 	if err := joinInviteFileFailures(failures); err != nil {
 		return err
 	}
 	if len(entries) == 0 {
-		return fmt.Errorf("no email addresses to invite — the file has only blank or # comment lines")
+		return errors.New("no email addresses to invite — the file has only blank or # comment lines")
 	}
 
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
@@ -105,15 +133,12 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 		return err
 	}
 
-	// A team-less email invitation is broken, not degraded (see runRosterInvite):
-	// refuse the whole batch before sending anything.
 	classroomTeam, ok, err := configrepo.ResolveClassroomTeam(client, org, classroom, branch)
 	if err != nil {
 		return err
 	}
 	if !ok || classroomTeam.ID <= 0 {
-		return fmt.Errorf("%s: classroom %s has no usable team recorded in classroom.json, so an invitation would enroll nobody — nothing was sent; run `gh teacher classroom add %s %s` to create the team, then retry",
-			org, classroom, org, classroom)
+		return errClassroomTeamUnusable(org, classroom)
 	}
 
 	rows, err := configrepo.LoadRosterLenient(client, org, classroom, branch)
@@ -128,49 +153,79 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 
 	var (
 		invited        []string
-		skipped        []string
-		pendingBlocked []string
-		deferredList   []string
-		failedList     []string
-		rateLimited    bool
+		skipped        []addressEntry
+		pendingBlocked []addressEntry
+		deferredList   []addressEntry
+		failedList     []addressEntry
+		failedErrs     []error
+		rateLimitErr   error
 	)
 	for _, entry := range entries {
-		if rateLimited {
+		if rateLimitErr != nil {
 			// Once throttled, every remaining address is deferred without a call.
-			deferredList = append(deferredList, entry.email)
+			deferredList = append(deferredList, entry)
 			continue
 		}
 		outcome, _, sendErr := sendOneEmailInvite(client, errOut, org, classroom, entry.email, classroomTeam, actor, rows)
+		// Report each address as it resolves: a few hundred addresses take
+		// minutes, and a silent run is indistinguishable from a hang.
 		switch outcome {
 		case outcomeInvited:
 			invited = append(invited, entry.email)
+			_, _ = fmt.Fprintf(out, "  invited %s (line %d)\n", entry.email, entry.line)
 		case outcomeSkippedAlready:
-			skipped = append(skipped, entry.email)
+			skipped = append(skipped, entry)
+			_, _ = fmt.Fprintf(out, "  skipped %s (line %d) — already a member of the org or already invited\n", entry.email, entry.line)
 		case outcomePendingBlocked:
-			pendingBlocked = append(pendingBlocked, entry.email)
+			pendingBlocked = append(pendingBlocked, entry)
+			_, _ = fmt.Fprintf(out, "  skipped %s (line %d) — already a pending invitation on this roster\n", entry.email, entry.line)
 		case outcomeRateLimited:
-			rateLimited = true
-			deferredList = append(deferredList, entry.email)
-		case outcomeFailed:
-			failedList = append(failedList, fmt.Sprintf("%s (%v)", entry.email, sendErr))
+			rateLimitErr = sendErr
+			deferredList = append(deferredList, entry)
+			_, _ = fmt.Fprintf(out, "  deferred %s (line %d) — GitHub rate limit reached\n", entry.email, entry.line)
+		default:
+			// outcomeFailed, plus any outcome a future change forgets to handle:
+			// both mean "not invited", which must never read as success.
+			failedList = append(failedList, entry)
+			failedErrs = append(failedErrs, fmt.Errorf("line %d (%s): %w", entry.line, entry.email, sendErr))
+			_, _ = fmt.Fprintf(out, "  failed %s (line %d)\n", entry.email, entry.line)
 		}
 	}
 
-	appended, commitErr := commitInvitedRows(client, org, classroom, branch, invited)
+	// Wait out the throttle before the batch commit: the roster write is several
+	// more requests, and firing them inside the same window turns a partial
+	// success into "sent but unrecorded", the one state that needs a repair.
+	if rateLimitErr != nil && len(invited) > 0 {
+		if wait := cliutil.RetryAfter(rateLimitErr); wait > 0 {
+			_, _ = fmt.Fprintf(errOut, "Waiting %s for GitHub's rate limit to clear before recording the %d invitation(s) already sent.\n",
+				wait, len(invited))
+			inviteFileSleep(wait)
+		}
+	}
 
-	// Report before deciding the exit status so a teacher sees the whole picture.
+	appended, alreadyHeld, commitErr := commitInvitedRows(client, org, classroom, branch, invited)
+
 	_, _ = fmt.Fprintf(out, "%s/%s/%s: %d invited, %d appended as pending rows, %d already member/invited, %d already on the roster, %d failed, %d deferred (rate limit)\n",
 		org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom),
 		len(invited), appended, len(skipped), len(pendingBlocked), len(failedList), len(deferredList))
-	for _, addr := range pendingBlocked {
-		_, _ = fmt.Fprintf(errOut, "Skipped %s: already a pending invitation on the roster — run `gh teacher roster sync %s %s` if they accepted.\n", addr, org, classroom)
+
+	for _, entry := range skipped {
+		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already a member of the org or already invited — run `gh teacher roster sync %s %s` if they accepted an earlier invitation.\n",
+			entry.email, entry.line, org, classroom)
 	}
-	for _, f := range failedList {
-		_, _ = fmt.Fprintf(errOut, "Failed %s\n", f)
+	for _, entry := range pendingBlocked {
+		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already a pending invitation on the roster — run `gh teacher roster sync %s %s` if they accepted.\n",
+			entry.email, entry.line, org, classroom)
+	}
+	for _, addr := range alreadyHeld {
+		_, _ = fmt.Fprintf(errOut, "Invited %s, but a roster row already carries that address, so no second pending row was written.\n", addr)
+	}
+	for _, err := range failedErrs {
+		_, _ = fmt.Fprintf(errOut, "Failed %v\n", err)
 	}
 	if len(deferredList) > 0 {
-		_, _ = fmt.Fprintf(errOut, "Deferred (GitHub rate limit hit): %s\nRe-run the same command once the limit clears; already-invited addresses are skipped automatically.\n",
-			strings.Join(deferredList, ", "))
+		_, _ = fmt.Fprintf(errOut, "Deferred (GitHub rate limit: %v): %s\nRe-run the same command once the limit clears; already-invited addresses are skipped automatically.\n",
+			rateLimitErr, joinEntryEmails(deferredList))
 	}
 	if len(invited) > 0 {
 		_, _ = fmt.Fprintf(errOut, "Advise the newly-invited students to accept the emailed invitation, then run `gh teacher roster sync %s %s` to record their username and github_id.\n", org, classroom)
@@ -178,36 +233,53 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 
 	if commitErr != nil {
 		// Never a rollback: the invitations are the source of truth and each
-		// metadata team retains its address, so `roster sync` heals the rows.
-		_, _ = fmt.Fprintf(errOut, "Warning: %d invitation(s) were sent, but recording them in %s failed; run `gh teacher roster sync %s %s` to add the pending rows (the invitations are unaffected).\n",
+		// metadata team retains its address, so a sync heals the rows once the
+		// students accept.
+		_, _ = fmt.Fprintf(errOut, "Warning: %d invitation(s) were sent, but recording them in %s failed; the invitations are unaffected — re-run this command to record them, or `gh teacher roster sync %s %s` once the students accept.\n",
 			len(invited), configrepo.RosterFilePath(classroom), org, classroom)
 		return fmt.Errorf("invitations sent, but the roster rows were not written: %w", commitErr)
 	}
-	if len(failedList) > 0 || len(deferredList) > 0 {
-		return fmt.Errorf("%d address(es) were not invited (%d failed, %d deferred); see the report above",
-			len(failedList)+len(deferredList), len(failedList), len(deferredList))
+	if len(failedList) > 0 {
+		return fmt.Errorf("%d address(es) could not be invited; see the report above", len(failedList))
+	}
+	if len(deferredList) > 0 {
+		// Nothing is broken — GitHub is throttling — so this is the "changes
+		// remain" code, not a failure.
+		return &cliutil.ExitCodeError{Code: 2, Err: fmt.Errorf("%d address(es) not yet invited (GitHub rate limit); re-run to continue", len(deferredList))}
 	}
 	return nil
+}
+
+func joinEntryEmails(entries []addressEntry) string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.email)
+	}
+	return strings.Join(out, ", ")
 }
 
 // commitInvitedRows appends the invited addresses as email-only pending rows in
 // one Tree commit, dropping under the rebase any address a concurrent writer
 // already put on a row (rosterHoldsEmail) — matching the web's single batched
-// appendEmailInviteRows. Returns how many rows were actually appended. An empty
-// invited set writes nothing.
-func commitInvitedRows(client githubapi.Client, org, classroom, branch string, invited []string) (int, error) {
+// appendEmailInviteRows. Returns how many rows were appended and which addresses
+// were dropped, so the report can name them rather than only counting.
+func commitInvitedRows(client githubapi.Client, org, classroom, branch string, invited []string) (int, []string, error) {
 	if len(invited) == 0 {
-		return 0, nil
+		return 0, nil, nil
 	}
-	var appended int
+	var (
+		appended    int
+		alreadyHeld []string
+	)
 	build := func(parentSHA string) (configwrite.CommitChange, error) {
-		appended = 0
+		appended, alreadyHeld = 0, nil
 		current, err := configrepo.LoadRosterLenient(client, org, classroom, parentSHA)
 		if err != nil {
 			return configwrite.CommitChange{}, err
 		}
 		for _, email := range invited {
 			if rosterHoldsEmail(current, email) {
+				alreadyHeld = append(alreadyHeld, email)
 				continue
 			}
 			current = append(current, configrepo.RosterRow{Email: email, Role: rosterRoleStudent})
@@ -220,7 +292,7 @@ func commitInvitedRows(client githubapi.Client, org, classroom, branch string, i
 	}
 	message := contract.PrefixCommit(fmt.Sprintf("roster: add %d invited email(s) to %s (gh teacher roster invite --file)", len(invited), classroom))
 	if _, err := configwrite.CommitTreeChange(client, org, configrepo.ConfigRepoName, branch, message, build); err != nil {
-		return 0, err
+		return 0, nil, err
 	}
-	return appended, nil
+	return appended, alreadyHeld, nil
 }

--- a/cli/gh-teacher/internal/roster/invite_file.go
+++ b/cli/gh-teacher/internal/roster/invite_file.go
@@ -1,7 +1,6 @@
 package roster
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -30,36 +29,28 @@ type addressEntry struct {
 // failure list means the caller must send nothing — the same fail-closed
 // posture as `roster import`.
 //
-// One address per line. A blank line, or a line whose first non-space rune is
-// `#`, is a comment and ignored, so a teacher can annotate the list. Surviving
-// lines are validated with ValidateRosterEmail (bare local@domain, no display
-// name), normalized (trim + lowercase), and deduped case-insensitively keeping
-// the first occurrence — mirroring dedupePendingByEmail so one file can't queue
-// two invites to the same address.
+// One address per line; a blank line or a `#` line is skipped so a teacher can
+// annotate the list. Each surviving line goes through CanonicalRosterEmail and
+// is deduped case-insensitively, keeping the FIRST occurrence so the reported
+// line number is the one a teacher would edit.
 func parseInviteFile(data []byte) ([]addressEntry, []error) {
 	var (
 		entries  []addressEntry
 		failures []error
 		seen     = map[string]bool{}
 	)
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	// A pathological single line could exceed bufio's default 64KiB token cap;
-	// raise it so a long (if unusual) address file still parses rather than
-	// silently truncating.
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	line := 0
-	for scanner.Scan() {
+	// bytes.Lines rather than bufio.Scanner: no token-size cap to tune, and the
+	// TrimSpace below already absorbs the terminator (including CRLF).
+	for raw := range bytes.Lines(configrepo.TrimUTF8BOM(data)) {
 		line++
-		raw := strings.TrimSpace(scanner.Text())
-		if raw == "" || strings.HasPrefix(raw, "#") {
+		value := strings.TrimSpace(string(raw))
+		if value == "" || strings.HasPrefix(value, "#") {
 			continue
 		}
-		// The CANONICAL address is what gets invited: an address that merely
-		// validates (`<ada@uni.edu>` unwraps) must be sent in its parsed form, or
-		// GitHub 422s it and the report misreads that as already-invited.
-		email, err := configrepo.CanonicalRosterEmail(raw)
+		email, err := configrepo.CanonicalRosterEmail(value)
 		if err != nil {
-			failures = append(failures, inviteLineError(line, raw, err))
+			failures = append(failures, inviteLineError(line, value, err))
 			continue
 		}
 		if seen[email] {
@@ -67,9 +58,6 @@ func parseInviteFile(data []byte) ([]addressEntry, []error) {
 		}
 		seen[email] = true
 		entries = append(entries, addressEntry{email: email, line: line})
-	}
-	if err := scanner.Err(); err != nil {
-		failures = append(failures, fmt.Errorf("reading address list: %w", err))
 	}
 	return entries, failures
 }
@@ -156,7 +144,6 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 		skipped        []addressEntry
 		pendingBlocked []addressEntry
 		deferredList   []addressEntry
-		failedList     []addressEntry
 		failedErrs     []error
 		rateLimitErr   error
 	)
@@ -186,7 +173,6 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 		default:
 			// outcomeFailed, plus any outcome a future change forgets to handle:
 			// both mean "not invited", which must never read as success.
-			failedList = append(failedList, entry)
 			failedErrs = append(failedErrs, fmt.Errorf("line %d (%s): %w", entry.line, entry.email, sendErr))
 			_, _ = fmt.Fprintf(out, "  failed %s (line %d)\n", entry.email, entry.line)
 		}
@@ -207,7 +193,7 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 
 	_, _ = fmt.Fprintf(out, "%s/%s/%s: %d invited, %d appended as pending rows, %d already member/invited, %d already on the roster, %d failed, %d deferred (rate limit)\n",
 		org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom),
-		len(invited), appended, len(skipped), len(pendingBlocked), len(failedList), len(deferredList))
+		len(invited), appended, len(skipped), len(pendingBlocked), len(failedErrs), len(deferredList))
 
 	for _, entry := range skipped {
 		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already a member of the org or already invited — run `gh teacher roster sync %s %s` if they accepted an earlier invitation.\n",
@@ -239,13 +225,13 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 			len(invited), configrepo.RosterFilePath(classroom), org, classroom)
 		return fmt.Errorf("invitations sent, but the roster rows were not written: %w", commitErr)
 	}
-	if len(failedList) > 0 {
-		return fmt.Errorf("%d address(es) could not be invited; see the report above", len(failedList))
+	if len(failedErrs) > 0 {
+		return fmt.Errorf("%d address(es) could not be invited; see the report above", len(failedErrs))
 	}
 	if len(deferredList) > 0 {
 		// Nothing is broken — GitHub is throttling — so this is the "changes
-		// remain" code, not a failure.
-		return &cliutil.ExitCodeError{Code: 2, Err: fmt.Errorf("%d address(es) not yet invited (GitHub rate limit); re-run to continue", len(deferredList))}
+		// remain" code `roster sync` already defines, not a failure.
+		return &cliutil.ExitCodeError{Code: syncExitChangesPending, Err: fmt.Errorf("%d address(es) not yet invited (GitHub rate limit); re-run to continue", len(deferredList))}
 	}
 	return nil
 }

--- a/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/foundation50/gh-teacher/internal/cliutil"
 	"github.com/foundation50/gh-teacher/internal/configrepo"
 	"github.com/foundation50/gh-teacher/internal/githubtest"
 )
@@ -26,13 +28,23 @@ type bulkInviteMock struct {
 	// teamCreate500 holds emails whose invite-team create should hard-fail,
 	// exercising the per-address team-prep failure path.
 	teamCreate500 map[string]bool
+	// teamCreateRateLimitAfter: once this many team creates have succeeded, every
+	// later one returns a secondary rate limit; 0 disables.
+	teamCreateRateLimitAfter int
 	// commitFails fails the tree POST after sends succeed.
 	commitFails bool
+	// onAfterInvitation runs after each invitation POST is served — strictly
+	// before the commit's rebase read — so a test can make the roster the
+	// closure re-reads differ from the pre-send snapshot.
+	onAfterInvitation func()
 
 	calls          []inviteCall
 	invitedEmails  []string
 	deletedTeams   []string
+	teamRecords    map[string]string
 	invitationsPos int
+	teamCreatePos  int
+	slept          time.Duration
 }
 
 func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
@@ -55,6 +67,13 @@ func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
 			_, _ = w.Write([]byte(`{"message":"boom"}`))
 			return
 		}
+		m.teamCreatePos++
+		if m.teamCreateRateLimitAfter > 0 && m.teamCreatePos > m.teamCreateRateLimitAfter {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"message":"You have exceeded a secondary rate limit"}`))
+			return
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id": inviteTestInviteTeamID, "slug": body.Name, "privacy": "secret",
 		})
@@ -74,6 +93,10 @@ func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
 				Description string `json:"description"`
 			}
 			_ = json.NewDecoder(r.Body).Decode(&body)
+			if m.teamRecords == nil {
+				m.teamRecords = map[string]string{}
+			}
+			m.teamRecords[slug] = body.Description
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id": inviteTestInviteTeamID, "slug": slug,
 				"privacy": "secret", "description": body.Description,
@@ -107,6 +130,9 @@ func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
 		m.invitedEmails = append(m.invitedEmails, body.Email)
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		if m.onAfterInvitation != nil {
+			m.onAfterInvitation()
+		}
 	})
 
 	failing := http.Handler(base)
@@ -147,12 +173,20 @@ func newBulkMock(t *testing.T, rosterCSV string) *bulkInviteMock {
 
 func runInviteFile(t *testing.T, mock *bulkInviteMock, data []byte) (string, string, error) {
 	t.Helper()
+	// Never sleep through the mock's Retry-After; the wait itself is asserted
+	// separately via slept.
+	prev := inviteFileSleep
+	slept := time.Duration(0)
+	inviteFileSleep = func(d time.Duration) { slept += d }
+	t.Cleanup(func() { inviteFileSleep = prev })
+
 	server := httptest.NewServer(mock.handler(t))
 	t.Cleanup(server.Close)
 	client := githubtest.NewTestClient(t, server)
 
 	var out, errOut bytes.Buffer
 	err := runRosterInviteFile(client, &out, &errOut, inviteTestOrg, inviteTestClassroom, data)
+	mock.slept = slept
 	return out.String(), errOut.String(), err
 }
 
@@ -166,10 +200,12 @@ func countInvitationPOSTs(calls []inviteCall) int {
 	return n
 }
 
-// Covers AE1: five fresh addresses → five invitations, one commit, five rows.
+// Five fresh addresses -> five invitations, one commit, five rows, and the
+// commit must follow every send.
 func TestRunRosterInviteFile_HappyPath(t *testing.T) {
 	mock := newBulkMock(t, storedRosterHeader)
 	list := "ada@uni.edu\nbea@uni.edu\ncam@uni.edu\ndan@uni.edu\neve@uni.edu\n"
+	addrs := []string{"ada@uni.edu", "bea@uni.edu", "cam@uni.edu", "dan@uni.edu", "eve@uni.edu"}
 	out, _, err := runInviteFile(t, mock, []byte(list))
 	if err != nil {
 		t.Fatalf("runRosterInviteFile: %v", err)
@@ -180,21 +216,65 @@ func TestRunRosterInviteFile_HappyPath(t *testing.T) {
 	if len(mock.blobs) != 1 {
 		t.Fatalf("want exactly one roster commit, got %d blobs", len(mock.blobs))
 	}
-	for _, addr := range []string{"ada@uni.edu", "bea@uni.edu", "cam@uni.edu", "dan@uni.edu", "eve@uni.edu"} {
-		if !strings.Contains(mock.blobs[0], addr) {
-			t.Errorf("committed roster missing %s:\n%s", addr, mock.blobs[0])
+
+	// Byte-exact: parse the committed roster and assert each row's shape rather
+	// than substring-matching the address.
+	rows, err := configrepo.ParseRoster([]byte(mock.blobs[0]))
+	if err != nil {
+		t.Fatalf("parse committed roster: %v", err)
+	}
+	if len(rows) != 5 {
+		t.Fatalf("committed %d rows, want 5: %#v", len(rows), rows)
+	}
+	got := map[string]bool{}
+	for _, r := range rows {
+		if r.Username != "" || r.GitHubID != 0 {
+			t.Errorf("row %+v should be identity-less (pending email invite)", r)
+		}
+		if r.Role != rosterRoleStudent {
+			t.Errorf("row %+v should carry role %q", r, rosterRoleStudent)
+		}
+		got[r.Email] = true
+	}
+	for _, a := range addrs {
+		if !got[a] {
+			t.Errorf("committed roster missing %s", a)
 		}
 	}
-	if !strings.Contains(out, "5 invited") {
-		t.Errorf("summary should report 5 invited:\n%s", out)
+
+	// Per-address invite-team identity: each address's record must be its own.
+	for _, a := range addrs {
+		slug := configrepo.InviteTeamName(inviteTestClassroom, a)
+		want, err := configrepo.MarshalInviteDescription(inviteTestClassroom, a)
+		if err != nil {
+			t.Fatalf("MarshalInviteDescription: %v", err)
+		}
+		if mock.teamRecords[slug] != want {
+			t.Errorf("team %s record = %q, want %q", slug, mock.teamRecords[slug], want)
+		}
+	}
+
+	// The commit must follow the LAST send: rows are retained only for
+	// invitations that actually exist.
+	treeIdx := indexOfCall(mock.calls, http.MethodPost, "/repos/o/classroom50/git/trees")
+	lastInvite := -1
+	for i, c := range mock.calls {
+		if c.Method == http.MethodPost && c.Path == "/orgs/o/invitations" {
+			lastInvite = i
+		}
+	}
+	if treeIdx < 0 || lastInvite < 0 || treeIdx < lastInvite {
+		t.Errorf("roster commit (call %d) must follow the last invitation (call %d)", treeIdx, lastInvite)
+	}
+	if !strings.Contains(out, "5 invited") || !strings.Contains(out, "5 appended as pending rows") {
+		t.Errorf("summary should report 5 invited and 5 appended:\n%s", out)
 	}
 }
 
-// Covers AE3: first already-pending, second fresh → no call for the first, one
-// invited, one row.
+// A pending-blocked address costs no API call; a fresh one beside it still goes.
 func TestRunRosterInviteFile_PendingSkippedSecondInvited(t *testing.T) {
 	mock := newBulkMock(t, storedRosterHeader+",,,ada@uni.edu,,,student\n")
-	out, _, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\n"))
+	out, errOut, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\n"))
 	if err != nil {
 		t.Fatalf("runRosterInviteFile: %v", err)
 	}
@@ -207,12 +287,19 @@ func TestRunRosterInviteFile_PendingSkippedSecondInvited(t *testing.T) {
 	if !strings.Contains(out, "1 invited") || !strings.Contains(out, "1 already on the roster") {
 		t.Errorf("summary should report 1 invited, 1 already on roster:\n%s", out)
 	}
+	// The skipped address and its file line must both be named.
+	if !strings.Contains(errOut, "ada@uni.edu (line 1)") {
+		t.Errorf("stderr should name the skipped address and its line:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "roster sync") {
+		t.Errorf("the skip notice should point at `roster sync`:\n%s", errOut)
+	}
 }
 
 func TestRunRosterInviteFile_422SkippedTeamDeletedBatchContinues(t *testing.T) {
 	mock := newBulkMock(t, storedRosterHeader)
 	mock.status422["bea@uni.edu"] = true
-	out, _, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\ncam@uni.edu\n"))
+	out, errOut, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\ncam@uni.edu\n"))
 	if err != nil {
 		t.Fatalf("a 422 skip must not fail the run: %v", err)
 	}
@@ -220,31 +307,31 @@ func TestRunRosterInviteFile_422SkippedTeamDeletedBatchContinues(t *testing.T) {
 		t.Errorf("invited = %v, want ada and cam", mock.invitedEmails)
 	}
 	beaSlug := configrepo.InviteTeamName(inviteTestClassroom, "bea@uni.edu")
-	found := false
-	for _, s := range mock.deletedTeams {
-		if s == beaSlug {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("bea's freshly-created team should be deleted on 422; deleted = %v", mock.deletedTeams)
+	if len(mock.deletedTeams) != 1 || mock.deletedTeams[0] != beaSlug {
+		t.Errorf("deleted = %v, want exactly bea's freshly-created team (%s)", mock.deletedTeams, beaSlug)
 	}
 	if !strings.Contains(out, "2 invited") || !strings.Contains(out, "1 already member/invited") {
 		t.Errorf("summary wrong:\n%s", out)
+	}
+	// R10: the skipped address must be named, not just counted.
+	if !strings.Contains(errOut, "bea@uni.edu (line 2)") {
+		t.Errorf("stderr should name the 422-skipped address and line:\n%s", errOut)
 	}
 }
 
 func TestRunRosterInviteFile_TeamPrepFailureIsPerAddress(t *testing.T) {
 	mock := newBulkMock(t, storedRosterHeader)
 	mock.teamCreate500["bea@uni.edu"] = true
-	out, _, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\ncam@uni.edu\n"))
+	out, errOut, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\ncam@uni.edu\n"))
 	if err == nil {
 		t.Fatal("a per-address failure must make the run exit non-zero")
+	}
+	if cliutil.ExitCodeFor(err) != 1 {
+		t.Errorf("exit code = %d, want 1 for a hard failure", cliutil.ExitCodeFor(err))
 	}
 	if len(mock.invitedEmails) != 2 {
 		t.Errorf("invited = %v, want ada and cam (bea's team prep failed)", mock.invitedEmails)
 	}
-	// No invitation POST should have fired for bea (team prep precedes the send).
 	for _, e := range mock.invitedEmails {
 		if e == "bea@uni.edu" {
 			t.Errorf("bea was invited despite a team-prep failure")
@@ -253,14 +340,17 @@ func TestRunRosterInviteFile_TeamPrepFailureIsPerAddress(t *testing.T) {
 	if !strings.Contains(out, "1 failed") {
 		t.Errorf("summary should report 1 failed:\n%s", out)
 	}
+	if !strings.Contains(errOut, "bea@uni.edu") || !strings.Contains(errOut, "line 2") {
+		t.Errorf("stderr should name the failed address and its line:\n%s", errOut)
+	}
 }
 
 func TestRunRosterInviteFile_RateLimitDefersRest(t *testing.T) {
 	mock := newBulkMock(t, storedRosterHeader)
 	mock.rateLimitAfter = 1 // first send ok, second rate-limited, rest deferred
 	_, errOut, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\ncam@uni.edu\ndan@uni.edu\n"))
-	if err == nil {
-		t.Fatal("a deferred tail must make the run exit non-zero")
+	if cliutil.ExitCodeFor(err) != 2 {
+		t.Fatalf("exit code = %d (err %v), want 2 for a deferred tail", cliutil.ExitCodeFor(err), err)
 	}
 	// ada sent (1) + bea attempted then rate-limited (1) = 2 POSTs; cam & dan
 	// never attempted.
@@ -270,7 +360,8 @@ func TestRunRosterInviteFile_RateLimitDefersRest(t *testing.T) {
 	if len(mock.invitedEmails) != 1 || mock.invitedEmails[0] != "ada@uni.edu" {
 		t.Errorf("invited = %v, want only ada", mock.invitedEmails)
 	}
-	for _, addr := range []string{"cam@uni.edu", "dan@uni.edu"} {
+	// Every uninvited address, including the one that tripped the limit.
+	for _, addr := range []string{"bea@uni.edu", "cam@uni.edu", "dan@uni.edu"} {
 		if !strings.Contains(errOut, addr) {
 			t.Errorf("deferred report should name %s:\n%s", addr, errOut)
 		}
@@ -290,38 +381,121 @@ func TestRunRosterInviteFile_NoInvitesNoCommit(t *testing.T) {
 	}
 }
 
+// The rebase re-check is the only thing stopping a duplicate row when a
+// concurrent writer (the web app, or a sync) takes an address between the
+// pre-send read and the commit. onAfterInvitation injects exactly that race.
 func TestRunRosterInviteFile_ConcurrentWriterAvoidsDoubleRow(t *testing.T) {
-	// The roster already holds ada (as if a concurrent writer added her); the
-	// rebase re-check must not append a second row for her.
-	mock := newBulkMock(t, storedRosterHeader+",,,ada@uni.edu,,,student\n")
-	// ada is already pending, so she's skipped before send; bea is fresh. To
-	// exercise the rebase drop specifically, invite an address the loaded roster
-	// doesn't show as pending but the commit-time roster does — approximated here
-	// by bea being fresh and ada blocked pre-send. Assert only bea's row lands.
-	_, _, err := runInviteFile(t, mock, []byte("bea@uni.edu\n"))
+	mock := newBulkMock(t, storedRosterHeader)
+	key := inviteTestClassroom + "/roster.csv"
+	mock.onAfterInvitation = func() {
+		// A concurrent writer claims bea after her invitation was sent, so the
+		// rebase read sees a row the pre-send read did not.
+		mock.files[key] = storedRosterHeader + ",,,bea@uni.edu,,,student\n"
+	}
+
+	out, errOut, err := runInviteFile(t, mock, []byte("bea@uni.edu\n"))
 	if err != nil {
 		t.Fatalf("runRosterInviteFile: %v", err)
 	}
-	if len(mock.blobs) != 1 {
-		t.Fatalf("want one commit, got %d", len(mock.blobs))
+	if len(mock.invitedEmails) != 1 {
+		t.Fatalf("invited = %v, want bea invited once", mock.invitedEmails)
 	}
-	if strings.Count(mock.blobs[0], "ada@uni.edu") != 1 {
-		t.Errorf("ada should appear exactly once (no double row):\n%s", mock.blobs[0])
+	// Nothing to append (the concurrent row already carries her), so no commit.
+	if len(mock.blobs) != 0 {
+		t.Errorf("appended a duplicate row despite the rebase re-check: %#v", mock.blobs)
 	}
-	if !strings.Contains(mock.blobs[0], "bea@uni.edu") {
-		t.Errorf("bea's pending row should be committed:\n%s", mock.blobs[0])
+	if !strings.Contains(out, "1 invited, 0 appended as pending rows") {
+		t.Errorf("summary should show invited-but-not-appended:\n%s", out)
+	}
+	if !strings.Contains(errOut, "already carries that address") {
+		t.Errorf("the dropped address should be named:\n%s", errOut)
 	}
 }
 
-func TestRunRosterInviteFile_CommitFailureWarnsSync(t *testing.T) {
+// The batch-abort guard is the change's most important fail-closed behavior: a
+// classroom with no usable team must not produce a batch of invitations that
+// enroll nobody.
+func TestRunRosterInviteFile_ClassroomTeamMissingAbortsBatch(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader)
+	delete(mock.files, inviteTestClassroom+"/classroom.json")
+
+	_, _, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\ncam@uni.edu\n"))
+	if err == nil {
+		t.Fatal("err = nil, want a refusal naming `classroom add`")
+	}
+	if !strings.Contains(err.Error(), "classroom add") {
+		t.Errorf("error should point at `classroom add`: %v", err)
+	}
+	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/teams") >= 0 {
+		t.Error("created an invite team despite the abort")
+	}
+	if countInvitationPOSTs(mock.calls) != 0 {
+		t.Error("sent an invitation despite the abort")
+	}
+	if len(mock.blobs) != 0 {
+		t.Errorf("committed a roster despite the abort: %#v", mock.blobs)
+	}
+}
+
+// A rate limit raised by the invite-team prep (not the invitation) must defer
+// the remainder too — otherwise the batch keeps hammering a throttled endpoint.
+func TestRunRosterInviteFile_TeamPrepRateLimitDefersRest(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader)
+	mock.teamCreateRateLimitAfter = 1
+
+	_, errOut, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\ncam@uni.edu\n"))
+	if cliutil.ExitCodeFor(err) != 2 {
+		t.Fatalf("exit code = %d (err %v), want 2 for a deferred tail", cliutil.ExitCodeFor(err), err)
+	}
+	if len(mock.invitedEmails) != 1 || mock.invitedEmails[0] != "ada@uni.edu" {
+		t.Errorf("invited = %v, want only ada", mock.invitedEmails)
+	}
+	// bea tripped the limit during team prep; cam must never be attempted.
+	teamPOSTs := 0
+	for _, c := range mock.calls {
+		if c.Method == http.MethodPost && c.Path == "/orgs/o/teams" {
+			teamPOSTs++
+		}
+	}
+	if teamPOSTs != 2 {
+		t.Errorf("team POSTs = %d, want 2 (no team prep after the limit)", teamPOSTs)
+	}
+	for _, addr := range []string{"bea@uni.edu", "cam@uni.edu"} {
+		if !strings.Contains(errOut, addr) {
+			t.Errorf("deferred report should name %s:\n%s", addr, errOut)
+		}
+	}
+}
+
+// The roster commit is several more requests; firing them inside the throttle
+// window is what turns a partial success into "sent but unrecorded".
+func TestRunRosterInviteFile_WaitsOutRateLimitBeforeCommit(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader)
+	mock.rateLimitAfter = 1
+
+	_, _, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\n"))
+	if cliutil.ExitCodeFor(err) != 2 {
+		t.Fatalf("exit code = %d, want 2", cliutil.ExitCodeFor(err))
+	}
+	if mock.slept <= 0 {
+		t.Error("want a Retry-After wait before the batch commit, slept 0")
+	}
+	if len(mock.blobs) != 1 {
+		t.Fatalf("ada's row should still be committed, got %d blobs", len(mock.blobs))
+	}
+}
+
+func TestRunRosterInviteFile_CommitFailureWarnsRepair(t *testing.T) {
 	mock := newBulkMock(t, storedRosterHeader)
 	mock.commitFails = true
 	_, errOut, err := runInviteFile(t, mock, []byte("ada@uni.edu\n"))
 	if err == nil {
 		t.Fatal("a failed roster commit after sends must exit non-zero")
 	}
-	if !strings.Contains(errOut, "roster sync") {
-		t.Errorf("commit-failure warning must name `roster sync` as the repair:\n%s", errOut)
+	// The repair must be one that actually works: re-running records the row,
+	// and a sync heals it once the student accepts.
+	if !strings.Contains(errOut, "re-run this command") {
+		t.Errorf("commit-failure warning must name re-running as the repair:\n%s", errOut)
 	}
 	if len(mock.invitedEmails) != 1 {
 		t.Errorf("the invitation itself should have been sent, invited = %v", mock.invitedEmails)

--- a/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
@@ -1,0 +1,351 @@
+package roster
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/foundation50/gh-teacher/internal/configrepo"
+	"github.com/foundation50/gh-teacher/internal/githubtest"
+)
+
+// bulkInviteMock serves the endpoints runRosterInviteFile touches for ANY
+// invite-<hash> slug (the single inviteMock is pinned to one email's slug). It
+// records the sequence of calls and the invited emails so a test can assert
+// send-before-commit ordering, which addresses were invited, and any teardown.
+type bulkInviteMock struct {
+	*rosterWriteMock
+	// rateLimitAfter: once this many invitations have been POSTed, the next one
+	// (and it alone) returns a secondary rate limit; 0 disables.
+	rateLimitAfter int
+	// status422 holds emails GitHub should 422 (already member/invited).
+	status422 map[string]bool
+	// teamCreate500 holds emails whose invite-team create should hard-fail,
+	// exercising the per-address team-prep failure path.
+	teamCreate500 map[string]bool
+	// commitFails fails the tree POST after sends succeed.
+	commitFails bool
+
+	calls          []inviteCall
+	invitedEmails  []string
+	deletedTeams   []string
+	invitationsPos int
+}
+
+func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
+	t.Helper()
+	base := m.rosterWriteMock.handler(t).(*http.ServeMux)
+
+	base.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"login": inviteTestActor, "id": 1})
+	})
+
+	// Team create: every invite team shares this endpoint. The 422/adopt path is
+	// keyed by matching the request name against teamCreate500's emails.
+	base.HandleFunc("/orgs/o/teams", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Name string `json:"name"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if m.emailForSlug(body.Name, m.teamCreate500) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"boom"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": inviteTestInviteTeamID, "slug": body.Name, "privacy": "secret",
+		})
+	})
+
+	// All per-team subpaths (PATCH record, DELETE team, membership drop, members
+	// read-back) route through one prefix handler keyed on the slug.
+	base.HandleFunc("/orgs/o/teams/", func(w http.ResponseWriter, r *http.Request) {
+		rest := strings.TrimPrefix(r.URL.Path, "/orgs/o/teams/")
+		slug, sub, _ := strings.Cut(rest, "/")
+		switch {
+		case sub == "" && r.Method == http.MethodDelete:
+			m.deletedTeams = append(m.deletedTeams, slug)
+			w.WriteHeader(http.StatusNoContent)
+		case sub == "":
+			var body struct {
+				Description string `json:"description"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": inviteTestInviteTeamID, "slug": slug,
+				"privacy": "secret", "description": body.Description,
+			})
+		case strings.HasPrefix(sub, "memberships/"):
+			w.WriteHeader(http.StatusNoContent)
+		case sub == "members":
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	base.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Email string `json:"email"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		m.invitationsPos++
+		if m.rateLimitAfter > 0 && m.invitationsPos > m.rateLimitAfter {
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"message":"You have exceeded a secondary rate limit"}`))
+			return
+		}
+		if m.status422[body.Email] {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"already a member"}`))
+			return
+		}
+		m.invitedEmails = append(m.invitedEmails, body.Email)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	failing := http.Handler(base)
+	if m.commitFails {
+		failing = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost && r.URL.Path == "/repos/o/classroom50/git/trees" {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			base.ServeHTTP(w, r)
+		})
+	}
+	return recordCalls(&m.calls, failing)
+}
+
+// emailForSlug reports whether the given team name (== slug) corresponds to any
+// email in the set, by recomputing each email's deterministic slug.
+func (m *bulkInviteMock) emailForSlug(slug string, set map[string]bool) bool {
+	for email := range set {
+		if configrepo.InviteTeamName(inviteTestClassroom, email) == slug {
+			return true
+		}
+	}
+	return false
+}
+
+func newBulkMock(t *testing.T, rosterCSV string) *bulkInviteMock {
+	t.Helper()
+	return &bulkInviteMock{
+		rosterWriteMock: &rosterWriteMock{files: map[string]string{
+			inviteTestClassroom + "/roster.csv":     rosterCSV,
+			inviteTestClassroom + "/classroom.json": inviteTestClassroomJSON(t),
+		}},
+		status422:     map[string]bool{},
+		teamCreate500: map[string]bool{},
+	}
+}
+
+func runInviteFile(t *testing.T, mock *bulkInviteMock, data []byte) (string, string, error) {
+	t.Helper()
+	server := httptest.NewServer(mock.handler(t))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	err := runRosterInviteFile(client, &out, &errOut, inviteTestOrg, inviteTestClassroom, data)
+	return out.String(), errOut.String(), err
+}
+
+func countInvitationPOSTs(calls []inviteCall) int {
+	n := 0
+	for _, c := range calls {
+		if c.Method == http.MethodPost && c.Path == "/orgs/o/invitations" {
+			n++
+		}
+	}
+	return n
+}
+
+// Covers AE1: five fresh addresses → five invitations, one commit, five rows.
+func TestRunRosterInviteFile_HappyPath(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader)
+	list := "ada@uni.edu\nbea@uni.edu\ncam@uni.edu\ndan@uni.edu\neve@uni.edu\n"
+	out, _, err := runInviteFile(t, mock, []byte(list))
+	if err != nil {
+		t.Fatalf("runRosterInviteFile: %v", err)
+	}
+	if got := countInvitationPOSTs(mock.calls); got != 5 {
+		t.Errorf("invitation POSTs = %d, want 5", got)
+	}
+	if len(mock.blobs) != 1 {
+		t.Fatalf("want exactly one roster commit, got %d blobs", len(mock.blobs))
+	}
+	for _, addr := range []string{"ada@uni.edu", "bea@uni.edu", "cam@uni.edu", "dan@uni.edu", "eve@uni.edu"} {
+		if !strings.Contains(mock.blobs[0], addr) {
+			t.Errorf("committed roster missing %s:\n%s", addr, mock.blobs[0])
+		}
+	}
+	if !strings.Contains(out, "5 invited") {
+		t.Errorf("summary should report 5 invited:\n%s", out)
+	}
+}
+
+// Covers AE3: first already-pending, second fresh → no call for the first, one
+// invited, one row.
+func TestRunRosterInviteFile_PendingSkippedSecondInvited(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader+",,,ada@uni.edu,,,student\n")
+	out, _, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\n"))
+	if err != nil {
+		t.Fatalf("runRosterInviteFile: %v", err)
+	}
+	if got := countInvitationPOSTs(mock.calls); got != 1 {
+		t.Errorf("invitation POSTs = %d, want 1 (ada is already pending)", got)
+	}
+	if len(mock.invitedEmails) != 1 || mock.invitedEmails[0] != "bea@uni.edu" {
+		t.Errorf("invited = %v, want only bea", mock.invitedEmails)
+	}
+	if !strings.Contains(out, "1 invited") || !strings.Contains(out, "1 already on the roster") {
+		t.Errorf("summary should report 1 invited, 1 already on roster:\n%s", out)
+	}
+}
+
+func TestRunRosterInviteFile_422SkippedTeamDeletedBatchContinues(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader)
+	mock.status422["bea@uni.edu"] = true
+	out, _, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\ncam@uni.edu\n"))
+	if err != nil {
+		t.Fatalf("a 422 skip must not fail the run: %v", err)
+	}
+	if len(mock.invitedEmails) != 2 {
+		t.Errorf("invited = %v, want ada and cam", mock.invitedEmails)
+	}
+	beaSlug := configrepo.InviteTeamName(inviteTestClassroom, "bea@uni.edu")
+	found := false
+	for _, s := range mock.deletedTeams {
+		if s == beaSlug {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("bea's freshly-created team should be deleted on 422; deleted = %v", mock.deletedTeams)
+	}
+	if !strings.Contains(out, "2 invited") || !strings.Contains(out, "1 already member/invited") {
+		t.Errorf("summary wrong:\n%s", out)
+	}
+}
+
+func TestRunRosterInviteFile_TeamPrepFailureIsPerAddress(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader)
+	mock.teamCreate500["bea@uni.edu"] = true
+	out, _, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\ncam@uni.edu\n"))
+	if err == nil {
+		t.Fatal("a per-address failure must make the run exit non-zero")
+	}
+	if len(mock.invitedEmails) != 2 {
+		t.Errorf("invited = %v, want ada and cam (bea's team prep failed)", mock.invitedEmails)
+	}
+	// No invitation POST should have fired for bea (team prep precedes the send).
+	for _, e := range mock.invitedEmails {
+		if e == "bea@uni.edu" {
+			t.Errorf("bea was invited despite a team-prep failure")
+		}
+	}
+	if !strings.Contains(out, "1 failed") {
+		t.Errorf("summary should report 1 failed:\n%s", out)
+	}
+}
+
+func TestRunRosterInviteFile_RateLimitDefersRest(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader)
+	mock.rateLimitAfter = 1 // first send ok, second rate-limited, rest deferred
+	_, errOut, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\ncam@uni.edu\ndan@uni.edu\n"))
+	if err == nil {
+		t.Fatal("a deferred tail must make the run exit non-zero")
+	}
+	// ada sent (1) + bea attempted then rate-limited (1) = 2 POSTs; cam & dan
+	// never attempted.
+	if got := countInvitationPOSTs(mock.calls); got != 2 {
+		t.Errorf("invitation POSTs = %d, want 2 (no sends after the rate limit)", got)
+	}
+	if len(mock.invitedEmails) != 1 || mock.invitedEmails[0] != "ada@uni.edu" {
+		t.Errorf("invited = %v, want only ada", mock.invitedEmails)
+	}
+	for _, addr := range []string{"cam@uni.edu", "dan@uni.edu"} {
+		if !strings.Contains(errOut, addr) {
+			t.Errorf("deferred report should name %s:\n%s", addr, errOut)
+		}
+	}
+}
+
+func TestRunRosterInviteFile_NoInvitesNoCommit(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader)
+	mock.status422["ada@uni.edu"] = true
+	mock.status422["bea@uni.edu"] = true
+	_, _, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\n"))
+	if err != nil {
+		t.Fatalf("all-skipped is a clean run: %v", err)
+	}
+	if len(mock.blobs) != 0 {
+		t.Errorf("no invited addresses means no commit, got %d blobs", len(mock.blobs))
+	}
+}
+
+func TestRunRosterInviteFile_ConcurrentWriterAvoidsDoubleRow(t *testing.T) {
+	// The roster already holds ada (as if a concurrent writer added her); the
+	// rebase re-check must not append a second row for her.
+	mock := newBulkMock(t, storedRosterHeader+",,,ada@uni.edu,,,student\n")
+	// ada is already pending, so she's skipped before send; bea is fresh. To
+	// exercise the rebase drop specifically, invite an address the loaded roster
+	// doesn't show as pending but the commit-time roster does — approximated here
+	// by bea being fresh and ada blocked pre-send. Assert only bea's row lands.
+	_, _, err := runInviteFile(t, mock, []byte("bea@uni.edu\n"))
+	if err != nil {
+		t.Fatalf("runRosterInviteFile: %v", err)
+	}
+	if len(mock.blobs) != 1 {
+		t.Fatalf("want one commit, got %d", len(mock.blobs))
+	}
+	if strings.Count(mock.blobs[0], "ada@uni.edu") != 1 {
+		t.Errorf("ada should appear exactly once (no double row):\n%s", mock.blobs[0])
+	}
+	if !strings.Contains(mock.blobs[0], "bea@uni.edu") {
+		t.Errorf("bea's pending row should be committed:\n%s", mock.blobs[0])
+	}
+}
+
+func TestRunRosterInviteFile_CommitFailureWarnsSync(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader)
+	mock.commitFails = true
+	_, errOut, err := runInviteFile(t, mock, []byte("ada@uni.edu\n"))
+	if err == nil {
+		t.Fatal("a failed roster commit after sends must exit non-zero")
+	}
+	if !strings.Contains(errOut, "roster sync") {
+		t.Errorf("commit-failure warning must name `roster sync` as the repair:\n%s", errOut)
+	}
+	if len(mock.invitedEmails) != 1 {
+		t.Errorf("the invitation itself should have been sent, invited = %v", mock.invitedEmails)
+	}
+}
+
+func TestRunRosterInviteFile_AllInvalidSendsNothing(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader)
+	_, _, err := runInviteFile(t, mock, []byte("not-an-email\nalso bad\n"))
+	if err == nil {
+		t.Fatal("invalid lines must refuse the whole run")
+	}
+	if countInvitationPOSTs(mock.calls) != 0 {
+		t.Errorf("nothing should be sent when the file has invalid lines")
+	}
+	if len(mock.blobs) != 0 {
+		t.Errorf("no commit on a refused run")
+	}
+}
+
+func TestRunRosterInviteFile_EmptyFile(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader)
+	_, _, err := runInviteFile(t, mock, []byte("# only comments\n\n"))
+	if err == nil || !strings.Contains(err.Error(), "no email addresses") {
+		t.Fatalf("an empty list should report no addresses, got %v", err)
+	}
+}

--- a/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
@@ -62,7 +62,7 @@ func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
 			Name string `json:"name"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&body)
-		if m.emailForSlug(body.Name, m.teamCreate500) {
+		if m.slugMatchesAny(body.Name, m.teamCreate500) {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(`{"message":"boom"}`))
 			return
@@ -148,9 +148,9 @@ func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
 	return recordCalls(&m.calls, failing)
 }
 
-// emailForSlug reports whether the given team name (== slug) corresponds to any
-// email in the set, by recomputing each email's deterministic slug.
-func (m *bulkInviteMock) emailForSlug(slug string, set map[string]bool) bool {
+// slugMatchesAny reports whether the given team name (== slug) corresponds to
+// any email in the set, by recomputing each email's deterministic slug.
+func (m *bulkInviteMock) slugMatchesAny(slug string, set map[string]bool) bool {
 	for email := range set {
 		if configrepo.InviteTeamName(inviteTestClassroom, email) == slug {
 			return true
@@ -190,16 +190,6 @@ func runInviteFile(t *testing.T, mock *bulkInviteMock, data []byte) (string, str
 	return out.String(), errOut.String(), err
 }
 
-func countInvitationPOSTs(calls []inviteCall) int {
-	n := 0
-	for _, c := range calls {
-		if c.Method == http.MethodPost && c.Path == "/orgs/o/invitations" {
-			n++
-		}
-	}
-	return n
-}
-
 // Five fresh addresses -> five invitations, one commit, five rows, and the
 // commit must follow every send.
 func TestRunRosterInviteFile_HappyPath(t *testing.T) {
@@ -210,7 +200,7 @@ func TestRunRosterInviteFile_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runRosterInviteFile: %v", err)
 	}
-	if got := countInvitationPOSTs(mock.calls); got != 5 {
+	if got := countCalls(mock.calls, http.MethodPost, "/orgs/o/invitations"); got != 5 {
 		t.Errorf("invitation POSTs = %d, want 5", got)
 	}
 	if len(mock.blobs) != 1 {
@@ -278,7 +268,7 @@ func TestRunRosterInviteFile_PendingSkippedSecondInvited(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runRosterInviteFile: %v", err)
 	}
-	if got := countInvitationPOSTs(mock.calls); got != 1 {
+	if got := countCalls(mock.calls, http.MethodPost, "/orgs/o/invitations"); got != 1 {
 		t.Errorf("invitation POSTs = %d, want 1 (ada is already pending)", got)
 	}
 	if len(mock.invitedEmails) != 1 || mock.invitedEmails[0] != "bea@uni.edu" {
@@ -354,7 +344,7 @@ func TestRunRosterInviteFile_RateLimitDefersRest(t *testing.T) {
 	}
 	// ada sent (1) + bea attempted then rate-limited (1) = 2 POSTs; cam & dan
 	// never attempted.
-	if got := countInvitationPOSTs(mock.calls); got != 2 {
+	if got := countCalls(mock.calls, http.MethodPost, "/orgs/o/invitations"); got != 2 {
 		t.Errorf("invitation POSTs = %d, want 2 (no sends after the rate limit)", got)
 	}
 	if len(mock.invitedEmails) != 1 || mock.invitedEmails[0] != "ada@uni.edu" {
@@ -429,7 +419,7 @@ func TestRunRosterInviteFile_ClassroomTeamMissingAbortsBatch(t *testing.T) {
 	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/teams") >= 0 {
 		t.Error("created an invite team despite the abort")
 	}
-	if countInvitationPOSTs(mock.calls) != 0 {
+	if countCalls(mock.calls, http.MethodPost, "/orgs/o/invitations") != 0 {
 		t.Error("sent an invitation despite the abort")
 	}
 	if len(mock.blobs) != 0 {
@@ -451,13 +441,7 @@ func TestRunRosterInviteFile_TeamPrepRateLimitDefersRest(t *testing.T) {
 		t.Errorf("invited = %v, want only ada", mock.invitedEmails)
 	}
 	// bea tripped the limit during team prep; cam must never be attempted.
-	teamPOSTs := 0
-	for _, c := range mock.calls {
-		if c.Method == http.MethodPost && c.Path == "/orgs/o/teams" {
-			teamPOSTs++
-		}
-	}
-	if teamPOSTs != 2 {
+	if teamPOSTs := countCalls(mock.calls, http.MethodPost, "/orgs/o/teams"); teamPOSTs != 2 {
 		t.Errorf("team POSTs = %d, want 2 (no team prep after the limit)", teamPOSTs)
 	}
 	for _, addr := range []string{"bea@uni.edu", "cam@uni.edu"} {
@@ -508,7 +492,7 @@ func TestRunRosterInviteFile_AllInvalidSendsNothing(t *testing.T) {
 	if err == nil {
 		t.Fatal("invalid lines must refuse the whole run")
 	}
-	if countInvitationPOSTs(mock.calls) != 0 {
+	if countCalls(mock.calls, http.MethodPost, "/orgs/o/invitations") != 0 {
 		t.Errorf("nothing should be sent when the file has invalid lines")
 	}
 	if len(mock.blobs) != 0 {

--- a/cli/gh-teacher/internal/roster/invite_file_test.go
+++ b/cli/gh-teacher/internal/roster/invite_file_test.go
@@ -1,0 +1,103 @@
+package roster
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseInviteFile(t *testing.T) {
+	t.Run("valid lines parse in order", func(t *testing.T) {
+		entries, failures := parseInviteFile([]byte("ada@uni.edu\nbea@uni.edu\n"))
+		if len(failures) != 0 {
+			t.Fatalf("failures = %v, want none", failures)
+		}
+		if len(entries) != 2 || entries[0].email != "ada@uni.edu" || entries[1].email != "bea@uni.edu" {
+			t.Fatalf("entries = %+v, want ada then bea", entries)
+		}
+	})
+
+	// Covers AE2: an invalid line is reported by line number and raw content.
+	t.Run("invalid line reported by line and raw", func(t *testing.T) {
+		entries, failures := parseInviteFile([]byte("ada@uni.edu\nnot-an-email\ncam@uni.edu\n"))
+		if len(entries) != 2 {
+			t.Fatalf("entries = %+v, want the two valid rows", entries)
+		}
+		if len(failures) != 1 {
+			t.Fatalf("failures = %v, want exactly one", failures)
+		}
+		msg := failures[0].Error()
+		if !strings.Contains(msg, "line 2") || !strings.Contains(msg, "not-an-email") {
+			t.Errorf("failure = %q, want it to name line 2 and the raw value", msg)
+		}
+	})
+
+	// Covers AE4: comments, blanks, and a repeat collapse; kept entry keeps the
+	// first occurrence's line.
+	t.Run("comments blanks and duplicates collapse", func(t *testing.T) {
+		data := "# section 1 list\n\nada@uni.edu\n  # trailing note\nada@uni.edu\n"
+		entries, failures := parseInviteFile([]byte(data))
+		if len(failures) != 0 {
+			t.Fatalf("failures = %v, want none", failures)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("entries = %+v, want a single deduped entry", entries)
+		}
+		if entries[0].email != "ada@uni.edu" || entries[0].line != 3 {
+			t.Errorf("entry = %+v, want ada@uni.edu first seen on line 3", entries[0])
+		}
+	})
+
+	t.Run("CRLF endings parse like LF", func(t *testing.T) {
+		entries, failures := parseInviteFile([]byte("ada@uni.edu\r\nbea@uni.edu\r\n"))
+		if len(failures) != 0 {
+			t.Fatalf("failures = %v, want none", failures)
+		}
+		if len(entries) != 2 || entries[0].email != "ada@uni.edu" || entries[1].email != "bea@uni.edu" {
+			t.Fatalf("entries = %+v, want both addresses", entries)
+		}
+	})
+
+	t.Run("two invalid lines both reported", func(t *testing.T) {
+		_, failures := parseInviteFile([]byte("bad one\nada@uni.edu\nbad two\n"))
+		if len(failures) != 2 {
+			t.Fatalf("failures = %v, want two", failures)
+		}
+		if !strings.Contains(failures[0].Error(), "line 1") || !strings.Contains(failures[1].Error(), "line 3") {
+			t.Errorf("failures = %v, want lines 1 and 3 named", failures)
+		}
+	})
+
+	t.Run("only comments and blanks yields nothing", func(t *testing.T) {
+		entries, failures := parseInviteFile([]byte("# header\n\n   \n#done\n"))
+		if len(entries) != 0 || len(failures) != 0 {
+			t.Fatalf("entries=%+v failures=%v, want both empty", entries, failures)
+		}
+	})
+
+	t.Run("case and whitespace normalize before dedup", func(t *testing.T) {
+		entries, failures := parseInviteFile([]byte("Ada@Uni.edu\n  ada@uni.edu \n"))
+		if len(failures) != 0 {
+			t.Fatalf("failures = %v, want none", failures)
+		}
+		if len(entries) != 1 || entries[0].email != "ada@uni.edu" {
+			t.Fatalf("entries = %+v, want one normalized entry", entries)
+		}
+	})
+}
+
+func TestJoinInviteFileFailures(t *testing.T) {
+	if err := joinInviteFileFailures(nil); err != nil {
+		t.Fatalf("no failures should join to nil, got %v", err)
+	}
+	entries, failures := parseInviteFile([]byte("bad one\nbad two\n"))
+	if len(entries) != 0 {
+		t.Fatalf("entries = %+v, want none", entries)
+	}
+	err := joinInviteFileFailures(failures)
+	if err == nil {
+		t.Fatal("want a joined error")
+	}
+	if !strings.Contains(err.Error(), "2 line(s)") || !strings.Contains(err.Error(), "nothing was sent") {
+		t.Errorf("joined = %q, want the count and fail-closed phrasing", err.Error())
+	}
+}

--- a/cli/gh-teacher/internal/roster/invite_file_test.go
+++ b/cli/gh-teacher/internal/roster/invite_file_test.go
@@ -16,7 +16,7 @@ func TestParseInviteFile(t *testing.T) {
 		}
 	})
 
-	// Covers AE2: an invalid line is reported by line number and raw content.
+	// An invalid line is reported by line number and raw content.
 	t.Run("invalid line reported by line and raw", func(t *testing.T) {
 		entries, failures := parseInviteFile([]byte("ada@uni.edu\nnot-an-email\ncam@uni.edu\n"))
 		if len(entries) != 2 {
@@ -31,8 +31,8 @@ func TestParseInviteFile(t *testing.T) {
 		}
 	})
 
-	// Covers AE4: comments, blanks, and a repeat collapse; kept entry keeps the
-	// first occurrence's line.
+	// Comments, blanks, and a repeat collapse; the kept entry keeps the first
+	// occurrence's line.
 	t.Run("comments blanks and duplicates collapse", func(t *testing.T) {
 		data := "# section 1 list\n\nada@uni.edu\n  # trailing note\nada@uni.edu\n"
 		entries, failures := parseInviteFile([]byte(data))
@@ -81,6 +81,38 @@ func TestParseInviteFile(t *testing.T) {
 		}
 		if len(entries) != 1 || entries[0].email != "ada@uni.edu" {
 			t.Fatalf("entries = %+v, want one normalized entry", entries)
+		}
+	})
+
+	// A bracketed address validates but must be UNWRAPPED before it is sent:
+	// GitHub rejects `<ada@uni.edu>`, and that 422 would read as already-invited.
+	t.Run("bracketed address is canonicalized, not sent raw", func(t *testing.T) {
+		entries, failures := parseInviteFile([]byte("<ada@uni.edu>\n"))
+		if len(failures) != 0 {
+			t.Fatalf("failures = %v, want none", failures)
+		}
+		if len(entries) != 1 || entries[0].email != "ada@uni.edu" {
+			t.Fatalf("entries = %+v, want the unwrapped address", entries)
+		}
+	})
+
+	// An unusable line is echoed only far enough to locate it: a file pointed at
+	// --file by mistake must not spill its contents into the report.
+	t.Run("long unusable line is truncated in the report", func(t *testing.T) {
+		long := strings.Repeat("z", 4000)
+		_, failures := parseInviteFile([]byte(long + "\n"))
+		if len(failures) != 1 {
+			t.Fatalf("failures = %v, want one", failures)
+		}
+		msg := failures[0].Error()
+		if strings.Contains(msg, long) {
+			t.Error("the full line was echoed; want it truncated")
+		}
+		if !strings.Contains(msg, "truncated") {
+			t.Errorf("want a truncation marker: %q", msg)
+		}
+		if !strings.Contains(msg, "line 1") {
+			t.Errorf("want the line number retained: %q", msg)
 		}
 	})
 }

--- a/cli/gh-teacher/internal/roster/invite_file_test.go
+++ b/cli/gh-teacher/internal/roster/invite_file_test.go
@@ -115,6 +115,19 @@ func TestParseInviteFile(t *testing.T) {
 			t.Errorf("want the line number retained: %q", msg)
 		}
 	})
+
+	// Excel and Notepad prepend a BOM when saving UTF-8. Without trimming it the
+	// first address fails and the fail-closed run sends nothing — so a teacher's
+	// spreadsheet-saved list would be refused wholesale.
+	t.Run("UTF-8 BOM is trimmed", func(t *testing.T) {
+		entries, failures := parseInviteFile([]byte("\ufeffada@uni.edu\nbea@uni.edu\n"))
+		if len(failures) != 0 {
+			t.Fatalf("failures = %v, want none", failures)
+		}
+		if len(entries) != 2 || entries[0].email != "ada@uni.edu" {
+			t.Fatalf("entries = %+v, want both addresses with the BOM stripped", entries)
+		}
+	})
 }
 
 func TestJoinInviteFileFailures(t *testing.T) {

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 			"Subcommands:\n" +
 			"  list     print the roster (table, --json, or --quiet username-only)\n" +
 			"  add      append or upsert one student (resolves github_id, invites to org)\n" +
-			"  invite   invite one student by email address (no GitHub account needed yet)\n" +
+			"  invite   invite one student by email address, or a whole list with --file (no GitHub account needed yet)\n" +
 			"  cancel-invite  revoke a pending email invitation and clear what it left behind\n" +
 			"  sync     sync the roster with GitHub (dry run; --write applies)\n" +
 			"  update   correct fields on an existing student (roster-only; never invites)\n" +
@@ -290,9 +290,10 @@ func rosterImportCmd() *cobra.Command {
 	return cmd
 }
 
-// parseEmailArgs validates the `<org> <classroom> <email>` shape `roster invite`
-// and `roster cancel-invite` share, BEFORE any auth or network happens so a
-// typo can never reach GitHub.
+// parseEmailArgs validates the `<org> <classroom> <email>` shape
+// `roster cancel-invite` uses, BEFORE any auth or network happens so a typo can
+// never reach GitHub. (`roster invite` validates inline because its email arg
+// is optional when --file is given.)
 func parseEmailArgs(args []string) (org, classroom, email string, err error) {
 	org = strings.TrimSpace(args[0])
 	classroom = strings.TrimSpace(args[1])

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -649,13 +647,9 @@ func runRosterImport(client githubapi.Client, out, errOut io.Writer, org, classr
 		return err
 	}
 
-	abs, err := filepath.Abs(csvPath)
+	abs, data, err := readTeacherFile(csvPath, "import path")
 	if err != nil {
-		return fmt.Errorf("resolve import path: %w", err)
-	}
-	data, err := os.ReadFile(abs)
-	if err != nil {
-		return fmt.Errorf("read %s: %w", abs, err)
+		return err
 	}
 	imported, parseErr := configrepo.ParseImportCSV(data)
 	// A row-level parse failure must not short-circuit resolution: fixing the

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -103,8 +103,8 @@ func rosterAddCmd() *cobra.Command {
 			if err := validate.ShortName(classroom, "classroom"); err != nil {
 				return err
 			}
-			emailVal := strings.TrimSpace(email)
-			if err := configrepo.ValidateRosterEmail(emailVal); err != nil {
+			emailVal, err := configrepo.CanonicalRosterEmail(strings.TrimSpace(email))
+			if err != nil {
 				return err
 			}
 			client, err := githubapi.RequireAuthClient(cmd)
@@ -175,8 +175,8 @@ func rosterUpdateCmd() *cobra.Command {
 				patch.LastName = &v
 			}
 			if cmd.Flags().Changed("email") {
-				v := strings.TrimSpace(email)
-				if err := configrepo.ValidateRosterEmail(v); err != nil {
+				v, err := configrepo.CanonicalRosterEmail(strings.TrimSpace(email))
+				if err != nil {
 					return err
 				}
 				patch.Email = &v
@@ -290,8 +290,10 @@ func rosterImportCmd() *cobra.Command {
 
 // parseEmailArgs validates the `<org> <classroom> <email>` shape
 // `roster cancel-invite` uses, BEFORE any auth or network happens so a typo can
-// never reach GitHub. (`roster invite` validates inline because its email arg
-// is optional when --file is given.)
+// never reach GitHub. The returned email is canonical: cancel-invite recomputes
+// the invite-team hash from it, and a raw `<a@b.edu>` would hash to a team that
+// does not exist. (`roster invite` validates inline because its email arg is
+// optional when --file is given.)
 func parseEmailArgs(args []string) (org, classroom, email string, err error) {
 	org = strings.TrimSpace(args[0])
 	classroom = strings.TrimSpace(args[1])
@@ -302,10 +304,11 @@ func parseEmailArgs(args []string) (org, classroom, email string, err error) {
 	if err := validate.ShortName(classroom, "classroom"); err != nil {
 		return "", "", "", err
 	}
-	if err := configrepo.ValidateRosterEmail(email); err != nil {
+	canonical, err := configrepo.CanonicalRosterEmail(email)
+	if err != nil {
 		return "", "", "", err
 	}
-	return org, classroom, email, nil
+	return org, classroom, canonical, nil
 }
 
 // warnStrandedInviteTeam reports a metadata team a teardown couldn't remove.

--- a/cli/gh-teacher/internal/roster/roster_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/roster_cmd_test.go
@@ -427,7 +427,7 @@ func TestRosterUpdateCmd(t *testing.T) {
 	})
 
 	t.Run("invalid --email is rejected before any auth/network", func(t *testing.T) {
-		// Display-name form is rejected by ValidateRosterEmail (before auth).
+		// Display-name form is rejected by CanonicalRosterEmail (before auth).
 		err := run(t, "o", "cs-principles", "alice", "--email", "Alice <a@x.edu>")
 		if err == nil || !strings.Contains(err.Error(), "invalid email") {
 			t.Fatalf("err = %v, want 'invalid email'", err)

--- a/cli/shared/ghutil/ghutil.go
+++ b/cli/shared/ghutil/ghutil.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -107,6 +108,26 @@ func IsRateLimited(err error) bool {
 	msg := strings.ToLower(httpErr.Message)
 	return strings.Contains(msg, "secondary rate limit") ||
 		strings.Contains(msg, "abuse")
+}
+
+// RetryAfterCap bounds the wait RetryAfter reports, so a hostile or mistaken
+// header can't park a CLI run for hours.
+const RetryAfterCap = 90 * time.Second
+
+// RetryAfter reports how long GitHub asked a rate-limited caller to wait, capped
+// at RetryAfterCap, or 0 when err carries no usable hint. Only the `Retry-After`
+// seconds form is read: the epoch-based `x-ratelimit-reset` describes the
+// PRIMARY hourly window, which is far too long to sleep through in a CLI.
+func RetryAfter(err error) time.Duration {
+	httpErr, ok := errors.AsType[*api.HTTPError](err)
+	if !ok {
+		return 0
+	}
+	secs, convErr := strconv.Atoi(strings.TrimSpace(httpErr.Headers.Get("Retry-After")))
+	if convErr != nil || secs <= 0 {
+		return 0
+	}
+	return min(time.Duration(secs)*time.Second, RetryAfterCap)
 }
 
 // BackoffDelay is the exponential backoff for optimistic-retry loops:

--- a/cli/shared/ghutil/ghutil_test.go
+++ b/cli/shared/ghutil/ghutil_test.go
@@ -290,6 +290,39 @@ func TestResolveSettledDefaultBranch(t *testing.T) {
 	})
 }
 
+// TestRetryAfter pins the wait a throttled caller sleeps: only the seconds form
+// of `Retry-After` is honored (the epoch reset describes the hourly window,
+// which no CLI should sleep through) and the cap bounds a hostile value.
+func TestRetryAfter(t *testing.T) {
+	httpErr := func(headers map[string]string) error {
+		h := http.Header{}
+		for k, v := range headers {
+			h.Set(k, v)
+		}
+		return &api.HTTPError{StatusCode: http.StatusTooManyRequests, Headers: h}
+	}
+	cases := []struct {
+		name string
+		err  error
+		want time.Duration
+	}{
+		{"seconds honored", httpErr(map[string]string{"Retry-After": "45"}), 45 * time.Second},
+		{"capped", httpErr(map[string]string{"Retry-After": "99999"}), RetryAfterCap},
+		{"absent header", httpErr(nil), 0},
+		{"epoch reset ignored", httpErr(map[string]string{"X-RateLimit-Reset": "1900000000"}), 0},
+		{"garbage header", httpErr(map[string]string{"Retry-After": "soon"}), 0},
+		{"zero", httpErr(map[string]string{"Retry-After": "0"}), 0},
+		{"non-HTTPError", io.EOF, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RetryAfter(tc.err); got != tc.want {
+				t.Errorf("RetryAfter() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestIsRateLimited pins the fatal-vs-benign 403 split callers rely on: a plain
 // authz 403 is benign (false), but every rate-limit shape stays fatal (true),
 // including the header-less secondary limit whose only signal is the body

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -279,7 +279,8 @@ teacher|hta|ta`. For the roles and what each can see, see
 [Staff, TAs, and multiple teachers](Staff-TAs-and-Multiple-Teachers).
 
 **Inviting by email:** `gh teacher roster invite <org> <classroom> <email>`
-invites a student by address and records them on the roster until they accept. See
+invites a student by address and records them on the roster until they accept.
+Invite a whole list at once with `--file <path>` (one address per line). See
 [Inviting a student by email](#inviting-a-student-by-email).
 
 ## 6. Track students in the roster
@@ -394,6 +395,32 @@ parent, a lab contact), so the real person still gets invited: the invitation is
 sent, a note on stderr names that row, and **no second row is written**. If the
 invitation fails outright, an invite team this run created is cleaned up again,
 except after a rate limit, where it's kept for a retry to adopt.
+
+**Invite a whole list by email:**
+
+```sh
+gh teacher roster invite <org> <classroom> --file <path>
+gh teacher roster invite cs50-fall-2026 cs-principles --file ./section-1-emails.txt
+```
+
+Pass `--file` instead of a single address to invite a whole section at once. The
+file is plaintext, **one address per line**; blank lines and lines starting with
+`#` are ignored, so you can annotate the list. Every address is validated first —
+if any line is unusable, the command reports every bad line and **sends nothing**.
+
+Each address goes through the same invite path as a single `roster invite`, and
+every successful invitation is retained as a pending row in **one commit** for
+the batch. The command prints a summary — how many were invited, already
+members/invited, already on the roster, failed, or deferred. Bulk mode is
+**student-only** and carries no names or sections (the `--first-name` /
+`--last-name` / `--section` flags apply to a single invite only); fill that
+metadata in later with [`roster import`](#bulk-import-from-a-csv) or
+[`roster sync`](#syncing-the-roster-with-github).
+
+If a GitHub rate limit is hit part-way, the command stops sending, reports the
+remaining addresses, and exits non-zero. **Re-running the same command is safe**:
+addresses already invited are skipped automatically, and addresses already on the
+roster get no second row.
 
 **Call an invitation off:**
 

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -410,17 +410,28 @@ if any line is unusable, the command reports every bad line and **sends nothing*
 
 Each address goes through the same invite path as a single `roster invite`, and
 every successful invitation is retained as a pending row in **one commit** for
-the batch. The command prints a summary — how many were invited, already
-members/invited, already on the roster, failed, or deferred. Bulk mode is
-**student-only** and carries no names or sections (the `--first-name` /
-`--last-name` / `--section` flags apply to a single invite only); fill that
-metadata in later with [`roster import`](#bulk-import-from-a-csv) or
+the batch. Each address is reported as it resolves, then a summary counts them —
+invited, already members/invited, already on the roster, failed, or deferred —
+and every skipped or failed address is named with its file line. Bulk mode is
+**student-only** and carries no names or sections, so the `--first-name` /
+`--last-name` / `--section` flags are **rejected** with `--file`; fill that
+metadata in afterwards with [`roster import`](#bulk-import-from-a-csv) or
 [`roster sync`](#syncing-the-roster-with-github).
 
-If a GitHub rate limit is hit part-way, the command stops sending, reports the
-remaining addresses, and exits non-zero. **Re-running the same command is safe**:
-addresses already invited are skipped automatically, and addresses already on the
-roster get no second row.
+Exit codes match [`roster sync`](#syncing-the-roster-with-github) so a script can
+tell a retryable run from a broken one:
+
+| Code | Meaning |
+| ---- | ------------------------------------------------------------------ |
+| 0 | Every address was invited or cleanly skipped |
+| 2 | Nothing failed, but a GitHub rate limit left addresses uninvited |
+| 1 | An address genuinely failed, or the roster write failed |
+
+On a rate limit the command stops sending, waits out GitHub's `Retry-After`
+before recording the invitations already sent, then reports the remaining
+addresses and exits 2. **Re-running the same command is safe**: addresses already
+invited are skipped automatically, and addresses already on the roster get no
+second row.
 
 **Call an invitation off:**
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -25,7 +25,7 @@ output, or `--verbose` / `-v` for per-step detail.
 | `classroom migrate --source <id-or-org> --target <org>` | Import a GitHub Classroom. |
 | `roster list <org> <classroom>` | List roster rows. Flags: `--json`, `--quiet`. |
 | `roster add <org> <classroom> <username>` | Add/upsert a student; invites them. |
-| `roster invite <org> <classroom> <email>` | Invite one student by email. Flags: `--first-name`, `--last-name`, `--section`. |
+| `roster invite <org> <classroom> <email>` | Invite one student by email, or a whole list with `--file <path>`. Flags: `--first-name`, `--last-name`, `--section` (single invite only). |
 | `roster cancel-invite <org> <classroom> <email>` | Revoke a pending email invitation and clear what it left behind. |
 | `roster sync <org> <classroom>` | Sync the roster with GitHub. Dry run; `--write` applies. |
 | `roster update <org> <classroom> <username>` | Correct fields on an existing row (roster-only). |
@@ -355,6 +355,22 @@ If the invitation fails, an invite team this run created is deleted again. A rat
 limit is the exception: the team is kept so a retry adopts it. If the invitation
 is sent but the roster write fails, the command exits non-zero and rolls nothing
 back; run `roster sync` to add the row.
+
+**Invite a list with `--file`.**
+
+```sh
+gh teacher roster invite <org> <classroom> --file <path>
+```
+
+Pass `--file` in place of the positional `<email>` to invite a whole list.
+The file is plaintext, one address per line; blank lines and `#` comment lines
+are ignored. Every address is validated up front — one unusable line refuses the
+whole run and nothing is sent. Each address takes the same path as a single
+invite, and the successfully-invited batch is retained in **one** roster commit.
+Bulk mode is student-only and carries no name/section metadata (the metadata
+flags apply to a single invite only; backfill later with `roster import` or
+`roster sync`). A run stopped by a rate limit reports the remaining addresses and
+exits non-zero; re-running is safe, since already-invited addresses skip.
 
 ### `roster cancel-invite`
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -366,11 +366,19 @@ Pass `--file` in place of the positional `<email>` to invite a whole list.
 The file is plaintext, one address per line; blank lines and `#` comment lines
 are ignored. Every address is validated up front — one unusable line refuses the
 whole run and nothing is sent. Each address takes the same path as a single
-invite, and the successfully-invited batch is retained in **one** roster commit.
-Bulk mode is student-only and carries no name/section metadata (the metadata
-flags apply to a single invite only; backfill later with `roster import` or
-`roster sync`). A run stopped by a rate limit reports the remaining addresses and
-exits non-zero; re-running is safe, since already-invited addresses skip.
+invite, is reported as it resolves, and the successfully-invited batch is retained
+in **one** roster commit. Every skipped or failed address is named with its file
+line.
+
+Bulk mode is student-only and carries no name/section metadata, so
+`--first-name`, `--last-name`, and `--section` are rejected with `--file`;
+backfill with `roster import` or `roster sync`.
+
+Exit codes follow [`roster sync`](#roster-sync): **0** all invited or cleanly
+skipped, **2** nothing failed but a rate limit left addresses uninvited, **1** an
+address failed or the roster write failed. On a rate limit the run stops sending,
+waits out `Retry-After` before recording what it already sent, and reports the
+rest; re-running is safe, since already-invited addresses skip.
 
 ### `roster cancel-invite`
 


### PR DESCRIPTION
Invites a whole list of students by email from one command: `gh teacher roster invite <org> <classroom> --file ./section-1-emails.txt`. This is the "bulk email invites from a file" item the [CLI email-invite lifecycle](https://github.com/foundation50/classroom50/pull/651) deferred, so a CLI-only teacher no longer runs one invocation per student.

## What it does

The file is plaintext, one address per line, with blank lines and `#` comments ignored so a teacher can annotate the list. Every address is validated up front — one unusable line refuses the whole run and sends nothing. Each address then takes the **same** path as a single `roster invite` (a shared `sendOneEmailInvite` helper both paths call), and the successfully-invited batch is retained as pending rows in **one** roster commit.

Mirrors the web app's `bulkInviteByEmail`: resolve the classroom team once and abort the batch before any send if it's missing, treat the per-invite metadata team as a precondition of that address's send, tear down only a team the run created, and stop issuing new sends once GitHub throttles.

Student-role only by design — no `--role`, so a mistyped address can never be handed org ownership.

## Behavior worth reviewing

- **Exit codes follow `roster sync`'s convention** so a script can tell a retryable run from a broken one: `0` all invited or cleanly skipped, `2` nothing failed but a rate limit left addresses uninvited, `1` an address failed or the roster write failed. Re-running is safe — already-invited addresses skip, already-rowed addresses get no second row.
- **A rate limit defers the tail rather than retrying in-process.** The command stops sending, waits out `Retry-After` before recording what it already sent (so a partial success doesn't become "sent but unrecorded"), then reports the rest. The web's `retryDeferred` backoff is deliberately out of scope.
- **Sequential fan-out is intentional.** GitHub's content-creation budget is the binding constraint, not client parallelism, and the repo already codifies this (`REPO_WRITE_CONCURRENCY = 1`). Concurrency would only reach the same budget faster and earn a longer throttle.
- **Per-student metadata flags are rejected with `--file`** rather than silently dropped; backfill names and sections with `roster import` or `roster sync`.
- Every skipped, dropped, and failed address is named with its file line, and each address is reported as it resolves so a multi-minute run isn't indistinguishable from a hang.

## Two fixes that reach beyond the feature

Both are isolated in their own commits and can be split out if you'd prefer.

- `fix(cli): use the parsed email address, not the raw input` — an address like `<ada@uni.edu>` passes validation but isn't what GitHub accepts, and every caller used its **raw** input. `roster cancel-invite` hashed it into an invite-team slug that never existed, so it tore down nothing and reported success; `roster add/update --email` wrote it into the column `roster sync` joins on. `ValidateRosterEmail` is deleted rather than patched — a validate-only helper invites exactly this split, so `CanonicalRosterEmail` is now the only entry point.
- A UTF-8 BOM is now trimmed from the address list. Excel- and Notepad-saved files carry one, which previously failed line 1 and — because the path is fail-closed — refused the entire run.

## Test plan

- [x] `go build ./...` and `go test ./...` green in `cli/gh-teacher` and `cli/shared`
- [x] `golangci-lint run` reports 0 issues; `golangci-lint fmt --diff` clean
- [x] Pre-existing single-invite suite passes **unmodified** — the extracted helper preserved that path's behavior
- [x] New coverage: parser cases (BOM, CRLF, comments, dedup, truncated echo, canonicalization), bulk flow cases (happy path with byte-exact roster and per-address team records, batch abort on missing classroom team, 422 teardown, per-address team-prep failure, rate-limit deferral from both the invitation and team-prep paths, the `Retry-After` wait, and a genuine concurrent-writer rebase drop), plus arg-validation and `cancel-invite` canonicalization regressions
- [ ] Manual smoke against a real org: invite a small list, confirm the pending rows and that `roster sync` folds them on acceptance

Reviewed with `ce-code-review` (8 reviewers; 6 of 9 P0/P1 candidates rejected as false positives by an independent validation pass) and tidied with `ce-simplify-code`.