### PR TITLE
docs: make individual Glossary terms linkable

### DIFF
--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -11,35 +11,49 @@ disagrees with it,
 
 ## Core concepts
 
-**Classroom** — The basic unit of Classroom 50: one course's students,
+#### Classroom
+
+The basic unit of Classroom 50: one course's students,
 assignments, roster, and scores. A classroom belongs to a GitHub organization,
 and an organization can hold several classrooms (for example, one per term or
 section).
 
-**Assignment** — A piece of coursework in a classroom. May be individual or
+#### Assignment
+
+A piece of coursework in a classroom. May be individual or
 group, may include starter code, and may have a due date and autograding.
 
-**Individual assignment** — Each student gets their own repository.
+#### Individual assignment
 
-**Group assignment** — Teammates share one repository. The first student to
+Each student gets their own repository.
+
+#### Group assignment
+
+Teammates share one repository. The first student to
 accept creates it and invites the others. Groups replace GitHub Classroom's
 teams: there is no separate team-creation step and no group names.
 
-**Roster** — The list of students in a classroom. Backed by a `roster.csv`
+#### Roster
+
+The list of students in a classroom. Backed by a `roster.csv`
 file, but the classroom's GitHub team is the source of truth for who is
 enrolled. A row identifies a student by `github_id` or GitHub username; a student
 invited by email has a **pending row**, identified by their address, until they
 accept. There is no equivalent of GitHub Classroom's roster identifier or student
 self-linking.
 
-**Pending row** — A `roster.csv` row for someone invited by email who hasn't
+#### Pending row
+
+A `roster.csv` row for someone invited by email who hasn't
 accepted yet. It holds the invited address and role, with no username or
 `github_id`, because GitHub offers no way to look up an account from an email
 address. A sync fills in the account once they accept; cancelling the
 invitation removes the row immediately, and an expired one is cleared by the next
 sync, from either tool.
 
-**Invite team** — A `secret` GitHub team, named `invite-<hash>`, that holds one
+#### Invite team
+
+A `secret` GitHub team, named `invite-<hash>`, that holds one
 invited address until that person joins. It is how an email invitation is
 matched to the GitHub account that accepts it. Classroom 50 creates one per
 email invitation and removes it once the invitation has been accepted, cancelled,
@@ -48,7 +62,9 @@ invitation sent from one can be completed or revoked from the other. For more
 information, see
 [Invitations by email](How-Classroom-50-Works#invitations-by-email).
 
-**Sync** — A pass that catches `roster.csv` up with the classroom's GitHub state:
+#### Sync
+
+A pass that catches `roster.csv` up with the classroom's GitHub state:
 it records the students who accepted an email invitation, fills in a missing
 `github_id`, drops the pending rows nothing backs, and retires the invite teams
 that are done. Nothing runs on its own: the web app runs a sync when a teacher
@@ -56,86 +72,128 @@ opens a classroom or its roster, and `gh teacher roster sync` runs one on demand
 This is not **Sync now**, which collects scores. See
 [What triggers a sync](How-Classroom-50-Works#what-triggers-a-sync).
 
-**Organization (org)** — The GitHub organization that hosts a Classroom 50
+#### Organization (org)
+
+The GitHub organization that hosts a Classroom 50
 setup. Requires the Team or Enterprise plan.
 
-**The `classroom50` repository** — The private repository named `classroom50`
+#### The `classroom50` repository
+
+The private repository named `classroom50`
 in your organization. It holds every classroom's settings, roster,
 assignments, autograders, and scores. Classroom 50 has no other backend.
 
 ## Roles
 
-**Teacher** — Full control of a classroom. Granted organization owner and write
+#### Teacher
+
+Full control of a classroom. Granted organization owner and write
 access to the `classroom50` repository.
 
-**Head TA** — Write access to the `classroom50` repository, but not
+#### Head TA
+
+Write access to the `classroom50` repository, but not
 organization owner.
 
-**TA** — Read-only access to the `classroom50` repository.
+#### TA
 
-**Student** — A member of the classroom who accepts and submits assignments.
+Read-only access to the `classroom50` repository.
 
-**Founder** — For a group assignment, the student who accepts first: they create
+#### Student
+
+A member of the classroom who accepts and submits assignments.
+
+#### Founder
+
+For a group assignment, the student who accepts first: they create
 the shared repository and invite the other teammates as collaborators.
 
 ## Assignments and grading
 
-**Template repository** — A GitHub repository, flagged as a template, that
+#### Template repository
+
+A GitHub repository, flagged as a template, that
 supplies an assignment's **starter code**. Each student who accepts gets a copy.
 Assignments can also be template-less, in which case a student's repository
 starts with a README and the autograding setup instead of starter code (see
 [Repository shapes](Assignment-Templates#repository-shapes) for variations).
 
-**Due date** — An optional date and time for an assignment. Submissions after
+#### Due date
+
+An optional date and time for an assignment. Submissions after
 it are marked *late*; nothing is blocked, unlike GitHub Classroom's cutoff
 date. To actually stop submissions, use **Close submission** on the
 submissions page.
 
-**Autograder** — The grading logic that runs on each submission. Can be
+#### Autograder
+
+The grading logic that runs on each submission. Can be
 declarative tests (defined in the assignment) or a Python script you write.
 
-**Declarative tests** — Input/output, run-command, and pytest checks defined
+#### Declarative tests
+
+Input/output, run-command, and pytest checks defined
 directly on an assignment, graded with no code to write. They fill the role
 of GitHub Classroom's `autograding.json` presets; an existing
 `autograding.json` workflow can be kept with a
 [custom runner workflow](Advanced-Autograding#custom-runner-workflow-rare).
 
-**Runner** — The shared grading engine that runs in GitHub Actions on every
+#### Runner
+
+The shared grading engine that runs in GitHub Actions on every
 submission.
 
-**Submission** — A push to a student's assignment repository. Each submission
+#### Submission
+
+A push to a student's assignment repository. Each submission
 is tagged, graded, and published as a GitHub Release.
 
-**Feedback pull request** — An optional, long-lived pull request per student
+#### Feedback pull request
+
+An optional, long-lived pull request per student
 repository for inline review of a student's work.
 
-**Score / collected scores** — A **score** is the number a submission earned
+#### Score / collected scores
+
+A **score** is the number a submission earned
 (`score` out of `max-score`). The **collected scores** (`scores.json` in the
 `classroom50` repository) are the record of every submission, built by the
 score-collection workflow. Teachers can download them as CSV. See
 [Reading results](Autograding-Basics#reading-results) in Autograding Basics.
 
-**Score override** — A teacher-set score entered on the submissions page,
+#### Score override
+
+A teacher-set score entered on the submissions page,
 stored with the collected scores and left untouched by autograding until
 cleared. Used for manual grading and for overriding an autograded result
 (which is preserved and restored when the override is cleared).
 
 ## Access and setup
 
-**Service token** — A fine-grained personal access token (PAT) stored as a
+#### Service token
+
+A fine-grained personal access token (PAT) stored as a
 secret in the `classroom50` repository. The score-collection, regrade, and
 token-probe workflows use it to read and update student repositories.
 
-**Workflow files** — The GitHub Actions files Classroom 50 places in the
+#### Workflow files
+
+The GitHub Actions files Classroom 50 places in the
 `classroom50` repository and in each assignment repository (such as
 `autograde.yaml`) to run grading, collection, and publishing.
 
-**Accept** — The student action that creates their assignment repository from
+#### Accept
+
+The student action that creates their assignment repository from
 the template.
 
-**Submit** — The student action that pushes work for grading.
+#### Submit
 
-**Unlisted classroom** — A classroom whose published files live at an
+The student action that pushes work for grading.
+
+#### Unlisted classroom
+
+A classroom whose published files live at an
 unguessable URL instead of a predictable one. This is obscurity, not access
 control: anyone with the link can read the files.
 


### PR DESCRIPTION
## Summary

Promotes the 29 bold run-in entries in the wiki Glossary to `####` (h4) headings so each term gets its own anchor. Every term is now linkable as `Glossary#pending-row`, `Glossary#sync`, and so on, instead of only the six section headings being linkable.

Closes #653.

## What changed

The entries went from a bold run-in (`**Term** — definition`) to a heading plus a plain-paragraph definition, dropping the em-dash separator per the wiki writing-style house rule. Definition text is otherwise byte-for-byte unchanged; this is a purely structural edit.

The six `##` section headings are untouched, so the existing inbound links to `Glossary#roles` and `Glossary#coming-from-github-classroom` (from FAQ, How Classroom 50 Works, and the migration guide) keep resolving.

## Notes

Term headings are `####` rather than `###` to keep the 29 new headings from bloating the wiki sidebar and any auto-generated table of contents. This intentionally skips the `###` level (the style guide says "never skip levels"), but GitHub derives anchors from heading text, not level, so linkability — the point of the issue — is identical at either depth.

## Test plan

- [ ] Verify every inbound `Glossary#...` link still resolves after publish, especially `#roles` and `#coming-from-github-classroom`.
- [ ] Spot-check a few new term anchors on the published wiki (`Glossary#pending-row`, `Glossary#organization-org`, `Glossary#the-classroom50-repository`, `Glossary#score--collected-scores`).