### PR TITLE
fix: correct email-invite docs, comments, and two contract defects

### DIFF
--- a/cli/gh-teacher/internal/cliutil/doc.go
+++ b/cli/gh-teacher/internal/cliutil/doc.go
@@ -1,6 +1,7 @@
 // Package cliutil holds cross-cutting CLI helpers that aren't domain logic:
-// the HTTP-status predicates and the exit-code carrier main() maps to a process
-// status. It gives per-domain files a small named seam instead of one flat
+// the HTTP-status and rate-limit classifiers (including the Retry-After wait
+// hint) and the exit-code carrier main() maps to a process status. It gives
+// per-domain files a small named seam instead of one flat
 // package main namespace, and stays free of GitHub-API types (the transport
 // seam lives in internal/githubapi).
 package cliutil

--- a/cli/gh-teacher/internal/cliutil/exitcode.go
+++ b/cli/gh-teacher/internal/cliutil/exitcode.go
@@ -4,7 +4,8 @@ import "errors"
 
 // ExitCodeError carries a specific process exit code out of a cobra RunE, for
 // the few commands whose exit status is a machine-readable RESULT rather than
-// just success/failure (`roster sync` defines the one such contract today).
+// just success/failure — `roster sync` defines the contract (0/1/2) and
+// `roster invite --file` reuses its codes.
 //
 // Err still carries the message cobra prints, so a non-failure code must wrap a
 // sentence that reads as a report rather than a fault.

--- a/cli/gh-teacher/internal/configrepo/invite_team.go
+++ b/cli/gh-teacher/internal/configrepo/invite_team.go
@@ -231,12 +231,11 @@ func findTeamMembersWithIDs(client githubapi.Client, org, slug string) ([]TeamMe
 //     membership is then READ BACK; a survivor is ErrInviteTeamNotEmpty. This is
 //     what lets a reconcile treat any member of any role as the invitee.
 //   - EMAIL LAST: the create carries only contract.InviteProvisionalDescription.
-//     GitHub
-//     adds the creator during the create itself, so the drop is necessarily a
-//     second request and an interrupted run can always strand a team with a
-//     teacher on it. Writing the email last makes that leftover harmless — it
-//     holds no address and no valid record, so a reconcile skips it and the next
-//     invite to the same address adopts and heals it.
+//     GitHub adds the creator during the create itself, so the drop is
+//     necessarily a second request and an interrupted run can always strand a
+//     team with a teacher on it. Writing the email last makes that leftover
+//     harmless — it holds no address and no valid record, so a reconcile skips it
+//     and the next invite to the same address adopts and heals it.
 func EnsureInviteTeam(client githubapi.Client, org, classroom, email, actor string) (ref TeamRef, created bool, err error) {
 	name := InviteTeamName(classroom, email)
 	record, err := MarshalInviteDescription(classroom, email)

--- a/cli/gh-teacher/internal/configrepo/students_csv.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv.go
@@ -12,12 +12,14 @@ import (
 	"strings"
 )
 
-// RosterColumns: canonical required column order. github_id is CLI-managed
-// (from `GET /users/{username}`); the immutable numeric ID defends against
-// mid-class username changes. Email may be empty. role is best-effort recorded
-// metadata (teacher/ta/student, or "") refreshed from the classroom's GitHub
-// teams on sync — the teams, not this column, remain the enrollment/role
-// authority; nothing reads it for logic.
+// RosterColumns: canonical required column order. github_id is tool-managed —
+// `GET /users/{username}` on add/import, else the classroom team's own
+// membership on sync; the immutable numeric ID defends against mid-class
+// username changes. Email may be empty. role is best-effort recorded metadata
+// (teacher/hta/ta/student, or ""), refreshed from the classroom's GitHub teams
+// by the web's sync and recorded here only on a row `roster sync` appends — the
+// teams, not this column, remain the enrollment/role authority; nothing reads it
+// for logic.
 var RosterColumns = []string{"username", "first_name", "last_name", "email", "section", "github_id", "role"}
 
 // legacyRequiredColumns is the canonical prefix a pre-role roster.csv carries.
@@ -59,8 +61,9 @@ func TrimUTF8BOM(data []byte) []byte {
 	return bytes.TrimPrefix(data, utf8BOM)
 }
 
-// RosterRow is one student in the roster. GitHubID == 0 means unresolved (a
-// 5-column import row before GET /users/{username}, or a cell we couldn't use).
+// RosterRow is one student in the roster. GitHubID == 0 means unresolved — a
+// pending email-invite row, a 5-column import row before
+// GET /users/{username}, or a cell we couldn't use.
 type RosterRow struct {
 	Username  string
 	FirstName string
@@ -71,9 +74,9 @@ type RosterRow struct {
 	// githubIDRaw holds a github_id cell that read as unresolved, so a rewrite
 	// preserves the teacher's value instead of silently clearing it.
 	githubIDRaw string
-	// Role is best-effort recorded metadata: "teacher", "ta", "student", or
-	// "" (unknown / a pre-role file). Refreshed from team membership on sync;
-	// never consulted for enrollment decisions.
+	// Role is best-effort recorded metadata: "teacher", "hta", "ta", "student",
+	// or "" (unknown / a pre-role file). Never consulted for enrollment
+	// decisions — the classroom's teams are the authority.
 	Role string
 	// Line is the 1-based CSV line this row was read from, recorded only by
 	// ParseImportCSV: an import reports failures per line, and a file with a

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -23,9 +23,8 @@ func classroomTeamName(shortName string) string {
 	return "classroom50-" + shortName
 }
 
-// classroomTeamSlug is the URL slug GitHub assigns the team. Since
-// classroomTeamName is already lowercase-with-hyphens, the slug equals the
-// name; deriving it directly avoids reading the team back.
+// classroomTeamSlug: slug == name (see classroomTeamName), so deriving it
+// directly avoids reading the team back.
 func classroomTeamSlug(shortName string) string {
 	return classroomTeamName(shortName)
 }

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -554,8 +554,9 @@ var inviteTeamSlugRe = regexp.MustCompile(
 		fmt.Sprintf(`[0-9a-f]{%d}$`, contract.InviteHashHexLen))
 
 // IsInviteTeamSlug reports whether a slug is one this feature owns — the
-// fail-closed predicate both the sweep's filter and its delete share, mirroring
-// the web's isInviteTeamSlug.
+// fail-closed predicate both the sweep's filter and its delete share.
+// Deliberately STRICTER than the web's isInviteTeamSlug, which tests the bare
+// prefix: a sweep that deletes must never match a human team like "Invite Only".
 func IsInviteTeamSlug(slug string) bool {
 	return inviteTeamSlugRe.MatchString(slug)
 }

--- a/cli/gh-teacher/internal/member/member_list.go
+++ b/cli/gh-teacher/internal/member/member_list.go
@@ -22,10 +22,12 @@ import (
 )
 
 // memberListEntry is one row of `member list` output. Kind separates the
-// surfaces reconciled against the roster (org member, pending invitation, repo
+// surfaces compared against the roster (org member, pending invitation, repo
 // collaborator). Role is the org role or repo permission level; empty when
-// GitHub didn't report it. github_id is 0 for pending invitations (keyed on
-// login/email, not id).
+// GitHub didn't report it. github_id is an ACCOUNT id for a member or
+// collaborator, but for a pending invitation it is GitHub's INVITATION id (the
+// invitations API reports no invitee account id), so it must not be joined
+// against roster.csv's github_id.
 type memberListEntry struct {
 	Login    string `json:"login"`
 	Kind     string `json:"kind"`

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -51,15 +51,18 @@ func rosterInviteCmd() *cobra.Command {
 			"lines starting with `#` are ignored. Every address is validated first,\n" +
 			"and if any line is unusable nothing is sent. Successful invitations are\n" +
 			"retained as pending rows in one commit. --file carries no names or\n" +
-			"sections (fill those later with `roster import` or `roster sync`), so\n" +
-			"the --first-name/--last-name/--section flags are rejected with it.\n" +
+			"sections (fill those later with `roster import`, or `roster update`\n" +
+			"once the student has accepted; a sync never writes either), so the\n" +
+			"--first-name/--last-name/--section flags are rejected with it.\n" +
 			"Each address is reported as it resolves, then a summary counts them.\n\n" +
 			"Bulk exit codes follow `roster sync`: 0 every address was invited or\n" +
 			"cleanly skipped, 2 nothing failed but a GitHub rate limit left\n" +
 			"addresses uninvited (re-run to continue — already-invited addresses are\n" +
 			"skipped), 1 an address genuinely failed or the roster write failed.\n\n" +
-			"Returns non-zero on: classroom missing a GitHub team, an address the\n" +
-			"roster already lists as invited, or a failed invitation. An address\n" +
+			"A single address returns non-zero on: classroom missing a GitHub team,\n" +
+			"an address the roster already lists as invited, or a failed\n" +
+			"invitation. With --file that same already-listed address is reported\n" +
+			"as skipped instead, and does not affect the exit code. An address\n" +
 			"that already belongs to a member (or already has a pending\n" +
 			"invitation) is reported as skipped and exits 0. An address some other\n" +
 			"row already carries is still invited, but gets no second row.",

--- a/cli/gh-teacher/internal/roster/list.go
+++ b/cli/gh-teacher/internal/roster/list.go
@@ -19,7 +19,7 @@ import (
 // rosterListEntry is the `--json` view of one roster.csv row. Field names
 // mirror the CSV columns. github_id is always present; 0 for an unresolved row
 // — consumers branch on `github_id == 0`, not key presence. role is a display
-// snapshot of the account's highest team-derived role ("teacher"/"ta"/
+// snapshot of the account's highest team-derived role ("teacher"/"hta"/"ta"/
 // "student", or "" when unknown); the teams remain the enrollment/role
 // authority. An account holding several roles (dual roles aren't disallowed)
 // reads as its highest one here while still being an enrolled student.
@@ -48,9 +48,10 @@ func rosterListCmd() *cobra.Command {
 			"`<org>/<repo>/<classroom>/roster.csv: N student(s)` summary\n" +
 			"on stderr.\n\n" +
 			"The `role` column is a display snapshot of the account's\n" +
-			"highest team-derived role (teacher/ta/student, or empty when\n" +
-			"unknown) refreshed on sync; the classroom's GitHub teams — not\n" +
-			"this column — remain the enrollment/role authority. An account\n" +
+			"highest team-derived role (teacher/hta/ta/student, or empty\n" +
+			"when unknown), refreshed whenever the web app syncs the\n" +
+			"roster; the classroom's GitHub teams — not this column —\n" +
+			"remain the enrollment/role authority. An account\n" +
 			"holding several roles (dual roles aren't disallowed) reads as\n" +
 			"its highest one here while still being an enrolled student.\n\n" +
 			"Pass --json for the full array of\n" +

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -38,9 +38,12 @@ func NewCmd() *cobra.Command {
 			"All writes use a single Tree commit on <org>/classroom50's\n" +
 			"default branch and retry with an optimistic rebase loop\n" +
 			"(up to 5 attempts) so concurrent edits don't silently lose\n" +
-			"each other's work. Each row stores the student's immutable\n" +
-			"numeric github_id (resolved via GET /users/{username}) so a\n" +
-			"username change mid-class doesn't desynchronize records.",
+			"each other's work. Each row that names an account stores the\n" +
+			"student's immutable numeric github_id — resolved from\n" +
+			"GET /users/{username} on add/import, or from the classroom team\n" +
+			"on sync — so a username change mid-class doesn't desynchronize\n" +
+			"records. A row awaiting an email invitation carries only the\n" +
+			"address until a sync records the account.",
 	}
 	cmd.AddCommand(rosterListCmd())
 	cmd.AddCommand(rosterAddCmd())
@@ -73,9 +76,10 @@ func rosterAddCmd() *cobra.Command {
 			"If no username matches and --email is given, an existing row\n" +
 			"holding only that address is completed in place instead of a\n" +
 			"second row being added: that is the pending row an email\n" +
-			"invitation created in the web app. Only a row with no username\n" +
-			"and no github_id can be completed this way, and it does not\n" +
-			"carry over that row's recorded role.\n\n" +
+			"invitation created, from `gh teacher roster invite` or the\n" +
+			"web app. Only a row with no username and no github_id can be\n" +
+			"completed this way, and it does not carry over that row's\n" +
+			"recorded role.\n\n" +
 			"After the roster write lands, if the student isn't already a\n" +
 			"member of <org> (and doesn't already have a pending invite),\n" +
 			"this command sends an org invitation (same path `gh teacher\n" +

--- a/cli/gh-teacher/internal/roster/sync.go
+++ b/cli/gh-teacher/internal/roster/sync.go
@@ -90,8 +90,9 @@ func rosterSyncCmd() *cobra.Command {
 		Long: "Sync <org>/classroom50/<classroom>/roster.csv with GitHub:\n" +
 			"record the students who accepted an email invitation, drop the\n" +
 			"pending rows whose invitation is gone, and fill in any missing\n" +
-			"github_id. The web app runs the same sync when a teacher opens\n" +
-			"the roster — here it is explicit and script-callable.\n\n" +
+			"github_id. The web app runs this same sync when a teacher opens\n" +
+			"the roster (and additionally refreshes recorded roles) — here\n" +
+			"it is explicit and script-callable.\n\n" +
 			"Reports by default and changes nothing: a dry run issues no write\n" +
 			"request at all. Pass --write to apply what it found.\n\n" +
 			"An accepted email invitation is the case that needs this: GitHub\n" +

--- a/cli/gh-teacher/internal/teardown/teardown.go
+++ b/cli/gh-teacher/internal/teardown/teardown.go
@@ -179,12 +179,13 @@ func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, o
 		_, _ = fmt.Fprintf(out, "%s: deleted team %s\n", org, t.Slug)
 	}
 
-	// Sweep the web's per-invite metadata teams too. They hold an invited
-	// student's email address, are recorded nowhere in the config repo (so the
-	// snapshot above can't see them), and nothing else ever reaps them — leaving
-	// them behind would strand that email in the org after teardown. Org-wide by
-	// nature: the slug is a hash, so a sweep can't be scoped to one classroom
-	// without reading each description. Best-effort, like the classroom sweep.
+	// Sweep the per-invite metadata teams too — either writer (the web app or
+	// `roster invite`) may have created one. They hold an invited student's email
+	// address and are recorded nowhere in the config repo, so the snapshot above
+	// can't see them; `roster sync`'s GC collects them per classroom, but a
+	// teardown deletes the classrooms it would read from. Org-wide by nature: the
+	// slug is a hash, so a sweep can't be scoped to one classroom without reading
+	// each description. Best-effort, like the classroom sweep.
 	sweepInviteTeams(client, org, out, errOut)
 
 	if failed > 0 {

--- a/cli/shared/ghutil/ghutil.go
+++ b/cli/shared/ghutil/ghutil.go
@@ -1,8 +1,10 @@
 // Package ghutil holds small, proven-duplicated helpers for talking to the
 // GitHub API via go-gh, shared by the gh-teacher and gh-student CLIs. Not a
-// client wrapper — go-gh's *api.RESTClient already is that; this only collects
-// the primitives both modules had copied: HTTP-status classification and the
-// retry backoff schedule.
+// client wrapper — go-gh's *api.RESTClient already is that; this collects the
+// primitives both modules had copied: HTTP-status and rate-limit
+// classification, the retry backoff and Retry-After schedules, the
+// pagination-termination predicate, fresh-repo branch settling, and a few
+// shared reads.
 package ghutil
 
 import (
@@ -174,15 +176,6 @@ func WaitForStableBranch(client *api.RESTClient, owner, repo, branch string) err
 	return fmt.Errorf("branch %s/%s:%s did not stabilize", owner, repo, branch)
 }
 
-// ResolveSettledDefaultBranch waits out GitHub's async template-copy lag and
-// returns the branch that actually materialized. Right after POST .../generate,
-// GET /repos reports a transient default_branch (the org default, e.g., `main`)
-// while the real branch (copied from the template, e.g., `master`) hasn't been
-// created yet — so trusting default_branch, or an immediate confirming GET,
-// can pin a `heads/main` that never exists. This polls the repo's branch list
-// until at least one ref exists, then returns the live default_branch when it
-// names a real branch, else the sole/first materialized branch. Falls back to
-// `fallback` if nothing materializes within the window.
 // ResolveSettledDefaultBranch waits out GitHub's async template-copy lag and
 // returns the branch that actually materialized. Right after POST .../generate,
 // GET /repos reports a transient default_branch (the org default, e.g., `main`)

--- a/cli/shared/gittree/gittree.go
+++ b/cli/shared/gittree/gittree.go
@@ -13,10 +13,6 @@
 //     *freshly-created* repo whose ref/git-data APIs briefly 404/409 until they
 //     propagate (the teacher's first skeleton land; the student's accept-time
 //     control-file commit).
-//
-// TreeEntry.SHA is a pointer so a nil value marshals to `"sha":null`, which the
-// Trees API treats as "remove this path from base_tree" (see DeletionEntries).
-// Callers that never delete simply never build a nil entry.
 package gittree
 
 import (

--- a/web/src/domain/orgMembers/bulkRemoveFromClassroom.ts
+++ b/web/src/domain/orgMembers/bulkRemoveFromClassroom.ts
@@ -61,6 +61,7 @@ const rowToStudent = (row: OrgMemberRow): Student => ({
 //     widen a removal), so bulkUnenrollStudents drops such a target and it would
 //     otherwise reconcile to "already removed" while both the row AND the live
 //     invitation survived. Cancelling the invitation is the action that retires it.
+//
 // so only removable rows reach the batch writer. Per-row outcomes are
 // reconciled from the batch result (removed / not-found).
 export async function bulkRemoveFromClassroom(

--- a/web/src/domain/reconcileClassroom.ts
+++ b/web/src/domain/reconcileClassroom.ts
@@ -64,7 +64,8 @@ const NOOP_RESULT: ClassroomReconcileResult = {
 // maintainer of every team it makes, and an owner sitting on those teams is the
 // mixed-role state the roster would miscount. The drop is unconditional (not
 // gated on created-vs-adopted) so a pre-existing stray membership self-heals —
-// mirrors createClassroomFiles' dropCreatorFromNonTeacherTeams.
+// mirrors createClassroomFiles' inline creator drop (and the CLI's
+// dropCreatorFromNonTeacherTeams).
 export async function reconcileClassroom(
   client: GitHubClient,
   org: string,

--- a/web/src/domain/students/enrollment.ts
+++ b/web/src/domain/students/enrollment.ts
@@ -196,8 +196,9 @@ export type InviteByEmailResult = {
 // On acceptance the invitee lands on both teams; a later reconcile pass recovers
 // the email <-> account mapping from the metadata team and folds it into
 // roster.csv. The invite also shows up in the roster's `pending` section via the
-// org pending-invitations list. The invite is BLOCKED (throws) unless BOTH teams
-// are ready: an invite that can't carry the classroom team would land the
+// classroom team's own pending-invitation list — it carries that team, which is
+// what scopes it to this classroom. The invite is BLOCKED (throws) unless BOTH
+// teams are ready: an invite that can't carry the classroom team would land the
 // student in the org with nothing to collect them, and one without its metadata
 // team would silently lose the address it was sent to. Nothing has been sent at
 // that point, so the teacher just retries.

--- a/web/src/domain/students/inviteRoster.ts
+++ b/web/src/domain/students/inviteRoster.ts
@@ -254,10 +254,10 @@ export type BulkInviteByEmailResult = {
 // in ONE commit for the batch (see appendEmailInviteRows); each row lives exactly
 // as long as its invite team does. A target whose metadata team can't be
 // prepared is reported as FAILED rather than invited without email retention.
-// The invite also surfaces as a `pending` row via the org pending-invitations
-// list. Mirrors inviteRosterStudents' rate-limit handling (stop issuing new
-// invites once throttled; defer the rest), and the same team resolution
-// (resolveTeamIdByRole ensures the staff team for a teacher/ta invite,
+// The invite also surfaces as a `pending` row via the role team's own
+// pending-invitation list. Mirrors inviteRosterStudents' rate-limit handling
+// (stop issuing new invites once throttled; defer the rest), and the same team
+// resolution (resolveTeamIdByRole ensures the staff team for a teacher/ta invite,
 // students-only never creates empty staff teams).
 export async function bulkInviteByEmail(
   client: GitHubClient,
@@ -298,11 +298,11 @@ export async function bulkInviteByEmail(
 
   // Block the whole batch if any role's team couldn't be resolved, mirroring the
   // single inviteByEmail guard: a team-less email invite is broken — the invitee
-  // accepts into the org attached to no team and, since we write no roster.csv
-  // row, is silently uncollected. Fail loudly BEFORE sending anything rather than
-  // send a batch of orphaning invites. (The username bulk path can tolerate a
-  // teamless invite because its CSV row still surfaces the person; an email
-  // invite has no such fallback.)
+  // accepts into the org attached to no team and, since the pending row carries
+  // no identity until acceptance, no collectable roster row either. Fail loudly
+  // BEFORE sending anything rather than send a batch of orphaning invites. (The
+  // username bulk path can tolerate a teamless invite because its CSV row names
+  // an account; a pending email row names none until the student accepts.)
   const rolesMissingTeam = [...new Set(targets.map((t) => t.role))].filter(
     (role) => teamIdByRole[role] === undefined,
   )

--- a/web/src/domain/students/roleWrites.ts
+++ b/web/src/domain/students/roleWrites.ts
@@ -412,8 +412,8 @@ export type ApplyClassroomRoleChangeResult = {
 //     with the member unchanged (still teacher + owner) rather than
 //     half-moved-but-still-owner. If a LATER step fails after this committed,
 //     the error explicitly says the owner was revoked so the caller re-runs.
-//  2) Add to the target team (student -> classroom team; ta/teacher -> the
-//     staff team, created + granted its role's config-repo access — write for
+//  2) Add to the target team (student -> classroom team; a staff role -> its
+//     staff team, created + granted that role's config-repo access — write for
 //     teacher/hta, read-only for ta — if missing), then promote
 //     to org owner when the target is teacher.
 //  3) Remove from EVERY currently-held classroom team that isn't the target

--- a/web/src/domain/students/rosterPrimitives.ts
+++ b/web/src/domain/students/rosterPrimitives.ts
@@ -62,8 +62,9 @@ export function rosterWriteTree(
   ]
 }
 
-// The conflict-safe roster.csv read-modify-write shared by the roster writers
-// (writeClassroomRoles, updateClassroomMetadata). Runs inside withGitConflictRetry:
+// The conflict-safe roster.csv read-modify-write shared by every roster writer
+// (the role/metadata/username writers in roleWrites, plus the email-invite row
+// append/remove below). Runs inside withGitConflictRetry:
 // reads the config branch/ref/commit, reads roster.csv,
 // parses it tolerantly and REFUSES a malformed file with a typed
 // RosterCsvMalformedError (a positional re-serialize would corrupt the bad row),
@@ -495,7 +496,8 @@ export const normalizeGithubUsername = (username: string) => {
 }
 
 export const isLikelyGithubUsername = (username: string) => {
-  // alphanumeric + hyphens, no hyphens at start or end
+  // GitHub's login rule: 1-39 chars, alphanumeric or hyphen, no leading or
+  // trailing hyphen.
   return /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/.test(username)
 }
 
@@ -721,11 +723,11 @@ export async function retryDeferred<T>(opts: {
 }
 
 // Resolve the team id for each role present in the invite batch: student ->
-// classroom team, teacher/ta -> the staff team (created if missing, mirroring
-// the Settings staff flow so a teacher/ta invite lands them on the right
-// team on acceptance). Only ensures a staff team when that role is actually
+// classroom team, each staff role (teacher/hta/ta) -> its staff team (created if
+// missing, mirroring the Settings staff flow so a staff invite lands them on the
+// right team on acceptance). Only ensures a staff team when that role is actually
 // being invited — a students-only upload must not create (and grant config-repo
-// write to) empty teacher/ta teams as a side effect. A failed resolve leaves
+// access to) empty staff teams as a side effect. A failed resolve leaves
 // that role's id undefined — the invite still sends teamless.
 export async function resolveTeamIdByRole(
   client: GitHubClient,

--- a/web/src/domain/students/rosterSync.ts
+++ b/web/src/domain/students/rosterSync.ts
@@ -86,8 +86,6 @@ export async function syncRosterFromTeam(
   const slugs = await resolveClassroomTeamSlugs(client, org, classroom)
 
   return withGitConflictRetry(async () => {
-    // Re-read teams + CSV on every attempt so the diff is always against the
-    // latest state (a concurrent add/edit can't be clobbered or duplicated).
     const [{ members, fullyRead, pendingRoleKeys }, configBranch] =
       await Promise.all([
         listClassroomMembersWithRoles(client, org, slugs),

--- a/web/src/domain/students/unenroll.ts
+++ b/web/src/domain/students/unenroll.ts
@@ -65,7 +65,8 @@ export async function unenrollStudent(
 
   // Read org state and viewer before the commit. State is null on read failure
   // (then we skip the org action). The viewer guards against removing the
-  // signed-in teacher. An email-only row has no username to resolve state for.
+  // signed-in teacher. A row identified only by github_id has no login to
+  // resolve state for.
   const orgStatePromise = normalizedUsername
     ? getOrgMembershipState(client, org, normalizedUsername)
     : Promise.resolve(null)
@@ -123,7 +124,7 @@ export async function unenrollStudent(
   const warnings: string[] = []
 
   // Drop from the classroom team. Idempotent (404 = not a member / team gone);
-  // org membership untouched. Skipped for an email-only row.
+  // org membership untouched. Skipped when the row carries only a github_id.
   if (normalizedUsername) {
     try {
       const teamSlug = await teamSlugPromise
@@ -248,8 +249,6 @@ export async function bulkUnenrollStudents(
 
   log.info("bulk unenroll: started", { org, classroom, total: targets.length })
 
-  // Same per-row match predicate as unenrollStudent (shared matchesRosterRow):
-  // username/github_id.
   const matchesTarget = (row: StudentCsvRow, target: Student): boolean =>
     matchesRosterRow(row, target)
 
@@ -341,8 +340,8 @@ export async function bulkUnenrollStudents(
       message: `Updating team membership for ${username || student.email || "student"}...`,
     })
 
-    // Drop from the classroom team (idempotent). Skipped for an email-only row
-    // and when the slug couldn't be resolved.
+    // Drop from the classroom team (idempotent). Skipped for an id-only row and
+    // when the slug couldn't be resolved.
     if (username && teamSlug) {
       try {
         await removeUserFromTeam(client, { org, teamSlug, username })

--- a/web/src/github-core/mutations/inviteTeams.ts
+++ b/web/src/github-core/mutations/inviteTeams.ts
@@ -226,12 +226,13 @@ export async function readInviteTeam(
   }
 }
 
-// Enumerate the org's invite-<hash> teams (secret teams this feature owns),
-// filtering the org team list by the invite- prefix. STRICT: a failed listing
-// throws rather than degrading to [] — the reconcile uses this list to decide
-// which email-only roster rows are still backed by a live invite, and a
-// degraded read must never masquerade as "no invite teams" (which would wipe
-// every pending email row). Owner/member visibility still applies.
+// Enumerate the org's candidate invite teams, filtering the org team list by the
+// `invite-` prefix. That prefix is a namespace, not proof of ownership, so every
+// caller re-checks the description for a valid v1 record before acting. STRICT:
+// a failed listing throws rather than degrading to [] — the reconcile uses this
+// list to decide which email-only roster rows are still backed by a live invite,
+// and a degraded read must never masquerade as "no invite teams" (which would
+// wipe every pending email row). Owner/member visibility still applies.
 export async function listInviteTeams(
   client: GitHubClient,
   org: string,
@@ -244,9 +245,10 @@ export async function listInviteTeams(
   return teams.filter((t) => t.slug && isInviteTeamSlug(t.slug))
 }
 
-// Delete an invite team by slug. Fail-closed: refuses any slug outside the
-// invite- namespace so a caller can't steer a delete into an unrelated team.
-// 404 = already gone (success), so teardown is idempotent.
+// Delete an invite team by slug. Refuses any slug outside the `invite-`
+// namespace so a caller can't steer a delete into an unrelated team; the
+// namespace alone isn't proof of ownership, so callers establish that from the
+// team's v1 record first. 404 = already gone (success), so teardown is idempotent.
 export async function deleteInviteTeam(
   client: GitHubClient,
   org: string,

--- a/web/src/github-core/mutations/orgMembership.ts
+++ b/web/src/github-core/mutations/orgMembership.ts
@@ -42,7 +42,9 @@ export function createOrgInvitation(
 // invitation, or { cancelled: false } on a 404 — the invite was already gone
 // (e.g., a resend replaced it, or it was cancelled elsewhere). A 404 stays
 // non-throwing so resend's cancel-then-recreate and best-effort dismiss still
-// proceed, but the boolean lets a caller avoid reporting a phantom cancel.
+// proceed, but the boolean lets a caller avoid reporting a phantom cancel — and
+// tells a caller retiring an email invite's stored details apart from one whose
+// invitee can still accept a live invitation for the same address.
 export async function cancelOrgInvitation(
   client: GitHubClient,
   input: { org: string; invitationId: number },

--- a/web/src/github-core/queries/invitationReads.ts
+++ b/web/src/github-core/queries/invitationReads.ts
@@ -22,11 +22,12 @@ export async function getOrgFailedInvitations(
 }
 
 // PENDING org invitations across all pages (GET /orgs/{org}/invitations).
-// Owner-only. The liveness source for the invite-team GC: a member-less
-// invite team whose (classroom, email) no longer matches any pending
-// invitation is stale (cancelled/expired). NOT error-tolerated — a degraded
-// read must fail the GC pass closed rather than read as "no live invites"
-// and delete every pending team.
+// Owner-only. The liveness source for the invite lifecycle: the invite-team GC
+// (a member-less invite team whose (classroom, email) matches no pending
+// invitation is stale — cancelled or expired) and the roster sync's dead
+// email-row confirmation. NOT error-tolerated — a degraded read must fail
+// closed rather than read as "no live invites" and delete every pending team or
+// drop every pending row.
 export async function listOrgInvitations(
   client: GitHubClient,
   org: string,

--- a/web/src/hooks/mutations/useDismissFailedInvite.ts
+++ b/web/src/hooks/mutations/useDismissFailedInvite.ts
@@ -26,11 +26,8 @@ export function useDismissFailedInvite(org: string, classroom: string) {
         org,
         invitationId: input.invitationId,
       })
-      // Only retire on a real cancellation: a stale id 404s (cancelled: false)
-      // while a live invitation for the same address may still exist —
-      // resendOrgInvitation recreates before cancelling — and dropping the row
-      // there would delete the invite-time details of someone who can still
-      // accept.
+      // Only retire on a real cancellation (see cancelOrgInvitation's
+      // `cancelled` flag).
       if (result.cancelled && input.inviteEmail) {
         await retireEmailInvite(client, {
           org,

--- a/web/src/hooks/mutations/useEnrollOrInviteStudent.ts
+++ b/web/src/hooks/mutations/useEnrollOrInviteStudent.ts
@@ -19,11 +19,12 @@ export type EnrollOrInviteFormValues = {
 }
 
 // Add one student: a username enrolls via GitHub (resolve, team-add, org
-// invite) and stores the email; an email-only value sends a pure org invite
-// carrying the classroom team (no roster.csv write). Hook owns the cache
-// reconcile — invite-query invalidation plus the optimistic seed-and-reconcile
-// of the enrolled roster; toast/success/warning + form reset stay at the call
-// site (see ./README.md).
+// invite) and stores the email; an email-only value sends an org invite carrying
+// the classroom team plus a per-invite metadata team, and retains the address —
+// with the typed name and section — as a pending roster.csv row. Hook owns the
+// cache reconcile — invite-query invalidation plus the optimistic
+// seed-and-reconcile of the enrolled roster; toast/success/warning + form reset
+// stay at the call site (see ./README.md).
 export function useEnrollOrInviteStudent(
   org: string,
   classroom: string,

--- a/web/src/hooks/useGetStudents.ts
+++ b/web/src/hooks/useGetStudents.ts
@@ -102,4 +102,19 @@ export const useUpdateRosterCache = (
   }
 }
 
+// Drop the cached roster so the next read comes from GitHub. For a write whose
+// post-commit rows the caller doesn't compute (a bulk email invite appends its
+// pending rows inside the domain call), where useUpdateRosterCache's optimistic
+// patch has nothing to write.
+export const useInvalidateRosterCache = (
+  org: string | undefined,
+  classroom: string | undefined,
+) => {
+  const queryClient = useQueryClient()
+  return () => {
+    if (!org || !classroom) return
+    void queryClient.invalidateQueries({ queryKey: rosterKey(org, classroom) })
+  }
+}
+
 export default useGetStudents

--- a/web/src/hooks/useTeamRoster.ts
+++ b/web/src/hooks/useTeamRoster.ts
@@ -93,8 +93,8 @@ export type UseTeamRosterResult = {
   refetch: () => void
 }
 
-// The teacher roster, driven by GitHub (team members + pending org invites),
-// with roster.csv joined only as optional display metadata. Resolves the team
+// The teacher roster, driven by GitHub (team members + each role team's pending
+// invitations), with roster.csv joined only as optional display metadata. Resolves the team
 // slug from classroom.json (fallback classroom50-<classroom>) so the grade
 // collector, Go download, and this view agree on the slug.
 export function useTeamRoster(
@@ -215,18 +215,19 @@ export function useTeamRoster(
       buildTeamRoster({
         members: members ?? [],
         // A non-owner can't read invitations; pass none rather than a partial.
-        // (org invitations forbidden => pendingHidden => the whole pending
-        // section collapses to the owners-only note.)
+        // (the team-scoped pending read forbidden => pendingHidden => the whole
+        // pending section collapses to the owners-only note.)
         invitations: pendingHidden ? [] : invitations,
         staffMembers: {
           teacher: teacherMembers ?? [],
           hta: htaMembers ?? [],
           ta: taMembers ?? [],
         },
-        // Each staff team's pending is independent: an owner who can read org
-        // invitations but hits a per-team 403/error still sees the readable
-        // teams' pending — that team's `data` is undefined -> [] (omitted), not
-        // a hide-all. Zeroed wholesale only when pendingHidden (non-owner).
+        // Each staff team's pending is independent: an owner who can read the
+        // student team's pending but hits a per-team 403/error still sees the
+        // readable teams' pending — that team's `data` is undefined -> []
+        // (omitted), not a hide-all. Zeroed wholesale only when pendingHidden
+        // (non-owner).
         staffInvitations: pendingHidden
           ? {}
           : {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -498,7 +498,7 @@
   },
   "students": {
     "addTitle": "Add member",
-    "addHint": "Enter a GitHub username to add a student with their details, or an email to send an organization invite. Email invites capture no name or section — add those later by username or by uploading a roster.",
+    "addHint": "Enter a GitHub username to add a student with their details, or an email to send an organization invite. An email invite keeps the name and section you enter on a pending roster row until the student accepts.",
     "addRoleLabel": "Role",
     "addStaffHint": "Teachers, head TAs, and TAs are added by GitHub username. Teachers and head TAs get write access to the classroom50 repository; TAs get read-only. A teacher is granted organization owner.",
     "namePlaceholder": "Name (optional)",

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -12,7 +12,10 @@ import InviteLinksModal from "@/pages/students/InviteLinksModal"
 import { GitHubLink } from "@/components/GitHubLink"
 import { useParams } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
-import useGetStudents, { useUpdateRosterCache } from "@/hooks/useGetStudents"
+import useGetStudents, {
+  useUpdateRosterCache,
+  useInvalidateRosterCache,
+} from "@/hooks/useGetStudents"
 import { useTeamRoster, useInvalidateTeamRoster } from "@/hooks/useTeamRoster"
 import { useSuppressedLogins } from "@/hooks/useSuppressedLogins"
 import { invalidateInviteQueries } from "@/github-core/queries"
@@ -45,6 +48,7 @@ const TeamRosterContent = ({
   const client = useGitHubClient()
   const queryClient = useQueryClient()
   const updateRosterCache = useUpdateRosterCache(org, classroom)
+  const invalidateRosterCache = useInvalidateRosterCache(org, classroom)
   const invalidateTeamRoster = useInvalidateTeamRoster(org, classroom)
   // Session-unenrolled logins, owned here so both the roster (which remembers on
   // unenroll and skips them in the auto-backfills) and the Add modal (which
@@ -190,11 +194,13 @@ const TeamRosterContent = ({
               invalidateInviteQueries(queryClient, org)
             }}
             onEmailSuccess={() => {
-              // Email invites write no roster.csv row; they surface as `pending`
-              // rows via the org pending-invitations list, so refresh those + the
-              // team roster to show them at once.
+              // Each invited address is retained as a pending email-only
+              // roster.csv row, and surfaces as a `pending` row through the
+              // classroom team's pending-invitation list. Refresh both, or the
+              // rows just written render without their name and section.
               invalidateInviteQueries(queryClient, org)
               invalidateTeamRoster()
+              invalidateRosterCache()
             }}
           />
           <InviteLinksModal

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -64,7 +64,7 @@ const MemberDetailModal = ({
   }
 
   if (!row) {
-    // No selected member: render nothing (the modal is closed in this state).
+    // Still mounted (empty) so the close animation can run.
     return <Modal open={open} onClose={handleClose} aria-labelledby={titleId} />
   }
 

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -190,23 +190,22 @@ const EnrolledStudents = ({
   // student enrollment) isn't selectable either: bulk-unenroll drops the CSV row
   // + student-team membership, so it only applies to rows with a student
   // enrollment. A student who is ALSO staff IS selectable — unenroll drops only
-  // their student side and leaves the staff role intact — matching the row
-  // modal's unenroll gate (both use hasStudentEnrollment AND
-  // canTargetForUnenroll) so the two never diverge (previously a
-  // student+teacher was removable in the modal but silently skipped by
-  // select-all).
+  // their student side and leaves the staff role intact — matching the row modal
+  // in requiring hasStudentEnrollment, so a student+teacher is never silently
+  // skipped by select-all.
   const isSelf = (row: TeamRosterRow) =>
     isSameGitHubUser(viewer ?? null, {
       github_id: row.github_id,
       username: row.username,
     })
-  // Selectable for the bulk actions bar. The bar offers THREE actions (unenroll,
-  // role change, cancel invite), so eligibility is per-action rather than one
-  // unenroll-shaped gate: a pending email invite can't be unenrolled (the roster
-  // matcher keys on username/github_id, so it would report "already removed"
-  // while the row and the live invitation survive) but cancelling its invitation
-  // is exactly the right bulk action. Gating selection on unenroll alone made
-  // that path unreachable — and a class-sized email invite un-bulk-cancellable.
+  // Selectable for the bulk actions bar. The bar offers THREE actions (resend
+  // invite, cancel invite, unenroll), so eligibility is per-action rather than
+  // one unenroll-shaped gate: a pending email invite can't be unenrolled (the
+  // roster matcher keys on username/github_id, so it would report "already
+  // removed" while the row and the live invitation survive) but cancelling its
+  // invitation is exactly the right bulk action. Gating selection on unenroll
+  // alone made that path unreachable — and a class-sized email invite
+  // un-bulk-cancellable.
   const isSelectable = (row: TeamRosterRow) =>
     !isSelf(row) &&
     hasStudentEnrollment(row) &&

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -86,10 +86,10 @@ const buildUnenrollResult = (
 }
 
 // Roster multi-select toolbar: select-all header + count label, and — once a
-// selection exists — Resend (pending subset only) / Unenroll / Clear. Owns its
-// progress -> results <dialog> for the unenroll run. Resend routes its per-row
-// outcomes into the same results modal. On completion it calls onDone so the
-// page can refresh its roster/invite caches.
+// selection exists — Resend / Cancel invite / Unenroll / Clear, each acting on
+// the subset of the selection it can target. Owns one progress -> results
+// <dialog> shared by all three runs. On completion it calls onDone so the page
+// can refresh its roster/invite caches.
 const RosterBulkActionsBar = ({
   org,
   classroom,

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -43,7 +43,10 @@ import { Badge, Button, EmphasisLtr, Modal, Select } from "@/components/ui"
 // roster row. Shares the identity header with the Org Members modal; everything
 // below is classroom-scoped and gated by row.state:
 //   enrolled -> edit metadata + unenroll
-//   pending  -> resend invite + unenroll (cancels the invite); no edit
+//   pending  -> resend invite + cancel invite, and edit name/section. The
+//               address is locked: it keys the row and hashes into the invite
+//               team name. An email-only pending row can't be unenrolled (it
+//               names no account), so cancelling is the action.
 //   needs_attention_in_org -> assign a role (adds to the chosen team)
 //   needs_attention_not_in_org -> invite to the organization
 //

--- a/web/src/pages/students/RosterPreviewTable.tsx
+++ b/web/src/pages/students/RosterPreviewTable.tsx
@@ -13,10 +13,10 @@ import {
 } from "@/pages/students/rosterImportResolve"
 import { coerceImportRole } from "./rosterImportParse"
 
-// Per-row metadata changes the preflight detected (from metadata_update or
-// role_change outcomes), keyed by identityKey. Drives the cell highlighting +
-// hover tooltips in the preview so the teacher sees exactly which values the
-// import will overwrite, in place, rather than in a separate list.
+// Per-row metadata changes the preflight detected (from metadata_update,
+// role_change, or enroll outcomes), keyed by identityKey. Drives the cell
+// highlighting + hover tooltips in the preview so the teacher sees exactly which
+// values the import will overwrite, in place, rather than in a separate list.
 export type RowChanges = Record<string, MetadataChange[]>
 
 // Per-row role change (current -> CSV role), keyed by identityKey, so the Role
@@ -88,11 +88,11 @@ const PreviewCell = ({
 }
 
 // The identity column. An account row shows its login, tinted with an inline
-// "was <username>" hint when a github_id corrected it — the same treatment the
-// Role column uses for a role change, rather than a hover tooltip a keyboard or
-// touch user can't reach. An email row shows an explicit badge instead of a blank
-// cell, which would otherwise read as missing data (and announce as nothing at
-// all to a screen reader).
+// "file said <username>" hint when a github_id corrected it — the same treatment
+// the Role column uses for a role change, rather than a hover tooltip a keyboard
+// or touch user can't reach. An email row shows an explicit badge instead of a
+// blank cell, which would otherwise read as missing data (and announce as nothing
+// at all to a screen reader).
 const IdentityCell = ({
   row,
   declaredUsername,
@@ -192,7 +192,6 @@ export const RosterPreviewTable = ({
         <tbody>
           {loading
             ? skeletonRows.map((_, index) => (
-                // Decorative loading placeholder — hidden from assistive tech.
                 <tr key={`skeleton-${index}`} aria-hidden="true">
                   <td>{index + 1}</td>
                   <SkeletonCell bar="h-4 w-24" />

--- a/web/src/pages/students/RosterRow.tsx
+++ b/web/src/pages/students/RosterRow.tsx
@@ -10,8 +10,9 @@ import { ClickableRow } from "@/lib/motionComponents"
 import type { TeamRosterRow } from "@/util/teamRoster"
 
 // One roster row: avatar + identity, role/section/state badges, and the
-// selection checkbox (disabled for the signed-in teacher's own row). Clicking
-// the row opens the detail modal; the checkbox is selection-only.
+// selection checkbox (disabled for the viewer's own row and for rows the bulk
+// bar can't act on). Clicking the row opens the detail modal; the checkbox is
+// selection-only.
 export const RosterRow = ({
   row,
   selfRow,

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -705,8 +705,8 @@ const UploadRoster = ({
         {phase === "idle" && (
           <div className="mt-6">
             {/* Drop zone + click-to-pick. One entry for all three formats; the
-                file is auto-classified on receipt and shown in the preview with
-                an override. */}
+                file always opens as Roster CSV — its parser reads all three
+                shapes — with an explicit override in the preview. */}
             <div
               role="button"
               tabIndex={0}

--- a/web/src/pages/students/enrolledStudentsHelpers.ts
+++ b/web/src/pages/students/enrolledStudentsHelpers.ts
@@ -42,9 +42,9 @@ export function groupStudentsBySection<T extends { section?: string }>(
 }
 
 // After a metadata save, where should the open detail modal's selection point?
-// An edit can't change an editable row's identity (rows key on
-// github_id/username; the form edits only name/email/section), so this is
-// normally a no-op — but if the key ever moves, follow it so the modal stays on
+// Rows key on github_id || username || email, and the one field that can be a
+// key — the address of a pending invite — is locked in the form, so this is
+// normally a no-op. If the key ever moves, follow it so the modal stays on
 // the same person instead of snapping shut. Only re-points the row that was
 // saved; any other selection is left alone.
 export function nextSelectedKeyAfterSave(

--- a/web/src/pages/students/rosterImportHeaders.ts
+++ b/web/src/pages/students/rosterImportHeaders.ts
@@ -30,8 +30,9 @@ export const OPTIONAL_IMPORT_HEADERS = [
 ] as const
 
 // Header tokens that mark the first line as a real header row rather than a bare
-// one-value-per-line list, so a file whose only column is `github_id` is
-// diagnosed as a mis-headered CSV instead of treated as a username list.
+// one-value-per-line list, so a file whose only column is `section` is diagnosed
+// as a header row missing an identity column instead of being read as a list of
+// usernames.
 export const RECOGNIZED_IMPORT_HEADERS = [
   ...IDENTITY_IMPORT_HEADERS,
   ...OPTIONAL_IMPORT_HEADERS,

--- a/web/src/pages/students/rosterImportParse.ts
+++ b/web/src/pages/students/rosterImportParse.ts
@@ -170,7 +170,6 @@ const parseRowsWithLines = (text: string) => {
   return { rows, fields: parsed.meta.fields ?? [], errors }
 }
 
-// Read a row's identity cells in precedence order. A present-but-unusable
 // Read a row's identity cells in precedence order, reporting any cell whose
 // content we could not use. A present-but-unusable github_id is recorded ON the
 // identity (so resolution reports it as an unresolvable id rather than the parser

--- a/web/src/pages/students/runRosterImport.ts
+++ b/web/src/pages/students/runRosterImport.ts
@@ -146,9 +146,6 @@ export async function runRosterImport(
         onProgress,
       })
     } catch (err) {
-      // NoNewStudentsError means every row already exists in roster.csv. Benign:
-      // keep the empty result so the completed view renders, and fall through to
-      // the invite pass so a previously rate-limited student is re-invited.
       if (!(err instanceof NoNewStudentsError)) {
         log.error("roster import failed", { err, record: true })
         return {

--- a/web/src/pages/students/uploadClassify.ts
+++ b/web/src/pages/students/uploadClassify.ts
@@ -2,8 +2,8 @@
 // unified upload modal's routing:
 //   - roster-csv:     the DEFAULT and the smart one — a structured CSV with a
 //                     header row (github_id/username/email + optional
-//                     name/section/role), or a bare list whose lines are each
-//                     read as a handle or an address.
+//                     first_name/last_name/name/section/role), or a bare list
+//                     whose lines are each read as a handle or an address.
 //   - username-list:  a manual override forcing every bare line to a GitHub
 //                     handle, even one shaped like an address.
 //   - email-list:     a manual override routing every line to an email

--- a/web/src/util/inviteTeam.ts
+++ b/web/src/util/inviteTeam.ts
@@ -74,8 +74,11 @@ export async function inviteTeamName(
   return `${INVITE_TEAM_PREFIX}${hex.slice(0, INVITE_HASH_HEX_LEN)}`
 }
 
-// True when a team slug is one this feature owns (an `invite-` metadata team),
-// so a GC/enumeration pass can filter org teams to only the ones it may touch.
+// True when a slug is in the `invite-` NAMESPACE, so an enumeration pass can
+// narrow the org team list to candidates. Looser than the shape this feature
+// writes (`invite-<16 hex>`) and looser than the CLI's IsInviteTeamSlug, so a
+// caller that DELETES must also require a valid v1 record — a human team named
+// "Invite Only" slugs into this namespace.
 export function isInviteTeamSlug(slug: string): boolean {
   return slug.startsWith(INVITE_TEAM_PREFIX)
 }

--- a/web/src/util/rosterCsv.ts
+++ b/web/src/util/rosterCsv.ts
@@ -7,7 +7,7 @@ import {
 
 // The pure roster.csv parse/serialize layer, lifted out of the mutation module
 // so problem detection lives next to the other pure roster helpers (teamRoster)
-// and carries no GitHubClient dependency. `api/mutations/students` re-exports
+// and carries no GitHubClient dependency. `domain/students` re-exports
 // every symbol here, so existing importers are unaffected.
 
 export const STUDENT_CSV_FIELDS = [
@@ -122,8 +122,7 @@ export function parseRosterCsv(csv: string): ParsedRosterCsv {
   return { rows, problems }
 }
 
-// Format roster problems into a single-line message for the throwing wrapper
-// and logs. The view uses the structured `problems` instead.
+// The view uses the structured `problems` instead of this flattened form.
 export function formatRosterProblems(problems: RosterCsvProblem[]): string {
   return problems.map((p) => `line ${p.line}: ${p.message}`).join("; ")
 }

--- a/web/src/util/rosterUploadPreflight.ts
+++ b/web/src/util/rosterUploadPreflight.ts
@@ -27,7 +27,8 @@ import {
 //                 additive team-add onto the CSV role's team (no team to leave,
 //                 so no destructive move and no confirmation needed).
 //  - role_change: an active org member whose current classroom role differs from
-//                 the CSV role (student<->ta<->teacher). Requires explicit
+//                 the CSV role (any of student/ta/hta/teacher to any other).
+//                 Requires explicit
 //                 teacher confirmation because applying it MOVES them between
 //                 teams (and a teacher promotion grants org-owner access).
 //
@@ -137,9 +138,9 @@ export type PreflightResult = {
   allAlreadyMembers: boolean
 }
 
-// The highest-precedence role in a set (teacher > ta > student), or undefined
-// for an account on no classroom team. Uses the canonical sortRolesByRank so the
-// precedence order has a single source (teamRoster.ROLE_RANK).
+// The highest-precedence role in a set (teacher > hta > ta > student), or
+// undefined for an account on no classroom team. Uses the canonical
+// sortRolesByRank so the precedence order has a single source (authz ROLE_RANK).
 function primaryOf(roles: ClassroomRole[]): ClassroomRole | undefined {
   return roles.length === 0 ? undefined : sortRolesByRank(roles)[0]
 }
@@ -235,7 +236,8 @@ export function classifyRosterUpload(
     }
 
     // Active member whose current role differs from the CSV role -> a move that
-    // requires confirmation (student<->ta<->teacher, up or down). Carry the
+    // requires confirmation (any of student/ta/hta/teacher to any other, up or
+    // down). Carry the
     // full current role set so the move drops every non-target team, not just
     // the primary one, plus any metadata delta so the move also updates (and
     // shows) the member's changed details rather than folding them in blindly.

--- a/web/src/util/teamRoster.ts
+++ b/web/src/util/teamRoster.ts
@@ -38,7 +38,8 @@ export {
 //
 // Row states:
 //  - enrolled: an active classroom-team / staff-team member.
-//  - pending:  a pending org / staff-team invitation (no active membership yet).
+//  - pending:  a pending invitation on the classroom or a staff team (no active
+//    membership yet).
 //  - needs_attention_in_org: on roster.csv, an active org member, but on none of
 //    this classroom's teams — the teacher assigns them a team/role.
 //  - needs_attention_not_in_org: on roster.csv, NOT an org member and no pending
@@ -134,8 +135,9 @@ const metadataFrom = (
 export type BuildTeamRosterInput = {
   // Active classroom-team / org members (the enrolled source of truth).
   members: GitHubUser[]
-  // Pending org invitations. May be empty for a non-owner who can't read them
-  // (owner-only endpoint) — enrolled rows still render.
+  // Pending invitations on the classroom student team (team-scoped, so they're
+  // already narrowed to this classroom). May be empty for a non-owner who can't
+  // read them (owner-only endpoint) — enrolled rows still render.
   invitations?: GitHubOrgInvitation[]
   // Active members of the per-classroom staff teams, keyed by role. Merged into
   // the same rows as `members` (a person on both the student and teacher
@@ -211,8 +213,8 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
   // Logins of ACTIVE members only. A pending invite for one of these is stale
   // (already enrolled) and skipped — distinct from a login already claimed by
   // another PENDING invite, which must instead union its role onto that pending
-  // row. Adding a not-yet-org-member to a staff team lists the same person in
-  // BOTH the org-level invitations (tagged student) and the team invitations
+  // row. Adding a not-yet-org-member to a staff team lists the same person under
+  // BOTH the student team's invitations (tagged student) and the staff team's
   // (tagged ta/teacher); keying only on member logins would drop the second.
   const memberLogins = new Set<string>()
   // Enrolled rows already emitted, keyed by member id, so a person on several
@@ -258,10 +260,11 @@ export function buildTeamRoster(input: BuildTeamRosterInput): TeamRosterRow[] {
 
   // Pending, tagged by role. Staff-team invitations are AUTHORITATIVE for a
   // staff role and are processed FIRST: adding a not-yet-org-member to a staff
-  // team lists them in BOTH the team invitations (tagged ta/teacher) AND the
-  // org-level invitations (which we can only blanket-tag "student"). Ordering
-  // staff first lets the org-level "student" invite recognize the person as an
-  // already-tagged pending staffer and NOT add a spurious "student" role.
+  // team lists them under BOTH that team's invitations (tagged ta/teacher) AND
+  // the student team's (which we can only blanket-tag "student", since a
+  // team-scoped invite carries no role). Ordering staff first lets the student
+  // invite recognize the person as an already-tagged pending staffer and NOT add
+  // a spurious "student" role.
   const roleInvites: Array<{
     role: ClassroomRole
     invite: GitHubOrgInvitation

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -482,8 +482,9 @@ records the role of the classroom team the account was found on, so a staff memb
 who accepted an email invitation is recorded with their staff role rather than as
 a student. A role already recorded is never rewritten.
 
-The web app runs the same sync when a teacher opens the roster; this is the same
-work without a browser. For every trigger, see
+The web app runs this same sync when a teacher opens the roster, and
+additionally refreshes each row's recorded `role` from live team membership; this
+is the rest of that work without a browser. For every trigger, see
 [What triggers a sync](How-Classroom-50-Works#what-triggers-a-sync).
 
 **Dry run unless you pass `--write`**: without it, no write request is issued at

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -114,7 +114,7 @@ organization.
 Create a **fine-grained personal access token** at **Settings → Developer
 settings → Personal access tokens → Fine-grained tokens → Generate new token**:
 
-1. **Token name** — e.g., `classroom50-<org>`.
+1. **Token name** — `classroom50-<org>`, for example.
 2. **Resource owner** — select **the organization**. This is critical: the token
    can only reach repos owned by the resource owner you pick.
 3. **Expiration** — up to 1 year. Set a reminder to rotate it.
@@ -133,9 +133,10 @@ settings → Personal access tokens → Fine-grained tokens → Generate new tok
 > token you create is auto-approved even if your org requires approval for
 > fine-grained PATs.
 
-**Supply the token** via the `CLASSROOM50_SERVICE_TOKEN` environment variable or
-the interactive prompt — there is no `--token` flag (command-line tokens leak
-via shell history). `init` validates the token against your organization before
+**Supply the token** through the `CLASSROOM50_SERVICE_TOKEN` environment variable
+or the interactive prompt. There is no `--token` flag, because command-line tokens
+leak through shell history. `init` validates the token against your organization
+before
 storing it. On a re-run, an existing secret is left untouched; to replace it, set
 the variable and re-run, or use `gh teacher rotate-service-token <org>`.
 
@@ -212,7 +213,7 @@ Each classroom is a directory in `<org>/classroom50` holding four files:
 | File | Purpose |
 | --- | --- |
 | `classroom.json` | Name, term, and organization metadata. |
-| `assignments.json` | The assignment manifest (published via Pages; read by `gh student accept` and the autograde runner). |
+| `assignments.json` | The assignment manifest (published through Pages; read by `gh student accept` and the autograde runner). |
 | `roster.csv` | The roster (private). |
 | `scores.json` | Collected scores (private). |
 
@@ -265,7 +266,7 @@ pending invite when they accept their first assignment.
 **Other targets:**
 
 ```sh
-gh teacher invite --admin <org> <username>              # invite as org admin (e.g., a TA)
+gh teacher invite --admin <org> <username>              # invite as org admin (a TA, for example)
 gh teacher invite <org>/<repo> <username>               # invite to one repo (default: push)
 gh teacher invite -p maintain <org>/<repo> <username>   # other permissions
 ```
@@ -273,7 +274,7 @@ gh teacher invite -p maintain <org>/<repo> <username>   # other permissions
 `-p` accepts `pull`, `triage`, `push`, `maintain`, `admin`. Re-running updates
 the collaborator's permission in place.
 
-**Adding staff:** to give a TA or co-teacher a classroom role (not just org
+**Adding staff:** to give a TA or co-teacher a classroom role (not only org
 membership), use `gh teacher staff add <org> <classroom> <username> --role
 teacher|hta|ta`. For the roles and what each can see, see
 [Staff, TAs, and multiple teachers](Staff-TAs-and-Multiple-Teachers).
@@ -322,7 +323,7 @@ gh teacher roster import <org> <classroom> <path-to-csv>
 
 Accepts three header shapes: the stored roster header
 (`username,first_name,last_name,email,section,github_id,role`), the same without
-`role`, and just the first five columns, so a `roster.csv` exported from a
+`role`, and the first five columns alone, so a `roster.csv` exported from a
 web-managed classroom imports verbatim. The column-by-column reference is in
 [Roster CSV fields](Web-Teacher-Guide#roster-csv-fields).
 
@@ -363,7 +364,7 @@ gh teacher roster remove <org> <classroom> <username>
 > able to revoke a student's access to every repo in the organization.
 
 > [!NOTE]
-> Roster writes use an optimistic-rebase loop, so two teachers editing at once
+> Roster writes retry on top of each other, so two teachers editing at once
 > can't lose each other's work. If you see `lost the rebase race`, retry.
 
 ### Inviting a student by email
@@ -390,7 +391,9 @@ pending invitation, is reported as skipped and the command exits 0.
 
 It refuses to send in two cases: the classroom has no usable team recorded in
 `classroom.json`, or the roster already lists the address as a **pending
-invitation**. An address some *other* row merely carries is a shared address (a
+invitation**. (With `--file` that second case is a skip rather than a refusal, so
+one already-invited address doesn't stop the batch.) An address some *other* row
+merely carries is a shared address (a
 parent, a lab contact), so the real person still gets invited: the invitation is
 sent, a note on stderr names that row, and **no second row is written**. If the
 invitation fails outright, an invite team this run created is cleaned up again,
@@ -414,9 +417,11 @@ the batch. Each address is reported as it resolves, then a summary counts them �
 invited, already members/invited, already on the roster, failed, or deferred —
 and every skipped or failed address is named with its file line. Bulk mode is
 **student-only** and carries no names or sections, so the `--first-name` /
-`--last-name` / `--section` flags are **rejected** with `--file`; fill that
-metadata in afterwards with [`roster import`](#bulk-import-from-a-csv) or
-[`roster sync`](#syncing-the-roster-with-github).
+`--last-name` / `--section` flags are **rejected** with `--file`. Fill that
+metadata in afterwards with [`roster import`](gh-teacher#roster-import), or with
+`roster update` once the student has accepted and has a username. A sync never
+writes a name or a section: those columns are yours, and are never derived from a
+GitHub profile.
 
 Exit codes match [`roster sync`](#syncing-the-roster-with-github) so a script can
 tell a retryable run from a broken one:
@@ -513,7 +518,7 @@ Wrap the call in `set +e` (or the `case` above) if your script runs under `set
 
 > [!NOTE]
 > `sync` is deliberately conservative. Any degraded read, whether GitHub's
-> pending invitations or one of the invite teams, makes the whole pass read-mostly
+> pending invitations or one of the invite teams, makes the whole pass report-only
 > and exits `1`, because an unreadable team can't prove that a pending row is
 > dead. No row is dropped and no invite team is deleted at all. Warnings about a
 > team it left standing go to stderr; the planned edits go to stdout.
@@ -538,13 +543,13 @@ and the autograding setup). The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 | --- | --- |
 | `--template <owner>/<repo>[@branch]` | Starter-code repository (must be flagged as a template). Branch defaults to the template's default. |
 | `--description <text>` | Short description. |
-| `--due <ISO-8601>` | Due date, e.g., `2026-09-15T23:59:00-04:00`. Stored as UTC; local timezone assumed if you omit the offset. A bare date with no time is rejected. |
+| `--due <ISO-8601>` | Due date, such as `2026-09-15T23:59:00-04:00`. Stored as UTC; local timezone assumed if you omit the offset. A bare date with no time is rejected. |
 | `--mode individual\|group` | `individual` (default) or `group`. Group requires `--max-group-size`. |
 | `--max-group-size <N>` | Max collaborators on a group repo (2–100). Advisory, not hard-enforced. |
 | `--runtime <path>` | JSON describing the autograde environment (`runs-on`, language versions, `apt`, or a `container`). Omit for ubuntu-latest + Python 3.14. See [Advanced Autograding](Advanced-Autograding#the-runtime-block). |
 | `--autograder <name>` | Reserved for swapping the whole reusable workflow (rare). Use `--runtime` for language toolchains. |
 | `--submission-mode every-push\|tag` | When the autograder fires. `every-push` (default) grades every push; `tag` grades only on explicit submits (`gh student submit`, or a hand-pushed `submit/*` tag) — regular pushes cost no Actions minutes, the cost lever for large classrooms. |
-| `--submission-tag <pattern>` | Milestone tag (repeatable) that also triggers grading — e.g. `--submission-tag phase1 --submission-tag phase2`. Students grade a milestone with plain git: `git tag phase1 && git push origin phase1`. Works with either mode; the graded record still appears as a `submit/*` release. |
+| `--submission-tag <pattern>` | Milestone tag (repeatable) that also triggers grading, such as `--submission-tag phase1 --submission-tag phase2`. Students grade a milestone with plain git: `git tag phase1 && git push origin phase1`. Works with either mode; the graded record still appears as a `submit/*` release. |
 
 > [!NOTE]
 > **Custom grading isn't registered here.** Drop an `autograder.py` at
@@ -636,13 +641,13 @@ the `schedule:` block in `.github/workflows/collect-scores.yaml`.
 <details>
 <summary>What each collection run does</summary>
 
-1. Iterates each classroom (or just the one you passed).
+1. Iterates each classroom (or only the one you passed).
 2. For each `(member, assignment)` pair — every student team member plus every
    staff team member, narrowed to one assignment when you passed
    `assignment=` — computes the repo name
    `<classroom>-<assignment>-<username>` and walks its `submit/*` releases. No
    releases means the member hasn't accepted or submitted yet (a staff member
-   who never accepted simply drops out here).
+   who never accepted drops out here).
 3. Downloads and schema-validates each `result.json`, checking its identity
    against the source repo (a hostile payload can't land in another student's
    scores). For a group assignment, it reads the repo's collaborators and

--- a/wiki/Course-Lifecycle-and-End-of-Term.md
+++ b/wiki/Course-Lifecycle-and-End-of-Term.md
@@ -86,14 +86,14 @@ Wrap up a finished course in this order:
 
    If you invited students by email, clear the stored addresses before you
    archive: an archived classroom's roster is frozen, so nothing can be
-   recorded onto it afterwards. Each invitation holds the address in a hidden
+   recorded onto it afterwards. Each invitation holds the address in a `secret`
    invite team until the student joins. **Clean up invite data**, on the
    classroom's Settings page, writes anything still recoverable onto the
    roster and deletes every remaining team. From a terminal,
-   `gh teacher roster sync <org> <classroom> --write` does less: it records the
-   invitations that were accepted and retires the teams that are done, but
-   keeps a team whose invitation is still pending. It is refused once the
-   classroom is archived.
+   `gh teacher roster sync cs50-fall-2026 cs-principles --write` does less: it
+   records the invitations that were accepted and retires the teams that are
+   done, but keeps a team whose invitation is still pending. `roster sync
+   --write` is refused once the classroom is archived.
 4. Optionally, archive the student repositories on GitHub. Archiving a
    repository makes it read-only for everyone while preserving it. Classroom
    50 has no bulk action for this yet, but the GitHub CLI handles it. List

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -83,17 +83,20 @@ address**, so one file can mix students whose handle you know with ones you
 only have an address for. Each address goes onto the roster right away as a
 pending row, and is matched to the student's GitHub account when they accept.
 
-Bulk email invitations are web-app-only. From the CLI, invite one address per run
-with `gh teacher roster invite <org> <classroom> <email>`.
-`gh teacher roster import` adds and invites every student a stored `roster.csv`
-identifies by username, but it never sends an email invitation: on an email-only
-row it updates only the name and section, leaving the invitation alone. See
+From the CLI, invite one address with
+`gh teacher roster invite cs50-fall-2026 cs-principles ada@example.edu`, or a
+whole list with `--file`, a plaintext file holding one address per line. Only the
+web app can invite **staff** by email; `gh teacher roster invite` always sends a
+student invitation. `gh teacher roster import` adds and invites every student a
+stored `roster.csv` identifies by username, but it never sends an email
+invitation: on an email-only row it updates only the name and section, leaving the
+invitation alone. See
 [Invitations by email](How-Classroom-50-Works#invitations-by-email) and
 [Roster CSV fields](Web-Teacher-Guide#roster-csv-fields).
 
 ### Can I see the whole roster, including students who haven't accepted?
 
-Yes. The submissions view lists every rostered student, not just those who
+Yes. The submissions view lists every rostered student, not only those who
 accepted, with their status — so you can see at a glance who hasn't started.
 Students you invited by email appear too, listed by address until they accept,
 though only organization owners see them: GitHub keeps pending invitations
@@ -171,7 +174,7 @@ Both start from no template; the difference is what (if anything) is committed:
 only affects repositories accepted from then on** — repositories students
 already accepted aren't retrofitted, so they keep their original shape. The web
 edit form asks you to confirm when students have already accepted. (**Assignment
-type** — Individual vs. Group — is the exception and stays locked, since
+type** — Individual or Group — is the exception and stays locked, since
 switching it would invalidate existing submissions.) For every shape in one
 table, see [Repository shapes](Assignment-Templates#repository-shapes).
 
@@ -218,7 +221,7 @@ what your assignments need in the runner image. See
 ### Can the autograder show students *why* a test failed?
 
 Yes. Each submission's Release and the Actions run summary include a per-test
-breakdown (expected vs. actual output for I/O tests, captured stderr). A custom
+breakdown (expected against actual output for I/O tests, captured stderr). A custom
 `autograder.py` can add its own diagnostic messages to `result.json`.
 
 ### Can students use GitHub Codespaces?
@@ -273,7 +276,7 @@ Overridden scores show a **Manual** badge and aren't changed by autograding
 until you clear the override. Use **Clear override** in the dialog to revert.
 
 This editor appears only for organization owners (writing a score writes the
-`classroom50` repository). Under the hood, an override is just an entry in the classroom's
+`classroom50` repository). Under the hood, an override is an entry in the classroom's
 `scores.json` with `"override": true`, which collection leaves untouched on
 future runs — so you can still edit it by hand if you prefer (see
 [Collect scores](CLI-Teacher-Guide#9-collect-scores)).
@@ -283,8 +286,8 @@ future runs — so you can still edit it by hand if you prefer (see
 Download scores as a CSV from the submissions page
 (**Download scores (CSV)**). For the work itself, **Download all submissions**
 in the same **Actions** menu bundles every repository's latest submission into
-a single zip (built in your browser). For real clones — e.g. to run your own
-tooling locally — `gh teacher download` clones every submission repo and also
+a single zip (built in your browser). For real clones, to run your own
+tooling locally, `gh teacher download` clones every submission repository and also
 writes a `scores.csv` summary at the destination root. The raw score data also
 lives in `scores.json` in your `classroom50` repository, so you can build your own
 automations against it. The column-by-column reference for both CSVs is in

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -81,7 +81,7 @@ Opening the classroom in the web app as an owner does the same on its own. Witho
 `--write`, `roster sync` reports and changes nothing. **Sync now** covers scores.
 See [What triggers a sync](#what-triggers-a-sync).
 
-## Interactive vs. background work
+## Interactive and background work
 
 Work happens in one of two ways. Knowing which applies explains most questions
 about why a change did or did not take effect:
@@ -165,11 +165,10 @@ account. Classroom 50 bridges that gap with an **invite team**.
 The web app and the teacher CLI both invite this way, and each reads the other's
 invite teams, so an invitation sent from one can be completed or revoked from the
 other. In the app, invite from the classroom's **Roster** page; from the CLI, use
-`gh teacher roster invite`, one address per run. Two things only the web app does:
-inviting a list of addresses in one upload, and inviting someone by email as a
-teacher, head TA, or TA. A `gh teacher roster invite` is always a student
-invitation, so it can never hand out organization ownership from a mistyped
-address.
+`gh teacher roster invite`, one address at a time or a whole list with `--file`.
+One thing only the web app does: inviting someone by email as a teacher, head TA,
+or TA. A `gh teacher roster invite` is always a student invitation, so it can
+never hand out organization ownership from a mistyped address.
 
 An outstanding invitation keeps its team and its pending row, so a teacher can see
 who was invited. Cancelling one, from the app's roster or with
@@ -321,7 +320,7 @@ tool (or an org/enterprise policy) is changing it back.
 
 ## How grading flows
 
-1. A student pushes to their repository (via `gh student submit` or a plain
+1. A student pushes to their repository (with `gh student submit` or a plain
    `git push`).
 2. A small workflow in their repo calls the shared **autograde runner** in your
    `classroom50` repository, which fetches the grading logic from Pages and runs it.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -29,20 +29,20 @@ Commands with informational output also accept `--quiet` / `-q`.
 ### classroom50.org won't load, or is flagged as unsafe
 
 A few ISPs and school web filters have blocked `classroom50.org` (a relatively
-new domain) as a suspected phishing site — the symptom is a timeout, a
-DNS failure, or an ISP warning page (Safari may just time out without showing
-the warning). Classroom 50 is not compromised; we file unblock requests with
-ISPs and security vendors as reports come in.
+new domain) as a suspected phishing site. The symptom is a timeout, a
+DNS failure, or an ISP warning page (Safari can time out without showing
+the warning). Classroom 50 is not compromised; unblock requests go to ISPs and
+security vendors as reports come in.
 
 Workarounds:
 
-- **Add an exception.** On a home connection, add `classroom50.org` to the
-  ISP's security-feature exception list (e.g. AT&T ActiveArmor) or switch the
-  device's DNS resolver (e.g. `1.1.1.1` or `8.8.8.8`).
-- **School/district filters:** ask IT to allow the domains in
+- **Home connections.** Add `classroom50.org` to the ISP's security-feature
+  exception list (AT&T ActiveArmor, for example) or switch the device's DNS
+  resolver to `1.1.1.1` or `8.8.8.8`.
+- **School and district filters.** Ask IT to allow the domains in
   [Network and allowed domains](GitHub-Integration#network-and-allowed-domains).
-- Please still [report it](https://github.com/foundation50/classroom50/issues)
-  with the ISP's name so we can request an unblock.
+- **Reporting a block.** [Open an issue](https://github.com/foundation50/classroom50/issues)
+  with the ISP's name, which is what an unblock request needs.
 
 ### "Network error reaching the Cloudflare Worker proxy"
 
@@ -116,7 +116,7 @@ still leaves the browser grant to do.
 Setup creates a **$0 GitHub Actions spending cap** so a runaway workflow can't
 run up a bill — but only when your organization has no Actions cap yet; a cap
 you set yourself is never modified. It then verifies the cap, and that
-verification can fail with an advisory warning (e.g. `read failed (400)`) when
+verification can fail with an advisory warning (for example, `read failed (400)`) when
 billing isn't readable by your token — typically **enterprise-managed
 billing**, a plan that doesn't expose organization budgets, or a token without
 Organization Administration read.
@@ -152,7 +152,7 @@ token, which makes you a member of each, then removes you from all but the
 
 ### `git/trees: HTTP 404` on `gh teacher init`
 
-`init` commits workflow files via the Git Data API, which GitHub gates behind
+`init` commits workflow files with the Git Data API, which GitHub gates behind
 the `workflow` scope. A token without it is rejected with a misleading 404,
 leaving `classroom50` with only a README. Re-authenticate:
 
@@ -194,7 +194,7 @@ gh auth refresh -h github.com -s admin:org,read:org,repo,workflow   # widen in p
 export GH_TOKEN=<a PAT with those scopes>                           # or bring your own
 ```
 
-So if `gh` is already set up, you usually don't need `login` at all — just run
+So if `gh` is already set up, you usually don't need `login` at all — run
 the command you want and let it add any missing scope in place.
 
 With **multiple `gh` accounts**, the CLIs use whichever account is active for
@@ -537,7 +537,7 @@ Students generate their repositories from the template, and GitHub can't
 generate from an empty repository. The CLI refuses with:
 
 ```text
-template `<owner>/<repo>` has no commits — add at least one commit (e.g. a README) so students can generate from it, then re-run
+template `<owner>/<repo>` has no commits — add at least one commit (a README, for example) so students can generate from it, then re-run
 ```
 
 Push at least one commit (a README is enough) and re-run. If the template does
@@ -684,7 +684,7 @@ instead — a not-graded commit never shows green there). To be graded, submit e
 - `gh student submit` (it pushes the `submit/…` tag that triggers grading), or
 - tag a commit yourself: `git tag submit/final && git push origin
   submit/final` — any tag under `submit/` grades, plus any milestone tag
-  your teacher named (e.g. `git tag phase1 && git push origin phase1`).
+  your teacher named, such as `git tag phase1 && git push origin phase1`.
 
 If a push shows NO workflow run at all, that's normal for tag mode too: the
 repo's workflow only fires on submission tags.

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -9,7 +9,7 @@ create a classroom → create assignments → add students → share accept link
 collect submissions.
 
 > [!TIP]
-> Have feedback, a bug, or an idea? Reach out in our
+> Have feedback, a bug, or an idea? Raise it in the project's
 > [discussions](https://github.com/foundation50/classroom50/discussions).
 
 ## Before you start: GitHub setup
@@ -159,22 +159,23 @@ How each student's repository is created:
 
 - **Start with a template** — **No template** or **Template repository**: a
   [template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository)
-  used as each student's starting point. Enter `<owner>/<repo>`, or just
-  `<repo>` if it's in this organization. See
+  used as each student's starting point. Enter `OWNER/REPOSITORY`, or
+  `REPOSITORY` alone if it's in this organization, replacing each with the
+  template's owner and name. See
   [Assignment Templates](Assignment-Templates) for requirements.
 - **Add a README** (no-template assignments) — whether the repository starts
   with an initial commit. With it **off**, what students get depends on the
   built-in autograder choice under [Submission and
   grading](#submission-and-grading):
   - autograder **off** → a **truly bare repository**: no commit,
-    no autograding, and no feedback pull request (permanently — not just until
+    no autograding, and no feedback pull request (permanently, not only until
     the student's first commit). Use it when students build everything from
     scratch, including their own GitHub Actions.
   - autograder **on** → an initialized repository carrying only the control
     files (no README, no starter content) that grades normally.
 - **Include all branches** (templated) — copy **all** of the template's
-  branches into each student repository, not just the default branch. Useful
-  for multi-branch starter repos.
+  branches into each student repository, not only the default branch. Useful
+  for multi-branch template repositories.
 - **Feedback pull request** — automatically opens a pull request per student so
   you can review changes and leave inline feedback.
 
@@ -208,7 +209,7 @@ section — most assignments never need them:
 > retrofitted, so they keep their original starter code and setup. When at least
 > one student has already accepted, the edit form asks you to confirm and warns
 > that you'll need to update the existing repositories yourself. (**Assignment
-> type** — Individual vs. Group — is the exception: it stays locked on edit,
+> type** — Individual or Group — is the exception: it stays locked on edit,
 > because switching it would invalidate every existing submission.)
 
 ### Submission and grading
@@ -231,7 +232,7 @@ section — most assignments never need them:
   branch** (the default) grades each push. **A tagged commit** grades only
   when a student submits (`gh student submit`) or pushes a `submit/*` tag —
   regular pushes cost no Actions minutes, which matters at scale.
-- **Submission tags** (optional) — tag names (e.g. `phase1`, `phase2`,
+- **Submission tags** (optional) — tag names such as `phase1`, `phase2`,
   `complete`) that also trigger grading. A student pushes the tag with plain
   git (`git tag phase1 && git push origin phase1`) and that commit grades; the
   result appears as a normal `submit/*` release titled "via phase1". Prefer
@@ -368,7 +369,7 @@ then `username`, then `email`:
 | Column | Identifies a student | Description |
 | --- | --- | --- |
 | `github_id` | Yes, first choice | The account's immutable numeric id, as written by Classroom 50's own `roster.csv`. Used to look up the account's current username, so a student who renamed their account is still found. |
-| `username` | Yes, if there's no `github_id` | The student's GitHub username, e.g. `octocat`. |
+| `username` | Yes, if there's no `github_id` | The student's GitHub username, such as `octocat`. |
 | `email` | Yes, if there's neither | Invites the student by email. Also stored as their contact email on every row. |
 | `first_name` | No | Given name, for display and score exports. |
 | `last_name` | No | Family name, for display and score exports. |
@@ -493,9 +494,9 @@ last synced (a per-assignment `collected_at` stamp in `scores.json`). Click
 
 The top of the page shows:
 
-- **Submitted** — submissions vs. students enrolled.
+- **Submitted** — submissions against students enrolled.
 - **Classroom average** — average score among students who submitted.
-- **Passing** — how many students are passing vs. failing.
+- **Passing** — how many students are passing and how many are failing.
 - **Accepted** — how many students accepted (one per student).
 
 > [!TIP]
@@ -538,7 +539,7 @@ assignment:
 - **Collect now** — trigger a score collection scoped to this assignment.
 - **Regrade all** — re-run the autograder on every collected submission.
 - **Update student repo access** — bulk-set every student's role on their
-  repository (e.g. drop everyone to read-only for grading, restore write
+  repository (drop everyone to read-only for grading, then restore write
   afterwards).
 - **Update repository features** — re-apply the assignment's Issues / Wiki /
   Projects / Pull-requests settings to every existing student repository
@@ -547,7 +548,7 @@ assignment:
 - **Update autograding triggers** — retrofit existing repositories after a
   submission-type change (see below).
 - **Pause autograding** / **Resume autograding** — disable or re-enable the
-  built-in `autograde.yaml` workflow in every student repository via GitHub's
+  built-in `autograde.yaml` workflow in every student repository with GitHub's
   workflow-disable API. No files are changed, and you can resume anytime;
   other workflows in student repositories keep running. Use it to stop
   autograding for one assignment without touching the rest of the org.
@@ -581,7 +582,7 @@ spreadsheet or external tool. The column-by-column reference is in
   Same form as creating one, pre-filled. Provisioning settings (repository
   source, built-in autograder, grading mode) are editable; a change only affects
   repositories accepted from then on, so the form asks you to confirm when
-  students have already accepted. **Assignment type** (Individual vs. Group)
+  students have already accepted. **Assignment type** (Individual or Group)
   stays locked, since switching it would invalidate existing submissions.
 - **Edit a classroom** — open the classroom, then **Settings**. Same form as
   creating one, pre-filled. The page also offers **Clean up invite data**, which

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -421,8 +421,10 @@ gh teacher roster sync <org> <classroom> --write    # apply
 Catches `roster.csv` up with GitHub: records the students who accepted an email
 invitation, fills in a missing `github_id` from the classroom team's membership,
 drops the pending rows nothing backs, and deletes the invite teams that are done.
-The web app runs the same sync when a teacher opens the roster; here it's
-explicit and script-callable.
+The web app runs this same sync when a teacher opens the roster; here it's
+explicit and script-callable. The web app's pass does two things more: it
+refreshes each row's recorded `role` from live team membership, and it adds a row
+for a classroom-team member the roster is missing.
 
 Its scope is the email-invite lifecycle and `github_id`. It never rewrites a
 `role` already recorded on a row, and it doesn't add rows for organization
@@ -847,6 +849,11 @@ Shows *actual* GitHub membership (the roster is the *intended* list), so you can
 spot mismatches, such as a student who never accepted their invitation. Default is an
 aligned table; `--json` emits `{login, kind, role, github_id}`; `--quiet` prints
 one login per line. Reading org invitations needs `admin:org`. Read-only.
+
+On a `member` or `collaborator` row, `github_id` is the account's id. On a
+`pending invitation` row it is the **invitation's** id instead, since GitHub's
+invitations API reports no account id for an invitee, so don't join it against
+`roster.csv`'s `github_id`.
 
 ## `download`
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -12,8 +12,8 @@ output, or `--verbose` / `-v` for per-step detail.
 | Command | Description |
 | --- | --- |
 | `whoami` | Print the authenticated GitHub user. |
-| `login` | Log in with the Classroom 50 scopes (`admin:org`, `read:org`, `repo`, `workflow`). Add scopes with `-s` (e.g., `delete_repo`). |
-| `logout` | Log out via `gh auth logout`. |
+| `login` | Log in with the Classroom 50 scopes (`admin:org`, `read:org`, `repo`, `workflow`). Add scopes with `-s`, such as `delete_repo`. |
+| `logout` | Log out with `gh auth logout`. |
 | `init <org>` | Set up `<org>/classroom50` (org lockdown, repository, Pages, branch protection, service token). Idempotent. |
 | `audit <org>` | Read-only audit of the org member-privilege lockdown. |
 | `rotate-service-token <org>` | Replace the `CLASSROOM50_SERVICE_TOKEN` secret. |
@@ -288,7 +288,7 @@ and author grading under `<classroom>/autograders/<slug>/`.
 ## `roster`
 
 Manage student rows in `<org>/classroom50/<classroom>/roster.csv`. All write
-subcommands use an optimistic-rebase loop (up to 5 retries), so concurrent
+subcommands retry on top of each other (up to 5 attempts), so concurrent
 teacher edits don't lose each other's work. Every row for a student who has
 joined carries an immutable numeric `github_id` (CLI-managed — don't hand-edit
 it) so a username change doesn't desynchronize records. A student invited by
@@ -341,9 +341,9 @@ with `gh teacher staff add` once the person has an account.
 
 Once the student accepts, `roster sync` fills in their username and `github_id`.
 
-Non-zero on: a classroom with no usable team recorded in `classroom.json`
-(nothing is sent), an address the roster already lists **as a pending
-invitation**, or a failed invitation. An address that already belongs to an
+A single address is non-zero on: a classroom with no usable team recorded in
+`classroom.json` (nothing is sent), an address the roster already lists **as a
+pending invitation**, or a failed invitation. An address that already belongs to an
 organization member, or that already has a pending invitation, is reported as
 skipped and exits **0**.
 
@@ -371,14 +371,18 @@ in **one** roster commit. Every skipped or failed address is named with its file
 line.
 
 Bulk mode is student-only and carries no name/section metadata, so
-`--first-name`, `--last-name`, and `--section` are rejected with `--file`;
-backfill with `roster import` or `roster sync`.
+`--first-name`, `--last-name`, and `--section` are rejected with `--file`. Fill
+that metadata in afterwards with `roster import`, or with `roster update` once the
+student has accepted and has a username. A sync never writes a name or a section:
+those columns are yours, and are never derived from a GitHub profile.
 
 Exit codes follow [`roster sync`](#roster-sync): **0** all invited or cleanly
 skipped, **2** nothing failed but a rate limit left addresses uninvited, **1** an
-address failed or the roster write failed. On a rate limit the run stops sending,
-waits out `Retry-After` before recording what it already sent, and reports the
-rest; re-running is safe, since already-invited addresses skip.
+address failed or the roster write failed. An address the roster already lists as
+pending is a skip here, not a failure, so it doesn't change the exit code. On a
+rate limit the run stops sending, waits out `Retry-After` before recording what it
+already sent, and reports the rest; re-running is safe, since already-invited
+addresses skip.
 
 ### `roster cancel-invite`
 
@@ -446,7 +450,7 @@ Exit codes follow `terraform plan -detailed-exitcode`:
 | `2` | A dry run found changes pending. |
 
 Conservative by construction. Any degraded read (the pending-invitation list, a
-team) makes the whole pass read-mostly: no row is dropped and **no invite team is
+team) makes the whole pass report-only: no row is dropped and **no invite team is
 deleted at all**, not even one whose address the roster already records. Such a
 pass doesn't report a deletion it won't make. A team whose stored address no
 longer hashes to its name, or that has more than one member, is reported on
@@ -482,7 +486,7 @@ gh teacher roster import <org> <classroom> <path-to-csv>
 
 Bulk upsert. Accepts three header shapes: the stored roster shape
 (`username,first_name,last_name,email,section,github_id,role`), the same without
-`role`, and just the first five columns, so a `roster.csv` exported from a
+`role`, and the first five columns alone, so a `roster.csv` exported from a
 web-managed classroom imports verbatim. The field reference is in
 [Roster CSV fields](Web-Teacher-Guide#roster-csv-fields).
 
@@ -497,7 +501,8 @@ Each row is routed by what identifies it:
   sends or cancels an invitation, and never creates an identity-less row, so an
   address with no pending row is skipped with a notice. Send the invitation with
   [`roster invite`](#roster-invite) first.
-- **A `github_id` with no `username`.** Round-trip cargo: `import` resolves
+- **A `github_id` with no `username`.** The one shape a round-trip can't
+  preserve: `import` resolves
   students by username and has no id-to-account lookup, so the row is skipped
   with a notice pointing at the web app's **Upload**, and anything stored for
   that student is left untouched. A row whose `github_id` cell is present but
@@ -560,8 +565,8 @@ The CLI-visible effects:
 ## `assignment`
 
 Manage entries in `<org>/classroom50/<classroom>/assignments.json` — the manifest
-the autograde workflow and `gh student accept` both read. Writes use the same
-optimistic-rebase loop as roster commands.
+the autograde workflow and `gh student accept` both read. Writes retry on top of
+each other, the same as roster commands.
 
 ### `assignment add`
 
@@ -584,7 +589,7 @@ The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 | --- | --- |
 | `--template <owner>/<repo>[@branch]` | Starter-code repo (must be flagged as a template). Omit for a template-less assignment (an initialized repo: README plus the control files). Branch defaults to the template's default. |
 | `--description <text>` | Short description. |
-| `--due <ISO-8601>` | Due date, e.g. `2026-09-15T23:59:00-04:00`. Stored as UTC; the machine's local timezone is assumed if you omit the offset. |
+| `--due <ISO-8601>` | Due date, such as `2026-09-15T23:59:00-04:00`. Stored as UTC; the machine's local timezone is assumed if you omit the offset. |
 | `--available-from <ISO-8601>` | Release date; stored as UTC (local timezone assumed without an offset). Assignments are hidden from the student list by default (invite-link accept only); set this to list it for everyone once the date passes. Listing-only, not access control: students who already accepted always see it. |
 | `--mode individual\|group` | `individual` (default) or `group` (requires `--max-group-size`). |
 | `--max-group-size <N>` | Max group collaborators (2–100). Advisory. |
@@ -601,7 +606,7 @@ The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
 
 **Where grading logic lives** (increasing effort): declarative `--tests` → a
 per-assignment `<classroom>/autograders/<slug>/autograder.py` → a classroom
-default via `gh teacher autograder set-default`. See
+default with `gh teacher autograder set-default`. See
 [Autograding Basics](Autograding-Basics#declarative-tests) and
 [Advanced Autograding](Advanced-Autograding#writing-an-autograderpy).
 
@@ -704,7 +709,7 @@ reach already-accepted repos without the retrofit.
 | Flag | Purpose |
 | --- | --- |
 | `--update-shims` | Retrofit each existing repo's shim (default on). `--update-shims=false` flips only the assignments.json field. |
-| `--user <login>` | Retrofit a single student's repo (e.g., one that failed on a previous run). |
+| `--user <login>` | Retrofit a single student's repo (for instance, one that failed on a previous run). |
 | `--dry-run` | Report the field flip and per-repo changes without writing anything. |
 | `-q, --quiet` | Suppress per-repo and summary lines. |
 
@@ -839,7 +844,7 @@ gh teacher member list <org> --quiet
 ```
 
 Shows *actual* GitHub membership (the roster is the *intended* list), so you can
-spot mismatches — e.g., a student who never accepted their invite. Default is an
+spot mismatches, such as a student who never accepted their invitation. Default is an
 aligned table; `--json` emits `{login, kind, role, github_id}`; `--quiet` prints
 one login per line. Reading org invitations needs `admin:org`. Read-only.
 


### PR DESCRIPTION
## Summary

Reviewed [release v1.31.0](https://github.com/foundation50/classroom50/pull/618) against the code and fixed what the email-invite work outpaced. Every claim below was verified against source, not inferred from the changelog. Two review passes: the first on the wiki and the invite-lifecycle comments, the second sweeping the ~120 remaining files the release touched.

### Wiki claims the code contradicts

`roster invite --file` shipped in this same release ([#656](https://github.com/foundation50/classroom50/pull/656)), but `FAQ.md` still read "Bulk email invitations are web-app-only. From the CLI, invite one address per run," and `How-Classroom-50-Works.md` listed bulk email invite as one of "two things only the web app does." The only remaining web-only capability is inviting **staff** by email.

Three wiki spots and the CLI's own `--file` help text told teachers to backfill names and sections with `roster sync` — a command that writes neither (`ClaimPendingEmailRow`, `RecordRosterEmail`, and `BackfillRosterGitHubID` touch only identity columns, and `sync.go` says so: "name and section stay teacher-owned, never fabricated from a GitHub profile"). That sent teachers to a command that would silently do nothing; corrected to `roster import` / `roster update`. `roster invite`'s documented exit-code contract was also wrong for `--file`, where an already-invited address is a skip rather than a failure. Both tools' docs also claimed the CLI runs "the same sync" as the web app, which does two things more (refreshes recorded roles, and appends a row for a team member the roster is missing).

### Two contract defects

**`member list --json` documents the wrong `github_id`.** On a pending-invitation row the field carries GitHub's *invitation* id, not an account id (`GitHubID: inv.ID`), because the invitations API reports no invitee account id. The comment claimed `github_id is 0 for pending invitations`, so a consumer trusting it would join an unrelated number against `roster.csv`. Fixed the comment and documented the distinction in the wiki reference, since `--json` is a consumed contract.

**Teardown's invite-team sweep.** Its comment still called these "the web's" teams and claimed "nothing else ever reaps them" — both untrue since the CLI became a co-writer and `roster sync` / `cancel-invite` gained GC. The repo contradicted itself: `roster.go` already calls sync's GC "the backstop."

### Comments falsified after the earlier sweep

`5b39f09c` swept comments once; these are what it missed or what the four commits merged after it broke.

`IsInviteTeamSlug` claimed to mirror the web's `isInviteTeamSlug`, but Go is anchored `^invite-[0-9a-f]{16}$` while the web is a bare `startsWith("invite-")` — that comment is the only link across a hand-mirrored contract, and `contract.go` explicitly warns the loose form is unsafe, so the asymmetry is now documented on both sides. Three comments still said an email invite writes no roster row (false since it began appending a pending row carrying name and section), and four named the org-wide pending-invitations list where the roster reads the team-scoped endpoint — the distinction that scopes invites to one classroom.

The second pass added: `hta` missing from four separate role enumerations including two user-facing help strings and a `--json` field description; `unenroll.ts` explaining three branches as the email-only case when an email-only target is rejected 200 lines earlier (they're the id-only case); a claim that rows key on `github_id/username` when `studentKey` falls back to email (the invariant survives only because the form locks that address); `EnrolledStudents` describing a bulk **role change** action that doesn't exist; `rosterImportHeaders` whose example was inverted (`github_id` is an identity header, so it never triggers the diagnostic); an "auto-classified on receipt" claim the classifier's own comment contradicts ("There is deliberately no content classifier"); a comment quoting copy that now reads "file said …"; a `withRosterRewrite` writer list naming two of five callers; and a duplicated `ghutil` doc block whose two copies disagreed about the function's own parameters.

Also two dangling pointers verified by resolving them: `api/mutations/students` (no `src/api/` exists; it's `domain/students`) and `createClassroomFiles' dropCreatorFromNonTeacherTeams` (that function is the CLI's; the web does it inline).

### Two real bugs found alongside

`onEmailSuccess` never invalidated the roster CSV query, so pending rows written by a bulk email invite could render without their name and section; fixed with a new `useInvalidateRosterCache` hook, kept in `hooks/` rather than importing `githubKeys` into a page. And `students.addHint` still told teachers "Email invites capture no name or section," which [#648](https://github.com/foundation50/classroom50/pull/648) made untrue.

### Style and links

Applied the unambiguous `docs/github-docs-writing-style.md` fixes on the release pages: 24 Latin abbreviations, eight prose uses of "via", banned minimizers, first-person "we/our", "starter repos" to template repositories, and jargon the guide bars from user-facing copy ("read-mostly", "optimistic-rebase", "Round-trip cargo"). Also fixes a pre-existing broken anchor (`#bulk-import-from-a-csv`, introduced by #656).

Titled `fix:` because the wiki misdirection, the `--json` contract, and the stale cache are user-visible defects, so they belong in the release notes.

## Test plan

- [x] `npm run check` exit 0 — `tsc -b`, 0 eslint errors, Prettier clean, `arch:validate` clean (989 modules), 3991 tests pass. The 22 eslint warnings are byte-identical before and after.
- [x] `go build ./...` and `go test ./...` green in `cli/gh-teacher`, `cli/gh-student`, and `cli/shared`.
- [x] `golangci-lint run` reports 0 issues in both modules; `golangci-lint fmt --diff` is empty.
- [x] Rebuilt the CLI and rendered every reworded `--help` block to confirm no ragged wraps.
- [x] `audit_i18n.py --strict` PASS (0 missing, 0 dead keys) after the `addHint` rewording.
- [x] 719 + 388 Python tests pass (run per-suite; running both paths together hits an unrelated pre-existing `conftest` name collision).
- [x] Wrote a link validator over all 26 wiki pages: every cross-page link and anchor resolves, including after the `Interactive and background work` header rename (no inbound references).

## Left for a follow-up, deliberately

- `gh teacher init --json` still emits a `preflight` key while the prose says "setup checks." That's a consumed machine contract, so renaming it is a breaking change rather than a copy sweep.
- Bulk **Invite** is enabled for email-only pending rows but silently skips them, while the row modal's **Re-send** handles them correctly. A UI defect rather than a docs one, so it wants its own `fix(web):` PR.