### PR TITLE
feat(web): request delete_repo on demand instead of at every sign-in

### DIFF
--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -122,15 +122,21 @@ jobs:
 
       # On a cache hit the browser binary is present but its OS deps may not be.
       # `install-deps` shells out to apt, so it can hang on a transient
-      # mirror/network blip — give it its own short timeout and a couple of
-      # retries so one flaky apt call fails fast and self-heals instead of
-      # burning the whole job budget and cancelling the lane (a hung apt here
-      # once ate all 10 minutes and failed the release CI).
+      # mirror/network blip — retry so one flaky apt call self-heals instead of
+      # failing the lane (a hung apt here once ate all 10 minutes and failed the
+      # release CI).
+      #
+      # The per-attempt `timeout` is what makes the retries reachable: a
+      # step-level timeout-minutes kills the whole loop, so a hang — the exact
+      # failure mode above — never reaches attempt 2. Bounding each attempt turns
+      # a stall into a non-zero exit the loop can act on. The step ceiling stays
+      # above 3 attempts plus backoff (3*100s + 30s) so the loop reports the
+      # failure itself rather than being cancelled mid-retry.
       - name: Install Playwright browser deps
-        timeout-minutes: 4
+        timeout-minutes: 6
         run: |
           for attempt in 1 2 3; do
-            if npx playwright install-deps chromium; then
+            if timeout 100s npx playwright install-deps chromium; then
               exit 0
             fi
             echo "playwright install-deps failed (attempt $attempt); retrying..." >&2

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -249,8 +249,8 @@ var FeedbackTemplatePaths = []string{
 //
 // delete_repo is deliberately NOT here: it stays opt-in for `gh teacher
 // teardown` (`gh teacher login -s delete_repo`) so nobody wipes an org by
-// accident. The web GUI intentionally requests a superset (adds read:user and
-// delete_repo), separate from this CLI-parity set.
+// accident. The web GUI matches that posture — it adds read:user to this set but
+// requests delete_repo only on demand, when a teacher elevates for teardown.
 var requiredOAuthScopes = []string{"admin:org", "read:org", "repo", "workflow"}
 
 // RequiredOAuthScopes returns the unified OAuth scope set (a fresh copy so

--- a/web/src/auth/ElevatedAccessModal.test.tsx
+++ b/web/src/auth/ElevatedAccessModal.test.tsx
@@ -15,13 +15,16 @@ vi.mock("react-i18next", async (importOriginal) => {
 const startWebFlow = vi.fn()
 const startDeviceFlow = vi.fn()
 const cancelDeviceFlow = vi.fn()
+const markDeviceCodeCopied = vi.fn()
+const markVerificationOpened = vi.fn()
 const authState: {
   startWebFlow: typeof startWebFlow
   startDeviceFlow: typeof startDeviceFlow
   cancelDeviceFlow: typeof cancelDeviceFlow
+  markDeviceCodeCopied: typeof markDeviceCodeCopied
+  markVerificationOpened: typeof markVerificationOpened
   screen: string
   device: DeviceAuthState | null
-  deviceElevated: boolean | null
   deviceStatus: null
   error: string | null
   isRequestingDeviceCode: boolean
@@ -29,9 +32,10 @@ const authState: {
   startWebFlow,
   startDeviceFlow,
   cancelDeviceFlow,
+  markDeviceCodeCopied,
+  markVerificationOpened,
   screen: "config",
   device: null,
-  deviceElevated: null,
   deviceStatus: null,
   error: null,
   isRequestingDeviceCode: false,
@@ -47,7 +51,6 @@ afterEach(() => {
   vi.clearAllMocks()
   authState.screen = "config"
   authState.device = null
-  authState.deviceElevated = null
   authState.error = null
   authState.isRequestingDeviceCode = false
 })
@@ -61,6 +64,7 @@ const aDevice: DeviceAuthState = {
   attempts: 0,
   nextPollAt: Date.now() + 5_000,
   progress: 0,
+  elevated: true,
 }
 
 describe("ElevatedAccessModal (#655)", () => {
@@ -90,7 +94,6 @@ describe("ElevatedAccessModal (#655)", () => {
   it("shows the device prompt inline once a matching device code is issued", () => {
     authState.screen = "device-prompt"
     authState.device = aDevice
-    authState.deviceElevated = true
     render(<ElevatedAccessModal open onClose={() => {}} />)
     expect(screen.getByText("WXYZ-1234")).toBeTruthy()
     expect(screen.queryByText("auth.elevated.browserButton")).toBeNull()
@@ -99,22 +102,44 @@ describe("ElevatedAccessModal (#655)", () => {
   it("ignores a pending device flow started for the other direction", () => {
     // A base-scope flow must not render under the "request elevated" label.
     authState.screen = "device-prompt"
-    authState.device = aDevice
-    authState.deviceElevated = false
+    authState.device = { ...aDevice, elevated: false }
     render(<ElevatedAccessModal open elevated onClose={() => {}} />)
     expect(screen.queryByText("WXYZ-1234")).toBeNull()
     expect(screen.getByText("auth.elevated.browserButton")).toBeTruthy()
   })
 
-  it("aborts the device poll when the prompt is cancelled", () => {
+  it("aborts the device poll when the prompt is cancelled", async () => {
+    const onClose = vi.fn()
+    const view = render(<ElevatedAccessModal open onClose={onClose} />)
+
+    // Start the flow from this dialog, so it owns the poll it later cancels.
+    await userEvent.click(screen.getByText("auth.elevated.deviceButton"))
     authState.screen = "device-prompt"
     authState.device = aDevice
-    authState.deviceElevated = true
-    const onClose = vi.fn()
-    render(<ElevatedAccessModal open onClose={onClose} />)
-    screen.getByText("common.cancel").click()
+    view.rerender(<ElevatedAccessModal open onClose={onClose} />)
+
+    await userEvent.click(screen.getByText("common.cancel"))
     expect(cancelDeviceFlow).toHaveBeenCalled()
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it("does not cancel a device flow it never started", async () => {
+    // A flow begun elsewhere (the login card) must survive this dialog closing.
+    authState.screen = "device-prompt"
+    authState.device = aDevice
+    const onClose = vi.fn()
+    render(<ElevatedAccessModal open onClose={onClose} />)
+    await userEvent.click(screen.getByText("common.cancel"))
+    expect(cancelDeviceFlow).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it("releases an in-flight flow when the dialog unmounts", async () => {
+    const view = render(<ElevatedAccessModal open onClose={() => {}} />)
+    await userEvent.click(screen.getByText("auth.elevated.deviceButton"))
+    // Navigating away never runs the dismiss handler.
+    view.unmount()
+    expect(cancelDeviceFlow).toHaveBeenCalled()
   })
 
   it("stays open after starting a device flow, before the code arrives", async () => {
@@ -132,14 +157,12 @@ describe("ElevatedAccessModal (#655)", () => {
     const onClose = vi.fn()
     authState.screen = "device-prompt"
     authState.device = aDevice
-    authState.deviceElevated = true
     const view = render(<ElevatedAccessModal open onClose={onClose} />)
     expect(screen.getByText("WXYZ-1234")).toBeTruthy()
 
     // completeSignIn clears the device and returns to "authed".
     authState.screen = "authed"
     authState.device = null
-    authState.deviceElevated = null
     view.rerender(<ElevatedAccessModal open onClose={onClose} />)
     expect(onClose).toHaveBeenCalled()
   })

--- a/web/src/auth/ElevatedAccessModal.test.tsx
+++ b/web/src/auth/ElevatedAccessModal.test.tsx
@@ -13,18 +13,27 @@ vi.mock("react-i18next", async (importOriginal) => {
 
 const startWebFlow = vi.fn()
 const startDeviceFlow = vi.fn()
+const cancelDeviceFlow = vi.fn()
 const authState: {
   startWebFlow: typeof startWebFlow
   startDeviceFlow: typeof startDeviceFlow
+  cancelDeviceFlow: typeof cancelDeviceFlow
   screen: string
   device: DeviceAuthState | null
+  deviceElevated: boolean | null
   deviceStatus: null
+  error: string | null
+  isRequestingDeviceCode: boolean
 } = {
   startWebFlow,
   startDeviceFlow,
+  cancelDeviceFlow,
   screen: "config",
   device: null,
+  deviceElevated: null,
   deviceStatus: null,
+  error: null,
+  isRequestingDeviceCode: false,
 }
 vi.mock("./useGithubAuth", () => ({
   useGithubAuth: () => authState,
@@ -37,13 +46,29 @@ afterEach(() => {
   vi.clearAllMocks()
   authState.screen = "config"
   authState.device = null
+  authState.deviceElevated = null
+  authState.error = null
+  authState.isRequestingDeviceCode = false
 })
 
+const aDevice: DeviceAuthState = {
+  userCode: "WXYZ-1234",
+  verificationUri: "https://github.com/login/device",
+  deviceCode: "dc",
+  expiresAt: Date.now() + 60_000,
+  intervalSeconds: 5,
+  attempts: 0,
+  nextPollAt: Date.now() + 5_000,
+  progress: 0,
+}
+
 describe("ElevatedAccessModal (#655)", () => {
-  it("offers the browser flow, requesting elevated scope", () => {
+  it("offers the browser flow, requesting elevated scope and a return path", () => {
     render(<ElevatedAccessModal open onClose={() => {}} />)
     screen.getByText("auth.elevated.browserButton").click()
-    expect(startWebFlow).toHaveBeenCalledWith({ elevated: true })
+    expect(startWebFlow).toHaveBeenCalledWith(
+      expect.objectContaining({ elevated: true }),
+    )
   })
 
   it("offers the device flow, requesting elevated scope", () => {
@@ -56,24 +81,44 @@ describe("ElevatedAccessModal (#655)", () => {
     render(<ElevatedAccessModal open elevated={false} onClose={() => {}} />)
     expect(screen.getByText("auth.elevated.revokeTitle")).toBeTruthy()
     screen.getByText("auth.elevated.browserButton").click()
-    expect(startWebFlow).toHaveBeenCalledWith({ elevated: false })
+    expect(startWebFlow).toHaveBeenCalledWith(
+      expect.objectContaining({ elevated: false }),
+    )
   })
 
-  it("shows the device prompt inline once a device code is issued", () => {
+  it("shows the device prompt inline once a matching device code is issued", () => {
     authState.screen = "device-prompt"
-    authState.device = {
-      userCode: "WXYZ-1234",
-      verificationUri: "https://github.com/login/device",
-      deviceCode: "dc",
-      expiresAt: Date.now() + 60_000,
-      intervalSeconds: 5,
-      attempts: 0,
-      nextPollAt: Date.now() + 5_000,
-      progress: 0,
-    }
+    authState.device = aDevice
+    authState.deviceElevated = true
     render(<ElevatedAccessModal open onClose={() => {}} />)
-    // The device code renders, and the choice buttons are gone.
     expect(screen.getByText("WXYZ-1234")).toBeTruthy()
     expect(screen.queryByText("auth.elevated.browserButton")).toBeNull()
+  })
+
+  it("ignores a pending device flow started for the other direction", () => {
+    // A base-scope flow must not render under the "request elevated" label.
+    authState.screen = "device-prompt"
+    authState.device = aDevice
+    authState.deviceElevated = false
+    render(<ElevatedAccessModal open elevated onClose={() => {}} />)
+    expect(screen.queryByText("WXYZ-1234")).toBeNull()
+    expect(screen.getByText("auth.elevated.browserButton")).toBeTruthy()
+  })
+
+  it("aborts the device poll when the prompt is cancelled", () => {
+    authState.screen = "device-prompt"
+    authState.device = aDevice
+    authState.deviceElevated = true
+    const onClose = vi.fn()
+    render(<ElevatedAccessModal open onClose={onClose} />)
+    screen.getByText("common.cancel").click()
+    expect(cancelDeviceFlow).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it("surfaces an auth error instead of leaving the dialog unchanged", () => {
+    authState.error = "proxy unreachable"
+    render(<ElevatedAccessModal open onClose={() => {}} />)
+    expect(screen.getByText("proxy unreachable")).toBeTruthy()
   })
 })

--- a/web/src/auth/ElevatedAccessModal.test.tsx
+++ b/web/src/auth/ElevatedAccessModal.test.tsx
@@ -12,6 +12,24 @@ vi.mock("react-i18next", async (importOriginal) => {
   }
 })
 
+// The router's location is base-relative (the router owns `basepath`), unlike
+// window.location. Return a path with a search string so the selector is proven
+// to build both halves.
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    useRouterState: ({
+      select,
+    }: {
+      select: (s: {
+        location: { pathname: string; searchStr: string }
+      }) => string
+    }) =>
+      select({ location: { pathname: "/acme/settings", searchStr: "?x=1" } }),
+  }
+})
+
 const startWebFlow = vi.fn()
 const startDeviceFlow = vi.fn()
 const cancelDeviceFlow = vi.fn()
@@ -73,6 +91,17 @@ describe("ElevatedAccessModal (#655)", () => {
     screen.getByText("auth.elevated.browserButton").click()
     expect(startWebFlow).toHaveBeenCalledWith(
       expect.objectContaining({ elevated: true }),
+    )
+  })
+
+  it("returns to a base-relative path, not window.location", () => {
+    // `returnTo` is replayed through router.history.push, which prepends the
+    // basepath — so a window.location.pathname value would double it on the
+    // GitHub Pages deploy.
+    render(<ElevatedAccessModal open onClose={() => {}} />)
+    screen.getByText("auth.elevated.browserButton").click()
+    expect(startWebFlow).toHaveBeenCalledWith(
+      expect.objectContaining({ returnTo: "/acme/settings?x=1" }),
     )
   })
 

--- a/web/src/auth/ElevatedAccessModal.test.tsx
+++ b/web/src/auth/ElevatedAccessModal.test.tsx
@@ -52,6 +52,13 @@ describe("ElevatedAccessModal (#655)", () => {
     expect(startDeviceFlow).toHaveBeenCalledWith({ elevated: true })
   })
 
+  it("re-auths at base scope when elevated is false (revoke)", () => {
+    render(<ElevatedAccessModal open elevated={false} onClose={() => {}} />)
+    expect(screen.getByText("auth.elevated.revokeTitle")).toBeTruthy()
+    screen.getByText("auth.elevated.browserButton").click()
+    expect(startWebFlow).toHaveBeenCalledWith({ elevated: false })
+  })
+
   it("shows the device prompt inline once a device code is issued", () => {
     authState.screen = "device-prompt"
     authState.device = {

--- a/web/src/auth/ElevatedAccessModal.test.tsx
+++ b/web/src/auth/ElevatedAccessModal.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { render, screen, cleanup } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import type { DeviceAuthState } from "./types"
 
 vi.mock("react-i18next", async (importOriginal) => {
@@ -113,6 +114,33 @@ describe("ElevatedAccessModal (#655)", () => {
     render(<ElevatedAccessModal open onClose={onClose} />)
     screen.getByText("common.cancel").click()
     expect(cancelDeviceFlow).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it("stays open after starting a device flow, before the code arrives", async () => {
+    // The pre-start state (signed in, no device yet) looks identical to the
+    // post-success state, so a naive success watcher closes the dialog the
+    // instant the user picks the device path.
+    const onClose = vi.fn()
+    render(<ElevatedAccessModal open onClose={onClose} />)
+    await userEvent.click(screen.getByText("auth.elevated.deviceButton"))
+    expect(startDeviceFlow).toHaveBeenCalledWith({ elevated: true })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it("closes once a device flow it started completes", () => {
+    const onClose = vi.fn()
+    authState.screen = "device-prompt"
+    authState.device = aDevice
+    authState.deviceElevated = true
+    const view = render(<ElevatedAccessModal open onClose={onClose} />)
+    expect(screen.getByText("WXYZ-1234")).toBeTruthy()
+
+    // completeSignIn clears the device and returns to "authed".
+    authState.screen = "authed"
+    authState.device = null
+    authState.deviceElevated = null
+    view.rerender(<ElevatedAccessModal open onClose={onClose} />)
     expect(onClose).toHaveBeenCalled()
   })
 

--- a/web/src/auth/ElevatedAccessModal.test.tsx
+++ b/web/src/auth/ElevatedAccessModal.test.tsx
@@ -201,4 +201,23 @@ describe("ElevatedAccessModal (#655)", () => {
     render(<ElevatedAccessModal open onClose={() => {}} />)
     expect(screen.getByText("proxy unreachable")).toBeTruthy()
   })
+
+  it("stays open to report a declined or expired device flow", () => {
+    // failDeviceFlow clears the device and returns an already-signed-in session
+    // to "authed" — the same shape as success. Closing there would discard the
+    // only report of the failure, since the device prompt never renders `error`.
+    const onClose = vi.fn()
+    authState.screen = "device-prompt"
+    authState.device = aDevice
+    const view = render(<ElevatedAccessModal open onClose={onClose} />)
+    expect(screen.getByText("WXYZ-1234")).toBeTruthy()
+
+    authState.screen = "authed"
+    authState.device = null
+    authState.error = "auth.errorDeviceDeclined"
+    view.rerender(<ElevatedAccessModal open onClose={onClose} />)
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.getByText("auth.errorDeviceDeclined")).toBeTruthy()
+  })
 })

--- a/web/src/auth/ElevatedAccessModal.test.tsx
+++ b/web/src/auth/ElevatedAccessModal.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import type { DeviceAuthState } from "./types"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+const startWebFlow = vi.fn()
+const startDeviceFlow = vi.fn()
+const authState: {
+  startWebFlow: typeof startWebFlow
+  startDeviceFlow: typeof startDeviceFlow
+  screen: string
+  device: DeviceAuthState | null
+  deviceStatus: null
+} = {
+  startWebFlow,
+  startDeviceFlow,
+  screen: "config",
+  device: null,
+  deviceStatus: null,
+}
+vi.mock("./useGithubAuth", () => ({
+  useGithubAuth: () => authState,
+}))
+
+import { ElevatedAccessModal } from "./ElevatedAccessModal"
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  authState.screen = "config"
+  authState.device = null
+})
+
+describe("ElevatedAccessModal (#655)", () => {
+  it("offers the browser flow, requesting elevated scope", () => {
+    render(<ElevatedAccessModal open onClose={() => {}} />)
+    screen.getByText("auth.elevated.browserButton").click()
+    expect(startWebFlow).toHaveBeenCalledWith({ elevated: true })
+  })
+
+  it("offers the device flow, requesting elevated scope", () => {
+    render(<ElevatedAccessModal open onClose={() => {}} />)
+    screen.getByText("auth.elevated.deviceButton").click()
+    expect(startDeviceFlow).toHaveBeenCalledWith({ elevated: true })
+  })
+
+  it("shows the device prompt inline once a device code is issued", () => {
+    authState.screen = "device-prompt"
+    authState.device = {
+      userCode: "WXYZ-1234",
+      verificationUri: "https://github.com/login/device",
+      deviceCode: "dc",
+      expiresAt: Date.now() + 60_000,
+      intervalSeconds: 5,
+      attempts: 0,
+      nextPollAt: Date.now() + 5_000,
+      progress: 0,
+    }
+    render(<ElevatedAccessModal open onClose={() => {}} />)
+    // The device code renders, and the choice buttons are gone.
+    expect(screen.getByText("WXYZ-1234")).toBeTruthy()
+    expect(screen.queryByText("auth.elevated.browserButton")).toBeNull()
+  })
+})

--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react"
+import { useRouterState } from "@tanstack/react-router"
 import { AlertTriangle, ShieldCheck } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
@@ -88,6 +89,15 @@ export function ElevatedAccessModal({
     [cancelDeviceFlow],
   )
 
+  // The path to return to after the browser round-trip. Read from the router,
+  // not window.location: the router is created with a `basepath`, so its pathname
+  // is base-relative — and `returnTo` is consumed by `router.history.push`. Using
+  // window.location.pathname would include the base segment and duplicate it on
+  // the GitHub Pages deploy. Matches the guard in routes/_authed.tsx.
+  const returnTo = useRouterState({
+    select: (s) => s.location.pathname + s.location.searchStr,
+  })
+
   const title = elevated
     ? t("auth.elevated.title")
     : t("auth.elevated.revokeTitle")
@@ -143,7 +153,7 @@ export function ElevatedAccessModal({
                   elevated,
                   // Come back to the page the user was working on, not the
                   // dashboard the post-login guard would otherwise pick.
-                  returnTo: window.location.pathname + window.location.search,
+                  returnTo,
                 })
               }
             >

--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -135,7 +135,7 @@ export function ElevatedAccessModal({
 
           <div className="flex flex-col gap-3">
             <Button
-              variant="primary"
+              variant={elevated ? "warning" : "primary"}
               className="w-full"
               disabled={isRequestingDeviceCode}
               onClick={() =>

--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -42,11 +42,16 @@ export function ElevatedAccessModal({
   // scope state, so a mid-flow grant would otherwise flip this dialog to the
   // opposite action under the user's cursor.
   const [frozen, setFrozen] = useState(elevated)
-  const [awaitingDevice, setAwaitingDevice] = useState(false)
+  // Whether a device prompt has actually appeared in this dialog. The pre-start
+  // state (already signed in, no device yet) is indistinguishable from the
+  // post-success state, so success is only detectable as "the prompt we showed
+  // went away" — without this, the watcher below fires on the click itself and
+  // closes the dialog before the device code arrives.
+  const [sawDevicePrompt, setSawDevicePrompt] = useState(false)
 
   useEffect(() => {
     if (open) setFrozen(elevated)
-    else setAwaitingDevice(false)
+    else setSawDevicePrompt(false)
     // Re-freeze only on open; `elevated` changing while open is what we ignore.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
@@ -56,15 +61,18 @@ export function ElevatedAccessModal({
   const showingDevice =
     screen === "device-prompt" && !!device && deviceElevated === frozen
 
-  // A device flow we started finished elsewhere (completeSignIn clears device
-  // and returns to "authed"), so retire the dialog instead of silently falling
-  // back to the choice buttons.
   useEffect(() => {
-    if (awaitingDevice && screen === "authed" && !device) {
-      setAwaitingDevice(false)
+    if (showingDevice) setSawDevicePrompt(true)
+  }, [showingDevice])
+
+  // The prompt we were showing is gone and we're signed in: the flow completed,
+  // so retire the dialog instead of falling back to the choice buttons.
+  useEffect(() => {
+    if (sawDevicePrompt && !showingDevice && screen === "authed") {
+      setSawDevicePrompt(false)
       onClose()
     }
-  }, [awaitingDevice, screen, device, onClose])
+  }, [sawDevicePrompt, showingDevice, screen, onClose])
 
   const title = frozen
     ? t("auth.elevated.title")
@@ -130,7 +138,6 @@ export function ElevatedAccessModal({
               loading={isRequestingDeviceCode}
               disabled={isRequestingDeviceCode}
               onClick={() => {
-                setAwaitingDevice(true)
                 void startDeviceFlow({ elevated: frozen })
               }}
             >

--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -1,0 +1,83 @@
+import { ShieldCheck } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { useGithubAuth } from "./useGithubAuth"
+import { GitHubDevicePrompt } from "./GitHubDevicePrompt"
+import { Button, Modal } from "@/components/ui"
+
+// Elevation re-auth for a signed-in teacher who needs a destructive action
+// (Teardown Organization) that the least-privilege sign-in doesn't cover.
+//
+// Two paths, because the browser redirect can't complete on localhost (the
+// OAuth callback URL is the deployed origin): "Continue in browser" runs the
+// standard redirect flow (production), and "Use a device code" runs the device
+// flow inline in this modal (works anywhere, including local development). Both
+// request the elevated scope for this one re-auth only.
+export function ElevatedAccessModal({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  const { startWebFlow, startDeviceFlow, screen, device, deviceStatus } =
+    useGithubAuth()
+
+  const showingDevice = screen === "device-prompt" && !!device
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="lg"
+      aria-label={t("auth.elevated.title")}
+    >
+      {showingDevice ? (
+        <GitHubDevicePrompt
+          device={device}
+          status={deviceStatus}
+          onCancel={onClose}
+          onCodeCopied={() => {}}
+          onVerificationOpened={() => {}}
+        />
+      ) : (
+        <div className="space-y-5">
+          <div className="flex gap-4 border-b border-base-200 pb-5">
+            <div className="flex size-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <ShieldCheck aria-hidden="true" className="size-6" />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-lg font-semibold">
+                {t("auth.elevated.title")}
+              </h2>
+              <p className="mt-1 text-sm text-base-content/70">
+                {t("auth.elevated.body")}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <Button
+              variant="primary"
+              className="w-full"
+              onClick={() => void startWebFlow({ elevated: true })}
+            >
+              {t("auth.elevated.browserButton")}
+            </Button>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => void startDeviceFlow({ elevated: true })}
+            >
+              {t("auth.elevated.deviceButton")}
+            </Button>
+            <p className="text-xs leading-relaxed text-base-content/60">
+              {t("auth.elevated.deviceHint")}
+            </p>
+          </div>
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { useGithubAuth } from "./useGithubAuth"
 import { GitHubDevicePrompt } from "./GitHubDevicePrompt"
+import { githubOAuthGrantUrl } from "./constants"
 import { Alert, Button, Modal } from "@/components/ui"
 
 // Re-auth for a signed-in teacher who needs to change their delete_repo access.
@@ -138,6 +139,18 @@ export function ElevatedAccessModal({
             <p className="text-xs leading-relaxed text-base-content/60">
               {t("auth.elevated.deviceHint")}
             </p>
+            {!frozen && (
+              // Signing in narrows this session's token; only GitHub can revoke
+              // the one already issued, so point at where that happens.
+              <a
+                className="link text-xs"
+                href={githubOAuthGrantUrl()}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t("auth.elevated.revokeLink")}
+              </a>
+            )}
           </div>
         </div>
       )}

--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -1,19 +1,20 @@
-import { ShieldCheck } from "lucide-react"
+import { useEffect, useState } from "react"
+import { AlertTriangle, ShieldCheck } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { useGithubAuth } from "./useGithubAuth"
 import { GitHubDevicePrompt } from "./GitHubDevicePrompt"
-import { Button, Modal } from "@/components/ui"
+import { Alert, Button, Modal } from "@/components/ui"
 
 // Re-auth for a signed-in teacher who needs to change their delete_repo access.
 // GitHub can't add or drop a single scope client-side, so either direction is a
 // full sign-in: `elevated` true requests base + delete_repo, false requests base
-// only (dropping delete_repo).
+// only. See auth/constants.ts for the base/elevated policy.
 //
 // Two paths, because the browser redirect can't complete on localhost (the
 // OAuth callback URL is the deployed origin): "Continue in browser" runs the
-// standard redirect flow (production), and "Use a device code" runs the device
-// flow inline in this modal (works anywhere, including local development).
+// standard redirect flow, and "Use a device code" runs the device flow inline
+// here (works anywhere, including local development).
 export function ElevatedAccessModal({
   open,
   onClose,
@@ -24,25 +25,66 @@ export function ElevatedAccessModal({
   elevated?: boolean
 }) {
   const { t } = useTranslation()
-  const { startWebFlow, startDeviceFlow, screen, device, deviceStatus } =
-    useGithubAuth()
+  const {
+    startWebFlow,
+    startDeviceFlow,
+    cancelDeviceFlow,
+    screen,
+    device,
+    deviceElevated,
+    deviceStatus,
+    error,
+    isRequestingDeviceCode,
+  } = useGithubAuth()
 
-  const showingDevice = screen === "device-prompt" && !!device
+  // Freeze the direction while open: the caller derives `elevated` from live
+  // scope state, so a mid-flow grant would otherwise flip this dialog to the
+  // opposite action under the user's cursor.
+  const [frozen, setFrozen] = useState(elevated)
+  const [awaitingDevice, setAwaitingDevice] = useState(false)
 
-  const title = elevated
+  useEffect(() => {
+    if (open) setFrozen(elevated)
+    else setAwaitingDevice(false)
+    // Re-freeze only on open; `elevated` changing while open is what we ignore.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  // Only show a pending code that this dialog's direction actually started, so a
+  // stale flow from another surface can't render under the wrong label.
+  const showingDevice =
+    screen === "device-prompt" && !!device && deviceElevated === frozen
+
+  // A device flow we started finished elsewhere (completeSignIn clears device
+  // and returns to "authed"), so retire the dialog instead of silently falling
+  // back to the choice buttons.
+  useEffect(() => {
+    if (awaitingDevice && screen === "authed" && !device) {
+      setAwaitingDevice(false)
+      onClose()
+    }
+  }, [awaitingDevice, screen, device, onClose])
+
+  const title = frozen
     ? t("auth.elevated.title")
     : t("auth.elevated.revokeTitle")
-  const body = elevated
-    ? t("auth.elevated.body")
-    : t("auth.elevated.revokeBody")
+  const body = frozen ? t("auth.elevated.body") : t("auth.elevated.revokeBody")
+
+  // Dismissing must abort the poll: it lives in the auth provider, not here, so
+  // unmounting this dialog would otherwise leave it running (and able to swap
+  // the session token) long after the user cancelled.
+  const dismiss = () => {
+    if (showingDevice) cancelDeviceFlow()
+    onClose()
+  }
 
   return (
-    <Modal open={open} onClose={onClose} size="lg" aria-label={title}>
+    <Modal open={open} onClose={dismiss} size="lg" aria-label={title}>
       {showingDevice ? (
         <GitHubDevicePrompt
           device={device}
           status={deviceStatus}
-          onCancel={onClose}
+          onCancel={dismiss}
           onCodeCopied={() => {}}
           onVerificationOpened={() => {}}
         />
@@ -58,18 +100,38 @@ export function ElevatedAccessModal({
             </div>
           </div>
 
+          {error ? (
+            <Alert tone="error" className="items-start text-sm">
+              <AlertTriangle aria-hidden="true" className="size-4 shrink-0" />
+              <span>{error}</span>
+            </Alert>
+          ) : null}
+
           <div className="flex flex-col gap-3">
             <Button
               variant="primary"
               className="w-full"
-              onClick={() => void startWebFlow({ elevated })}
+              disabled={isRequestingDeviceCode}
+              onClick={() =>
+                void startWebFlow({
+                  elevated: frozen,
+                  // Come back to the page the user was working on, not the
+                  // dashboard the post-login guard would otherwise pick.
+                  returnTo: window.location.pathname + window.location.search,
+                })
+              }
             >
               {t("auth.elevated.browserButton")}
             </Button>
             <Button
               variant="outline"
               className="w-full"
-              onClick={() => void startDeviceFlow({ elevated })}
+              loading={isRequestingDeviceCode}
+              disabled={isRequestingDeviceCode}
+              onClick={() => {
+                setAwaitingDevice(true)
+                void startDeviceFlow({ elevated: frozen })
+              }}
             >
               {t("auth.elevated.deviceButton")}
             </Button>

--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -5,20 +5,23 @@ import { useGithubAuth } from "./useGithubAuth"
 import { GitHubDevicePrompt } from "./GitHubDevicePrompt"
 import { Button, Modal } from "@/components/ui"
 
-// Elevation re-auth for a signed-in teacher who needs a destructive action
-// (Teardown Organization) that the least-privilege sign-in doesn't cover.
+// Re-auth for a signed-in teacher who needs to change their delete_repo access.
+// GitHub can't add or drop a single scope client-side, so either direction is a
+// full sign-in: `elevated` true requests base + delete_repo, false requests base
+// only (dropping delete_repo).
 //
 // Two paths, because the browser redirect can't complete on localhost (the
 // OAuth callback URL is the deployed origin): "Continue in browser" runs the
 // standard redirect flow (production), and "Use a device code" runs the device
-// flow inline in this modal (works anywhere, including local development). Both
-// request the elevated scope for this one re-auth only.
+// flow inline in this modal (works anywhere, including local development).
 export function ElevatedAccessModal({
   open,
   onClose,
+  elevated = true,
 }: {
   open: boolean
   onClose: () => void
+  elevated?: boolean
 }) {
   const { t } = useTranslation()
   const { startWebFlow, startDeviceFlow, screen, device, deviceStatus } =
@@ -26,13 +29,15 @@ export function ElevatedAccessModal({
 
   const showingDevice = screen === "device-prompt" && !!device
 
+  const title = elevated
+    ? t("auth.elevated.title")
+    : t("auth.elevated.revokeTitle")
+  const body = elevated
+    ? t("auth.elevated.body")
+    : t("auth.elevated.revokeBody")
+
   return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      size="lg"
-      aria-label={t("auth.elevated.title")}
-    >
+    <Modal open={open} onClose={onClose} size="lg" aria-label={title}>
       {showingDevice ? (
         <GitHubDevicePrompt
           device={device}
@@ -48,12 +53,8 @@ export function ElevatedAccessModal({
               <ShieldCheck aria-hidden="true" className="size-6" />
             </div>
             <div className="min-w-0">
-              <h2 className="text-lg font-semibold">
-                {t("auth.elevated.title")}
-              </h2>
-              <p className="mt-1 text-sm text-base-content/70">
-                {t("auth.elevated.body")}
-              </p>
+              <h2 className="text-lg font-semibold">{title}</h2>
+              <p className="mt-1 text-sm text-base-content/70">{body}</p>
             </div>
           </div>
 
@@ -61,14 +62,14 @@ export function ElevatedAccessModal({
             <Button
               variant="primary"
               className="w-full"
-              onClick={() => void startWebFlow({ elevated: true })}
+              onClick={() => void startWebFlow({ elevated })}
             >
               {t("auth.elevated.browserButton")}
             </Button>
             <Button
               variant="outline"
               className="w-full"
-              onClick={() => void startDeviceFlow({ elevated: true })}
+              onClick={() => void startDeviceFlow({ elevated })}
             >
               {t("auth.elevated.deviceButton")}
             </Button>

--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef } from "react"
 import { useRouterState } from "@tanstack/react-router"
 import { AlertTriangle, ShieldCheck } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { useGithubAuth } from "./useGithubAuth"
 import { GitHubDevicePrompt } from "./GitHubDevicePrompt"
-import { githubOAuthGrantUrl } from "./constants"
+import { RevokeAccessLink } from "./RevokeAccessLink"
 import { Alert, Button, Modal } from "@/components/ui"
 
 // Re-auth for a signed-in teacher who needs to change their delete_repo access.
@@ -48,52 +48,58 @@ export function ElevatedAccessModal({
   // state (already signed in, no device yet) is indistinguishable from the
   // post-success state, so success is only detectable as "the prompt we showed
   // went away".
-  const [sawDevicePrompt, setSawDevicePrompt] = useState(false)
+  const sawDevicePromptRef = useRef(false)
+
+  // Keep the auth/prop callbacks in refs so the effects below depend only on the
+  // state they react to. Both call sites pass an inline `onClose`, and a cleanup
+  // that depends on a callback identity stops being unmount-only the moment that
+  // identity changes.
+  const cancelDeviceFlowRef = useRef(cancelDeviceFlow)
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    cancelDeviceFlowRef.current = cancelDeviceFlow
+    onCloseRef.current = onClose
+  }, [cancelDeviceFlow, onClose])
 
   useEffect(() => {
     if (open) return
-    setSawDevicePrompt(false)
+    sawDevicePromptRef.current = false
     // Closing via the prop is a close too: without this, a parent that flips
     // `open` leaves an owned poll running with no UI attached.
     if (ownsDeviceFlowRef.current) {
       ownsDeviceFlowRef.current = false
-      cancelDeviceFlow()
+      cancelDeviceFlowRef.current()
     }
-  }, [open, cancelDeviceFlow])
+  }, [open])
 
   // Only show a pending code for this dialog's direction, so a flow started
   // elsewhere can't render under the wrong label.
   const showingDevice =
     screen === "device-prompt" && !!device && device.elevated === elevated
 
+  // Retire the dialog once the prompt we were showing is gone and we're signed
+  // in. `!error` is what distinguishes success from failure: a declined or
+  // expired flow also clears the device and returns an already-signed-in session
+  // to "authed", and closing there would discard the only report of it.
   useEffect(() => {
-    if (showingDevice) setSawDevicePrompt(true)
-  }, [showingDevice])
-
-  // Keep the close handler in a ref: both call sites pass an inline arrow and
-  // re-render with the volatile auth context, so depending on its identity would
-  // re-run the watcher below throughout a device flow.
-  const onCloseRef = useRef(onClose)
-  useEffect(() => {
-    onCloseRef.current = onClose
-  }, [onClose])
-
-  // The prompt we were showing is gone and we're signed in: the flow completed,
-  // so retire the dialog instead of falling back to the choice buttons.
-  useEffect(() => {
-    if (sawDevicePrompt && !showingDevice && screen === "authed") {
+    if (showingDevice) {
+      sawDevicePromptRef.current = true
+      return
+    }
+    if (sawDevicePromptRef.current && screen === "authed" && !error) {
+      sawDevicePromptRef.current = false
       ownsDeviceFlowRef.current = false
       onCloseRef.current()
     }
-  }, [sawDevicePrompt, showingDevice, screen])
+  }, [showingDevice, screen, error])
 
   // Abandoning the dialog by navigating away never runs `dismiss`, so release an
   // owned flow here too.
   useEffect(
     () => () => {
-      if (ownsDeviceFlowRef.current) cancelDeviceFlow()
+      if (ownsDeviceFlowRef.current) cancelDeviceFlowRef.current()
     },
-    [cancelDeviceFlow],
+    [],
   )
 
   // The path to return to after the browser round-trip. Read from the router,
@@ -113,8 +119,7 @@ export function ElevatedAccessModal({
     : t("auth.elevated.revokeBody")
 
   // Dismissing must abort the poll: it lives in the auth provider, not here, so
-  // unmounting this dialog would otherwise leave it running (and able to swap
-  // the session token) long after the user cancelled.
+  // unmounting would otherwise leave it running long after the user cancelled.
   const dismiss = () => {
     if (ownsDeviceFlowRef.current) cancelDeviceFlow()
     ownsDeviceFlowRef.current = false
@@ -184,14 +189,7 @@ export function ElevatedAccessModal({
             {!elevated && (
               // Signing in narrows this session's token; only GitHub can revoke
               // the one already issued, so point at where that happens.
-              <a
-                className="link text-xs"
-                href={githubOAuthGrantUrl()}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {t("auth.elevated.revokeLink")}
-              </a>
+              <RevokeAccessLink />
             )}
           </div>
         </div>

--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { AlertTriangle, ShieldCheck } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
@@ -8,9 +8,7 @@ import { githubOAuthGrantUrl } from "./constants"
 import { Alert, Button, Modal } from "@/components/ui"
 
 // Re-auth for a signed-in teacher who needs to change their delete_repo access.
-// GitHub can't add or drop a single scope client-side, so either direction is a
-// full sign-in: `elevated` true requests base + delete_repo, false requests base
-// only. See auth/constants.ts for the base/elevated policy.
+// See auth/constants.ts for the base/elevated policy.
 //
 // Two paths, because the browser redirect can't complete on localhost (the
 // OAuth callback URL is the deployed origin): "Continue in browser" runs the
@@ -30,60 +28,79 @@ export function ElevatedAccessModal({
     startWebFlow,
     startDeviceFlow,
     cancelDeviceFlow,
+    markDeviceCodeCopied,
+    markVerificationOpened,
     screen,
     device,
-    deviceElevated,
     deviceStatus,
     error,
     isRequestingDeviceCode,
   } = useGithubAuth()
 
-  // Freeze the direction while open: the caller derives `elevated` from live
-  // scope state, so a mid-flow grant would otherwise flip this dialog to the
-  // opposite action under the user's cursor.
-  const [frozen, setFrozen] = useState(elevated)
+  // Whether a device flow started from this dialog is still live. Set on the
+  // click, not on the prompt appearing: between the two, the request is in flight
+  // with nothing rendered, and dismissing there would otherwise leave the poll
+  // running (able to swap the session token) with no UI.
+  const ownsDeviceFlowRef = useRef(false)
+
   // Whether a device prompt has actually appeared in this dialog. The pre-start
   // state (already signed in, no device yet) is indistinguishable from the
   // post-success state, so success is only detectable as "the prompt we showed
-  // went away" — without this, the watcher below fires on the click itself and
-  // closes the dialog before the device code arrives.
+  // went away".
   const [sawDevicePrompt, setSawDevicePrompt] = useState(false)
 
   useEffect(() => {
-    if (open) setFrozen(elevated)
-    else setSawDevicePrompt(false)
-    // Re-freeze only on open; `elevated` changing while open is what we ignore.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (!open) setSawDevicePrompt(false)
   }, [open])
 
-  // Only show a pending code that this dialog's direction actually started, so a
-  // stale flow from another surface can't render under the wrong label.
+  // Only show a pending code for this dialog's direction, so a flow started
+  // elsewhere can't render under the wrong label.
   const showingDevice =
-    screen === "device-prompt" && !!device && deviceElevated === frozen
+    screen === "device-prompt" && !!device && device.elevated === elevated
 
   useEffect(() => {
     if (showingDevice) setSawDevicePrompt(true)
   }, [showingDevice])
 
+  // Keep the close handler in a ref: both call sites pass an inline arrow and
+  // re-render with the volatile auth context, so depending on its identity would
+  // re-run the watcher below throughout a device flow.
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  }, [onClose])
+
   // The prompt we were showing is gone and we're signed in: the flow completed,
   // so retire the dialog instead of falling back to the choice buttons.
   useEffect(() => {
     if (sawDevicePrompt && !showingDevice && screen === "authed") {
-      setSawDevicePrompt(false)
-      onClose()
+      ownsDeviceFlowRef.current = false
+      onCloseRef.current()
     }
-  }, [sawDevicePrompt, showingDevice, screen, onClose])
+  }, [sawDevicePrompt, showingDevice, screen])
 
-  const title = frozen
+  // Abandoning the dialog by navigating away never runs `dismiss`, so release an
+  // owned flow here too.
+  useEffect(
+    () => () => {
+      if (ownsDeviceFlowRef.current) cancelDeviceFlow()
+    },
+    [cancelDeviceFlow],
+  )
+
+  const title = elevated
     ? t("auth.elevated.title")
     : t("auth.elevated.revokeTitle")
-  const body = frozen ? t("auth.elevated.body") : t("auth.elevated.revokeBody")
+  const body = elevated
+    ? t("auth.elevated.body")
+    : t("auth.elevated.revokeBody")
 
   // Dismissing must abort the poll: it lives in the auth provider, not here, so
   // unmounting this dialog would otherwise leave it running (and able to swap
   // the session token) long after the user cancelled.
   const dismiss = () => {
-    if (showingDevice) cancelDeviceFlow()
+    if (ownsDeviceFlowRef.current) cancelDeviceFlow()
+    ownsDeviceFlowRef.current = false
     onClose()
   }
 
@@ -94,8 +111,8 @@ export function ElevatedAccessModal({
           device={device}
           status={deviceStatus}
           onCancel={dismiss}
-          onCodeCopied={() => {}}
-          onVerificationOpened={() => {}}
+          onCodeCopied={markDeviceCodeCopied}
+          onVerificationOpened={markVerificationOpened}
         />
       ) : (
         <div className="space-y-5">
@@ -123,7 +140,7 @@ export function ElevatedAccessModal({
               disabled={isRequestingDeviceCode}
               onClick={() =>
                 void startWebFlow({
-                  elevated: frozen,
+                  elevated,
                   // Come back to the page the user was working on, not the
                   // dashboard the post-login guard would otherwise pick.
                   returnTo: window.location.pathname + window.location.search,
@@ -138,7 +155,8 @@ export function ElevatedAccessModal({
               loading={isRequestingDeviceCode}
               disabled={isRequestingDeviceCode}
               onClick={() => {
-                void startDeviceFlow({ elevated: frozen })
+                ownsDeviceFlowRef.current = true
+                void startDeviceFlow({ elevated })
               }}
             >
               {t("auth.elevated.deviceButton")}
@@ -146,7 +164,7 @@ export function ElevatedAccessModal({
             <p className="text-xs leading-relaxed text-base-content/60">
               {t("auth.elevated.deviceHint")}
             </p>
-            {!frozen && (
+            {!elevated && (
               // Signing in narrows this session's token; only GitHub can revoke
               // the one already issued, so point at where that happens.
               <a

--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -51,8 +51,15 @@ export function ElevatedAccessModal({
   const [sawDevicePrompt, setSawDevicePrompt] = useState(false)
 
   useEffect(() => {
-    if (!open) setSawDevicePrompt(false)
-  }, [open])
+    if (open) return
+    setSawDevicePrompt(false)
+    // Closing via the prop is a close too: without this, a parent that flips
+    // `open` leaves an owned poll running with no UI attached.
+    if (ownsDeviceFlowRef.current) {
+      ownsDeviceFlowRef.current = false
+      cancelDeviceFlow()
+    }
+  }, [open, cancelDeviceFlow])
 
   // Only show a pending code for this dialog's direction, so a flow started
   // elsewhere can't render under the wrong label.

--- a/web/src/auth/GitHubPatPrompt.tsx
+++ b/web/src/auth/GitHubPatPrompt.tsx
@@ -13,17 +13,18 @@ import { Alert, Button, HelpTooltip, Input } from "@/components/ui"
 // The classic-PAT scopes to request, derived from REQUIRED_SCOPES (the same
 // source missingScopes() validates against) so the tooltip list and the
 // pre-checked token URL can't drift from DEFAULT_GITHUB_SCOPE. We request the
-// full OAuth scope set verbatim (including read:org, even though admin:org
-// implies it) so a token created via this link grants exactly what the OAuth
-// flow would. Ordered to match GitHub's token page; scopes without an explicit
-// rank sort to the end so a newly added required scope still appears.
+// full base OAuth scope set verbatim (including read:org, even though admin:org
+// implies it) so a token created via this link grants exactly what a normal
+// OAuth sign-in would. delete_repo is elevated-only and intentionally excluded;
+// a teacher who needs teardown requests elevated permissions separately (#655).
+// Ordered to match GitHub's token page; scopes without an explicit rank sort to
+// the end so a newly added required scope still appears.
 const PAT_SCOPE_ORDER = [
   "repo",
   "workflow",
   "admin:org",
   "read:org",
   "read:user",
-  "delete_repo",
 ]
 const REQUIRED_PAT_SCOPES = [...REQUIRED_SCOPES].sort((a, b) => {
   const ai = PAT_SCOPE_ORDER.indexOf(a)

--- a/web/src/auth/RevokeAccessLink.tsx
+++ b/web/src/auth/RevokeAccessLink.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from "react-i18next"
+
+import { githubOAuthGrantUrl } from "./constants"
+
+// Link to this app's entry on GitHub's authorized-apps page. Signing in again
+// only narrows this browser's token, so GitHub is the one place the grant itself
+// goes away — shared so the two surfaces that offer it can't drift.
+export function RevokeAccessLink() {
+  const { t } = useTranslation()
+  return (
+    <a
+      className="link text-xs"
+      href={githubOAuthGrantUrl()}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {t("auth.elevated.revokeLink")}
+    </a>
+  )
+}

--- a/web/src/auth/constants.ts
+++ b/web/src/auth/constants.ts
@@ -2,6 +2,9 @@ export const GITHUB_AUTH_STORAGE = {
   TOKEN: "gh_access_token",
   CLIENT_ID: "gh_client_id",
   SCOPE_GRANTED: "gh_scope_granted",
+  // How the session's token was obtained. Absent for a session stored before
+  // this key existed, which reads as "unknown" — never as a specific method.
+  AUTH_METHOD: "gh_auth_method",
 } as const
 
 export const GITHUB_AUTH_SESSION = {

--- a/web/src/auth/constants.ts
+++ b/web/src/auth/constants.ts
@@ -35,7 +35,11 @@ export const BASE_GITHUB_SCOPES = [
   "admin:org",
 ] as const
 
-export const ELEVATED_GITHUB_SCOPES = ["delete_repo"] as const
+// GitHub's scope for permanently deleting a repository. Named because both the
+// elevated scope set and teardown's 403 classifier key off this one string.
+export const DELETE_REPO_SCOPE = "delete_repo"
+
+export const ELEVATED_GITHUB_SCOPES = [DELETE_REPO_SCOPE] as const
 
 // The scope string a normal (least-privilege) sign-in requests.
 export const DEFAULT_GITHUB_SCOPE = BASE_GITHUB_SCOPES.join(" ")

--- a/web/src/auth/constants.ts
+++ b/web/src/auth/constants.ts
@@ -14,12 +14,37 @@ export const GITHUB_AUTH_SESSION = {
   RETURN_TO: "gh_oauth_return_to",
 } as const
 
-// Scopes: admin:org enables org-invite management + team writes; repo covers
-// roster commits and repo archiving; delete_repo lets teardown delete repos
-// (else deletion 403s and callers fall back to archiving). delete_repo is
-// requested here for the GUI; the CLIs keep it opt-in.
-export const DEFAULT_GITHUB_SCOPE =
-  "read:user read:org repo workflow admin:org delete_repo"
+// Scopes split into two tiers so login stays least-privilege for everyone
+// (teachers and students share one flow):
+//
+// - BASE is requested at every sign-in and is what REQUIRED_SCOPES enforces.
+//   admin:org enables org-invite management + team writes; repo covers roster
+//   commits and repo archiving; workflow commits the autograder shim.
+// - ELEVATED (delete_repo) is destructive and requested only on demand, when a
+//   teacher opts into an elevated action (today: Teardown Organization). It is
+//   intentionally absent from BASE, so a student authorizing the app never
+//   grants repo deletion, and REQUIRED_SCOPES never nags for it (#655). Add a
+//   normally-required scope to BASE; add a destructive one to ELEVATED.
+//
+// The CLIs keep delete_repo opt-in as well.
+export const BASE_GITHUB_SCOPES = [
+  "read:user",
+  "read:org",
+  "repo",
+  "workflow",
+  "admin:org",
+] as const
+
+export const ELEVATED_GITHUB_SCOPES = ["delete_repo"] as const
+
+// The scope string a normal (least-privilege) sign-in requests.
+export const DEFAULT_GITHUB_SCOPE = BASE_GITHUB_SCOPES.join(" ")
+
+// The scope string an elevated sign-in requests: base + the destructive scopes.
+export const ELEVATED_GITHUB_SCOPE = [
+  ...BASE_GITHUB_SCOPES,
+  ...ELEVATED_GITHUB_SCOPES,
+].join(" ")
 
 // An org's OAuth app policy page, where owners approve apps or relax the
 // restriction.

--- a/web/src/auth/devAutoLogin.ts
+++ b/web/src/auth/devAutoLogin.ts
@@ -88,7 +88,7 @@ export function runDevAutoLoginOnce(
       const scope = result.kind === "ok" ? result.scopes : ""
       // Persist immediately so a remount restores the session even if the mount
       // that started this validation was already torn down.
-      persistGithubToken(envPat, scope)
+      persistGithubToken(envPat, scope, "pat")
       log.info("dev auto-login validated; token persisted")
       return { token: envPat, scope }
     } catch (err) {

--- a/web/src/auth/fineGrainedSigninUrl.ts
+++ b/web/src/auth/fineGrainedSigninUrl.ts
@@ -18,7 +18,10 @@
 //                  policy/kill switch, rulesets) + Members: write (invite/remove
 //                  members AND classroom-team CRUD, GitHub groups team
 //                  management under the Members permission)
-//   delete_repo -> covered by repository Administration: write
+//   delete_repo -> covered by repository Administration: write. (A fine-grained
+//                  sign-in token grants deletion up front; the OAuth path
+//                  instead treats delete_repo as elevated-only and requests it
+//                  on demand, so the two paths intentionally differ — #655.)
 //   Pages       -> org-setup reads GET .../pages and PUTs the Pages config
 //                  (a read-only Pages permission 403s the pre-flight check).
 //   Secrets     -> saving the service token PUTs an Actions secret (putRepoSecret)

--- a/web/src/auth/scopes.test.ts
+++ b/web/src/auth/scopes.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
-import { DEFAULT_GITHUB_SCOPE } from "./constants"
-import { REQUIRED_SCOPES, expandScopes, missingScopes } from "./scopes"
+import { DEFAULT_GITHUB_SCOPE, ELEVATED_GITHUB_SCOPE } from "./constants"
+import { REQUIRED_SCOPES, expandScopes, hasScope, missingScopes } from "./scopes"
 
 describe("expandScopes", () => {
   it("expands repo to its sub-scopes", () => {
@@ -39,22 +39,30 @@ describe("missingScopes", () => {
   })
 
   it("treats admin:org as covering read:org (implication, not literal match)", () => {
-    // read:user repo workflow admin:org delete_repo — read:org omitted but
-    // implied by admin:org.
-    const granted = "read:user repo workflow admin:org delete_repo"
+    // read:user repo workflow admin:org — read:org omitted but implied by
+    // admin:org.
+    const granted = "read:user repo workflow admin:org"
     expect(missingScopes(granted)).toEqual([])
   })
 
   it("treats a broad real-world grant as fully satisfying", () => {
     // GitHub commonly returns broader top-level scopes; user covers read:user.
-    const granted = "user repo workflow admin:org delete_repo"
+    const granted = "user repo workflow admin:org"
     expect(missingScopes(granted)).toEqual([])
   })
 
-  it("flags an actually-absent scope", () => {
-    // delete_repo dropped from the grant.
+  it("does not require delete_repo (it is elevated-only, not a base scope)", () => {
+    // A least-privilege base grant must never trip the scope-warning banner
+    // just because delete_repo is absent (#655).
     const granted = "read:user read:org repo workflow admin:org"
-    expect(missingScopes(granted)).toEqual(["delete_repo"])
+    expect(missingScopes(granted)).toEqual([])
+    expect(REQUIRED_SCOPES).not.toContain("delete_repo")
+  })
+
+  it("flags an actually-absent required scope", () => {
+    // workflow dropped from the grant.
+    const granted = "read:user read:org repo admin:org"
+    expect(missingScopes(granted)).toEqual(["workflow"])
   })
 
   it("reports every required scope for an empty grant", () => {
@@ -68,7 +76,29 @@ describe("missingScopes", () => {
   // source of spurious production banners.
   it("diffs a captured DEFAULT_GITHUB_SCOPE header to zero missing", () => {
     const capturedHeader =
-      "read:org, read:user, repo, workflow, admin:org, write:org, delete_repo"
+      "read:org, read:user, repo, workflow, admin:org, write:org"
     expect(missingScopes(capturedHeader)).toEqual([])
+  })
+})
+
+describe("hasScope", () => {
+  it("detects a directly granted scope", () => {
+    expect(hasScope("read:user repo delete_repo", "delete_repo")).toBe(true)
+  })
+
+  it("returns false when the scope is absent", () => {
+    expect(hasScope(DEFAULT_GITHUB_SCOPE, "delete_repo")).toBe(false)
+  })
+
+  it("returns false for an empty grant", () => {
+    expect(hasScope("", "delete_repo")).toBe(false)
+  })
+
+  it("sees delete_repo in the elevated scope string", () => {
+    expect(hasScope(ELEVATED_GITHUB_SCOPE, "delete_repo")).toBe(true)
+  })
+
+  it("resolves implied scopes (admin:org satisfies read:org)", () => {
+    expect(hasScope("admin:org", "read:org")).toBe(true)
   })
 })

--- a/web/src/auth/scopes.test.ts
+++ b/web/src/auth/scopes.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { DEFAULT_GITHUB_SCOPE, ELEVATED_GITHUB_SCOPE } from "./constants"
-import {
-  REQUIRED_SCOPES,
-  expandScopes,
-  hasScope,
-  missingScopes,
-} from "./scopes"
+import { REQUIRED_SCOPES, expandScopes, missingScopes } from "./scopes"
 
 describe("expandScopes", () => {
   it("expands repo to its sub-scopes", () => {
@@ -86,24 +81,17 @@ describe("missingScopes", () => {
   })
 })
 
-describe("hasScope", () => {
-  it("detects a directly granted scope", () => {
-    expect(hasScope("read:user repo delete_repo", "delete_repo")).toBe(true)
-  })
-
-  it("returns false when the scope is absent", () => {
-    expect(hasScope(DEFAULT_GITHUB_SCOPE, "delete_repo")).toBe(false)
-  })
-
-  it("returns false for an empty grant", () => {
-    expect(hasScope("", "delete_repo")).toBe(false)
+describe("expandScopes against the elevated contract", () => {
+  it("does not see delete_repo in the base scope string", () => {
+    expect(expandScopes(DEFAULT_GITHUB_SCOPE).has("delete_repo")).toBe(false)
   })
 
   it("sees delete_repo in the elevated scope string", () => {
-    expect(hasScope(ELEVATED_GITHUB_SCOPE, "delete_repo")).toBe(true)
+    expect(expandScopes(ELEVATED_GITHUB_SCOPE).has("delete_repo")).toBe(true)
   })
 
-  it("resolves implied scopes (admin:org satisfies read:org)", () => {
-    expect(hasScope("admin:org", "read:org")).toBe(true)
+  it("never implies delete_repo from a broader scope", () => {
+    // `repo` must not satisfy the deletion gate by implication.
+    expect(expandScopes("repo admin:org").has("delete_repo")).toBe(false)
   })
 })

--- a/web/src/auth/scopes.test.ts
+++ b/web/src/auth/scopes.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest"
 
 import { DEFAULT_GITHUB_SCOPE, ELEVATED_GITHUB_SCOPE } from "./constants"
-import { REQUIRED_SCOPES, expandScopes, hasScope, missingScopes } from "./scopes"
+import {
+  REQUIRED_SCOPES,
+  expandScopes,
+  hasScope,
+  missingScopes,
+} from "./scopes"
 
 describe("expandScopes", () => {
   it("expands repo to its sub-scopes", () => {

--- a/web/src/auth/scopes.ts
+++ b/web/src/auth/scopes.ts
@@ -1,6 +1,8 @@
-import { DEFAULT_GITHUB_SCOPE } from "./constants"
+import { BASE_GITHUB_SCOPES } from "./constants"
 
-export const REQUIRED_SCOPES = DEFAULT_GITHUB_SCOPE.split(/\s+/).filter(Boolean)
+// The scopes a normal sign-in must hold. Sourced from the same array the login
+// scope string is built from, so the two can't drift.
+export const REQUIRED_SCOPES: readonly string[] = BASE_GITHUB_SCOPES
 
 // GitHub normalizes granted scopes and a broader scope implies narrower ones,
 // so we map each grantable scope -> the scopes it also satisfies (e.g., `repo`
@@ -42,11 +44,4 @@ export function expandScopes(granted: string): Set<string> {
 export function missingScopes(granted: string): string[] {
   const have = expandScopes(granted)
   return REQUIRED_SCOPES.filter((scope) => !have.has(scope))
-}
-
-// Whether the expanded granted set satisfies a single scope. Used to gate
-// elevated (on-demand) actions like teardown on delete_repo, which is not part
-// of REQUIRED_SCOPES.
-export function hasScope(granted: string, scope: string): boolean {
-  return expandScopes(granted).has(scope)
 }

--- a/web/src/auth/scopes.ts
+++ b/web/src/auth/scopes.ts
@@ -42,6 +42,15 @@ export function expandScopes(granted: string): Set<string> {
 // every required scope reported missing; callers decide whether an absent
 // signal should suppress the warning (see useMissingScopes).
 export function missingScopes(granted: string): string[] {
+  return missingFrom(REQUIRED_SCOPES, granted)
+}
+
+// Which of `required` the granted string doesn't satisfy, so callers with their
+// own required set (e.g. the elevated scopes) reuse one implication-aware check.
+export function missingFrom(
+  required: readonly string[],
+  granted: string,
+): string[] {
   const have = expandScopes(granted)
-  return REQUIRED_SCOPES.filter((scope) => !have.has(scope))
+  return required.filter((scope) => !have.has(scope))
 }

--- a/web/src/auth/scopes.ts
+++ b/web/src/auth/scopes.ts
@@ -43,3 +43,10 @@ export function missingScopes(granted: string): string[] {
   const have = expandScopes(granted)
   return REQUIRED_SCOPES.filter((scope) => !have.has(scope))
 }
+
+// Whether the expanded granted set satisfies a single scope. Used to gate
+// elevated (on-demand) actions like teardown on delete_repo, which is not part
+// of REQUIRED_SCOPES.
+export function hasScope(granted: string, scope: string): boolean {
+  return expandScopes(granted).has(scope)
+}

--- a/web/src/auth/storage.test.ts
+++ b/web/src/auth/storage.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { GITHUB_AUTH_STORAGE } from "./constants"
+import {
+  clearGithubToken,
+  getStoredAuthMethod,
+  persistGithubToken,
+} from "./storage"
+
+// happy-dom doesn't back window.localStorage here, so install a minimal
+// in-memory store — the same shape the hiddenOrgsStore / useTheme tests use.
+function installLocalStorage() {
+  const store = new Map<string, string>()
+  Object.defineProperty(window, "localStorage", {
+    value: {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size
+      },
+    },
+    configurable: true,
+  })
+}
+
+beforeEach(installLocalStorage)
+
+// How a session signed in decides the remedy for a missing destructive scope:
+// an OAuth session can be re-authed in-app, a PAT has to be replaced on GitHub
+// (#655). Getting "unknown" wrong in either direction misroutes the user, so the
+// read is deliberately strict.
+describe("getStoredAuthMethod", () => {
+  it("round-trips a persisted method", () => {
+    persistGithubToken("gho_x", "repo", "oauth")
+    expect(getStoredAuthMethod()).toBe("oauth")
+
+    persistGithubToken("ghp_x", "repo", "pat")
+    expect(getStoredAuthMethod()).toBe("pat")
+  })
+
+  it("reports unknown for a session stored before the method was tracked", () => {
+    // The upgrade path: an existing signed-in user has a token and scopes but no
+    // method key. This must read as unknown rather than defaulting to a method.
+    window.localStorage.setItem(GITHUB_AUTH_STORAGE.TOKEN, "gho_x")
+    window.localStorage.setItem(GITHUB_AUTH_STORAGE.SCOPE_GRANTED, "repo")
+    expect(getStoredAuthMethod()).toBeNull()
+  })
+
+  it("rejects a value it doesn't recognize", () => {
+    // localStorage is user-writable, so an arbitrary string must never be
+    // trusted as a method.
+    window.localStorage.setItem(GITHUB_AUTH_STORAGE.AUTH_METHOD, "oauth-ish")
+    expect(getStoredAuthMethod()).toBeNull()
+  })
+
+  it("clears a stale method when a later sign-in doesn't know its own", () => {
+    // Otherwise a PAT session could inherit the previous OAuth session's method
+    // and be offered an elevation that can't help it.
+    persistGithubToken("gho_x", "repo", "oauth")
+    persistGithubToken("ghp_x", "repo")
+    expect(getStoredAuthMethod()).toBeNull()
+  })
+
+  it("forgets the method on sign-out", () => {
+    persistGithubToken("ghp_x", "repo", "pat")
+    clearGithubToken()
+    expect(getStoredAuthMethod()).toBeNull()
+    expect(window.localStorage.getItem(GITHUB_AUTH_STORAGE.TOKEN)).toBeNull()
+  })
+})

--- a/web/src/auth/storage.ts
+++ b/web/src/auth/storage.ts
@@ -1,5 +1,6 @@
 import { GITHUB_AUTH_SESSION, GITHUB_AUTH_STORAGE } from "./constants"
 import { isSafeReturnTo } from "./returnTo"
+import type { AuthMethod } from "./types"
 
 function canUseBrowserStorage() {
   return typeof window !== "undefined"
@@ -20,21 +21,42 @@ export function getStoredGithubScope() {
   return localStorage.getItem(GITHUB_AUTH_STORAGE.SCOPE_GRANTED) ?? ""
 }
 
+// How the stored session signed in, or null when unknowable: a session persisted
+// before this key existed, or a value localStorage no longer recognizes (it is
+// user-writable, so an unrecognized string must not be trusted as a method).
+export function getStoredAuthMethod(): AuthMethod | null {
+  if (!canUseBrowserStorage()) return null
+  const stored = localStorage.getItem(GITHUB_AUTH_STORAGE.AUTH_METHOD)
+  return stored === "oauth" || stored === "pat" ? stored : null
+}
+
 export function persistGithubClientId(clientId: string) {
   if (!canUseBrowserStorage()) return
   localStorage.setItem(GITHUB_AUTH_STORAGE.CLIENT_ID, clientId)
 }
 
-export function persistGithubToken(token: string, scope = "") {
+export function persistGithubToken(
+  token: string,
+  scope = "",
+  authMethod?: AuthMethod,
+) {
   if (!canUseBrowserStorage()) return
   localStorage.setItem(GITHUB_AUTH_STORAGE.TOKEN, token)
   localStorage.setItem(GITHUB_AUTH_STORAGE.SCOPE_GRANTED, scope)
+  // Remove rather than leave a stale value: a caller that doesn't know the
+  // method must produce "unknown", not inherit the previous session's.
+  if (authMethod) {
+    localStorage.setItem(GITHUB_AUTH_STORAGE.AUTH_METHOD, authMethod)
+  } else {
+    localStorage.removeItem(GITHUB_AUTH_STORAGE.AUTH_METHOD)
+  }
 }
 
 export function clearGithubToken() {
   if (!canUseBrowserStorage()) return
   localStorage.removeItem(GITHUB_AUTH_STORAGE.TOKEN)
   localStorage.removeItem(GITHUB_AUTH_STORAGE.SCOPE_GRANTED)
+  localStorage.removeItem(GITHUB_AUTH_STORAGE.AUTH_METHOD)
 }
 
 export function saveOAuthSession(input: {

--- a/web/src/auth/types.ts
+++ b/web/src/auth/types.ts
@@ -43,3 +43,9 @@ export type WebSignInOptions = SignInOptions & { returnTo?: string }
 // through. Classic spans every org the teacher owns (the multi-org default);
 // fine-grained is scoped to one org.
 export type PatTokenType = "classic" | "fine-grained"
+
+// How the session's token was obtained. Only OAuth tokens can be re-issued from
+// inside the app, so this decides whether a missing destructive scope is a
+// re-auth we can offer or a token the user has to replace on GitHub (#655).
+// `null` means unknown — a session stored before this was tracked.
+export type AuthMethod = "oauth" | "pat"

--- a/web/src/auth/types.ts
+++ b/web/src/auth/types.ts
@@ -33,6 +33,12 @@ export type DeviceAuthState = {
 export type GithubAuthScreen =
   "config" | "exchanging" | "device-prompt" | "pat-prompt" | "authed"
 
+// Options shared by every sign-in starter. `elevated` broadens the requested
+// scope for one flow only (see auth/constants.ts); `returnTo` survives the
+// GitHub round-trip so a caller mid-task lands back where it was (#71).
+export type SignInOptions = { elevated?: boolean }
+export type WebSignInOptions = SignInOptions & { returnTo?: string }
+
 // Which personal-access-token variant the PAT sign-in prompt guides the user
 // through. Classic spans every org the teacher owns (the multi-org default);
 // fine-grained is scoped to one org.

--- a/web/src/auth/types.ts
+++ b/web/src/auth/types.ts
@@ -25,6 +25,9 @@ export type DeviceAuthState = {
   attempts: number
   nextPollAt: number
   progress: 0 | 1 | 2
+  // Which scope tier this flow requested, so a surface offering both (the
+  // elevated-access dialog) never renders a pending code under the wrong label.
+  elevated: boolean
 }
 
 export type GithubAuthScreen =

--- a/web/src/auth/useGithubAuth.autoLogin.test.tsx
+++ b/web/src/auth/useGithubAuth.autoLogin.test.tsx
@@ -29,15 +29,18 @@ const storage = {
   token: null as string | null,
   clientId: "",
   scope: "",
+  authMethod: null as "oauth" | "pat" | null,
 }
-const persistGithubToken = vi.fn<(token: string, scope?: string) => void>()
+const persistGithubToken =
+  vi.fn<(token: string, scope?: string, authMethod?: string) => void>()
 
 vi.mock("./storage", () => ({
   getStoredGithubToken: () => storage.token,
   getStoredGithubClientId: () => storage.clientId,
   getStoredGithubScope: () => storage.scope,
-  persistGithubToken: (token: string, scope?: string) =>
-    persistGithubToken(token, scope),
+  getStoredAuthMethod: () => storage.authMethod,
+  persistGithubToken: (token: string, scope?: string, authMethod?: string) =>
+    persistGithubToken(token, scope, authMethod),
   persistGithubClientId: vi.fn(),
   clearGithubToken: vi.fn(),
   saveOAuthSession: vi.fn(),
@@ -87,6 +90,7 @@ beforeEach(() => {
   storage.token = null
   storage.clientId = ""
   storage.scope = ""
+  storage.authMethod = null
   window.history.replaceState({}, "", "/")
 })
 
@@ -110,7 +114,13 @@ describe("dev auto-login effect wiring", () => {
     })
 
     await waitFor(() => expect(result.current.token).toBe("ghp_valid"))
-    expect(persistGithubToken).toHaveBeenCalledWith("ghp_valid", FULL_SCOPES)
+    // The third argument records HOW the session signed in, so a later missing
+    // scope is reported as "replace your token", not an OAuth re-auth (#655).
+    expect(persistGithubToken).toHaveBeenCalledWith(
+      "ghp_valid",
+      FULL_SCOPES,
+      "pat",
+    )
     expect(result.current.screen).toBe("authed")
     expect(fetchGithubUserWithScopes).toHaveBeenCalledWith("ghp_valid")
   })
@@ -209,7 +219,11 @@ describe("dev auto-login effect wiring", () => {
     // Validation resolves after the initiating instance is gone.
     resolveValidation({ user: { login: "octocat" }, scopes: FULL_SCOPES })
     await waitFor(() =>
-      expect(persistGithubToken).toHaveBeenCalledWith("ghp_valid", FULL_SCOPES),
+      expect(persistGithubToken).toHaveBeenCalledWith(
+        "ghp_valid",
+        FULL_SCOPES,
+        "pat",
+      ),
     )
   })
 
@@ -243,7 +257,11 @@ describe("dev auto-login effect wiring", () => {
       expect(fetchGithubUserWithScopes).toHaveBeenCalledTimes(2),
     )
     await waitFor(() =>
-      expect(persistGithubToken).toHaveBeenCalledWith("ghp_valid", FULL_SCOPES),
+      expect(persistGithubToken).toHaveBeenCalledWith(
+        "ghp_valid",
+        FULL_SCOPES,
+        "pat",
+      ),
     )
   })
 

--- a/web/src/auth/useGithubAuth.elevated.test.tsx
+++ b/web/src/auth/useGithubAuth.elevated.test.tsx
@@ -46,6 +46,7 @@ vi.mock("./storage", () => ({
   getStoredGithubToken: () => null,
   getStoredGithubClientId: () => "Ov23liTEST",
   getStoredGithubScope: () => "",
+  getStoredAuthMethod: () => null,
   persistGithubToken: vi.fn(),
   persistGithubClientId: vi.fn(),
   clearGithubToken: vi.fn(),

--- a/web/src/auth/useGithubAuth.elevated.test.tsx
+++ b/web/src/auth/useGithubAuth.elevated.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+// The scope string that actually reaches GitHub is the whole point of #655:
+// a normal sign-in must never request delete_repo, and only an explicitly
+// elevated call may. Every other test in this area stops at a mocked
+// startWebFlow, so this file is the one that executes validateConfig's ternary.
+
+vi.mock("@/router", () => ({ default: { history: { push: vi.fn() } } }))
+
+const buildGithubAuthorizeUrl = vi.fn<(input: { scope: string }) => string>(
+  () => "https://example.test/auth",
+)
+const requestDeviceCode = vi.fn<
+  (input: { scope: string }) => Promise<Record<string, unknown>>
+>(async () => ({
+  device_code: "dc",
+  user_code: "UC-1",
+  verification_uri: "https://github.com/login/device",
+  expires_in: 900,
+  interval: 5,
+}))
+
+vi.mock("./github-oauth-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./github-oauth-api")>()
+  return {
+    ...actual,
+    buildGithubAuthorizeUrl: (input: { scope: string }) =>
+      buildGithubAuthorizeUrl(input),
+    requestDeviceCode: (input: { scope: string }) => requestDeviceCode(input),
+  }
+})
+
+const saveOAuthSession = vi.fn<(input: { scope: string }) => void>()
+
+vi.mock("./storage", () => ({
+  getStoredGithubToken: () => null,
+  getStoredGithubClientId: () => "Ov23liTEST",
+  getStoredGithubScope: () => "",
+  persistGithubToken: vi.fn(),
+  persistGithubClientId: vi.fn(),
+  clearGithubToken: vi.fn(),
+  saveOAuthSession: (input: { scope: string }) => saveOAuthSession(input),
+  consumeOAuthSession: () => ({
+    verifier: null,
+    expectedState: null,
+    clientId: null,
+    scope: null,
+    returnTo: null,
+  }),
+}))
+
+import { DEFAULT_GITHUB_SCOPE, ELEVATED_GITHUB_SCOPE } from "./constants"
+import { GitHubAuthProvider, useGithubAuth } from "./useGithubAuth"
+
+function wrapper({ children }: PropsWithChildren) {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  })
+  return createElement(
+    QueryClientProvider,
+    { client },
+    createElement(GitHubAuthProvider, null, children),
+  )
+}
+
+beforeEach(() => {
+  vi.stubEnv("DEV", false)
+  // jsdom/happy-dom forbids assigning location.href; swap in a plain object.
+  Object.defineProperty(window, "location", {
+    value: { origin: "https://classroom50.test", search: "", href: "" },
+    writable: true,
+    configurable: true,
+  })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.unstubAllEnvs()
+})
+
+describe("sign-in scope (#655)", () => {
+  it("requests base scopes, without delete_repo, for a normal web sign-in", async () => {
+    const { result } = renderHook(() => useGithubAuth(), { wrapper })
+    await result.current.startWebFlow()
+
+    await waitFor(() => expect(buildGithubAuthorizeUrl).toHaveBeenCalled())
+    const { scope } = buildGithubAuthorizeUrl.mock.calls[0]![0]
+    expect(scope).toBe(DEFAULT_GITHUB_SCOPE)
+    expect(scope).not.toContain("delete_repo")
+    // The callback trusts the session scope, so it must match what we requested.
+    expect(saveOAuthSession).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: DEFAULT_GITHUB_SCOPE }),
+    )
+  })
+
+  it("adds delete_repo only when the web flow is explicitly elevated", async () => {
+    const { result } = renderHook(() => useGithubAuth(), { wrapper })
+    await result.current.startWebFlow({ elevated: true })
+
+    await waitFor(() => expect(buildGithubAuthorizeUrl).toHaveBeenCalled())
+    const { scope } = buildGithubAuthorizeUrl.mock.calls[0]![0]
+    expect(scope).toBe(ELEVATED_GITHUB_SCOPE)
+    expect(scope).toContain("delete_repo")
+  })
+
+  it("requests base scopes for a normal device sign-in", async () => {
+    const { result } = renderHook(() => useGithubAuth(), { wrapper })
+    await result.current.startDeviceFlow()
+
+    await waitFor(() => expect(requestDeviceCode).toHaveBeenCalled())
+    const { scope } = requestDeviceCode.mock.calls[0]![0]
+    expect(scope).toBe(DEFAULT_GITHUB_SCOPE)
+    expect(scope).not.toContain("delete_repo")
+  })
+
+  it("adds delete_repo only when the device flow is explicitly elevated", async () => {
+    const { result } = renderHook(() => useGithubAuth(), { wrapper })
+    await result.current.startDeviceFlow({ elevated: true })
+
+    await waitFor(() => expect(requestDeviceCode).toHaveBeenCalled())
+    const { scope } = requestDeviceCode.mock.calls[0]![0]
+    expect(scope).toBe(ELEVATED_GITHUB_SCOPE)
+    expect(scope).toContain("delete_repo")
+  })
+})

--- a/web/src/auth/useGithubAuth.elevated.test.tsx
+++ b/web/src/auth/useGithubAuth.elevated.test.tsx
@@ -25,6 +25,10 @@ const requestDeviceCode = vi.fn<
   interval: 5,
 }))
 
+const pollDeviceToken = vi.fn<() => Promise<Record<string, unknown>>>(
+  async () => ({ error: "authorization_pending" }),
+)
+
 vi.mock("./github-oauth-api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./github-oauth-api")>()
   return {
@@ -32,6 +36,7 @@ vi.mock("./github-oauth-api", async (importOriginal) => {
     buildGithubAuthorizeUrl: (input: { scope: string }) =>
       buildGithubAuthorizeUrl(input),
     requestDeviceCode: (input: { scope: string }) => requestDeviceCode(input),
+    pollDeviceToken: () => pollDeviceToken(),
   }
 })
 
@@ -126,5 +131,60 @@ describe("sign-in scope (#655)", () => {
     const { scope } = requestDeviceCode.mock.calls[0]![0]
     expect(scope).toBe(ELEVATED_GITHUB_SCOPE)
     expect(scope).toContain("delete_repo")
+  })
+
+  it("records the requested tier on the stored device state", async () => {
+    // The modal decides which prompt is "its own" by comparing device.elevated
+    // to its direction, so the provider's writer must be correct — the modal's
+    // own tests use a hand-built fixture and can't prove this.
+    const { result } = renderHook(() => useGithubAuth(), { wrapper })
+    await result.current.startDeviceFlow({ elevated: true })
+
+    await waitFor(() => expect(result.current.device).toBeTruthy())
+    expect(result.current.device!.elevated).toBe(true)
+    expect(result.current.screen).toBe("device-prompt")
+  })
+
+  it("records a base device flow as not elevated", async () => {
+    const { result } = renderHook(() => useGithubAuth(), { wrapper })
+    await result.current.startDeviceFlow()
+
+    await waitFor(() => expect(result.current.device).toBeTruthy())
+    expect(result.current.device!.elevated).toBe(false)
+  })
+
+  it("discards a device code that arrives after the flow was cancelled", async () => {
+    // The device-code request is not abortable, so a cancel during the in-flight
+    // window must make its callback a no-op. Otherwise a poll starts with no UI
+    // and can silently swap the session token for an elevated one.
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    requestDeviceCode.mockImplementationOnce(async () => {
+      await gate
+      return {
+        device_code: "dc",
+        user_code: "UC-1",
+        verification_uri: "https://github.com/login/device",
+        expires_in: 900,
+        interval: 5,
+      }
+    })
+
+    const { result } = renderHook(() => useGithubAuth(), { wrapper })
+    const pending = result.current.startDeviceFlow({ elevated: true })
+    await waitFor(() => expect(requestDeviceCode).toHaveBeenCalled())
+    // Cancel while the request is still in flight, then let it resolve.
+    result.current.cancelDeviceFlow()
+    release!()
+    await pending
+    await gate
+    // Give any (incorrectly) started poll a chance to fire.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    // The hazard is a poll running with no UI attached, able to swap the token.
+    expect(pollDeviceToken).not.toHaveBeenCalled()
+    expect(result.current.device).toBeNull()
   })
 })

--- a/web/src/auth/useGithubAuth.recovery.test.ts
+++ b/web/src/auth/useGithubAuth.recovery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   classifyPatResult,
+  idleScreen,
   isTransientUserError,
   isValidationStuck,
   recoverStrandedExchange,
@@ -50,6 +51,19 @@ describe("recoverStrandedExchange", () => {
     expect(recoverStrandedExchange("config")).toBe("config")
     expect(recoverStrandedExchange("device-prompt")).toBe("device-prompt")
     expect(recoverStrandedExchange("authed")).toBe("authed")
+  })
+})
+
+// Where a device flow lands once it stops (cancel or failure). An elevated
+// re-auth runs from inside the authenticated app, so returning to "config" would
+// park a signed-in teacher on the login surface (#655).
+describe("idleScreen", () => {
+  it("returns a signed-in session to the authed screen", () => {
+    expect(idleScreen("gho_token")).toBe("authed")
+  })
+
+  it("returns a session with no token to the login surface", () => {
+    expect(idleScreen(null)).toBe("config")
   })
 })
 

--- a/web/src/auth/useGithubAuth.recovery.test.ts
+++ b/web/src/auth/useGithubAuth.recovery.test.ts
@@ -68,11 +68,11 @@ describe("classifyPatResult", () => {
     expect(result.kind).toBe("missing")
     if (result.kind === "missing") {
       // read:org is implied by admin:org, so it should not be reported once
-      // admin:org is present, but here neither admin:org nor read:user/delete_repo
-      // is granted.
+      // admin:org is present, but here neither admin:org nor read:user is
+      // granted. delete_repo is elevated-only, so it is never reported missing.
       expect(result.missing).toContain("admin:org")
       expect(result.missing).toContain("read:user")
-      expect(result.missing).toContain("delete_repo")
+      expect(result.missing).not.toContain("delete_repo")
     }
   })
 

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -51,6 +51,7 @@ import {
   clearGithubToken,
   consumeOAuthSession,
   getStoredGithubClientId,
+  getStoredAuthMethod,
   getStoredGithubScope,
   getStoredGithubToken,
   persistGithubClientId,
@@ -58,6 +59,7 @@ import {
   saveOAuthSession,
 } from "./storage"
 import type {
+  AuthMethod,
   DeviceAuthState,
   GithubAuthScreen,
   PatTokenType,
@@ -272,6 +274,10 @@ function useGithubAuthState() {
   // keying a cleanup effect off one would stop being unmount-only.
   const tokenRef = useRef(token)
   const [tokenScope, setTokenScope] = useState("")
+  // How the live session signed in; null until restored/known. Only an OAuth
+  // session can be re-issued in-app, so this gates whether a missing
+  // destructive scope offers a re-auth or a replace-your-token warning (#655).
+  const [authMethod, setAuthMethod] = useState<AuthMethod | null>(null)
   const [error, setError] = useState<string | null>(null)
   // Scoped to the PAT prompt so a token-entry failure surfaces on that screen
   // without disturbing the config screen's `error`.
@@ -339,11 +345,16 @@ function useGithubAuthState() {
   // authenticated and the /login guard redirects into the app. Until then the
   // card shows a spinner (no interstitial success splash).
   const completeSignIn = useCallback(
-    (data: { access_token: string; scope?: string }) => {
+    (data: {
+      access_token: string
+      scope?: string
+      authMethod: AuthMethod
+    }) => {
       log.info("sign-in complete, token acquired")
-      persistGithubToken(data.access_token, data.scope || "")
+      persistGithubToken(data.access_token, data.scope || "", data.authMethod)
       setToken(data.access_token)
       setTokenScope(data.scope || "")
+      setAuthMethod(data.authMethod)
       setSessionExpired(false)
       setDevice(null)
       setScreen("authed")
@@ -377,7 +388,11 @@ function useGithubAuthState() {
           // govern its per-resource permissions. It carries an empty granted
           // scope so useMissingScopes stays fail-open (no spurious banner).
           if (result.kind === "fine-grained-ok") {
-            completeSignIn({ access_token: token, scope: "" })
+            completeSignIn({
+              access_token: token,
+              scope: "",
+              authMethod: "pat",
+            })
             return
           }
 
@@ -393,7 +408,11 @@ function useGithubAuthState() {
             return
           }
 
-          completeSignIn({ access_token: token, scope: result.scopes })
+          completeSignIn({
+            access_token: token,
+            scope: result.scopes,
+            authMethod: "pat",
+          })
         },
         onError: (err) => {
           if (err instanceof GitHubUserFetchError && err.status === 401) {
@@ -433,6 +452,7 @@ function useGithubAuthState() {
     if (storedToken) {
       log.info("restored stored session")
       setToken(storedToken)
+      setAuthMethod(getStoredAuthMethod())
       setScreen("authed")
     } else {
       // Dev-only: skip the sign-in screen when VITE_GITHUB_PAT holds a valid PAT
@@ -460,7 +480,11 @@ function useGithubAuthState() {
         void runDevAutoLoginOnce(envPat)
           .then((res) => {
             if (res)
-              completeSignIn({ access_token: res.token, scope: res.scope })
+              completeSignIn({
+                access_token: res.token,
+                scope: res.scope,
+                authMethod: "pat",
+              })
           })
           .finally(() => setAutoLoginPending(false))
       }
@@ -538,7 +562,7 @@ function useGithubAuthState() {
       },
       {
         onSuccess: (data) => {
-          completeSignIn(data)
+          completeSignIn({ ...data, authMethod: "oauth" })
           // Defer the return until status is "authenticated" (effect below);
           // navigating now would race the router context and bounce through the
           // _authed guard (#71).
@@ -733,7 +757,11 @@ function useGithubAuthState() {
           return
         }
 
-        completeSignIn({ access_token: data.access_token, scope: data.scope })
+        completeSignIn({
+          access_token: data.access_token,
+          scope: data.scope,
+          authMethod: "oauth",
+        })
 
         return
       }
@@ -868,6 +896,7 @@ function useGithubAuthState() {
       clearGithubToken()
       setToken(null)
       setTokenScope("")
+      setAuthMethod(null)
       setDevice(null)
       setError(null)
       setScreen("config")
@@ -998,6 +1027,7 @@ function useGithubAuthState() {
     screen,
     token,
     tokenScope,
+    authMethod,
     error,
     device,
     deviceStatus,

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -239,6 +239,12 @@ function useGithubAuthState() {
   const { t } = useTranslation()
   const isOnline = useOnlineStatus()
   const abortRef = useRef<AbortController | null>(null)
+  // Bumped whenever a device flow is cancelled or fails. `startDeviceFlow`
+  // captures the current value and its callbacks no-op if it changed, because
+  // the device-code request itself is not abortable: abortRef only exists once
+  // polling starts, so without this a cancel during the in-flight request lets a
+  // poll start (and swap the session token) with no UI attached.
+  const deviceGenRef = useRef(0)
   // Deep link (#71) stashed at code-exchange, consumed by the status-driven
   // effect below so navigation runs against an authenticated router context.
   const pendingReturnToRef = useRef<string | null>(null)
@@ -605,14 +611,18 @@ function useGithubAuthState() {
     [validateConfig],
   )
 
-  const failDeviceFlow = useCallback((message: string) => {
-    log.warn("device flow failed", { record: true })
-    abortRef.current?.abort()
-    abortRef.current = null
-    setError(message)
-    setDevice(null)
-    setScreen("config")
-  }, [])
+  const failDeviceFlow = useCallback(
+    (message: string) => {
+      log.warn("device flow failed", { record: true })
+      deviceGenRef.current += 1
+      abortRef.current?.abort()
+      abortRef.current = null
+      setError(message)
+      setDevice(null)
+      setScreen(token ? "authed" : "config")
+    },
+    [token],
+  )
 
   const startDevicePolling = useCallback(
     async (input: {
@@ -722,8 +732,16 @@ function useGithubAuthState() {
       })
       setError(null)
 
+      // Capture the generation: a cancel (or navigation) while the request is in
+      // flight bumps it, and the callbacks below must then do nothing.
+      const generation = ++deviceGenRef.current
+
       requestDeviceCodeMutation.mutate(config, {
         onSuccess: (data) => {
+          if (generation !== deviceGenRef.current) {
+            log.info("device code issued after cancel, discarding")
+            return
+          }
           log.info("device code issued, awaiting authorization")
           const intervalSeconds = data.interval || 5
           const expiresAt = Date.now() + data.expires_in! * 1000
@@ -750,6 +768,7 @@ function useGithubAuthState() {
           })
         },
         onError: (err) => {
+          if (generation !== deviceGenRef.current) return
           failDeviceFlow(formatError(t, err))
         },
       })
@@ -764,12 +783,15 @@ function useGithubAuthState() {
   )
 
   const cancelDeviceFlow = useCallback(() => {
+    deviceGenRef.current += 1
     abortRef.current?.abort()
     abortRef.current = null
     setDevice(null)
     setError(null)
-    setScreen("config")
-  }, [])
+    // Restore the screen the session is actually in: hardcoding "config" parks an
+    // authenticated session on the login surface.
+    setScreen(token ? "authed" : "config")
+  }, [token])
 
   const markDeviceCodeCopied = useCallback(() => {
     setDevice((current) =>

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -710,50 +710,55 @@ function useGithubAuthState() {
     [completeSignIn, failDeviceFlow, t],
   )
 
-  const startDeviceFlow = useCallback(async () => {
-    const config = validateConfig()
-    if (!config) return
+  const startDeviceFlow = useCallback(
+    async (opts?: { elevated?: boolean }) => {
+      const config = validateConfig(opts)
+      if (!config) return
 
-    log.info("starting device sign-in flow")
-    setError(null)
+      log.info("starting device sign-in flow", {
+        elevated: opts?.elevated ?? false,
+      })
+      setError(null)
 
-    requestDeviceCodeMutation.mutate(config, {
-      onSuccess: (data) => {
-        log.info("device code issued, awaiting authorization")
-        const intervalSeconds = data.interval || 5
-        const expiresAt = Date.now() + data.expires_in! * 1000
+      requestDeviceCodeMutation.mutate(config, {
+        onSuccess: (data) => {
+          log.info("device code issued, awaiting authorization")
+          const intervalSeconds = data.interval || 5
+          const expiresAt = Date.now() + data.expires_in! * 1000
 
-        setDevice({
-          userCode: data.user_code!,
-          verificationUri: data.verification_uri!,
-          deviceCode: data.device_code!,
-          expiresAt,
-          intervalSeconds,
-          attempts: 0,
-          nextPollAt: Date.now() + intervalSeconds * 1000,
-          progress: 0,
-        })
+          setDevice({
+            userCode: data.user_code!,
+            verificationUri: data.verification_uri!,
+            deviceCode: data.device_code!,
+            expiresAt,
+            intervalSeconds,
+            attempts: 0,
+            nextPollAt: Date.now() + intervalSeconds * 1000,
+            progress: 0,
+          })
 
-        setScreen("device-prompt")
+          setScreen("device-prompt")
 
-        void startDevicePolling({
-          clientId: config.clientId,
-          deviceCode: data.device_code!,
-          expiresAt,
-          initialIntervalSeconds: intervalSeconds,
-        })
-      },
-      onError: (err) => {
-        failDeviceFlow(formatError(t, err))
-      },
-    })
-  }, [
-    failDeviceFlow,
-    requestDeviceCodeMutation,
-    startDevicePolling,
-    validateConfig,
-    t,
-  ])
+          void startDevicePolling({
+            clientId: config.clientId,
+            deviceCode: data.device_code!,
+            expiresAt,
+            initialIntervalSeconds: intervalSeconds,
+          })
+        },
+        onError: (err) => {
+          failDeviceFlow(formatError(t, err))
+        },
+      })
+    },
+    [
+      failDeviceFlow,
+      requestDeviceCodeMutation,
+      startDevicePolling,
+      validateConfig,
+      t,
+    ],
+  )
 
   const cancelDeviceFlow = useCallback(() => {
     abortRef.current?.abort()

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -255,6 +255,10 @@ function useGithubAuthState() {
   // prompt's guidance + pre-fill (classic vs fine-grained).
   const [patTokenType, setPatTokenType] = useState<PatTokenType>("classic")
   const [device, setDevice] = useState<DeviceAuthState | null>(null)
+  // Which scope tier the in-flight device flow requested, so a surface that
+  // offers both (the elevated-access modal) never renders a pending code under
+  // the wrong label. null when no device flow is in flight.
+  const [deviceElevated, setDeviceElevated] = useState<boolean | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const [hasLoadedStoredAuth, setHasLoadedStoredAuth] = useState(false)
   // Holds status at "loading" while a dev auto-login validates (see
@@ -317,6 +321,7 @@ function useGithubAuthState() {
       setTokenScope(data.scope || "")
       setSessionExpired(false)
       setDevice(null)
+      setDeviceElevated(null)
       setScreen("authed")
 
       queryClient.prefetchQuery({
@@ -566,7 +571,7 @@ function useGithubAuthState() {
   )
 
   const startWebFlow = useCallback(
-    async (opts?: { elevated?: boolean }) => {
+    async (opts?: { elevated?: boolean; returnTo?: string }) => {
       const config = validateConfig(opts)
       if (!config) return
 
@@ -579,11 +584,13 @@ function useGithubAuthState() {
       const challenge = await deriveChallenge(verifier)
       const oauthState = randomBase64Url(16)
 
-      // Stash the deep link (from /login?redirect=) in the OAuth session so it
-      // survives the GitHub round-trip; restored after the code exchange (#71).
-      const returnTo = new URLSearchParams(window.location.search).get(
-        "redirect",
-      )
+      // Stash the deep link in the OAuth session so it survives the GitHub
+      // round-trip; restored after the code exchange (#71). A caller mid-task
+      // (the elevation modal) passes its own path so the redirect returns there
+      // instead of the dashboard; otherwise this is /login?redirect=.
+      const returnTo =
+        opts?.returnTo ??
+        new URLSearchParams(window.location.search).get("redirect")
 
       saveOAuthSession({
         verifier,
@@ -609,6 +616,7 @@ function useGithubAuthState() {
     abortRef.current = null
     setError(message)
     setDevice(null)
+    setDeviceElevated(null)
     setScreen("config")
   }, [])
 
@@ -736,6 +744,7 @@ function useGithubAuthState() {
             nextPollAt: Date.now() + intervalSeconds * 1000,
             progress: 0,
           })
+          setDeviceElevated(opts?.elevated ?? false)
 
           setScreen("device-prompt")
 
@@ -764,6 +773,7 @@ function useGithubAuthState() {
     abortRef.current?.abort()
     abortRef.current = null
     setDevice(null)
+    setDeviceElevated(null)
     setError(null)
     setScreen("config")
   }, [])
@@ -828,6 +838,7 @@ function useGithubAuthState() {
       setToken(null)
       setTokenScope("")
       setDevice(null)
+      setDeviceElevated(null)
       setError(null)
       setScreen("config")
       setSessionExpired(expired)
@@ -960,6 +971,7 @@ function useGithubAuthState() {
     error,
     device,
     deviceStatus,
+    deviceElevated,
     user: githubUserQuery.data ?? null,
     isLoadingUser: githubUserQuery.isLoading,
     isStartingWebFlow: screen === "exchanging",

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -10,7 +10,11 @@ import {
   type PropsWithChildren,
 } from "react"
 import { useTranslation } from "react-i18next"
-import { DEFAULT_GITHUB_SCOPE, GITHUB_OAUTH_CLIENT_ID } from "./constants"
+import {
+  DEFAULT_GITHUB_SCOPE,
+  ELEVATED_GITHUB_SCOPE,
+  GITHUB_OAUTH_CLIENT_ID,
+} from "./constants"
 import {
   buildGithubAuthorizeUrl,
   exchangeWebCode,
@@ -539,53 +543,65 @@ function useGithubAuthState() {
     return () => window.removeEventListener("pageshow", onPageShow)
   }, [])
 
-  const validateConfig = useCallback(() => {
-    const trimmedClientId = clientId.trim()
+  const validateConfig = useCallback(
+    (opts?: { elevated?: boolean }) => {
+      const trimmedClientId = clientId.trim()
 
-    if (!trimmedClientId) {
-      setError(t("auth.errorClientIdMissing"))
-      return null
-    }
+      if (!trimmedClientId) {
+        setError(t("auth.errorClientIdMissing"))
+        return null
+      }
 
-    persistGithubClientId(trimmedClientId)
-    setError(null)
+      persistGithubClientId(trimmedClientId)
+      setError(null)
 
-    return {
-      clientId: trimmedClientId,
-      scope: DEFAULT_GITHUB_SCOPE,
-    }
-  }, [clientId, t])
+      return {
+        clientId: trimmedClientId,
+        // Elevation is one-shot: the broadened scope is chosen at call time and
+        // never persisted, so a later fresh login drops back to base (#655).
+        scope: opts?.elevated ? ELEVATED_GITHUB_SCOPE : DEFAULT_GITHUB_SCOPE,
+      }
+    },
+    [clientId, t],
+  )
 
-  const startWebFlow = useCallback(async () => {
-    const config = validateConfig()
-    if (!config) return
+  const startWebFlow = useCallback(
+    async (opts?: { elevated?: boolean }) => {
+      const config = validateConfig(opts)
+      if (!config) return
 
-    log.info("starting web (PKCE) sign-in flow")
-    setScreen("exchanging")
+      log.info("starting web (PKCE) sign-in flow", {
+        elevated: opts?.elevated ?? false,
+      })
+      setScreen("exchanging")
 
-    const verifier = generateVerifier()
-    const challenge = await deriveChallenge(verifier)
-    const oauthState = randomBase64Url(16)
+      const verifier = generateVerifier()
+      const challenge = await deriveChallenge(verifier)
+      const oauthState = randomBase64Url(16)
 
-    // Stash the deep link (from /login?redirect=) in the OAuth session so it
-    // survives the GitHub round-trip; restored after the code exchange (#71).
-    const returnTo = new URLSearchParams(window.location.search).get("redirect")
+      // Stash the deep link (from /login?redirect=) in the OAuth session so it
+      // survives the GitHub round-trip; restored after the code exchange (#71).
+      const returnTo = new URLSearchParams(window.location.search).get(
+        "redirect",
+      )
 
-    saveOAuthSession({
-      verifier,
-      state: oauthState,
-      clientId: config.clientId,
-      scope: config.scope,
-      returnTo,
-    })
+      saveOAuthSession({
+        verifier,
+        state: oauthState,
+        clientId: config.clientId,
+        scope: config.scope,
+        returnTo,
+      })
 
-    window.location.href = buildGithubAuthorizeUrl({
-      clientId: config.clientId,
-      scope: config.scope,
-      state: oauthState,
-      challenge,
-    })
-  }, [validateConfig])
+      window.location.href = buildGithubAuthorizeUrl({
+        clientId: config.clientId,
+        scope: config.scope,
+        state: oauthState,
+        challenge,
+      })
+    },
+    [validateConfig],
+  )
 
   const failDeviceFlow = useCallback((message: string) => {
     log.warn("device flow failed", { record: true })

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -255,10 +255,6 @@ function useGithubAuthState() {
   // prompt's guidance + pre-fill (classic vs fine-grained).
   const [patTokenType, setPatTokenType] = useState<PatTokenType>("classic")
   const [device, setDevice] = useState<DeviceAuthState | null>(null)
-  // Which scope tier the in-flight device flow requested, so a surface that
-  // offers both (the elevated-access modal) never renders a pending code under
-  // the wrong label. null when no device flow is in flight.
-  const [deviceElevated, setDeviceElevated] = useState<boolean | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const [hasLoadedStoredAuth, setHasLoadedStoredAuth] = useState(false)
   // Holds status at "loading" while a dev auto-login validates (see
@@ -321,7 +317,6 @@ function useGithubAuthState() {
       setTokenScope(data.scope || "")
       setSessionExpired(false)
       setDevice(null)
-      setDeviceElevated(null)
       setScreen("authed")
 
       queryClient.prefetchQuery({
@@ -616,7 +611,6 @@ function useGithubAuthState() {
     abortRef.current = null
     setError(message)
     setDevice(null)
-    setDeviceElevated(null)
     setScreen("config")
   }, [])
 
@@ -743,8 +737,8 @@ function useGithubAuthState() {
             attempts: 0,
             nextPollAt: Date.now() + intervalSeconds * 1000,
             progress: 0,
+            elevated: opts?.elevated ?? false,
           })
-          setDeviceElevated(opts?.elevated ?? false)
 
           setScreen("device-prompt")
 
@@ -773,7 +767,6 @@ function useGithubAuthState() {
     abortRef.current?.abort()
     abortRef.current = null
     setDevice(null)
-    setDeviceElevated(null)
     setError(null)
     setScreen("config")
   }, [])
@@ -838,7 +831,6 @@ function useGithubAuthState() {
       setToken(null)
       setTokenScope("")
       setDevice(null)
-      setDeviceElevated(null)
       setError(null)
       setScreen("config")
       setSessionExpired(expired)
@@ -971,7 +963,6 @@ function useGithubAuthState() {
     error,
     device,
     deviceStatus,
-    deviceElevated,
     user: githubUserQuery.data ?? null,
     isLoadingUser: githubUserQuery.isLoading,
     isStartingWebFlow: screen === "exchanging",

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -57,7 +57,13 @@ import {
   persistGithubToken,
   saveOAuthSession,
 } from "./storage"
-import type { DeviceAuthState, GithubAuthScreen, PatTokenType } from "./types"
+import type {
+  DeviceAuthState,
+  GithubAuthScreen,
+  PatTokenType,
+  SignInOptions,
+  WebSignInOptions,
+} from "./types"
 import type { AuthStatus } from "@/types/router"
 
 // Translator shape used for the auth error strings. Matches the subset of
@@ -217,18 +223,27 @@ export function recoverStrandedExchange(
   return current === "exchanging" ? "config" : current
 }
 
+// The screen a device flow returns to once it stops: the one the session is
+// actually in. Hardcoding "config" would park an authenticated session on the
+// login surface.
+export function idleScreen(token: string | null): GithubAuthScreen {
+  return token ? "authed" : "config"
+}
+
 function sleep(ms: number, signal: AbortSignal) {
   return new Promise<void>((resolve) => {
-    const timer = window.setTimeout(resolve, ms)
+    // One AbortController spans a whole device flow (~180 sleeps), so a listener
+    // that only self-removes on abort would pile up for the flow's lifetime.
+    const onAbort = () => {
+      window.clearTimeout(timer)
+      resolve()
+    }
+    const timer = window.setTimeout(() => {
+      signal.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
 
-    signal.addEventListener(
-      "abort",
-      () => {
-        window.clearTimeout(timer)
-        resolve()
-      },
-      { once: true },
-    )
+    signal.addEventListener("abort", onAbort, { once: true })
   })
 }
 
@@ -252,6 +267,10 @@ function useGithubAuthState() {
   const [screen, setScreen] = useState<GithubAuthScreen>("config")
   const [clientId, setClientId] = useState(GITHUB_OAUTH_CLIENT_ID)
   const [token, setToken] = useState<string | null>(null)
+  // Mirror of `token` for callbacks that only read it when invoked. Depending on
+  // `token` instead would churn their identity on every sign-in, and a consumer
+  // keying a cleanup effect off one would stop being unmount-only.
+  const tokenRef = useRef(token)
   const [tokenScope, setTokenScope] = useState("")
   const [error, setError] = useState<string | null>(null)
   // Scoped to the PAT prompt so a token-entry failure surfaces on that screen
@@ -270,6 +289,10 @@ function useGithubAuthState() {
   // /login can explain why the user was signed out. A deliberate signOut()
   // clears it.
   const [sessionExpired, setSessionExpired] = useState(false)
+
+  useEffect(() => {
+    tokenRef.current = token
+  }, [token])
 
   const githubUserQuery = useQuery({
     queryKey: ["github", "user", token],
@@ -550,7 +573,7 @@ function useGithubAuthState() {
   }, [])
 
   const validateConfig = useCallback(
-    (opts?: { elevated?: boolean }) => {
+    (opts?: SignInOptions) => {
       const trimmedClientId = clientId.trim()
 
       if (!trimmedClientId) {
@@ -572,13 +595,12 @@ function useGithubAuthState() {
   )
 
   const startWebFlow = useCallback(
-    async (opts?: { elevated?: boolean; returnTo?: string }) => {
+    async (opts?: WebSignInOptions) => {
       const config = validateConfig(opts)
       if (!config) return
 
-      log.info("starting web (PKCE) sign-in flow", {
-        elevated: opts?.elevated ?? false,
-      })
+      const elevated = opts?.elevated ?? false
+      log.info("starting web (PKCE) sign-in flow", { elevated })
       setScreen("exchanging")
 
       const verifier = generateVerifier()
@@ -611,18 +633,15 @@ function useGithubAuthState() {
     [validateConfig],
   )
 
-  const failDeviceFlow = useCallback(
-    (message: string) => {
-      log.warn("device flow failed", { record: true })
-      deviceGenRef.current += 1
-      abortRef.current?.abort()
-      abortRef.current = null
-      setError(message)
-      setDevice(null)
-      setScreen(token ? "authed" : "config")
-    },
-    [token],
-  )
+  const failDeviceFlow = useCallback((message: string) => {
+    log.warn("device flow failed", { record: true })
+    deviceGenRef.current += 1
+    abortRef.current?.abort()
+    abortRef.current = null
+    setError(message)
+    setDevice(null)
+    setScreen(idleScreen(tokenRef.current))
+  }, [])
 
   const startDevicePolling = useCallback(
     async (input: {
@@ -723,13 +742,12 @@ function useGithubAuthState() {
   )
 
   const startDeviceFlow = useCallback(
-    async (opts?: { elevated?: boolean }) => {
+    async (opts?: SignInOptions) => {
       const config = validateConfig(opts)
       if (!config) return
 
-      log.info("starting device sign-in flow", {
-        elevated: opts?.elevated ?? false,
-      })
+      const elevated = opts?.elevated ?? false
+      log.info("starting device sign-in flow", { elevated })
       setError(null)
 
       // Capture the generation: a cancel (or navigation) while the request is in
@@ -755,7 +773,7 @@ function useGithubAuthState() {
             attempts: 0,
             nextPollAt: Date.now() + intervalSeconds * 1000,
             progress: 0,
-            elevated: opts?.elevated ?? false,
+            elevated,
           })
 
           setScreen("device-prompt")
@@ -788,10 +806,8 @@ function useGithubAuthState() {
     abortRef.current = null
     setDevice(null)
     setError(null)
-    // Restore the screen the session is actually in: hardcoding "config" parks an
-    // authenticated session on the login surface.
-    setScreen(token ? "authed" : "config")
-  }, [token])
+    setScreen(idleScreen(tokenRef.current))
+  }, [])
 
   const markDeviceCodeCopied = useCallback(() => {
     setDevice((current) =>

--- a/web/src/context/github/GitHubProvider.test.tsx
+++ b/web/src/context/github/GitHubProvider.test.tsx
@@ -70,4 +70,16 @@ describe("useHasDeleteRepoScope (gate for elevated teardown)", () => {
     })
     expect(result.current).toBe(true)
   })
+
+  it("prefers the login scope over an empty observed header", () => {
+    // A present-but-empty x-oauth-scopes header must not beat a usable login
+    // scope and fail open — that would arm teardown for a base-scoped token.
+    authState.tokenScope = "read:user read:org repo workflow admin:org"
+    const { result } = renderHook(() => useHasDeleteRepoScope(), {
+      wrapper: wrapper("ghp_xxx"),
+      // No observation is injected here; the guard under test is the `||` in the
+      // hook, covered directly by the empty-string case below.
+    })
+    expect(result.current).toBe(false)
+  })
 })

--- a/web/src/context/github/GitHubProvider.test.tsx
+++ b/web/src/context/github/GitHubProvider.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from "vitest"
-import { renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, renderHook } from "@testing-library/react"
 import { createElement, type PropsWithChildren } from "react"
 
 // useMissingScopes reads the login scope from useGithubAuth and the live
@@ -17,12 +17,21 @@ import {
   GitHubProvider,
   useMissingScopes,
   useHasDeleteRepoScope,
+  useDeleteRepoScopeState,
 } from "./GitHubProvider"
 
 function wrapper(token: string | null) {
   return ({ children }: PropsWithChildren) =>
     createElement(GitHubProvider, { token }, children)
 }
+
+// The gate drives an irreversible action, so never let a scope string leak from
+// one case into the next.
+beforeEach(() => {
+  authState.tokenScope = ""
+})
+
+afterEach(cleanup)
 
 describe("useMissingScopes (fail-open backstop)", () => {
   it("returns [] for a fine-grained session (empty login scope, no observation)", () => {
@@ -43,17 +52,41 @@ describe("useMissingScopes (fail-open backstop)", () => {
   })
 })
 
-describe("useHasDeleteRepoScope (gate for elevated teardown)", () => {
-  it("returns true when the login scope carries delete_repo", () => {
-    authState.tokenScope =
-      "read:user read:org repo workflow admin:org delete_repo"
+describe("useDeleteRepoScopeState (honest three-way signal)", () => {
+  const state = (tokenScope: string, token = "ghp_xxx") => {
+    authState.tokenScope = tokenScope
+    return renderHook(() => useDeleteRepoScopeState(), {
+      wrapper: wrapper(token),
+    }).result.current
+  }
+
+  it("reports granted when the scope is present", () => {
+    expect(
+      state("read:user read:org repo workflow admin:org delete_repo"),
+    ).toBe("granted")
+  })
+
+  it("reports missing when a readable grant lacks it", () => {
+    expect(state("read:user read:org repo workflow admin:org")).toBe("missing")
+  })
+
+  it("reports unknown when no scopes are introspectable", () => {
+    // A fine-grained PAT sends no X-OAuth-Scopes header; claiming either answer
+    // would be a lie, and "granted" is the dangerous one to display.
+    expect(state("", "github_pat_xxx")).toBe("unknown")
+  })
+})
+
+describe("useHasDeleteRepoScope (gate: fails open)", () => {
+  it("allows the action when the scope is present", () => {
+    authState.tokenScope = "repo delete_repo"
     const { result } = renderHook(() => useHasDeleteRepoScope(), {
       wrapper: wrapper("ghp_xxx"),
     })
     expect(result.current).toBe(true)
   })
 
-  it("returns false for a positively-scoped classic token without delete_repo", () => {
+  it("blocks the action only when the grant readably lacks it", () => {
     authState.tokenScope = "read:user read:org repo workflow admin:org"
     const { result } = renderHook(() => useHasDeleteRepoScope(), {
       wrapper: wrapper("ghp_xxx"),
@@ -61,25 +94,11 @@ describe("useHasDeleteRepoScope (gate for elevated teardown)", () => {
     expect(result.current).toBe(false)
   })
 
-  it("fails open (true) for a fine-grained session with no introspectable scopes", () => {
-    // A fine-grained PAT can delete via Administration: write but reports no
-    // X-OAuth-Scopes header, so we must not nag it with an OAuth-only prompt.
+  it("fails open on unknown so GitHub stays the authority", () => {
     authState.tokenScope = ""
     const { result } = renderHook(() => useHasDeleteRepoScope(), {
       wrapper: wrapper("github_pat_xxx"),
     })
     expect(result.current).toBe(true)
-  })
-
-  it("prefers the login scope over an empty observed header", () => {
-    // A present-but-empty x-oauth-scopes header must not beat a usable login
-    // scope and fail open — that would arm teardown for a base-scoped token.
-    authState.tokenScope = "read:user read:org repo workflow admin:org"
-    const { result } = renderHook(() => useHasDeleteRepoScope(), {
-      wrapper: wrapper("ghp_xxx"),
-      // No observation is injected here; the guard under test is the `||` in the
-      // hook, covered directly by the empty-string case below.
-    })
-    expect(result.current).toBe(false)
   })
 })

--- a/web/src/context/github/GitHubProvider.test.tsx
+++ b/web/src/context/github/GitHubProvider.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@/auth/useGithubAuth", () => ({
   useGithubAuth: () => authState,
 }))
 
-import { GitHubProvider, useMissingScopes } from "./GitHubProvider"
+import { GitHubProvider, useMissingScopes, useHasDeleteRepoScope } from "./GitHubProvider"
 
 function wrapper(token: string | null) {
   return ({ children }: PropsWithChildren) =>
@@ -36,5 +36,33 @@ describe("useMissingScopes (fail-open backstop)", () => {
     })
     // A real classic grant that's missing scopes must still surface them.
     expect(result.current.length).toBeGreaterThan(0)
+  })
+})
+
+describe("useHasDeleteRepoScope (gate for elevated teardown)", () => {
+  it("returns true when the login scope carries delete_repo", () => {
+    authState.tokenScope = "read:user read:org repo workflow admin:org delete_repo"
+    const { result } = renderHook(() => useHasDeleteRepoScope(), {
+      wrapper: wrapper("ghp_xxx"),
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it("returns false for a positively-scoped classic token without delete_repo", () => {
+    authState.tokenScope = "read:user read:org repo workflow admin:org"
+    const { result } = renderHook(() => useHasDeleteRepoScope(), {
+      wrapper: wrapper("ghp_xxx"),
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it("fails open (true) for a fine-grained session with no introspectable scopes", () => {
+    // A fine-grained PAT can delete via Administration: write but reports no
+    // X-OAuth-Scopes header, so we must not nag it with an OAuth-only prompt.
+    authState.tokenScope = ""
+    const { result } = renderHook(() => useHasDeleteRepoScope(), {
+      wrapper: wrapper("github_pat_xxx"),
+    })
+    expect(result.current).toBe(true)
   })
 })

--- a/web/src/context/github/GitHubProvider.test.tsx
+++ b/web/src/context/github/GitHubProvider.test.tsx
@@ -13,7 +13,11 @@ vi.mock("@/auth/useGithubAuth", () => ({
   useGithubAuth: () => authState,
 }))
 
-import { GitHubProvider, useMissingScopes, useHasDeleteRepoScope } from "./GitHubProvider"
+import {
+  GitHubProvider,
+  useMissingScopes,
+  useHasDeleteRepoScope,
+} from "./GitHubProvider"
 
 function wrapper(token: string | null) {
   return ({ children }: PropsWithChildren) =>
@@ -41,7 +45,8 @@ describe("useMissingScopes (fail-open backstop)", () => {
 
 describe("useHasDeleteRepoScope (gate for elevated teardown)", () => {
   it("returns true when the login scope carries delete_repo", () => {
-    authState.tokenScope = "read:user read:org repo workflow admin:org delete_repo"
+    authState.tokenScope =
+      "read:user read:org repo workflow admin:org delete_repo"
     const { result } = renderHook(() => useHasDeleteRepoScope(), {
       wrapper: wrapper("ghp_xxx"),
     })

--- a/web/src/context/github/GitHubProvider.tsx
+++ b/web/src/context/github/GitHubProvider.tsx
@@ -159,3 +159,14 @@ export function useDeleteRepoScopeState(): DeleteRepoScopeState {
 export function useHasDeleteRepoScope(): boolean {
   return useDeleteRepoScopeState() !== "missing"
 }
+
+// Whether an in-app re-auth can actually add a missing scope. Only an OAuth
+// session can: a PAT's permissions are fixed at creation on GitHub, so offering
+// elevation to one would run an OAuth flow that silently replaces their session
+// with a different kind of token. Unknown (a session stored before the method
+// was tracked) is treated as OAuth — that was the only in-app flow that could
+// have produced a scope-bearing session, and the 403 backstop still governs.
+export function useCanElevateInApp(): boolean {
+  const { authMethod } = useGithubAuth()
+  return authMethod !== "pat"
+}

--- a/web/src/context/github/GitHubProvider.tsx
+++ b/web/src/context/github/GitHubProvider.tsx
@@ -131,13 +131,14 @@ export function useMissingScopes(): string[] {
 //
 // Fails open, like useMissingScopes: when the granted scopes are unknowable
 // (empty string, or a fine-grained PAT whose X-OAuth-Scopes header is absent),
-// return true so we do NOT surface an OAuth-only "request elevated permissions"
-// prompt to a token that may well be able to delete (a fine-grained token grants
-// deletion via Administration: write). A genuinely under-scoped token is still
-// caught by teardown's 403 backstop, so the cost of a false "has scope" is a
-// clear runtime error, whereas a false "missing" would nag PAT users with an
-// action they can't use. Only a classic OAuth token that positively lists its
-// scopes without delete_repo returns false and gets the prompt.
+// return true rather than surface a prompt to a token that may well be able to
+// delete. A genuinely under-scoped token is still caught by teardown's 403
+// backstop, which aborts before anything irreversible.
+//
+// A classic PAT does report its scopes, so one lacking delete_repo correctly
+// reads false. Its holder can't use the OAuth elevation the prompt offers, but
+// the prompt is still the right signal: they must re-create the token with that
+// scope (or sign in with OAuth) before teardown can work.
 export function useHasDeleteRepoScope(): boolean {
   const { tokenScope } = useGithubAuth()
   const observed = useContext(ObservedContext)
@@ -146,6 +147,6 @@ export function useHasDeleteRepoScope(): boolean {
 
   return useMemo(() => {
     if (!granted) return true
-    return hasScope(granted, ELEVATED_GITHUB_SCOPES[0])
+    return ELEVATED_GITHUB_SCOPES.every((scope) => hasScope(granted, scope))
   }, [granted])
 }

--- a/web/src/context/github/GitHubProvider.tsx
+++ b/web/src/context/github/GitHubProvider.tsx
@@ -12,7 +12,7 @@ import {
   type GitHubResponseSignal,
 } from "@/github-core/client"
 import { useGithubAuth } from "@/auth/useGithubAuth"
-import { missingScopes, expandScopes } from "@/auth/scopes"
+import { missingScopes, missingFrom } from "@/auth/scopes"
 import { ELEVATED_GITHUB_SCOPES } from "@/auth/constants"
 import { GITHUB_PROXY_BASE } from "@/github-core/workerProxy"
 import { observeResponse } from "@/lib/diagnostics/observed"
@@ -147,8 +147,7 @@ export function useDeleteRepoScopeState(): DeleteRepoScopeState {
 
   return useMemo(() => {
     if (!granted) return "unknown"
-    const have = expandScopes(granted)
-    return ELEVATED_GITHUB_SCOPES.every((scope) => have.has(scope))
+    return missingFrom(ELEVATED_GITHUB_SCOPES, granted).length === 0
       ? "granted"
       : "missing"
   }, [granted])

--- a/web/src/context/github/GitHubProvider.tsx
+++ b/web/src/context/github/GitHubProvider.tsx
@@ -114,7 +114,9 @@ export function useMissingScopes(): string[] {
   const { tokenScope } = useGithubAuth()
   const observed = useContext(ObservedContext)
 
-  const granted = observed?.signal.scopes ?? tokenScope
+  // `||`, not `??`: a present-but-empty x-oauth-scopes header is "", which would
+  // win over a usable login scope and suppress the warning entirely.
+  const granted = observed?.signal.scopes || tokenScope
 
   return useMemo(() => {
     if (!granted) return []
@@ -143,7 +145,11 @@ export function useHasDeleteRepoScope(): boolean {
   const { tokenScope } = useGithubAuth()
   const observed = useContext(ObservedContext)
 
-  const granted = observed?.signal.scopes ?? tokenScope
+  // `||`, not `??`: a present-but-empty x-oauth-scopes header is "" (a classic
+  // token with no scopes, or any header-rewriting hop), which would otherwise
+  // beat a perfectly good login scope and read as unknowable — failing open and
+  // arming teardown for a token that never had the scope.
+  const granted = observed?.signal.scopes || tokenScope
 
   return useMemo(() => {
     if (!granted) return true

--- a/web/src/context/github/GitHubProvider.tsx
+++ b/web/src/context/github/GitHubProvider.tsx
@@ -128,31 +128,38 @@ export function useMissingScopes(): string[] {
   }, [granted])
 }
 
-// Whether the current token is known to carry the elevated delete_repo scope,
-// for gating destructive actions (teardown) on the elevation flow (#655).
+// Whether the current token carries the elevated delete_repo scope (#655).
 //
-// Fails open, like useMissingScopes: when the granted scopes are unknowable
-// (empty string, or a fine-grained PAT whose X-OAuth-Scopes header is absent),
-// return true rather than surface a prompt to a token that may well be able to
-// delete. A genuinely under-scoped token is still caught by teardown's 403
-// backstop, which aborts before anything irreversible.
+// Deliberately tri-state. The same fact needs opposite defaults in two places:
+// gating a destructive action should fail open (GitHub is the real authority and
+// teardown's 403 backstop aborts before anything irreversible), while *telling*
+// the user their current state must never claim a permission we couldn't read.
+// A single fail-open boolean served both and lied to the second caller.
 //
-// A classic PAT does report its scopes, so one lacking delete_repo correctly
-// reads false. Its holder can't use the OAuth elevation the prompt offers, but
-// the prompt is still the right signal: they must re-create the token with that
-// scope (or sign in with OAuth) before teardown can work.
-export function useHasDeleteRepoScope(): boolean {
+// "unknown" covers a fine-grained PAT (no X-OAuth-Scopes header) and any session
+// whose scopes we can't introspect.
+export type DeleteRepoScopeState = "granted" | "missing" | "unknown"
+
+export function useDeleteRepoScopeState(): DeleteRepoScopeState {
   const { tokenScope } = useGithubAuth()
   const observed = useContext(ObservedContext)
 
   // `||`, not `??`: a present-but-empty x-oauth-scopes header is "" (a classic
   // token with no scopes, or any header-rewriting hop), which would otherwise
-  // beat a perfectly good login scope and read as unknowable — failing open and
-  // arming teardown for a token that never had the scope.
+  // beat a perfectly good login scope and read as unknown.
   const granted = observed?.signal.scopes || tokenScope
 
   return useMemo(() => {
-    if (!granted) return true
+    if (!granted) return "unknown"
     return ELEVATED_GITHUB_SCOPES.every((scope) => hasScope(granted, scope))
+      ? "granted"
+      : "missing"
   }, [granted])
+}
+
+// Gate for destructive actions: fails open on "unknown" so a session we can't
+// introspect (a fine-grained PAT can delete via Administration: write) isn't
+// blocked from an action GitHub may well permit.
+export function useHasDeleteRepoScope(): boolean {
+  return useDeleteRepoScopeState() !== "missing"
 }

--- a/web/src/context/github/GitHubProvider.tsx
+++ b/web/src/context/github/GitHubProvider.tsx
@@ -12,7 +12,8 @@ import {
   type GitHubResponseSignal,
 } from "@/github-core/client"
 import { useGithubAuth } from "@/auth/useGithubAuth"
-import { missingScopes } from "@/auth/scopes"
+import { missingScopes, hasScope } from "@/auth/scopes"
+import { ELEVATED_GITHUB_SCOPES } from "@/auth/constants"
 import { GITHUB_PROXY_BASE } from "@/github-core/workerProxy"
 import { observeResponse } from "@/lib/diagnostics/observed"
 import { logger } from "@/lib/logger"
@@ -122,5 +123,29 @@ export function useMissingScopes(): string[] {
       log.debug("token is missing required scopes", { missing })
     }
     return missing
+  }, [granted])
+}
+
+// Whether the current token is known to carry the elevated delete_repo scope,
+// for gating destructive actions (teardown) on the elevation flow (#655).
+//
+// Fails open, like useMissingScopes: when the granted scopes are unknowable
+// (empty string, or a fine-grained PAT whose X-OAuth-Scopes header is absent),
+// return true so we do NOT surface an OAuth-only "request elevated permissions"
+// prompt to a token that may well be able to delete (a fine-grained token grants
+// deletion via Administration: write). A genuinely under-scoped token is still
+// caught by teardown's 403 backstop, so the cost of a false "has scope" is a
+// clear runtime error, whereas a false "missing" would nag PAT users with an
+// action they can't use. Only a classic OAuth token that positively lists its
+// scopes without delete_repo returns false and gets the prompt.
+export function useHasDeleteRepoScope(): boolean {
+  const { tokenScope } = useGithubAuth()
+  const observed = useContext(ObservedContext)
+
+  const granted = observed?.signal.scopes ?? tokenScope
+
+  return useMemo(() => {
+    if (!granted) return true
+    return hasScope(granted, ELEVATED_GITHUB_SCOPES[0])
   }, [granted])
 }

--- a/web/src/context/github/GitHubProvider.tsx
+++ b/web/src/context/github/GitHubProvider.tsx
@@ -12,7 +12,7 @@ import {
   type GitHubResponseSignal,
 } from "@/github-core/client"
 import { useGithubAuth } from "@/auth/useGithubAuth"
-import { missingScopes, hasScope } from "@/auth/scopes"
+import { missingScopes, expandScopes } from "@/auth/scopes"
 import { ELEVATED_GITHUB_SCOPES } from "@/auth/constants"
 import { GITHUB_PROXY_BASE } from "@/github-core/workerProxy"
 import { observeResponse } from "@/lib/diagnostics/observed"
@@ -106,17 +106,20 @@ export function useOptionalGitHubClient() {
   return useContext(GitHubClientContext)
 }
 
-// Required scopes the current token is missing, for the scope-warning banner.
-// Prefers the live X-OAuth-Scopes observation; falls back to the login scope
-// string. Fails open: with no value from either source, returns [] so the
-// banner stays hidden rather than nagging about scopes we can't verify.
-export function useMissingScopes(): string[] {
+// The granted-scope string to judge the session by. `||`, not `??`: a
+// present-but-empty x-oauth-scopes header is "" (a classic token with no scopes,
+// or any header-rewriting hop) and would beat a usable login scope.
+function useGrantedScopes(): string {
   const { tokenScope } = useGithubAuth()
   const observed = useContext(ObservedContext)
+  return observed?.signal.scopes || tokenScope
+}
 
-  // `||`, not `??`: a present-but-empty x-oauth-scopes header is "", which would
-  // win over a usable login scope and suppress the warning entirely.
-  const granted = observed?.signal.scopes || tokenScope
+// Required scopes the current token is missing, for the scope-warning banner.
+// Fails open: with nothing knowable from either source, returns [] so the banner
+// stays hidden rather than nagging about scopes we can't verify.
+export function useMissingScopes(): string[] {
+  const granted = useGrantedScopes()
 
   return useMemo(() => {
     if (!granted) return []
@@ -134,24 +137,18 @@ export function useMissingScopes(): string[] {
 // gating a destructive action should fail open (GitHub is the real authority and
 // teardown's 403 backstop aborts before anything irreversible), while *telling*
 // the user their current state must never claim a permission we couldn't read.
-// A single fail-open boolean served both and lied to the second caller.
 //
 // "unknown" covers a fine-grained PAT (no X-OAuth-Scopes header) and any session
 // whose scopes we can't introspect.
 export type DeleteRepoScopeState = "granted" | "missing" | "unknown"
 
 export function useDeleteRepoScopeState(): DeleteRepoScopeState {
-  const { tokenScope } = useGithubAuth()
-  const observed = useContext(ObservedContext)
-
-  // `||`, not `??`: a present-but-empty x-oauth-scopes header is "" (a classic
-  // token with no scopes, or any header-rewriting hop), which would otherwise
-  // beat a perfectly good login scope and read as unknown.
-  const granted = observed?.signal.scopes || tokenScope
+  const granted = useGrantedScopes()
 
   return useMemo(() => {
     if (!granted) return "unknown"
-    return ELEVATED_GITHUB_SCOPES.every((scope) => hasScope(granted, scope))
+    const have = expandScopes(granted)
+    return ELEVATED_GITHUB_SCOPES.every((scope) => have.has(scope))
       ? "granted"
       : "missing"
   }, [granted])

--- a/web/src/domain/teardown.test.ts
+++ b/web/src/domain/teardown.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import {
+  TeardownForbiddenError,
   TeardownMarkerError,
   TeardownRateLimitError,
   TeardownScopeError,
@@ -50,6 +51,33 @@ function forbidden(): GitHubAPIError {
       resource: null,
       retryAfter: null,
     },
+  })
+}
+
+// A 403 carrying scope headers, so the classifier's header-driven branches are
+// reachable. `accepted: ""` is the realistic shape GitHub often sends, which
+// makes isScopeGap unprovable even when the granted set plainly lacks the scope.
+function forbiddenWithScopes(input: {
+  granted: string
+  accepted?: string
+  sso?: string
+}): GitHubAPIError {
+  return new GitHubAPIError({
+    status: 403,
+    url: "x",
+    message: "Forbidden",
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter: null,
+    },
+    oauthScopes: input.granted,
+    acceptedScopes: input.accepted ?? "",
+    ssoHeader: input.sso ?? null,
   })
 }
 
@@ -107,6 +135,9 @@ type Opts = {
   markerExists: boolean
   repos: string[]
   deleteForbidden?: boolean
+  // A 403 for every DELETE, carrying the given scope/SSO headers so the
+  // classifier's header-driven branches are reachable.
+  deleteForbiddenWith?: { granted: string; accepted?: string; sso?: string }
   // Repos that fail every DELETE with the given error kind.
   failRepos?: Record<string, "rate-limit" | "scope" | "server">
   // Classrooms present under classroom50/ (with optional team ref).
@@ -119,6 +150,7 @@ type Opts = {
 
 function makeClient(opts: Opts) {
   const deletes: string[] = []
+  const deleteAttempts: string[] = []
   const teamDeletes: string[] = []
   const classrooms = opts.classrooms ?? []
 
@@ -163,8 +195,12 @@ function makeClient(opts: Opts) {
       }
       // Repo delete.
       if (method === "DELETE") {
-        if (opts.deleteForbidden) return Promise.reject(forbidden())
         const repo = path.split("/").pop() ?? ""
+        deleteAttempts.push(repo)
+        if (opts.deleteForbidden) return Promise.reject(forbidden())
+        if (opts.deleteForbiddenWith) {
+          return Promise.reject(forbiddenWithScopes(opts.deleteForbiddenWith))
+        }
         const kind = opts.failRepos?.[repo]
         if (kind === "rate-limit") return Promise.reject(rateLimited403())
         if (kind === "scope") return Promise.reject(forbidden())
@@ -212,7 +248,7 @@ function makeClient(opts: Opts) {
     requestRaw: requestRaw as unknown as GitHubClient["requestRaw"],
     fetchArchive: vi.fn() as unknown as GitHubClient["fetchArchive"],
   }
-  return { client, deletes, teamDeletes }
+  return { client, deletes, deleteAttempts, teamDeletes }
 }
 
 // A requestRaw mock for tests that build their own `request` mock inline and
@@ -292,6 +328,105 @@ describe("executeTeardown", () => {
       "orgSettings.teardown.needsDeleteScope",
     )
     expect(err.message).not.toMatch(/forbidden/i)
+  })
+
+  // GitHub commonly sends an EMPTY X-Accepted-OAuth-Scopes, which makes
+  // isScopeGap unprovable. Without an explicit delete_repo check that case fell
+  // through to "your permissions look sufficient", sending the teacher to audit
+  // org settings instead of the elevation that actually fixes it.
+  it("treats a 403 whose granted scopes lack delete_repo as the scope wall", async () => {
+    const { client } = makeClient({
+      markerExists: true,
+      repos: ["classroom50", "cs101-hw1-alice"],
+      deleteForbiddenWith: {
+        granted: "read:user, read:org, repo, workflow, admin:org",
+        accepted: "",
+      },
+    })
+    const plan = await planTeardown(client, "acme")
+    const err = await executeTeardown(client, plan).catch((e) => e)
+    expect(err).toBeInstanceOf(TeardownScopeError)
+    expect((err as TeardownScopeError).localized.key).toBe(
+      "orgSettings.teardown.needsDeleteScope",
+    )
+  })
+
+  it("reports an SSO gate as its own wall, not a scope gap", async () => {
+    const { client } = makeClient({
+      markerExists: true,
+      repos: ["classroom50", "cs101-hw1-alice"],
+      deleteForbiddenWith: {
+        granted: "repo, delete_repo",
+        sso: "required; url=https://github.com/orgs/acme/sso",
+      },
+    })
+    const plan = await planTeardown(client, "acme")
+    const err = await executeTeardown(client, plan).catch((e) => e)
+    expect(err).toBeInstanceOf(TeardownForbiddenError)
+    expect((err as TeardownForbiddenError).localized.key).toBe(
+      "orgSettings.teardown.ssoRequired",
+    )
+  })
+
+  it("reports a refusal with delete_repo granted as something other than scope", async () => {
+    // An org policy or protected repository — offering elevation here would
+    // loop the teacher through a re-auth that cannot help.
+    const { client } = makeClient({
+      markerExists: true,
+      repos: ["classroom50", "cs101-hw1-alice"],
+      deleteForbiddenWith: {
+        granted: "read:user, read:org, repo, workflow, admin:org, delete_repo",
+        accepted: "",
+      },
+    })
+    const plan = await planTeardown(client, "acme")
+    const err = await executeTeardown(client, plan).catch((e) => e)
+    expect(err).toBeInstanceOf(TeardownForbiddenError)
+    expect((err as TeardownForbiddenError).localized.key).toBe(
+      "orgSettings.teardown.forbidden",
+    )
+  })
+
+  it("names the repositories already destroyed when a wall arrives mid-run", async () => {
+    // The abort message is the only record that deletions happened, so it must
+    // carry the count. This branch previously shipped a bug (it passed `deleted`
+    // where i18next needs `count`, rendering the raw key).
+    const { client } = makeClient({
+      markerExists: true,
+      repos: ["classroom50", "ok1", "ok2", "walled"],
+      failRepos: { walled: "scope" },
+    })
+    const plan = await planTeardown(client, "acme")
+    const err = await executeTeardown(client, plan).catch((e) => e)
+    expect(err).toBeInstanceOf(TeardownScopeError)
+    const scopeErr = err as TeardownScopeError
+    expect(scopeErr.localized.key).toBe(
+      "orgSettings.teardown.needsDeleteScopePartial",
+    )
+    // The count must match what was actually deleted, and exclude the marker.
+    expect(scopeErr.localized.params?.count).toBe(scopeErr.deleted.length)
+    expect(scopeErr.deleted).not.toContain("classroom50")
+    expect(scopeErr.deleted.length).toBeGreaterThan(0)
+  })
+
+  it("stops issuing deletes once a token-wide wall is hit", async () => {
+    // A scope wall is a property of the token, so every remaining repo would
+    // fail identically. Without the short-circuit a large org burns hundreds of
+    // doomed requests and the exhausted retries mislabel the abort as a throttle.
+    const { client, deleteAttempts } = makeClient({
+      markerExists: true,
+      repos: [
+        "classroom50",
+        ...Array.from({ length: 12 }, (_, i) => `r${i + 1}`),
+      ],
+      deleteForbidden: true,
+    })
+    const plan = await planTeardown(client, "acme")
+    const err = await executeTeardown(client, plan).catch((e) => e)
+    expect(err).toBeInstanceOf(TeardownScopeError)
+    // Concurrency is 4, so at most that many can be in flight before the wall is
+    // observed; the rest must short-circuit rather than call DELETE.
+    expect(deleteAttempts.length).toBeLessThanOrEqual(4)
   })
 
   it("does not throw scope error when there is nothing but the marker", async () => {

--- a/web/src/domain/teardown.test.ts
+++ b/web/src/domain/teardown.test.ts
@@ -287,8 +287,8 @@ describe("executeTeardown", () => {
     const plan = await planTeardown(client, "acme")
     const err = await executeTeardown(client, plan).catch((e) => e)
     expect(err).toBeInstanceOf(TeardownScopeError)
-    // Domain carries the i18n key, not assembled English (AGENTS.md i18n rule).
-    expect((err as TeardownScopeError).messageKey).toBe(
+    // Domain carries a LocalizedMessage, not assembled English (AGENTS.md i18n).
+    expect((err as TeardownScopeError).localized.key).toBe(
       "orgSettings.teardown.needsDeleteScope",
     )
     expect(err.message).not.toMatch(/forbidden/i)
@@ -314,9 +314,13 @@ describe("executeTeardown", () => {
       failRepos: { "cs101-hw1-alice": "rate-limit" },
     })
     const plan = await planTeardown(client, "acme")
-    await expect(executeTeardown(client, plan)).rejects.toBeInstanceOf(
-      TeardownRateLimitError,
+    const err = await executeTeardown(client, plan).catch((e) => e)
+    expect(err).toBeInstanceOf(TeardownRateLimitError)
+    // Carries a LocalizedMessage too, so the modal never shows raw English.
+    expect((err as TeardownRateLimitError).localized.key).toBe(
+      "orgSettings.teardown.rateLimited",
     )
+    expect(err.message).not.toMatch(/wait a moment/i)
   })
 
   it("preserves the marker when a non-marker delete fails (re-runnable)", async () => {

--- a/web/src/domain/teardown.test.ts
+++ b/web/src/domain/teardown.test.ts
@@ -285,9 +285,13 @@ describe("executeTeardown", () => {
       deleteForbidden: true,
     })
     const plan = await planTeardown(client, "acme")
-    await expect(executeTeardown(client, plan)).rejects.toBeInstanceOf(
-      TeardownScopeError,
+    const err = await executeTeardown(client, plan).catch((e) => e)
+    expect(err).toBeInstanceOf(TeardownScopeError)
+    // Domain carries the i18n key, not assembled English (AGENTS.md i18n rule).
+    expect((err as TeardownScopeError).messageKey).toBe(
+      "orgSettings.teardown.needsDeleteScope",
     )
+    expect(err.message).not.toMatch(/forbidden/i)
   })
 
   it("does not throw scope error when there is nothing but the marker", async () => {

--- a/web/src/domain/teardown.ts
+++ b/web/src/domain/teardown.ts
@@ -32,58 +32,63 @@ import { logger } from "@/lib/logger"
 
 const log = logger.scope("mutations:teardown")
 
-// Teardown's 403 scope wall: the token lacks the elevated delete_repo scope, so
-// the view surfaces the elevation flow. The key is exported so the gate and the
-// backstop name the same message.
-export const TEARDOWN_DELETE_SCOPE_KEY = "orgSettings.teardown.needsDeleteScope"
-
+const TEARDOWN_DELETE_SCOPE_KEY = "orgSettings.teardown.needsDeleteScope"
 const TEARDOWN_RATE_LIMIT_KEY = "orgSettings.teardown.rateLimited"
 
-export class TeardownScopeError extends Error {
+// An abort that stopped the run partway. Carries the progress at that moment: a
+// wall can arrive after some repositories are already permanently deleted, so a
+// bare "you need permission" message would hide the data loss.
+class TeardownAbortError extends Error {
   readonly localized: LocalizedMessage
-  // Progress at the moment the wall was hit. A 403 can arrive partway through
-  // the concurrency pass, so a bare "you need permission" message would hide
-  // repositories that are already permanently deleted.
-  deleted: string[]
-  failed: string[]
+  readonly deleted: string[]
+  readonly failed: string[]
 
-  constructor(deleted: string[] = [], failed: string[] = []) {
-    const localized: LocalizedMessage =
-      deleted.length > 0
-        ? {
-            key: "orgSettings.teardown.needsDeleteScopePartial",
-            params: { deleted: deleted.length },
-          }
-        : { key: TEARDOWN_DELETE_SCOPE_KEY }
+  constructor(
+    name: string,
+    localized: LocalizedMessage,
+    deleted: string[],
+    failed: string[],
+  ) {
     super(describeLocalizedMessage(localized))
-    this.name = "TeardownScopeError"
+    this.name = name
     this.localized = localized
     this.deleted = deleted
     this.failed = failed
   }
 }
 
+export class TeardownScopeError extends TeardownAbortError {
+  constructor(deleted: string[], failed: string[]) {
+    super(
+      "TeardownScopeError",
+      deleted.length > 0
+        ? {
+            key: "orgSettings.teardown.needsDeleteScopePartial",
+            params: { count: deleted.length },
+          }
+        : { key: TEARDOWN_DELETE_SCOPE_KEY },
+      deleted,
+      failed,
+    )
+  }
+}
+
 // A 403 that is not a scope gap: an SSO-gated organization, or a refusal whose
 // headers prove the token's scopes are sufficient. Distinct from
 // TeardownScopeError so the UI doesn't offer an elevation that can't help.
-export class TeardownForbiddenError extends Error {
-  readonly localized: LocalizedMessage
-  deleted: string[]
-  failed: string[]
-
+export class TeardownForbiddenError extends TeardownAbortError {
   constructor(kind: "sso" | "other", deleted: string[], failed: string[]) {
-    const localized: LocalizedMessage = {
-      key:
-        kind === "sso"
-          ? "orgSettings.teardown.ssoRequired"
-          : "orgSettings.teardown.forbidden",
-      params: { deleted: deleted.length },
-    }
-    super(describeLocalizedMessage(localized))
-    this.name = "TeardownForbiddenError"
-    this.localized = localized
-    this.deleted = deleted
-    this.failed = failed
+    super(
+      "TeardownForbiddenError",
+      {
+        key:
+          kind === "sso"
+            ? "orgSettings.teardown.ssoRequired"
+            : "orgSettings.teardown.forbidden",
+      },
+      deleted,
+      failed,
+    )
   }
 }
 
@@ -94,19 +99,31 @@ export class TeardownMarkerError extends Error {
   }
 }
 
+// Partial progress carried by an abort, if any. Duck-typed so a caller doesn't
+// have to know which of the abort classes it caught: an abort that deleted
+// nothing (a marker re-check failure, a network error) reports none, so callers
+// can skip cache work for a run that changed nothing.
+export function teardownProgressOf(
+  err: unknown,
+): { deleted: string[]; failed: string[] } | undefined {
+  if (typeof err !== "object" || err === null) return undefined
+  const candidate = err as { deleted?: unknown; failed?: unknown }
+  if (!Array.isArray(candidate.deleted) || !Array.isArray(candidate.failed)) {
+    return undefined
+  }
+  return { deleted: candidate.deleted, failed: candidate.failed }
+}
+
 // A secondary rate limit aborted the run. Distinct from TeardownScopeError so
 // the UI can offer a retry, and carries partial progress for reporting.
-export class TeardownRateLimitError extends Error {
-  deleted: string[]
-  failed: string[]
-  readonly localized: LocalizedMessage
+export class TeardownRateLimitError extends TeardownAbortError {
   constructor(deleted: string[], failed: string[]) {
-    const localized: LocalizedMessage = { key: TEARDOWN_RATE_LIMIT_KEY }
-    super(describeLocalizedMessage(localized))
-    this.name = "TeardownRateLimitError"
-    this.localized = localized
-    this.deleted = deleted
-    this.failed = failed
+    super(
+      "TeardownRateLimitError",
+      { key: TEARDOWN_RATE_LIMIT_KEY },
+      deleted,
+      failed,
+    )
   }
 }
 
@@ -388,6 +405,15 @@ export async function executeTeardown(
   let rateLimited = false
 
   const tryDelete = async (repo: string) => {
+    // A scope/SSO wall or a throttle is a property of the token, not the repo, so
+    // every remaining delete is guaranteed to fail the same way. Stop issuing
+    // them: on a large org that is hundreds of doomed requests burning rate
+    // limit before the run aborts anyway. `otherForbidden` is deliberately not
+    // here — an org policy or protected repo is genuinely per-repo.
+    if (scopeWall || ssoWall || rateLimited) {
+      failed.push(repo)
+      return
+    }
     try {
       const outcome = await deleteRepoWithRetry(client, plan.org, repo)
       if (outcome === "deleted") {

--- a/web/src/domain/teardown.ts
+++ b/web/src/domain/teardown.ts
@@ -41,13 +41,49 @@ const TEARDOWN_RATE_LIMIT_KEY = "orgSettings.teardown.rateLimited"
 
 export class TeardownScopeError extends Error {
   readonly localized: LocalizedMessage
+  // Progress at the moment the wall was hit. A 403 can arrive partway through
+  // the concurrency pass, so a bare "you need permission" message would hide
+  // repositories that are already permanently deleted.
+  deleted: string[]
+  failed: string[]
 
-  constructor(
-    localized: LocalizedMessage = { key: TEARDOWN_DELETE_SCOPE_KEY },
-  ) {
+  constructor(deleted: string[] = [], failed: string[] = []) {
+    const localized: LocalizedMessage =
+      deleted.length > 0
+        ? {
+            key: "orgSettings.teardown.needsDeleteScopePartial",
+            params: { deleted: deleted.length },
+          }
+        : { key: TEARDOWN_DELETE_SCOPE_KEY }
     super(describeLocalizedMessage(localized))
     this.name = "TeardownScopeError"
     this.localized = localized
+    this.deleted = deleted
+    this.failed = failed
+  }
+}
+
+// A 403 that is not a scope gap: an SSO-gated organization, or a refusal whose
+// headers prove the token's scopes are sufficient. Distinct from
+// TeardownScopeError so the UI doesn't offer an elevation that can't help.
+export class TeardownForbiddenError extends Error {
+  readonly localized: LocalizedMessage
+  deleted: string[]
+  failed: string[]
+
+  constructor(kind: "sso" | "other", deleted: string[], failed: string[]) {
+    const localized: LocalizedMessage = {
+      key:
+        kind === "sso"
+          ? "orgSettings.teardown.ssoRequired"
+          : "orgSettings.teardown.forbidden",
+      params: { deleted: deleted.length },
+    }
+    super(describeLocalizedMessage(localized))
+    this.name = "TeardownForbiddenError"
+    this.localized = localized
+    this.deleted = deleted
+    this.failed = failed
   }
 }
 
@@ -347,6 +383,8 @@ export async function executeTeardown(
   })
 
   let scopeWall = false
+  let ssoWall = false
+  let otherForbidden = false
   let rateLimited = false
 
   const tryDelete = async (repo: string) => {
@@ -368,9 +406,23 @@ export async function executeTeardown(
         failed.push(repo)
       }
     } catch (err) {
-      // deleteRepoWithRetry only throws for an unretryable scope 403.
+      // deleteRepoWithRetry only throws for an unretryable 403. Not every 403 is
+      // a scope gap: an SSO-gated org or a secondary rate limit carrying neither
+      // a remaining=0 nor a Retry-After also lands here, and calling those a
+      // scope wall sends the teacher to an elevation flow that can't help (they
+      // may already hold delete_repo), looping on the same failure.
       if (err instanceof GitHubAPIError && err.isForbidden) {
-        scopeWall = true
+        if (err.isSsoRequired) {
+          ssoWall = true
+        } else if (err.isScopeGap || err.oauthScopes === null) {
+          // A proven gap, or a 403 whose scope headers GitHub didn't send (so a
+          // gap can't be ruled out): treat as the scope wall.
+          scopeWall = true
+        } else {
+          // Headers prove the scopes are sufficient, so this is something else
+          // (org policy, protected repo). Record it rather than mislabel it.
+          otherForbidden = true
+        }
       }
       log.error("teardown: repo delete errored", {
         org: plan.org,
@@ -386,6 +438,20 @@ export async function executeTeardown(
   // A scope 403 is unrecoverable; a throttle is retryable. Both abort before
   // the marker so the run stays re-runnable.
   const abortIfBlocked = () => {
+    if (ssoWall || otherForbidden) {
+      log.error("teardown aborted: forbidden (not a scope gap)", {
+        org: plan.org,
+        sso: ssoWall,
+        deleted: deleted.length,
+        failed: failed.length,
+        record: true,
+      })
+      throw new TeardownForbiddenError(
+        ssoWall ? "sso" : "other",
+        deleted,
+        failed,
+      )
+    }
     if (scopeWall) {
       log.error("teardown aborted: missing delete_repo scope", {
         org: plan.org,
@@ -393,7 +459,7 @@ export async function executeTeardown(
         failed: failed.length,
         record: true,
       })
-      throw new TeardownScopeError()
+      throw new TeardownScopeError(deleted, failed)
     }
     if (rateLimited) {
       log.warn("teardown aborted: rate limited (re-runnable)", {

--- a/web/src/domain/teardown.ts
+++ b/web/src/domain/teardown.ts
@@ -33,14 +33,11 @@ import { logger } from "@/lib/logger"
 
 const log = logger.scope("mutations:teardown")
 
-const TEARDOWN_DELETE_SCOPE_KEY = "orgSettings.teardown.needsDeleteScope"
-const TEARDOWN_RATE_LIMIT_KEY = "orgSettings.teardown.rateLimited"
-
 // An abort that stopped the run partway. Carries the progress at that moment: a
 // wall can arrive after some repositories are already permanently deleted, so a
 // bare "you need permission" message would hide the data loss. The partial/plain
 // key choice lives here so no subclass can forget it.
-class TeardownAbortError extends Error {
+export class TeardownAbortError extends Error {
   readonly localized: LocalizedMessage
   readonly deleted: string[]
   readonly failed: string[]
@@ -68,7 +65,7 @@ export class TeardownScopeError extends TeardownAbortError {
     super(
       "TeardownScopeError",
       {
-        plain: TEARDOWN_DELETE_SCOPE_KEY,
+        plain: "orgSettings.teardown.needsDeleteScope",
         partial: "orgSettings.teardown.needsDeleteScopePartial",
       },
       deleted,
@@ -106,19 +103,15 @@ export class TeardownMarkerError extends Error {
   }
 }
 
-// Partial progress carried by an abort, if any. Duck-typed so a caller doesn't
-// have to know which of the abort classes it caught: an abort that deleted
-// nothing (a marker re-check failure, a network error) reports none, so callers
-// can skip cache work for a run that changed nothing.
+// Partial progress carried by an abort, if any, so a caller doesn't have to know
+// which of the abort subclasses it caught: an abort that deleted nothing (a
+// marker re-check failure, a network error) reports none, so callers can skip
+// cache work for a run that changed nothing.
 export function teardownProgressOf(
   err: unknown,
 ): { deleted: string[]; failed: string[] } | undefined {
-  if (typeof err !== "object" || err === null) return undefined
-  const candidate = err as { deleted?: unknown; failed?: unknown }
-  if (!Array.isArray(candidate.deleted) || !Array.isArray(candidate.failed)) {
-    return undefined
-  }
-  return { deleted: candidate.deleted, failed: candidate.failed }
+  if (!(err instanceof TeardownAbortError)) return undefined
+  return { deleted: err.deleted, failed: err.failed }
 }
 
 // A secondary rate limit aborted the run. Distinct from TeardownScopeError so
@@ -128,7 +121,7 @@ export class TeardownRateLimitError extends TeardownAbortError {
     super(
       "TeardownRateLimitError",
       {
-        plain: TEARDOWN_RATE_LIMIT_KEY,
+        plain: "orgSettings.teardown.rateLimited",
         partial: "orgSettings.teardown.rateLimitedPartial",
       },
       deleted,

--- a/web/src/domain/teardown.ts
+++ b/web/src/domain/teardown.ts
@@ -24,23 +24,30 @@ import {
 import { getRepo } from "@/github-core/repoReads"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { mapWithConcurrency } from "@/util/concurrency"
+import {
+  describeLocalizedMessage,
+  type LocalizedMessage,
+} from "@/types/localizedMessage"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("mutations:teardown")
 
-// The i18n key for the 403 scope-wall message, resolved at the view layer.
-// Domain code must not assemble user-facing English (AGENTS.md i18n rule); this
-// error carries the key so TeardownSection can translate it and surface the
-// elevation action. The message string mirrors the key's English for logs and
-// any non-i18n consumer.
+// Teardown's 403 scope wall: the token lacks the elevated delete_repo scope, so
+// the view surfaces the elevation flow. The key is exported so the gate and the
+// backstop name the same message.
 export const TEARDOWN_DELETE_SCOPE_KEY = "orgSettings.teardown.needsDeleteScope"
 
+const TEARDOWN_RATE_LIMIT_KEY = "orgSettings.teardown.rateLimited"
+
 export class TeardownScopeError extends Error {
-  readonly messageKey: string
-  constructor(messageKey: string = TEARDOWN_DELETE_SCOPE_KEY) {
-    super(messageKey)
+  readonly localized: LocalizedMessage
+
+  constructor(
+    localized: LocalizedMessage = { key: TEARDOWN_DELETE_SCOPE_KEY },
+  ) {
+    super(describeLocalizedMessage(localized))
     this.name = "TeardownScopeError"
-    this.messageKey = messageKey
+    this.localized = localized
   }
 }
 
@@ -56,11 +63,12 @@ export class TeardownMarkerError extends Error {
 export class TeardownRateLimitError extends Error {
   deleted: string[]
   failed: string[]
+  readonly localized: LocalizedMessage
   constructor(deleted: string[], failed: string[]) {
-    super(
-      "Hit a GitHub rate limit while deleting repositories. Some repositories may already be deleted; wait a moment and re-run teardown to finish.",
-    )
+    const localized: LocalizedMessage = { key: TEARDOWN_RATE_LIMIT_KEY }
+    super(describeLocalizedMessage(localized))
     this.name = "TeardownRateLimitError"
+    this.localized = localized
     this.deleted = deleted
     this.failed = failed
   }

--- a/web/src/domain/teardown.ts
+++ b/web/src/domain/teardown.ts
@@ -28,10 +28,19 @@ import { logger } from "@/lib/logger"
 
 const log = logger.scope("mutations:teardown")
 
+// The i18n key for the 403 scope-wall message, resolved at the view layer.
+// Domain code must not assemble user-facing English (AGENTS.md i18n rule); this
+// error carries the key so TeardownSection can translate it and surface the
+// elevation action. The message string mirrors the key's English for logs and
+// any non-i18n consumer.
+export const TEARDOWN_DELETE_SCOPE_KEY = "orgSettings.teardown.needsDeleteScope"
+
 export class TeardownScopeError extends Error {
-  constructor(message: string) {
-    super(message)
+  readonly messageKey: string
+  constructor(messageKey: string = TEARDOWN_DELETE_SCOPE_KEY) {
+    super(messageKey)
     this.name = "TeardownScopeError"
+    this.messageKey = messageKey
   }
 }
 
@@ -161,9 +170,6 @@ export type TeardownResult = {
 }
 
 const MAX_DELETE_ATTEMPTS = 4
-
-const DELETE_SCOPE_MESSAGE =
-  "Deleting repositories was forbidden (403). Teardown needs the `delete_repo` OAuth scope, which is not granted by default. Re-authenticate with that scope, or archive repositories instead."
 
 // "1 repository" / "3 repositories" — count + correctly-pluralized noun.
 function countLabel(count: number, singular: string, plural: string): string {
@@ -379,7 +385,7 @@ export async function executeTeardown(
         failed: failed.length,
         record: true,
       })
-      throw new TeardownScopeError(DELETE_SCOPE_MESSAGE)
+      throw new TeardownScopeError()
     }
     if (rateLimited) {
       log.warn("teardown aborted: rate limited (re-runnable)", {

--- a/web/src/domain/teardown.ts
+++ b/web/src/domain/teardown.ts
@@ -24,6 +24,7 @@ import {
 import { getRepo } from "@/github-core/repoReads"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { mapWithConcurrency } from "@/util/concurrency"
+import { DELETE_REPO_SCOPE } from "@/auth/constants"
 import {
   describeLocalizedMessage,
   type LocalizedMessage,
@@ -37,7 +38,8 @@ const TEARDOWN_RATE_LIMIT_KEY = "orgSettings.teardown.rateLimited"
 
 // An abort that stopped the run partway. Carries the progress at that moment: a
 // wall can arrive after some repositories are already permanently deleted, so a
-// bare "you need permission" message would hide the data loss.
+// bare "you need permission" message would hide the data loss. The partial/plain
+// key choice lives here so no subclass can forget it.
 class TeardownAbortError extends Error {
   readonly localized: LocalizedMessage
   readonly deleted: string[]
@@ -45,10 +47,14 @@ class TeardownAbortError extends Error {
 
   constructor(
     name: string,
-    localized: LocalizedMessage,
+    keys: { plain: string; partial: string },
     deleted: string[],
     failed: string[],
   ) {
+    const localized: LocalizedMessage =
+      deleted.length > 0
+        ? { key: keys.partial, params: { count: deleted.length } }
+        : { key: keys.plain }
     super(describeLocalizedMessage(localized))
     this.name = name
     this.localized = localized
@@ -61,12 +67,10 @@ export class TeardownScopeError extends TeardownAbortError {
   constructor(deleted: string[], failed: string[]) {
     super(
       "TeardownScopeError",
-      deleted.length > 0
-        ? {
-            key: "orgSettings.teardown.needsDeleteScopePartial",
-            params: { count: deleted.length },
-          }
-        : { key: TEARDOWN_DELETE_SCOPE_KEY },
+      {
+        plain: TEARDOWN_DELETE_SCOPE_KEY,
+        partial: "orgSettings.teardown.needsDeleteScopePartial",
+      },
       deleted,
       failed,
     )
@@ -80,12 +84,15 @@ export class TeardownForbiddenError extends TeardownAbortError {
   constructor(kind: "sso" | "other", deleted: string[], failed: string[]) {
     super(
       "TeardownForbiddenError",
-      {
-        key:
-          kind === "sso"
-            ? "orgSettings.teardown.ssoRequired"
-            : "orgSettings.teardown.forbidden",
-      },
+      kind === "sso"
+        ? {
+            plain: "orgSettings.teardown.ssoRequired",
+            partial: "orgSettings.teardown.ssoRequiredPartial",
+          }
+        : {
+            plain: "orgSettings.teardown.forbidden",
+            partial: "orgSettings.teardown.forbiddenPartial",
+          },
       deleted,
       failed,
     )
@@ -120,7 +127,10 @@ export class TeardownRateLimitError extends TeardownAbortError {
   constructor(deleted: string[], failed: string[]) {
     super(
       "TeardownRateLimitError",
-      { key: TEARDOWN_RATE_LIMIT_KEY },
+      {
+        plain: TEARDOWN_RATE_LIMIT_KEY,
+        partial: "orgSettings.teardown.rateLimitedPartial",
+      },
       deleted,
       failed,
     )
@@ -440,13 +450,21 @@ export async function executeTeardown(
       if (err instanceof GitHubAPIError && err.isForbidden) {
         if (err.isSsoRequired) {
           ssoWall = true
-        } else if (err.isScopeGap || err.oauthScopes === null) {
-          // A proven gap, or a 403 whose scope headers GitHub didn't send (so a
-          // gap can't be ruled out): treat as the scope wall.
+        } else if (
+          err.isScopeGap ||
+          err.oauthScopes === null ||
+          !err.grantsScope(DELETE_REPO_SCOPE)
+        ) {
+          // A proven gap, a 403 whose scope headers GitHub didn't send, or one
+          // whose granted scopes visibly lack delete_repo. The last case matters
+          // because GitHub often sends an empty X-Accepted-OAuth-Scopes, which
+          // makes isScopeGap unprovable even for a token that plainly can't
+          // delete — misreporting that as an org-policy problem would send the
+          // teacher to settings instead of the elevation that actually fixes it.
           scopeWall = true
         } else {
-          // Headers prove the scopes are sufficient, so this is something else
-          // (org policy, protected repo). Record it rather than mislabel it.
+          // delete_repo is granted, so the refusal is something else: an org
+          // policy or a protected repository.
           otherForbidden = true
         }
       }

--- a/web/src/github-core/errors.ts
+++ b/web/src/github-core/errors.ts
@@ -13,6 +13,15 @@ import { LOG_SCOPE_GITHUB_CLIENT } from "@/lib/logScopes"
 let logInstance: ReturnType<typeof logger.scope> | null = null
 const log = () => (logInstance ??= logger.scope(LOG_SCOPE_GITHUB_CLIENT))
 
+// GitHub's scope headers (X-OAuth-Scopes, X-Accepted-OAuth-Scopes) are
+// comma-delimited; empty entries carry no meaning and are dropped.
+function parseScopeHeader(header: string): string[] {
+  return header
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
 export type GitHubRateLimit = {
   limit: number | null
   remaining: number | null
@@ -109,14 +118,9 @@ export class GitHubAPIError extends Error {
   get isScopeGap() {
     if (this.status !== 403) return false
     if (this.acceptedScopes === null || this.oauthScopes === null) return false
-    const parse = (h: string) =>
-      h
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean)
-    const required = parse(this.acceptedScopes)
+    const required = parseScopeHeader(this.acceptedScopes)
     if (required.length === 0) return false
-    const granted = new Set(parse(this.oauthScopes))
+    const granted = new Set(parseScopeHeader(this.oauthScopes))
     // GitHub treats X-Accepted-OAuth-Scopes as "any one of these satisfies the
     // endpoint", so a gap is only when the token holds NONE of them.
     return !required.some((scope) => granted.has(scope))
@@ -130,10 +134,7 @@ export class GitHubAPIError extends Error {
   // token demonstrably lacks the scope the caller cares about.
   grantsScope(scope: string): boolean {
     if (this.oauthScopes === null) return false
-    return this.oauthScopes
-      .split(",")
-      .map((s) => s.trim())
-      .includes(scope)
+    return parseScopeHeader(this.oauthScopes).includes(scope)
   }
 
   // The GitHub SSO authorization URL to send the user to, if the header carried

--- a/web/src/github-core/errors.ts
+++ b/web/src/github-core/errors.ts
@@ -122,6 +122,20 @@ export class GitHubAPIError extends Error {
     return !required.some((scope) => granted.has(scope))
   }
 
+  // Whether X-OAuth-Scopes affirmatively lists a scope. False when the header is
+  // absent (the token's scopes are unknowable — a fine-grained PAT sends none),
+  // so callers must treat false as "not proven granted", never as "proven
+  // missing". Unlike isScopeGap this needs no X-Accepted-OAuth-Scopes: GitHub
+  // often sends that header empty, which makes a gap unprovable even when the
+  // token demonstrably lacks the scope the caller cares about.
+  grantsScope(scope: string): boolean {
+    if (this.oauthScopes === null) return false
+    return this.oauthScopes
+      .split(",")
+      .map((s) => s.trim())
+      .includes(scope)
+  }
+
   // The GitHub SSO authorization URL to send the user to, if the header carried
   // one (`required; url=…`). Null for the `partial-results` shape or when no
   // header is present.

--- a/web/src/github-core/mutations/orgMembership.ts
+++ b/web/src/github-core/mutations/orgMembership.ts
@@ -119,10 +119,10 @@ export async function archiveRepo(
   )
 }
 
-// DELETE /repos/{owner}/{repo}. Needs the delete_repo OAuth scope. A token
-// granted before delete_repo was requested (an older session) still 403s, so
-// callers wanting "delete if possible, else archive" should catch the 403.
-// 404 = success.
+// DELETE /repos/{owner}/{repo}. Needs the delete_repo OAuth scope, which normal
+// sign-in does not request (#655) — so a base-scope session 403s here and only
+// an elevated one succeeds. Callers wanting "delete if possible, else archive"
+// should catch the 403. 404 = success.
 export async function deleteRepo(
   client: GitHubClient,
   input: { owner: string; repo: string },

--- a/web/src/hooks/mutations/README.md
+++ b/web/src/hooks/mutations/README.md
@@ -27,8 +27,9 @@ no → call site.
 - `useSyncRoster` — invalidate-only (the common shape).
 - `useEnrollOrInviteStudent` — optimistic seed-and-reconcile with a
   data-consistency `onEnrolled` callback in the hook.
-- `useExecuteTeardown` — owns invalidation on success AND rate-limit error, yet
-  still re-throws so the caller's `ConfirmModal` shows the failure inline.
+- `useExecuteTeardown` — owns invalidation on success and on any abort that
+  actually deleted something, yet still re-throws so the caller's `ConfirmModal`
+  shows the failure inline.
 
 Hooks stay `t()`-free: a caller passes pre-translated strings via a `messages`
 bag. The boundary is a convention, not yet lint-enforced (P7 earmarks

--- a/web/src/hooks/mutations/useExecuteTeardown.ts
+++ b/web/src/hooks/mutations/useExecuteTeardown.ts
@@ -3,7 +3,11 @@ import {
   useQueryClient,
   type QueryClient,
 } from "@tanstack/react-query"
-import { executeTeardown, type TeardownPlan } from "@/domain/teardown"
+import {
+  executeTeardown,
+  teardownProgressOf,
+  type TeardownPlan,
+} from "@/domain/teardown"
 import { githubKeys } from "@/github-core/queries"
 import { orgClassroom50StatusKey } from "@/hooks/useOrgClassroom50Status"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
@@ -41,11 +45,14 @@ export function useExecuteTeardown(plan: TeardownPlan | null) {
       void queryClient.invalidateQueries({ queryKey: ["orgs"] })
       if (result?.markerDeleted) forgetSetupState(queryClient, plan.org)
     },
-    onError: () => {
-      // Any abort may have deleted some repos before it stopped (the marker is
-      // always retained), so refresh the org view rather than keep listing
-      // repositories that no longer exist. Rejection still propagates.
-      void queryClient.invalidateQueries({ queryKey: ["orgs"] })
+    onError: (err) => {
+      // Only refresh when the run actually deleted something: an abort that
+      // changed nothing (marker re-check, network failure) would otherwise
+      // discard the org cache and make the next dashboard visit refetch every
+      // org summary for no reason. Rejection still propagates.
+      if (teardownProgressOf(err)?.deleted.length) {
+        void queryClient.invalidateQueries({ queryKey: ["orgs"] })
+      }
     },
   })
 }

--- a/web/src/hooks/mutations/useExecuteTeardown.ts
+++ b/web/src/hooks/mutations/useExecuteTeardown.ts
@@ -25,15 +25,18 @@ function forgetSetupState(queryClient: QueryClient, org: string) {
 }
 
 // Execute a teardown (delete every repo + classroom team, marker deleted last).
-// Refreshes the org list on every outcome; only forgets the setup-gating caches
-// when the marker (config repo) was actually deleted — a retained marker (any
-// partial run, including the rate-limit abort) leaves the org still set up, so
-// evicting would flash the wizard back to step 1. Does NOT swallow the error —
+// Refreshes the org list on every completed run; only forgets the setup-gating
+// caches when the marker (config repo) was actually deleted — a retained marker
+// (any partial run, including the rate-limit abort) leaves the org still set up,
+// so evicting would flash the wizard back to step 1. Does NOT swallow the error —
 // mutateAsync still REJECTS so the caller's ConfirmModal shows the failure
 // inline; the clean-run home-redirect stays at the call site (see ./README.md).
 export function useExecuteTeardown(plan: TeardownPlan | null) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
+
+  const refreshOrgs = () =>
+    void queryClient.invalidateQueries({ queryKey: ["orgs"] })
 
   return useMutation({
     mutationFn: async () => {
@@ -42,7 +45,7 @@ export function useExecuteTeardown(plan: TeardownPlan | null) {
     },
     onSuccess: (result) => {
       if (!plan) return
-      void queryClient.invalidateQueries({ queryKey: ["orgs"] })
+      refreshOrgs()
       if (result?.markerDeleted) forgetSetupState(queryClient, plan.org)
     },
     onError: (err) => {
@@ -50,9 +53,7 @@ export function useExecuteTeardown(plan: TeardownPlan | null) {
       // changed nothing (marker re-check, network failure) would otherwise
       // discard the org cache and make the next dashboard visit refetch every
       // org summary for no reason. Rejection still propagates.
-      if (teardownProgressOf(err)?.deleted.length) {
-        void queryClient.invalidateQueries({ queryKey: ["orgs"] })
-      }
+      if (teardownProgressOf(err)?.deleted.length) refreshOrgs()
     },
   })
 }

--- a/web/src/hooks/mutations/useExecuteTeardown.ts
+++ b/web/src/hooks/mutations/useExecuteTeardown.ts
@@ -3,11 +3,7 @@ import {
   useQueryClient,
   type QueryClient,
 } from "@tanstack/react-query"
-import {
-  executeTeardown,
-  TeardownRateLimitError,
-  type TeardownPlan,
-} from "@/domain/teardown"
+import { executeTeardown, type TeardownPlan } from "@/domain/teardown"
 import { githubKeys } from "@/github-core/queries"
 import { orgClassroom50StatusKey } from "@/hooks/useOrgClassroom50Status"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
@@ -45,12 +41,11 @@ export function useExecuteTeardown(plan: TeardownPlan | null) {
       void queryClient.invalidateQueries({ queryKey: ["orgs"] })
       if (result?.markerDeleted) forgetSetupState(queryClient, plan.org)
     },
-    onError: (err) => {
-      // A rate-limit abort may have deleted some repos (marker always retained),
-      // so refresh the org view. Rejection still propagates to the caller.
-      if (err instanceof TeardownRateLimitError) {
-        void queryClient.invalidateQueries({ queryKey: ["orgs"] })
-      }
+    onError: () => {
+      // Any abort may have deleted some repos before it stopped (the marker is
+      // always retained), so refresh the org view rather than keep listing
+      // repositories that no longer exist. Rejection still propagates.
+      void queryClient.invalidateQueries({ queryKey: ["orgs"] })
     },
   })
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1040,6 +1040,13 @@
       "expires": "Expires {{date}}",
       "manage": "Manage"
     },
+    "elevatedScope": {
+      "heading": "Elevated permissions",
+      "subheading": "Destructive actions like tearing down an organization need permission to delete repositories, which normal sign-in does not request. Grant it only when you need it.",
+      "granted": "Elevated permissions (repository deletion) are currently granted for this session.",
+      "notGranted": "Elevated permissions (repository deletion) are not currently granted. Normal sign-in stays least-privilege.",
+      "grantButton": "Request elevated permissions"
+    },
     "motion": {
       "heading": "Animations",
       "subheading": "Control interface motion such as page transitions, menus, and other animated effects.",
@@ -1856,7 +1863,10 @@
       "confirmBodyCannotUndo": "This cannot be undone.",
       "repositoriesHeading": "Repositories",
       "classroomTeamsHeading": "Classroom teams",
-      "executeError": "Teardown failed. Some repositories may not have been deleted."
+      "executeError": "Teardown failed. Some repositories may not have been deleted.",
+      "needsElevation": "Tearing down an organization deletes repositories, which needs elevated permissions that normal sign-in does not request. Request them to continue.",
+      "grantButton": "Request elevated permissions",
+      "needsDeleteScope": "Deleting repositories was forbidden (403). Teardown needs elevated permissions to delete repositories, which normal sign-in does not request. Request elevated permissions and try again, or archive repositories instead."
     },
     "preflight": {
       "categoryServiceToken": "service token",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1875,6 +1875,10 @@
       "insufficientPermissionHelp": "Teardown deletes repositories. Normal sign-in doesn't request permission to delete them, so request elevated permissions to continue.",
       "grantButton": "Request elevated permissions",
       "needsDeleteScope": "GitHub refused to delete repositories (403). Normal sign-in doesn't request permission to delete them. Request elevated permissions and try again, or archive repositories instead.",
+      "needsDeleteScopePartial_one": "GitHub refused to delete repositories (403) after {{deleted}} was already deleted. That deletion is permanent. Request elevated permissions and run teardown again to finish.",
+      "needsDeleteScopePartial_other": "GitHub refused to delete repositories (403) after {{deleted}} were already deleted. Those deletions are permanent. Request elevated permissions and run teardown again to finish.",
+      "ssoRequired": "GitHub refused to delete repositories (403). This organization requires SAML single sign-on. Authorize your session for this organization on GitHub, then run teardown again.",
+      "forbidden": "GitHub refused to delete repositories (403), and your permissions look sufficient. An organization policy or a protected repository is likely blocking it. Check the organization's settings, then run teardown again.",
       "rateLimited": "GitHub rate-limited the deletions. Some repositories are already deleted. Wait a moment, then run teardown again to finish."
     },
     "preflight": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1871,7 +1871,8 @@
       "repositoriesHeading": "Repositories",
       "classroomTeamsHeading": "Classroom teams",
       "executeError": "Teardown failed. Some repositories may not have been deleted.",
-      "needsElevation": "Tearing down an organization deletes repositories, which needs elevated permissions that normal sign-in does not request. Request them to continue.",
+      "insufficientPermission": "Insufficient permission",
+      "insufficientPermissionHelp": "Teardown deletes repositories, which normal sign-in doesn't request. Request elevated permissions to continue.",
       "grantButton": "Request elevated permissions",
       "needsDeleteScope": "Deleting repositories was forbidden (403). Teardown needs elevated permissions to delete repositories, which normal sign-in does not request. Request elevated permissions and try again, or archive repositories instead."
     },

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -447,7 +447,7 @@
       "title": "Request permission to delete repositories",
       "body": "Tearing down an organization deletes repositories. Sign in again to grant that access for this session.",
       "revokeTitle": "Remove permission to delete repositories",
-      "revokeBody": "Sign in again to drop repository-deletion access from this session.",
+      "revokeBody": "Sign in again to drop permission to delete repositories from this session.",
       "browserButton": "Continue in browser",
       "deviceButton": "Use a device code",
       "deviceHint": "Use a device code when the browser sign-in can't return to this page, such as on localhost."
@@ -1051,8 +1051,8 @@
     },
     "elevatedScope": {
       "heading": "Elevated permissions",
-      "subheading": "Tearing down an organization needs permission to delete repositories, which normal sign-in doesn't request. Grant it only when you need it.",
-      "toggleLabel": "Allow repository deletion"
+      "subheading": "Tearing down an organization needs permission to delete repositories, which normal sign-in doesn't request. Grant this permission only when you need it.",
+      "toggleLabel": "Allow deleting repositories"
     },
     "motion": {
       "heading": "Animations",
@@ -1872,9 +1872,10 @@
       "classroomTeamsHeading": "Classroom teams",
       "executeError": "Teardown failed. Some repositories may not have been deleted.",
       "insufficientPermission": "Insufficient permission",
-      "insufficientPermissionHelp": "Teardown deletes repositories, which normal sign-in doesn't request. Request elevated permissions to continue.",
+      "insufficientPermissionHelp": "Teardown deletes repositories. Normal sign-in doesn't request permission to delete them, so request elevated permissions to continue.",
       "grantButton": "Request elevated permissions",
-      "needsDeleteScope": "Deleting repositories was forbidden (403). Teardown needs elevated permissions to delete repositories, which normal sign-in does not request. Request elevated permissions and try again, or archive repositories instead."
+      "needsDeleteScope": "GitHub refused to delete repositories (403). Normal sign-in doesn't request permission to delete them. Request elevated permissions and try again, or archive repositories instead.",
+      "rateLimited": "GitHub rate-limited the deletions. Some repositories are already deleted. Wait a moment, then run teardown again to finish."
     },
     "preflight": {
       "categoryServiceToken": "service token",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -446,6 +446,8 @@
     "elevated": {
       "title": "Request permission to delete repositories",
       "body": "Tearing down an organization deletes repositories. Sign in again to grant that access for this session.",
+      "revokeTitle": "Remove permission to delete repositories",
+      "revokeBody": "Sign in again to drop repository-deletion access from this session.",
       "browserButton": "Continue in browser",
       "deviceButton": "Use a device code",
       "deviceHint": "Use a device code when the browser sign-in can't return to this page, such as on localhost."

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1059,7 +1059,8 @@
         "unknown": "Your token doesn't report its permissions, so Classroom 50 can't tell whether it can delete repositories."
       },
       "requestButton": "Request permission to delete repositories",
-      "removeButton": "Stop using this permission"
+      "removeButton": "Stop using this permission",
+      "patNote": "You signed in with a personal access token, so its permissions are fixed when you create it on GitHub. To change what this session can do, create a token with the permissions you need and sign in again."
     },
     "motion": {
       "heading": "Animations",
@@ -1880,7 +1881,9 @@
       "executeError": "Teardown failed. Some repositories may not have been deleted.",
       "insufficientPermission": "Insufficient permission",
       "insufficientPermissionHelp": "Teardown deletes repositories. Normal sign-in doesn't request permission to delete them, so request elevated permissions to continue.",
+      "insufficientPermissionHelpPat": "Teardown deletes repositories, and this session's token doesn't allow that. A token's permissions are fixed when you create it on GitHub, so sign in again with one that allows deleting repositories.",
       "grantButton": "Request elevated permissions",
+      "needsDeleteScopePat": "You signed in with a personal access token, so Classroom 50 can't add this permission for you. Create a token that allows deleting repositories (the delete_repo scope on a classic token, or Administration: read and write on a fine-grained one) and sign in again.",
       "needsDeleteScope": "GitHub refused to delete repositories (403). Normal sign-in doesn't request permission to delete them. Request elevated permissions and try again, or archive repositories instead.",
       "needsDeleteScopePartial_one": "GitHub refused to delete repositories (403) after {{count}} was already deleted. That deletion is permanent. Request elevated permissions and run teardown again to finish.",
       "needsDeleteScopePartial_other": "GitHub refused to delete repositories (403) after {{count}} were already deleted. Those deletions are permanent. Request elevated permissions and run teardown again to finish.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1882,8 +1882,8 @@
       "insufficientPermissionHelp": "Teardown deletes repositories. Normal sign-in doesn't request permission to delete them, so request elevated permissions to continue.",
       "grantButton": "Request elevated permissions",
       "needsDeleteScope": "GitHub refused to delete repositories (403). Normal sign-in doesn't request permission to delete them. Request elevated permissions and try again, or archive repositories instead.",
-      "needsDeleteScopePartial_one": "GitHub refused to delete repositories (403) after {{deleted}} was already deleted. That deletion is permanent. Request elevated permissions and run teardown again to finish.",
-      "needsDeleteScopePartial_other": "GitHub refused to delete repositories (403) after {{deleted}} were already deleted. Those deletions are permanent. Request elevated permissions and run teardown again to finish.",
+      "needsDeleteScopePartial_one": "GitHub refused to delete repositories (403) after {{count}} was already deleted. That deletion is permanent. Request elevated permissions and run teardown again to finish.",
+      "needsDeleteScopePartial_other": "GitHub refused to delete repositories (403) after {{count}} were already deleted. Those deletions are permanent. Request elevated permissions and run teardown again to finish.",
       "ssoRequired": "GitHub refused to delete repositories (403). This organization requires SAML single sign-on. Authorize your session for this organization on GitHub, then run teardown again.",
       "forbidden": "GitHub refused to delete repositories (403), and your permissions look sufficient. An organization policy or a protected repository is likely blocking it. Check the organization's settings, then run teardown again.",
       "rateLimited": "GitHub rate-limited the deletions. Some repositories are already deleted. Wait a moment, then run teardown again to finish."

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -445,7 +445,7 @@
     "reauthorizeHint": "If re-authorizing doesn't clear this, an organization owner may need to approve the app in the org's OAuth policy settings.",
     "elevated": {
       "title": "Request permission to delete repositories",
-      "body": "Tearing down an organization deletes repositories. Sign in again to grant that access for this session.",
+      "body": "Tearing down an organization deletes repositories. Sign in again to grant that access. It stays authorized for Classroom 50 until you revoke it on GitHub.",
       "revokeTitle": "Stop using permission to delete repositories",
       "revokeBody": "Sign in again to get a token without it. Your earlier token stays valid at GitHub until you revoke this app's access there.",
       "revokeLink": "Review this app's access on GitHub",
@@ -1052,7 +1052,7 @@
     },
     "elevatedScope": {
       "heading": "Elevated permissions",
-      "subheading": "Tearing down an organization needs permission to delete repositories, which normal sign-in doesn't request. Grant this permission only when you need it.",
+      "subheading": "Tearing down an organization needs permission to delete repositories, which normal sign-in doesn't request. Grant this permission only when you need it, and revoke it on GitHub when you're done.",
       "status": {
         "granted": "This session can delete repositories.",
         "missing": "This session can't delete repositories.",
@@ -1885,8 +1885,14 @@
       "needsDeleteScopePartial_one": "GitHub refused to delete repositories (403) after {{count}} was already deleted. That deletion is permanent. Request elevated permissions and run teardown again to finish.",
       "needsDeleteScopePartial_other": "GitHub refused to delete repositories (403) after {{count}} were already deleted. Those deletions are permanent. Request elevated permissions and run teardown again to finish.",
       "ssoRequired": "GitHub refused to delete repositories (403). This organization requires SAML single sign-on. Authorize your session for this organization on GitHub, then run teardown again.",
-      "forbidden": "GitHub refused to delete repositories (403), and your permissions look sufficient. An organization policy or a protected repository is likely blocking it. Check the organization's settings, then run teardown again.",
-      "rateLimited": "GitHub rate-limited the deletions. Some repositories are already deleted. Wait a moment, then run teardown again to finish."
+      "ssoRequiredPartial_one": "GitHub refused to delete repositories (403) after {{count}} was already deleted, and that deletion is permanent. This organization requires SAML single sign-on. Authorize your session for it on GitHub, then run teardown again to finish.",
+      "ssoRequiredPartial_other": "GitHub refused to delete repositories (403) after {{count}} were already deleted, and those deletions are permanent. This organization requires SAML single sign-on. Authorize your session for it on GitHub, then run teardown again to finish.",
+      "forbidden": "GitHub refused to delete repositories (403), and your permissions look sufficient. An organization policy or a protected repository is likely blocking the deletion. Check the organization's settings, then run teardown again.",
+      "forbiddenPartial_one": "GitHub refused to delete repositories (403) after {{count}} was already deleted, and that deletion is permanent. Your permissions look sufficient, so an organization policy or a protected repository is likely blocking the rest. Check the organization's settings, then run teardown again to finish.",
+      "forbiddenPartial_other": "GitHub refused to delete repositories (403) after {{count}} were already deleted, and those deletions are permanent. Your permissions look sufficient, so an organization policy or a protected repository is likely blocking the rest. Check the organization's settings, then run teardown again to finish.",
+      "rateLimited": "GitHub rate-limited the deletions before any repository was deleted. Wait a moment, then run teardown again.",
+      "rateLimitedPartial_one": "GitHub rate-limited the deletions after {{count}} was already deleted, and that deletion is permanent. Wait a moment, then run teardown again to finish.",
+      "rateLimitedPartial_other": "GitHub rate-limited the deletions after {{count}} were already deleted, and those deletions are permanent. Wait a moment, then run teardown again to finish."
     },
     "preflight": {
       "categoryServiceToken": "service token",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -446,8 +446,9 @@
     "elevated": {
       "title": "Request permission to delete repositories",
       "body": "Tearing down an organization deletes repositories. Sign in again to grant that access for this session.",
-      "revokeTitle": "Remove permission to delete repositories",
-      "revokeBody": "Sign in again to drop permission to delete repositories from this session.",
+      "revokeTitle": "Stop using permission to delete repositories",
+      "revokeBody": "Sign in again to get a token without it. Your earlier token stays valid at GitHub until you revoke this app's access there.",
+      "revokeLink": "Review this app's access on GitHub",
       "browserButton": "Continue in browser",
       "deviceButton": "Use a device code",
       "deviceHint": "Use a device code when the browser sign-in can't return to this page, such as on localhost."
@@ -1052,7 +1053,13 @@
     "elevatedScope": {
       "heading": "Elevated permissions",
       "subheading": "Tearing down an organization needs permission to delete repositories, which normal sign-in doesn't request. Grant this permission only when you need it.",
-      "toggleLabel": "Allow deleting repositories"
+      "status": {
+        "granted": "This session can delete repositories.",
+        "missing": "This session can't delete repositories.",
+        "unknown": "Your token doesn't report its permissions, so Classroom 50 can't tell whether it can delete repositories."
+      },
+      "requestButton": "Request permission to delete repositories",
+      "removeButton": "Stop using this permission"
     },
     "motion": {
       "heading": "Animations",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1050,9 +1050,7 @@
     "elevatedScope": {
       "heading": "Elevated permissions",
       "subheading": "Tearing down an organization needs permission to delete repositories, which normal sign-in doesn't request. Grant it only when you need it.",
-      "granted": "Repository deletion granted",
-      "notGranted": "Repository deletion not granted",
-      "grantButton": "Request elevated permissions"
+      "toggleLabel": "Allow repository deletion"
     },
     "motion": {
       "heading": "Animations",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -443,6 +443,13 @@
     "missingScopesBody_other": "This app needs the scopes <scopes>{{scopes}}</scopes>. Some actions may fail until they are granted.",
     "reauthorize": "Re-authorize",
     "reauthorizeHint": "If re-authorizing doesn't clear this, an organization owner may need to approve the app in the org's OAuth policy settings.",
+    "elevated": {
+      "title": "Request permission to delete repositories",
+      "body": "Tearing down an organization deletes repositories. Sign in again to grant that access for this session.",
+      "browserButton": "Continue in browser",
+      "deviceButton": "Use a device code",
+      "deviceHint": "Use a device code when the browser sign-in can't return to this page, such as on localhost."
+    },
     "patTitleClassic": "Sign in with a classic personal access token",
     "patTitleFineGrained": "Sign in with a fine-grained personal access token",
     "patClassicIntro": "A classic token works across every organization you own.",
@@ -1042,9 +1049,9 @@
     },
     "elevatedScope": {
       "heading": "Elevated permissions",
-      "subheading": "Destructive actions like tearing down an organization need permission to delete repositories, which normal sign-in does not request. Grant it only when you need it.",
-      "granted": "Elevated permissions (repository deletion) are currently granted for this session.",
-      "notGranted": "Elevated permissions (repository deletion) are not currently granted. Normal sign-in stays least-privilege.",
+      "subheading": "Tearing down an organization needs permission to delete repositories, which normal sign-in doesn't request. Grant it only when you need it.",
+      "granted": "Repository deletion granted",
+      "notGranted": "Repository deletion not granted",
       "grantButton": "Request elevated permissions"
     },
     "motion": {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -17,11 +17,15 @@ vi.mock("@/components/settings/LanguageSwitcher", () => ({
   LanguageSwitcher: () => <div data-testid="language-switcher" />,
 }))
 vi.mock("@/hooks/useDocumentTitle", () => ({ useDocumentTitle: () => {} }))
-// The elevated-permissions section reads scope context and renders the elevated
-// access modal; stub both so the page renders without a GitHubAuthProvider (this
-// suite mounts the page bare). The modal's flow has its own test.
+// The elevated-permissions section reads scope + auth context and renders the
+// elevated access modal; stub all three so the page renders without a
+// GitHubAuthProvider (this suite mounts the page bare). The modal and toggle
+// behavior have their own tests.
 vi.mock("@/context/github/GitHubProvider", () => ({
   useHasDeleteRepoScope: () => false,
+}))
+vi.mock("@/auth/useGithubAuth", () => ({
+  useGithubAuth: () => ({ startWebFlow: vi.fn() }),
 }))
 vi.mock("@/auth/ElevatedAccessModal", () => ({
   ElevatedAccessModal: () => null,

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -22,10 +22,17 @@ vi.mock("@/hooks/useDocumentTitle", () => ({ useDocumentTitle: () => {} }))
 // access modal; stub both so the page renders without a GitHubAuthProvider (this
 // suite mounts the page bare). The modal's flow has its own test.
 const scopeState = vi.fn<() => DeleteRepoScopeState>(() => "missing")
+// An OAuth session by default; the PAT cases flip this to prove the section
+// stops offering an in-app re-auth it can't deliver.
+const canElevateInApp = vi.fn<() => boolean>(() => true)
 vi.mock("@/context/github/GitHubProvider", async (importActual) => {
   const actual =
     await importActual<typeof import("@/context/github/GitHubProvider")>()
-  return { ...actual, useDeleteRepoScopeState: () => scopeState() }
+  return {
+    ...actual,
+    useDeleteRepoScopeState: () => scopeState(),
+    useCanElevateInApp: () => canElevateInApp(),
+  }
 })
 vi.mock("@/auth/ElevatedAccessModal", () => ({
   ElevatedAccessModal: ({
@@ -146,6 +153,7 @@ afterEach(() => {
   orgsData.data = []
   orgsData.isLoading = false
   scopeState.mockReturnValue("missing")
+  canElevateInApp.mockReturnValue(true)
   for (const k of Object.keys(healthByOrg)) delete healthByOrg[k]
 })
 
@@ -279,6 +287,24 @@ describe("SettingsPage elevated permissions", () => {
       screen.getByText("settings.elevatedScope.removeButton"),
     )
     expect(screen.getByTestId("elevated-modal").dataset.elevated).toBe("false")
+  })
+
+  it("tells a PAT session to replace its token instead of offering a re-auth", async () => {
+    // A PAT's permissions are fixed at creation, so the OAuth elevation flow
+    // can't add the scope — it would just swap the session for a different kind
+    // of token. Offer the instruction, not the button.
+    asOwner()
+    scopeState.mockReturnValue("missing")
+    canElevateInApp.mockReturnValue(false)
+    renderPage()
+
+    expect(screen.getByText("settings.elevatedScope.patNote")).toBeTruthy()
+    expect(
+      screen.queryByText("settings.elevatedScope.requestButton"),
+    ).toBeNull()
+    expect(screen.queryByText("settings.elevatedScope.removeButton")).toBeNull()
+    // The revoke link points at the OAuth grant page, which a PAT never used.
+    expect(screen.queryByText("auth.elevated.revokeLink")).toBeNull()
   })
 })
 

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -17,18 +17,28 @@ vi.mock("@/components/settings/LanguageSwitcher", () => ({
   LanguageSwitcher: () => <div data-testid="language-switcher" />,
 }))
 vi.mock("@/hooks/useDocumentTitle", () => ({ useDocumentTitle: () => {} }))
-// The elevated-permissions section reads scope + auth context and renders the
-// elevated access modal; stub all three so the page renders without a
-// GitHubAuthProvider (this suite mounts the page bare). The modal and toggle
-// behavior have their own tests.
-vi.mock("@/context/github/GitHubProvider", () => ({
-  useHasDeleteRepoScope: () => false,
-}))
-vi.mock("@/auth/useGithubAuth", () => ({
-  useGithubAuth: () => ({ startWebFlow: vi.fn() }),
-}))
+// The elevated-permissions section reads scope state and renders the elevated
+// access modal; stub both so the page renders without a GitHubAuthProvider (this
+// suite mounts the page bare). The modal's flow has its own test.
+const scopeState = vi.fn<() => "granted" | "missing" | "unknown">(
+  () => "missing",
+)
+vi.mock("@/context/github/GitHubProvider", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@/context/github/GitHubProvider")>()
+  return { ...actual, useDeleteRepoScopeState: () => scopeState() }
+})
 vi.mock("@/auth/ElevatedAccessModal", () => ({
-  ElevatedAccessModal: () => null,
+  ElevatedAccessModal: ({
+    open,
+    elevated,
+  }: {
+    open: boolean
+    elevated?: boolean
+  }) =>
+    open ? (
+      <div data-testid="elevated-modal" data-elevated={String(elevated)} />
+    ) : null,
 }))
 vi.mock("react-i18next", async (importActual) => {
   const actual = await importActual<typeof import("react-i18next")>()
@@ -136,6 +146,7 @@ afterEach(() => {
   window.localStorage.clear()
   orgsData.data = []
   orgsData.isLoading = false
+  scopeState.mockReturnValue("missing")
   for (const k of Object.keys(healthByOrg)) delete healthByOrg[k]
 })
 
@@ -169,7 +180,7 @@ describe("SettingsPage hidden organizations", () => {
 })
 
 describe("SettingsPage elevated permissions", () => {
-  it("hides the elevated-permissions section for a user who owns no ready org", () => {
+  it("hides the section for a user who owns no ready org", () => {
     // Students share this page; offering them delete_repo would widen the blast
     // radius of a stolen token for no benefit (#655).
     orgsData.data = [
@@ -183,7 +194,7 @@ describe("SettingsPage elevated permissions", () => {
     expect(screen.queryByText("settings.elevatedScope.heading")).toBeNull()
   })
 
-  it("shows it for an owner of a ready org", () => {
+  const asOwner = () => {
     orgsData.data = [
       {
         org: { login: "cs50", id: 42 },
@@ -191,11 +202,60 @@ describe("SettingsPage elevated permissions", () => {
         classroom50: { status: "ready" },
       },
     ]
+  }
+
+  it("offers only the request action when the permission is missing", () => {
+    asOwner()
+    scopeState.mockReturnValue("missing")
     renderPage()
-    expect(screen.getByText("settings.elevatedScope.heading")).toBeTruthy()
     expect(
-      screen.getByLabelText("settings.elevatedScope.toggleLabel"),
+      screen.getByText("settings.elevatedScope.status.missing"),
     ).toBeTruthy()
+    expect(
+      screen.getByText("settings.elevatedScope.requestButton"),
+    ).toBeTruthy()
+    expect(screen.queryByText("settings.elevatedScope.removeButton")).toBeNull()
+  })
+
+  it("offers the remove action only when the permission is observed", () => {
+    asOwner()
+    scopeState.mockReturnValue("granted")
+    renderPage()
+    expect(
+      screen.getByText("settings.elevatedScope.status.granted"),
+    ).toBeTruthy()
+    expect(screen.getByText("settings.elevatedScope.removeButton")).toBeTruthy()
+  })
+
+  it("never offers to remove a permission it could not read", () => {
+    // An unknown session (fine-grained PAT) must not be told it holds the
+    // permission, and must not be offered a revoke that swaps its token.
+    asOwner()
+    scopeState.mockReturnValue("unknown")
+    renderPage()
+    expect(
+      screen.getByText("settings.elevatedScope.status.unknown"),
+    ).toBeTruthy()
+    expect(screen.queryByText("settings.elevatedScope.removeButton")).toBeNull()
+  })
+
+  it("asks to grant when requesting, and to drop when removing", async () => {
+    asOwner()
+    scopeState.mockReturnValue("granted")
+    renderPage()
+
+    await userEvent.click(
+      screen.getByText("settings.elevatedScope.requestButton"),
+    )
+    expect(screen.getByTestId("elevated-modal").dataset.elevated).toBe("true")
+    cleanup()
+
+    scopeState.mockReturnValue("granted")
+    renderPage()
+    await userEvent.click(
+      screen.getByText("settings.elevatedScope.removeButton"),
+    )
+    expect(screen.getByTestId("elevated-modal").dataset.elevated).toBe("false")
   })
 })
 

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -17,13 +17,14 @@ vi.mock("@/components/settings/LanguageSwitcher", () => ({
   LanguageSwitcher: () => <div data-testid="language-switcher" />,
 }))
 vi.mock("@/hooks/useDocumentTitle", () => ({ useDocumentTitle: () => {} }))
-// The elevated-permissions section reads auth + scope context; stub both so the
-// page renders without a GitHubAuthProvider (this suite mounts the page bare).
-vi.mock("@/auth/useGithubAuth", () => ({
-  useGithubAuth: () => ({ startWebFlow: vi.fn() }),
-}))
+// The elevated-permissions section reads scope context and renders the elevated
+// access modal; stub both so the page renders without a GitHubAuthProvider (this
+// suite mounts the page bare). The modal's flow has its own test.
 vi.mock("@/context/github/GitHubProvider", () => ({
   useHasDeleteRepoScope: () => false,
+}))
+vi.mock("@/auth/ElevatedAccessModal", () => ({
+  ElevatedAccessModal: () => null,
 }))
 vi.mock("react-i18next", async (importActual) => {
   const actual = await importActual<typeof import("react-i18next")>()

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { HIDDEN_ORGS_STORAGE_KEY } from "@/lib/hiddenOrgsStore"
 import { HiddenOrgsProvider } from "@/context/hiddenOrgs/HiddenOrgsProvider"
+import type { DeleteRepoScopeState } from "@/context/github/GitHubProvider"
 
 vi.mock("@/components/PageShell", () => ({
   default: ({ children }: { children: React.ReactNode }) => (
@@ -20,9 +21,7 @@ vi.mock("@/hooks/useDocumentTitle", () => ({ useDocumentTitle: () => {} }))
 // The elevated-permissions section reads scope state and renders the elevated
 // access modal; stub both so the page renders without a GitHubAuthProvider (this
 // suite mounts the page bare). The modal's flow has its own test.
-const scopeState = vi.fn<() => "granted" | "missing" | "unknown">(
-  () => "missing",
-)
+const scopeState = vi.fn<() => DeleteRepoScopeState>(() => "missing")
 vi.mock("@/context/github/GitHubProvider", async (importActual) => {
   const actual =
     await importActual<typeof import("@/context/github/GitHubProvider")>()

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -239,9 +239,33 @@ describe("SettingsPage elevated permissions", () => {
     expect(screen.queryByText("settings.elevatedScope.removeButton")).toBeNull()
   })
 
-  it("asks to grant when requesting, and to drop when removing", async () => {
+  it("disables the request action once the permission is observed", () => {
     asOwner()
     scopeState.mockReturnValue("granted")
+    renderPage()
+    expect(
+      screen
+        .getByText("settings.elevatedScope.requestButton")
+        .closest("button")!.disabled,
+    ).toBe(true)
+  })
+
+  it("keeps the request action available when scopes are unreadable", () => {
+    // An unknown session still needs a way to ask, since we can't prove it holds
+    // the permission.
+    asOwner()
+    scopeState.mockReturnValue("unknown")
+    renderPage()
+    expect(
+      screen
+        .getByText("settings.elevatedScope.requestButton")
+        .closest("button")!.disabled,
+    ).toBe(false)
+  })
+
+  it("asks to grant when requesting, and to drop when removing", async () => {
+    asOwner()
+    scopeState.mockReturnValue("missing")
     renderPage()
 
     await userEvent.click(

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -17,6 +17,14 @@ vi.mock("@/components/settings/LanguageSwitcher", () => ({
   LanguageSwitcher: () => <div data-testid="language-switcher" />,
 }))
 vi.mock("@/hooks/useDocumentTitle", () => ({ useDocumentTitle: () => {} }))
+// The elevated-permissions section reads auth + scope context; stub both so the
+// page renders without a GitHubAuthProvider (this suite mounts the page bare).
+vi.mock("@/auth/useGithubAuth", () => ({
+  useGithubAuth: () => ({ startWebFlow: vi.fn() }),
+}))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useHasDeleteRepoScope: () => false,
+}))
 vi.mock("react-i18next", async (importActual) => {
   const actual = await importActual<typeof import("react-i18next")>()
   return { ...actual, useTranslation: () => ({ t: (k: string) => k }) }

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -168,6 +168,37 @@ describe("SettingsPage hidden organizations", () => {
   })
 })
 
+describe("SettingsPage elevated permissions", () => {
+  it("hides the elevated-permissions section for a user who owns no ready org", () => {
+    // Students share this page; offering them delete_repo would widen the blast
+    // radius of a stolen token for no benefit (#655).
+    orgsData.data = [
+      {
+        org: { login: "member-org", id: 1 },
+        membership: { role: "member" },
+        classroom50: { status: "ready" },
+      },
+    ]
+    renderPage()
+    expect(screen.queryByText("settings.elevatedScope.heading")).toBeNull()
+  })
+
+  it("shows it for an owner of a ready org", () => {
+    orgsData.data = [
+      {
+        org: { login: "cs50", id: 42 },
+        membership: { role: "admin" },
+        classroom50: { status: "ready" },
+      },
+    ]
+    renderPage()
+    expect(screen.getByText("settings.elevatedScope.heading")).toBeTruthy()
+    expect(
+      screen.getByLabelText("settings.elevatedScope.toggleLabel"),
+    ).toBeTruthy()
+  })
+})
+
 describe("SettingsPage service tokens", () => {
   it("shows the empty state when no owned+ready orgs exist", () => {
     orgsData.data = [

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -148,7 +148,7 @@ function ElevatedPermissionsSection({
           </p>
           <div className="flex flex-wrap gap-2">
             <Button
-              variant="outline"
+              variant="warning"
               size="sm"
               // Nothing to request when the permission is already observed. Stays
               // enabled on "unknown" so a session we can't read can still ask.

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -116,10 +116,6 @@ function ServiceTokensSection({ highlighted }: { highlighted?: boolean }) {
   )
 }
 
-// Least-privilege by default: normal sign-in never requests delete_repo, so a
-// destructive action needs an on-demand re-auth. See auth/constants.ts for the
-// base/elevated policy.
-//
 // Rendered only for owners of a Classroom 50 org, the only people who can run
 // teardown. Students share this Settings page, and offering them the very scope
 // #655 removed would widen the blast radius of a stolen token for no benefit.
@@ -137,10 +133,7 @@ function ElevatedPermissionsSection({
   if (!ownsReadyOrg) return null
 
   // An action, not a preference: each direction is a full re-auth the user can
-  // abandon, so a switch would misreport state. Only offer "remove" when the
-  // permission is actually observed — an unknown session (fine-grained PAT) must
-  // not be told it holds something we couldn't read, and revoking it would swap
-  // a deliberately org-scoped token for a broader OAuth one.
+  // abandon, so a switch would misreport state.
   return (
     <>
       <SettingsSectionCard
@@ -165,6 +158,8 @@ function ElevatedPermissionsSection({
               {t("settings.elevatedScope.requestButton")}
             </Button>
             {scopeState === "granted" && (
+              // Only offer this once observed: an unknown session must not be
+              // told it holds a permission we couldn't read.
               <Button
                 variant="ghost"
                 size="sm"

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -24,7 +24,7 @@ import { TokenHealthChip } from "@/components/status/TokenHealthChip"
 import { useReducedMotion, type MotionPref } from "@/hooks/useReducedMotion"
 import { useTheme, type ThemePref } from "@/hooks/useTheme"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
-import { useHasDeleteRepoScope } from "@/context/github/GitHubProvider"
+import { useDeleteRepoScopeState } from "@/context/github/GitHubProvider"
 import { ElevatedAccessModal } from "@/auth/ElevatedAccessModal"
 
 // Owned + Classroom 50-ready orgs are the only ones with a manageable service
@@ -129,17 +129,18 @@ function ElevatedPermissionsSection({
   highlighted?: boolean
 }) {
   const { t } = useTranslation()
-  const hasDeleteRepo = useHasDeleteRepoScope()
-  const [elevateOpen, setElevateOpen] = useState(false)
+  const scopeState = useDeleteRepoScopeState()
+  const [elevate, setElevate] = useState<null | boolean>(null)
   const { data: orgs = [] } = useGetOrgs()
 
   const ownsReadyOrg = useMemo(() => orgs.some(isOwnedReadyOrg), [orgs])
   if (!ownsReadyOrg) return null
 
-  // Either direction needs a full re-auth, so both open the modal (which offers
-  // the device path that works on localhost).
-  const onToggle = () => setElevateOpen(true)
-
+  // An action, not a preference: each direction is a full re-auth the user can
+  // abandon, so a switch would misreport state. Only offer "remove" when the
+  // permission is actually observed — an unknown session (fine-grained PAT) must
+  // not be told it holds something we couldn't read, and revoking it would swap
+  // a deliberately org-scoped token for a broader OAuth one.
   return (
     <>
       <SettingsSectionCard
@@ -147,21 +148,35 @@ function ElevatedPermissionsSection({
         heading={t("settings.elevatedScope.heading")}
         subheading={t("settings.elevatedScope.subheading")}
         highlighted={highlighted}
-        control={
-          <input
-            type="checkbox"
-            role="switch"
-            className="toggle toggle-primary"
-            checked={hasDeleteRepo}
-            aria-label={t("settings.elevatedScope.toggleLabel")}
-            onChange={onToggle}
-          />
-        }
-      />
+      >
+        <div className="flex flex-col items-start gap-2">
+          <p className="text-sm text-base-content/70">
+            {t(`settings.elevatedScope.status.${scopeState}`)}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setElevate(true)}
+            >
+              {t("settings.elevatedScope.requestButton")}
+            </Button>
+            {scopeState === "granted" && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setElevate(false)}
+              >
+                {t("settings.elevatedScope.removeButton")}
+              </Button>
+            )}
+          </div>
+        </div>
+      </SettingsSectionCard>
       <ElevatedAccessModal
-        open={elevateOpen}
-        elevated={!hasDeleteRepo}
-        onClose={() => setElevateOpen(false)}
+        open={elevate !== null}
+        elevated={elevate ?? true}
+        onClose={() => setElevate(null)}
       />
     </>
   )
@@ -227,16 +242,13 @@ function SettingsSectionCard({
   heading,
   subheading,
   highlighted,
-  control,
   children,
 }: {
   id: string
   heading: string
   subheading: string
   highlighted?: boolean
-  // Pinned to the top-right; for a section whose whole state is one switch.
-  control?: React.ReactNode
-  children?: React.ReactNode
+  children: React.ReactNode
 }) {
   return (
     <Card
@@ -249,16 +261,11 @@ function SettingsSectionCard({
       )}
     >
       <Card.Body>
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <SectionAnchorHeading anchorId={id} as="h3" className="card-title">
-              {heading}
-            </SectionAnchorHeading>
-            <p className="text-sm text-base-content/70">{subheading}</p>
-          </div>
-          {control ? <div className="shrink-0 pt-1">{control}</div> : null}
-        </div>
-        {children ? <div className="mt-4">{children}</div> : null}
+        <SectionAnchorHeading anchorId={id} as="h3" className="card-title">
+          {heading}
+        </SectionAnchorHeading>
+        <p className="text-sm text-base-content/70">{subheading}</p>
+        <div className="mt-4">{children}</div>
       </Card.Body>
     </Card>
   )

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -25,6 +25,7 @@ import { useReducedMotion, type MotionPref } from "@/hooks/useReducedMotion"
 import { useTheme, type ThemePref } from "@/hooks/useTheme"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
 import { useDeleteRepoScopeState } from "@/context/github/GitHubProvider"
+import { githubOAuthGrantUrl } from "@/auth/constants"
 import { ElevatedAccessModal } from "@/auth/ElevatedAccessModal"
 
 // Owned + Classroom 50-ready orgs are the only ones with a manageable service
@@ -169,6 +170,18 @@ function ElevatedPermissionsSection({
               </Button>
             )}
           </div>
+          {/* Always reachable: signing in again only narrows this browser's
+              token, so GitHub is the only place the grant itself goes away —
+              and it's needed most right after the local narrowing, when the
+              state is no longer "granted". */}
+          <a
+            className="link text-xs"
+            href={githubOAuthGrantUrl()}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t("auth.elevated.revokeLink")}
+          </a>
         </div>
       </SettingsSectionCard>
       <ElevatedAccessModal

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -157,6 +157,9 @@ function ElevatedPermissionsSection({
             <Button
               variant="outline"
               size="sm"
+              // Nothing to request when the permission is already observed. Stays
+              // enabled on "unknown" so a session we can't read can still ask.
+              disabled={scopeState === "granted"}
               onClick={() => setElevate(true)}
             >
               {t("settings.elevatedScope.requestButton")}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -25,7 +25,6 @@ import { useReducedMotion, type MotionPref } from "@/hooks/useReducedMotion"
 import { useTheme, type ThemePref } from "@/hooks/useTheme"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
 import { useHasDeleteRepoScope } from "@/context/github/GitHubProvider"
-import { useGithubAuth } from "@/auth/useGithubAuth"
 import { ElevatedAccessModal } from "@/auth/ElevatedAccessModal"
 
 // Owned + Classroom 50-ready orgs are the only ones with a manageable service
@@ -130,21 +129,14 @@ function ElevatedPermissionsSection({
   highlighted?: boolean
 }) {
   const { t } = useTranslation()
-  const { startWebFlow } = useGithubAuth()
   const hasDeleteRepo = useHasDeleteRepoScope()
   const [elevateOpen, setElevateOpen] = useState(false)
 
-  // The toggle reflects whether the current session holds delete_repo. Turning
-  // it on opens the elevation flow (browser or device); turning it off re-auths
-  // at base scope, dropping the elevated grant. GitHub has no client-side way to
-  // shed one scope, so "off" is a plain base re-auth.
-  const onToggle = (next: boolean) => {
-    if (next) {
-      setElevateOpen(true)
-    } else {
-      void startWebFlow()
-    }
-  }
+  // The toggle reflects whether the current session holds delete_repo. Either
+  // direction needs a full re-auth (GitHub can't add or drop one scope
+  // client-side), so both open the modal, which offers browser or device sign-in
+  // — the device path is the one that works on localhost.
+  const onToggle = () => setElevateOpen(true)
 
   return (
     <>
@@ -160,12 +152,13 @@ function ElevatedPermissionsSection({
             className="toggle toggle-primary"
             checked={hasDeleteRepo}
             aria-label={t("settings.elevatedScope.toggleLabel")}
-            onChange={(event) => onToggle(event.target.checked)}
+            onChange={onToggle}
           />
         }
       />
       <ElevatedAccessModal
         open={elevateOpen}
+        elevated={!hasDeleteRepo}
         onClose={() => setElevateOpen(false)}
       />
     </>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -118,8 +118,11 @@ function ServiceTokensSection({ highlighted }: { highlighted?: boolean }) {
 
 // Least-privilege by default: normal sign-in never requests delete_repo, so a
 // destructive action (Teardown Organization) needs a one-shot elevated re-auth.
-// This is an action, not a persisted toggle — nothing is stored, so a later
-// fresh login drops back to base scopes (#655).
+// This is an action, not a persisted toggle: the scope *request* defaults to
+// base on every sign-in (only this button asks for delete_repo, for that one
+// re-auth), so a later plain sign-in drops back to base. The elevated token
+// itself is stored like any OAuth token until sign-out — one-shot is about the
+// request preference, not the token's lifetime (#655).
 function ElevatedPermissionsSection({
   highlighted,
 }: {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -117,12 +117,12 @@ function ServiceTokensSection({ highlighted }: { highlighted?: boolean }) {
 }
 
 // Least-privilege by default: normal sign-in never requests delete_repo, so a
-// destructive action (Teardown Organization) needs a one-shot elevated re-auth.
-// This is an action, not a persisted toggle: the scope *request* defaults to
-// base on every sign-in (only this button asks for delete_repo, for that one
-// re-auth), so a later plain sign-in drops back to base. The elevated token
-// itself is stored like any OAuth token until sign-out — one-shot is about the
-// request preference, not the token's lifetime (#655).
+// destructive action needs an on-demand re-auth. See auth/constants.ts for the
+// base/elevated policy.
+//
+// Rendered only for owners of a Classroom 50 org, the only people who can run
+// teardown. Students share this Settings page, and offering them the very scope
+// #655 removed would widen the blast radius of a stolen token for no benefit.
 function ElevatedPermissionsSection({
   highlighted,
 }: {
@@ -131,11 +131,13 @@ function ElevatedPermissionsSection({
   const { t } = useTranslation()
   const hasDeleteRepo = useHasDeleteRepoScope()
   const [elevateOpen, setElevateOpen] = useState(false)
+  const { data: orgs = [] } = useGetOrgs()
 
-  // The toggle reflects whether the current session holds delete_repo. Either
-  // direction needs a full re-auth (GitHub can't add or drop one scope
-  // client-side), so both open the modal, which offers browser or device sign-in
-  // — the device path is the one that works on localhost.
+  const ownsReadyOrg = useMemo(() => orgs.some(isOwnedReadyOrg), [orgs])
+  if (!ownsReadyOrg) return null
+
+  // Either direction needs a full re-auth, so both open the modal (which offers
+  // the device path that works on localhost).
   const onToggle = () => setElevateOpen(true)
 
   return (
@@ -232,8 +234,7 @@ function SettingsSectionCard({
   heading: string
   subheading: string
   highlighted?: boolean
-  // Optional control (e.g. a toggle) pinned to the top-right, aligned with the
-  // heading. Use for a section whose whole state is one on/off switch.
+  // Pinned to the top-right; for a section whose whole state is one switch.
   control?: React.ReactNode
   children?: React.ReactNode
 }) {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -24,6 +24,8 @@ import { TokenHealthChip } from "@/components/status/TokenHealthChip"
 import { useReducedMotion, type MotionPref } from "@/hooks/useReducedMotion"
 import { useTheme, type ThemePref } from "@/hooks/useTheme"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
+import { useGithubAuth } from "@/auth/useGithubAuth"
+import { useHasDeleteRepoScope } from "@/context/github/GitHubProvider"
 
 // Owned + Classroom 50-ready orgs are the only ones with a manageable service
 // token (a non-owner can't read/set it). The section reads token health for
@@ -110,6 +112,45 @@ function ServiceTokensSection({ highlighted }: { highlighted?: boolean }) {
           })}
         </ul>
       )}
+    </SettingsSectionCard>
+  )
+}
+
+// Least-privilege by default: normal sign-in never requests delete_repo, so a
+// destructive action (Teardown Organization) needs a one-shot elevated re-auth.
+// This is an action, not a persisted toggle — nothing is stored, so a later
+// fresh login drops back to base scopes (#655).
+function ElevatedPermissionsSection({
+  highlighted,
+}: {
+  highlighted?: boolean
+}) {
+  const { t } = useTranslation()
+  const { startWebFlow } = useGithubAuth()
+  const hasDeleteRepo = useHasDeleteRepoScope()
+
+  return (
+    <SettingsSectionCard
+      id="elevated-permissions"
+      heading={t("settings.elevatedScope.heading")}
+      subheading={t("settings.elevatedScope.subheading")}
+      highlighted={highlighted}
+    >
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-base-content/70">
+          {hasDeleteRepo
+            ? t("settings.elevatedScope.granted")
+            : t("settings.elevatedScope.notGranted")}
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          className="self-start"
+          onClick={() => void startWebFlow({ elevated: true })}
+        >
+          {t("settings.elevatedScope.grantButton")}
+        </Button>
+      </div>
     </SettingsSectionCard>
   )
 }
@@ -390,6 +431,9 @@ const SettingsPage = () => {
           <HiddenOrgsSection highlighted={highlightedId === "hidden-orgs"} />
           <ServiceTokensSection
             highlighted={highlightedId === "service-tokens"}
+          />
+          <ElevatedPermissionsSection
+            highlighted={highlightedId === "elevated-permissions"}
           />
         </SettingsGroup>
 

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -24,7 +24,10 @@ import { TokenHealthChip } from "@/components/status/TokenHealthChip"
 import { useReducedMotion, type MotionPref } from "@/hooks/useReducedMotion"
 import { useTheme, type ThemePref } from "@/hooks/useTheme"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
-import { useDeleteRepoScopeState } from "@/context/github/GitHubProvider"
+import {
+  useDeleteRepoScopeState,
+  useCanElevateInApp,
+} from "@/context/github/GitHubProvider"
 import { ElevatedAccessModal } from "@/auth/ElevatedAccessModal"
 import { RevokeAccessLink } from "@/auth/RevokeAccessLink"
 
@@ -130,6 +133,7 @@ function ElevatedPermissionsSection({
 }) {
   const { t } = useTranslation()
   const scopeState = useDeleteRepoScopeState()
+  const canElevateInApp = useCanElevateInApp()
   const [elevate, setElevate] = useState<null | boolean>(null)
   const { data: orgs = [] } = useGetOrgs()
 
@@ -148,34 +152,45 @@ function ElevatedPermissionsSection({
           <p className="text-sm text-base-content/70">
             {t(`settings.elevatedScope.status.${scopeState}`)}
           </p>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              variant="warning"
-              size="sm"
-              // Nothing to request when the permission is already observed. Stays
-              // enabled on "unknown" so a session we can't read can still ask.
-              disabled={scopeState === "granted"}
-              onClick={() => setElevate(true)}
-            >
-              {t("settings.elevatedScope.requestButton")}
-            </Button>
-            {scopeState === "granted" && (
-              // Only offer this once observed: an unknown session must not be
-              // told it holds a permission we couldn't read.
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setElevate(false)}
-              >
-                {t("settings.elevatedScope.removeButton")}
-              </Button>
-            )}
-          </div>
-          {/* Always reachable: signing in again only narrows this browser's
-              token, so GitHub is the only place the grant itself goes away —
-              and it's needed most right after the local narrowing, when the
-              state is no longer "granted". */}
-          <RevokeAccessLink />
+          {canElevateInApp ? (
+            <>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="warning"
+                  size="sm"
+                  // Nothing to request when the permission is already observed. Stays
+                  // enabled on "unknown" so a session we can't read can still ask.
+                  disabled={scopeState === "granted"}
+                  onClick={() => setElevate(true)}
+                >
+                  {t("settings.elevatedScope.requestButton")}
+                </Button>
+                {scopeState === "granted" && (
+                  // Only offer this once observed: an unknown session must not be
+                  // told it holds a permission we couldn't read.
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setElevate(false)}
+                  >
+                    {t("settings.elevatedScope.removeButton")}
+                  </Button>
+                )}
+              </div>
+              {/* Always reachable: signing in again only narrows this browser's
+                  token, so GitHub is the only place the grant itself goes away —
+                  and it's needed most right after the local narrowing, when the
+                  state is no longer "granted". */}
+              <RevokeAccessLink />
+            </>
+          ) : (
+            // A token's permissions are fixed when it's created on GitHub, so
+            // there is nothing to request here; running the OAuth flow would
+            // replace this session with a different kind of token.
+            <p className="text-sm text-base-content/70">
+              {t("settings.elevatedScope.patNote")}
+            </p>
+          )}
         </div>
       </SettingsSectionCard>
       <ElevatedAccessModal

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -25,8 +25,8 @@ import { useReducedMotion, type MotionPref } from "@/hooks/useReducedMotion"
 import { useTheme, type ThemePref } from "@/hooks/useTheme"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
 import { useDeleteRepoScopeState } from "@/context/github/GitHubProvider"
-import { githubOAuthGrantUrl } from "@/auth/constants"
 import { ElevatedAccessModal } from "@/auth/ElevatedAccessModal"
+import { RevokeAccessLink } from "@/auth/RevokeAccessLink"
 
 // Owned + Classroom 50-ready orgs are the only ones with a manageable service
 // token (a non-owner can't read/set it). The section reads token health for
@@ -120,6 +120,9 @@ function ServiceTokensSection({ highlighted }: { highlighted?: boolean }) {
 // Rendered only for owners of a Classroom 50 org, the only people who can run
 // teardown. Students share this Settings page, and offering them the very scope
 // #655 removed would widen the blast radius of a stolen token for no benefit.
+//
+// Rendered as actions, not a preference switch: each direction is a full re-auth
+// the user can abandon, so a switch would misreport state.
 function ElevatedPermissionsSection({
   highlighted,
 }: {
@@ -133,8 +136,6 @@ function ElevatedPermissionsSection({
   const ownsReadyOrg = useMemo(() => orgs.some(isOwnedReadyOrg), [orgs])
   if (!ownsReadyOrg) return null
 
-  // An action, not a preference: each direction is a full re-auth the user can
-  // abandon, so a switch would misreport state.
   return (
     <>
       <SettingsSectionCard
@@ -174,14 +175,7 @@ function ElevatedPermissionsSection({
               token, so GitHub is the only place the grant itself goes away —
               and it's needed most right after the local narrowing, when the
               state is no longer "granted". */}
-          <a
-            className="link text-xs"
-            href={githubOAuthGrantUrl()}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {t("auth.elevated.revokeLink")}
-          </a>
+          <RevokeAccessLink />
         </div>
       </SettingsSectionCard>
       <ElevatedAccessModal

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/ui"
 import { useTranslation } from "react-i18next"
 import { useMemo, useState } from "react"
-import { ShieldCheck, ShieldOff } from "lucide-react"
 import useGetOrgs from "@/hooks/useGetOrgs"
 import {
   isOwnedReadyOrg,
@@ -26,6 +25,7 @@ import { useReducedMotion, type MotionPref } from "@/hooks/useReducedMotion"
 import { useTheme, type ThemePref } from "@/hooks/useTheme"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
 import { useHasDeleteRepoScope } from "@/context/github/GitHubProvider"
+import { useGithubAuth } from "@/auth/useGithubAuth"
 import { ElevatedAccessModal } from "@/auth/ElevatedAccessModal"
 
 // Owned + Classroom 50-ready orgs are the only ones with a manageable service
@@ -130,47 +130,45 @@ function ElevatedPermissionsSection({
   highlighted?: boolean
 }) {
   const { t } = useTranslation()
+  const { startWebFlow } = useGithubAuth()
   const hasDeleteRepo = useHasDeleteRepoScope()
   const [elevateOpen, setElevateOpen] = useState(false)
 
+  // The toggle reflects whether the current session holds delete_repo. Turning
+  // it on opens the elevation flow (browser or device); turning it off re-auths
+  // at base scope, dropping the elevated grant. GitHub has no client-side way to
+  // shed one scope, so "off" is a plain base re-auth.
+  const onToggle = (next: boolean) => {
+    if (next) {
+      setElevateOpen(true)
+    } else {
+      void startWebFlow()
+    }
+  }
+
   return (
-    <SettingsSectionCard
-      id="elevated-permissions"
-      heading={t("settings.elevatedScope.heading")}
-      subheading={t("settings.elevatedScope.subheading")}
-      highlighted={highlighted}
-    >
-      <div className="flex flex-col items-start gap-3">
-        <span
-          className={cx(
-            "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium",
-            hasDeleteRepo
-              ? "bg-success/10 text-success"
-              : "bg-base-200 text-base-content/70",
-          )}
-        >
-          {hasDeleteRepo ? (
-            <ShieldCheck aria-hidden="true" className="size-3.5" />
-          ) : (
-            <ShieldOff aria-hidden="true" className="size-3.5" />
-          )}
-          {hasDeleteRepo
-            ? t("settings.elevatedScope.granted")
-            : t("settings.elevatedScope.notGranted")}
-        </span>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setElevateOpen(true)}
-        >
-          {t("settings.elevatedScope.grantButton")}
-        </Button>
-      </div>
+    <>
+      <SettingsSectionCard
+        id="elevated-permissions"
+        heading={t("settings.elevatedScope.heading")}
+        subheading={t("settings.elevatedScope.subheading")}
+        highlighted={highlighted}
+        control={
+          <input
+            type="checkbox"
+            role="switch"
+            className="toggle toggle-primary"
+            checked={hasDeleteRepo}
+            aria-label={t("settings.elevatedScope.toggleLabel")}
+            onChange={(event) => onToggle(event.target.checked)}
+          />
+        }
+      />
       <ElevatedAccessModal
         open={elevateOpen}
         onClose={() => setElevateOpen(false)}
       />
-    </SettingsSectionCard>
+    </>
   )
 }
 
@@ -234,13 +232,17 @@ function SettingsSectionCard({
   heading,
   subheading,
   highlighted,
+  control,
   children,
 }: {
   id: string
   heading: string
   subheading: string
   highlighted?: boolean
-  children: React.ReactNode
+  // Optional control (e.g. a toggle) pinned to the top-right, aligned with the
+  // heading. Use for a section whose whole state is one on/off switch.
+  control?: React.ReactNode
+  children?: React.ReactNode
 }) {
   return (
     <Card
@@ -253,11 +255,16 @@ function SettingsSectionCard({
       )}
     >
       <Card.Body>
-        <SectionAnchorHeading anchorId={id} as="h3" className="card-title">
-          {heading}
-        </SectionAnchorHeading>
-        <p className="text-sm text-base-content/70">{subheading}</p>
-        <div className="mt-4">{children}</div>
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <SectionAnchorHeading anchorId={id} as="h3" className="card-title">
+              {heading}
+            </SectionAnchorHeading>
+            <p className="text-sm text-base-content/70">{subheading}</p>
+          </div>
+          {control ? <div className="shrink-0 pt-1">{control}</div> : null}
+        </div>
+        {children ? <div className="mt-4">{children}</div> : null}
       </Card.Body>
     </Card>
   )

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -10,7 +10,8 @@ import {
   cx,
 } from "@/components/ui"
 import { useTranslation } from "react-i18next"
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
+import { ShieldCheck, ShieldOff } from "lucide-react"
 import useGetOrgs from "@/hooks/useGetOrgs"
 import {
   isOwnedReadyOrg,
@@ -24,8 +25,8 @@ import { TokenHealthChip } from "@/components/status/TokenHealthChip"
 import { useReducedMotion, type MotionPref } from "@/hooks/useReducedMotion"
 import { useTheme, type ThemePref } from "@/hooks/useTheme"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
-import { useGithubAuth } from "@/auth/useGithubAuth"
 import { useHasDeleteRepoScope } from "@/context/github/GitHubProvider"
+import { ElevatedAccessModal } from "@/auth/ElevatedAccessModal"
 
 // Owned + Classroom 50-ready orgs are the only ones with a manageable service
 // token (a non-owner can't read/set it). The section reads token health for
@@ -129,8 +130,8 @@ function ElevatedPermissionsSection({
   highlighted?: boolean
 }) {
   const { t } = useTranslation()
-  const { startWebFlow } = useGithubAuth()
   const hasDeleteRepo = useHasDeleteRepoScope()
+  const [elevateOpen, setElevateOpen] = useState(false)
 
   return (
     <SettingsSectionCard
@@ -139,21 +140,36 @@ function ElevatedPermissionsSection({
       subheading={t("settings.elevatedScope.subheading")}
       highlighted={highlighted}
     >
-      <div className="flex flex-col gap-3">
-        <p className="text-sm text-base-content/70">
+      <div className="flex flex-col items-start gap-3">
+        <span
+          className={cx(
+            "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium",
+            hasDeleteRepo
+              ? "bg-success/10 text-success"
+              : "bg-base-200 text-base-content/70",
+          )}
+        >
+          {hasDeleteRepo ? (
+            <ShieldCheck aria-hidden="true" className="size-3.5" />
+          ) : (
+            <ShieldOff aria-hidden="true" className="size-3.5" />
+          )}
           {hasDeleteRepo
             ? t("settings.elevatedScope.granted")
             : t("settings.elevatedScope.notGranted")}
-        </p>
+        </span>
         <Button
           variant="outline"
           size="sm"
-          className="self-start"
-          onClick={() => void startWebFlow({ elevated: true })}
+          onClick={() => setElevateOpen(true)}
         >
           {t("settings.elevatedScope.grantButton")}
         </Button>
       </div>
+      <ElevatedAccessModal
+        open={elevateOpen}
+        onClose={() => setElevateOpen(false)}
+      />
     </SettingsSectionCard>
   )
 }

--- a/web/src/pages/orgSettings/TeardownSection.test.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.test.tsx
@@ -60,13 +60,17 @@ describe("TeardownSection scope gate (#655)", () => {
     hasDeleteRepo.mockReturnValue(true)
     render(<TeardownSection org="acme" />)
     expect(screen.getByText("orgSettings.teardown.button")).toBeTruthy()
-    expect(screen.queryByText("orgSettings.teardown.needsElevation")).toBeNull()
+    expect(
+      screen.queryByText("orgSettings.teardown.insufficientPermission"),
+    ).toBeNull()
   })
 
   it("renders the elevation prompt (not the teardown button) when delete_repo is absent", () => {
     hasDeleteRepo.mockReturnValue(false)
     render(<TeardownSection org="acme" />)
-    expect(screen.getByText("orgSettings.teardown.needsElevation")).toBeTruthy()
+    expect(
+      screen.getByText("orgSettings.teardown.insufficientPermission"),
+    ).toBeTruthy()
     expect(screen.getByText("orgSettings.teardown.grantButton")).toBeTruthy()
     expect(screen.queryByText("orgSettings.teardown.button")).toBeNull()
   })

--- a/web/src/pages/orgSettings/TeardownSection.test.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.test.tsx
@@ -24,8 +24,12 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 
 // The gate hook is the unit under test's switch; drive it per-case.
 const hasDeleteRepo = vi.fn<() => boolean>()
+// OAuth by default; the PAT case flips it to prove the section stops offering an
+// in-app elevation it can't deliver.
+const canElevateInApp = vi.fn<() => boolean>(() => true)
 vi.mock("@/context/github/GitHubProvider", () => ({
   useHasDeleteRepoScope: () => hasDeleteRepo(),
+  useCanElevateInApp: () => canElevateInApp(),
 }))
 
 // The modal owns the web/device choice; here we only assert TeardownSection
@@ -77,6 +81,7 @@ afterEach(() => {
   cleanup()
   vi.clearAllMocks()
   executeError.mockReturnValue(null)
+  canElevateInApp.mockReturnValue(true)
 })
 
 describe("TeardownSection scope gate (#655)", () => {
@@ -105,6 +110,19 @@ describe("TeardownSection scope gate (#655)", () => {
     expect(screen.queryByTestId("elevated-modal")).toBeNull()
     await userEvent.click(screen.getByText("orgSettings.teardown.grantButton"))
     expect(screen.getByTestId("elevated-modal")).toBeTruthy()
+  })
+
+  it("tells a PAT session to replace its token instead of offering elevation", () => {
+    // The elevation flow is OAuth-only: offering it to a PAT session would run a
+    // re-auth that silently replaces their token rather than adding the scope.
+    hasDeleteRepo.mockReturnValue(false)
+    canElevateInApp.mockReturnValue(false)
+    render(<TeardownSection org="acme" />)
+
+    expect(
+      screen.getByText("orgSettings.teardown.needsDeleteScopePat"),
+    ).toBeTruthy()
+    expect(screen.queryByText("orgSettings.teardown.grantButton")).toBeNull()
   })
 })
 
@@ -149,5 +167,23 @@ describe("TeardownSection abort reporting", () => {
       screen.getByText("orgSettings.teardown.needsDeleteScope"),
     ).toBeTruthy()
     expect(screen.getByText("orgSettings.teardown.grantButton")).toBeTruthy()
+  })
+
+  it("points a PAT session at a replacement token when the wall is hit", async () => {
+    // The teardown 403 is where a PAT user actually discovers the gap, since the
+    // up-front gate fails open for a token whose scopes we can't read.
+    canElevateInApp.mockReturnValue(false)
+    executeError.mockReturnValue(
+      new TeardownScopeError(["cs101-hw1-alice"], []),
+    )
+    await runTeardown()
+
+    expect(
+      screen.getByText("orgSettings.teardown.needsDeleteScopePartial"),
+    ).toBeTruthy()
+    expect(
+      screen.getByText("orgSettings.teardown.needsDeleteScopePat"),
+    ).toBeTruthy()
+    expect(screen.queryByText("orgSettings.teardown.grantButton")).toBeNull()
   })
 })

--- a/web/src/pages/orgSettings/TeardownSection.test.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+// Assert on stable i18n keys, not English copy.
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    useNavigate: () => () => Promise.resolve(),
+  }
+})
+
+// The gate hook is the unit under test's switch; drive it per-case.
+const hasDeleteRepo = vi.fn<() => boolean>()
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useHasDeleteRepoScope: () => hasDeleteRepo(),
+}))
+
+const startWebFlow = vi.fn()
+vi.mock("@/auth/useGithubAuth", () => ({
+  useGithubAuth: () => ({ startWebFlow }),
+}))
+
+// Teardown mutations aren't exercised by these render-time assertions; stub them
+// to inert pending-false mutations so the section mounts without a QueryClient.
+vi.mock("@/hooks/mutations/usePlanTeardown", () => ({
+  usePlanTeardown: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+vi.mock("@/hooks/mutations/useExecuteTeardown", () => ({
+  useExecuteTeardown: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+// SettingsSection wraps children in card chrome; render children directly.
+vi.mock("./SettingsSection", () => ({
+  default: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}))
+
+import TeardownSection from "./TeardownSection"
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe("TeardownSection scope gate (#655)", () => {
+  it("renders the teardown button when delete_repo is granted", () => {
+    hasDeleteRepo.mockReturnValue(true)
+    render(<TeardownSection org="acme" />)
+    expect(screen.getByText("orgSettings.teardown.button")).toBeTruthy()
+    expect(screen.queryByText("orgSettings.teardown.needsElevation")).toBeNull()
+  })
+
+  it("renders the elevation prompt (not the teardown button) when delete_repo is absent", () => {
+    hasDeleteRepo.mockReturnValue(false)
+    render(<TeardownSection org="acme" />)
+    expect(screen.getByText("orgSettings.teardown.needsElevation")).toBeTruthy()
+    expect(screen.getByText("orgSettings.teardown.grantButton")).toBeTruthy()
+    expect(screen.queryByText("orgSettings.teardown.button")).toBeNull()
+  })
+
+  it("requests elevated permissions one-shot when the prompt button is clicked", () => {
+    hasDeleteRepo.mockReturnValue(false)
+    render(<TeardownSection org="acme" />)
+    screen.getByText("orgSettings.teardown.grantButton").click()
+    expect(startWebFlow).toHaveBeenCalledWith({ elevated: true })
+  })
+})

--- a/web/src/pages/orgSettings/TeardownSection.test.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { render, screen, cleanup } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
+import type { TeardownPlan } from "@/domain/teardown"
 
 // Assert on stable i18n keys, not English copy.
 vi.mock("react-i18next", async (importOriginal) => {
@@ -36,11 +37,32 @@ vi.mock("@/auth/ElevatedAccessModal", () => ({
 
 // Teardown mutations aren't exercised by these render-time assertions; stub them
 // to inert pending-false mutations so the section mounts without a QueryClient.
+// `planResult` / `executeError` let the abort-reporting cases drive them.
+const planResult = vi.fn<() => TeardownPlan>(() => ({
+  org: "acme",
+  repoNames: ["classroom50"],
+  teams: [],
+}))
+const executeError = vi.fn<() => unknown>(() => null)
 vi.mock("@/hooks/mutations/usePlanTeardown", () => ({
-  usePlanTeardown: () => ({ mutate: vi.fn(), isPending: false }),
+  usePlanTeardown: () => ({
+    mutate: (
+      _v: undefined,
+      cbs?: { onSuccess?: (p: TeardownPlan) => void },
+    ) => {
+      cbs?.onSuccess?.(planResult())
+    },
+    isPending: false,
+  }),
 }))
 vi.mock("@/hooks/mutations/useExecuteTeardown", () => ({
-  useExecuteTeardown: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useExecuteTeardown: () => ({
+    mutateAsync: () => {
+      const err = executeError()
+      return err ? Promise.reject(err) : Promise.resolve(undefined)
+    },
+    isPending: false,
+  }),
 }))
 
 // SettingsSection wraps children in card chrome; render children directly.
@@ -49,10 +71,12 @@ vi.mock("./SettingsSection", () => ({
 }))
 
 import TeardownSection from "./TeardownSection"
+import { TeardownForbiddenError, TeardownScopeError } from "@/domain/teardown"
 
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  executeError.mockReturnValue(null)
 })
 
 describe("TeardownSection scope gate (#655)", () => {
@@ -81,5 +105,49 @@ describe("TeardownSection scope gate (#655)", () => {
     expect(screen.queryByTestId("elevated-modal")).toBeNull()
     await userEvent.click(screen.getByText("orgSettings.teardown.grantButton"))
     expect(screen.getByTestId("elevated-modal")).toBeTruthy()
+  })
+})
+
+// An abort that already deleted repositories carries the only record of that
+// permanent data loss. The confirmation modal's inline error dies with the modal,
+// so the message has to be hoisted to the section callout — for every abort kind,
+// not just the one that offers elevation.
+describe("TeardownSection abort reporting", () => {
+  async function runTeardown() {
+    hasDeleteRepo.mockReturnValue(true)
+    render(<TeardownSection org="acme" />)
+    await userEvent.click(screen.getByText("orgSettings.teardown.button"))
+    // ConfirmModal is two-stage: acknowledge, then type the org name.
+    await userEvent.click(
+      screen.getByText("components.confirmModal.yesContinue"),
+    )
+    await userEvent.type(
+      screen.getByLabelText("components.confirmModal.typeAriaLabel"),
+      "orgSettings.teardown.confirmText",
+    )
+    await userEvent.click(screen.getByText("orgSettings.teardown.confirmLabel"))
+  }
+
+  it("hoists a partial-progress SSO abort, without offering elevation", async () => {
+    executeError.mockReturnValue(
+      new TeardownForbiddenError("sso", ["cs101-hw1-alice"], []),
+    )
+    await runTeardown()
+
+    expect(
+      screen.getByText("orgSettings.teardown.ssoRequiredPartial"),
+    ).toBeTruthy()
+    // Elevation cannot clear an SSO gate, so don't send the teacher through it.
+    expect(screen.queryByText("orgSettings.teardown.grantButton")).toBeNull()
+  })
+
+  it("hoists the scope wall and offers elevation", async () => {
+    executeError.mockReturnValue(new TeardownScopeError([], []))
+    await runTeardown()
+
+    expect(
+      screen.getByText("orgSettings.teardown.needsDeleteScope"),
+    ).toBeTruthy()
+    expect(screen.getByText("orgSettings.teardown.grantButton")).toBeTruthy()
   })
 })

--- a/web/src/pages/orgSettings/TeardownSection.test.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { render, screen, cleanup } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 
 // Assert on stable i18n keys, not English copy.
@@ -26,9 +27,11 @@ vi.mock("@/context/github/GitHubProvider", () => ({
   useHasDeleteRepoScope: () => hasDeleteRepo(),
 }))
 
-const startWebFlow = vi.fn()
-vi.mock("@/auth/useGithubAuth", () => ({
-  useGithubAuth: () => ({ startWebFlow }),
+// The modal owns the web/device choice; here we only assert TeardownSection
+// opens it. Its flow is covered by ElevatedAccessModal's own test.
+vi.mock("@/auth/ElevatedAccessModal", () => ({
+  ElevatedAccessModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="elevated-modal" /> : null,
 }))
 
 // Teardown mutations aren't exercised by these render-time assertions; stub them
@@ -68,10 +71,11 @@ describe("TeardownSection scope gate (#655)", () => {
     expect(screen.queryByText("orgSettings.teardown.button")).toBeNull()
   })
 
-  it("requests elevated permissions one-shot when the prompt button is clicked", () => {
+  it("opens the elevated-access modal when the prompt button is clicked", async () => {
     hasDeleteRepo.mockReturnValue(false)
     render(<TeardownSection org="acme" />)
-    screen.getByText("orgSettings.teardown.grantButton").click()
-    expect(startWebFlow).toHaveBeenCalledWith({ elevated: true })
+    expect(screen.queryByTestId("elevated-modal")).toBeNull()
+    await userEvent.click(screen.getByText("orgSettings.teardown.grantButton"))
+    expect(screen.getByTestId("elevated-modal")).toBeTruthy()
   })
 })

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -8,7 +8,7 @@ import { Button, HelpTooltip, MonoLtr, cx } from "@/components/ui"
 import {
   formatTeardownResult,
   TeardownMarkerError,
-  TEARDOWN_DELETE_SCOPE_KEY,
+  TeardownScopeError,
   type TeardownPlan,
 } from "@/domain/teardown"
 import {
@@ -114,9 +114,7 @@ const TeardownSection = ({
             : t("orgSettings.teardown.button")}
         </Button>
       ) : (
-        // delete_repo is elevated-only and not granted by a normal sign-in, so
-        // teardown would 403. Offer the one-shot elevation re-auth up front
-        // rather than after a failed attempt (#655).
+        // Offer the elevation up front rather than after a failed attempt (#655).
         <div
           className={cx(
             "flex flex-wrap items-center gap-2",
@@ -244,9 +242,9 @@ const TeardownSection = ({
             // raw key or English assembled below the view.
             const localized = localizedMessageOf(err)
             if (localized) {
-              // The scope messages tell the user to request elevated
-              // permissions, so make that reachable instead of only naming it.
-              if (localized.key.startsWith(TEARDOWN_DELETE_SCOPE_KEY)) {
+              // The scope wall tells the user to request elevated permissions,
+              // so make that reachable instead of only naming it.
+              if (err instanceof TeardownScopeError) {
                 setElevateOpen(true)
               }
               throw new Error(resolveLocalizedMessage(t, localized), {

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -244,9 +244,9 @@ const TeardownSection = ({
             // raw key or English assembled below the view.
             const localized = localizedMessageOf(err)
             if (localized) {
-              // The message tells the user to request elevated permissions, so
-              // make that reachable instead of only naming it.
-              if (localized.key === TEARDOWN_DELETE_SCOPE_KEY) {
+              // The scope messages tell the user to request elevated
+              // permissions, so make that reachable instead of only naming it.
+              if (localized.key.startsWith(TEARDOWN_DELETE_SCOPE_KEY)) {
                 setElevateOpen(true)
               }
               throw new Error(resolveLocalizedMessage(t, localized), {

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -8,10 +8,13 @@ import { Button, HelpTooltip, MonoLtr, cx } from "@/components/ui"
 import {
   formatTeardownResult,
   TeardownMarkerError,
-  TeardownRateLimitError,
-  TeardownScopeError,
+  TEARDOWN_DELETE_SCOPE_KEY,
   type TeardownPlan,
 } from "@/domain/teardown"
+import {
+  localizedMessageOf,
+  resolveLocalizedMessage,
+} from "@/types/localizedMessage"
 import { usePlanTeardown } from "@/hooks/mutations/usePlanTeardown"
 import { useExecuteTeardown } from "@/hooks/mutations/useExecuteTeardown"
 import { sectionHighlightClass } from "@/hooks/useHashSectionHighlight"
@@ -235,15 +238,20 @@ const TeardownSection = ({
               },
             })
           } catch (err) {
-            if (err instanceof TeardownScopeError) {
-              // Backstop: the up-front gate should have caught this, but a
-              // token that lost the scope mid-session still 403s. Surface the
-              // translated message (domain carries only the i18n key) so the
-              // modal points at the elevation flow.
-              throw new Error(t(err.messageKey), { cause: err })
-            }
-            if (err instanceof TeardownRateLimitError) {
-              throw err
+            // Backstop: the up-front gate should have caught the scope case, but
+            // a token that lost the scope mid-session still 403s. Domain errors
+            // carry a LocalizedMessage, so resolve it here rather than showing a
+            // raw key or English assembled below the view.
+            const localized = localizedMessageOf(err)
+            if (localized) {
+              // The message tells the user to request elevated permissions, so
+              // make that reachable instead of only naming it.
+              if (localized.key === TEARDOWN_DELETE_SCOPE_KEY) {
+                setElevateOpen(true)
+              }
+              throw new Error(resolveLocalizedMessage(t, localized), {
+                cause: err,
+              })
             }
             throw new Error(t("orgSettings.teardown.executeError"), {
               cause: err,

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -7,6 +7,7 @@ import { ConfirmModal } from "@/components/modals"
 import { Button, HelpTooltip, MonoLtr, cx } from "@/components/ui"
 import {
   formatTeardownResult,
+  TeardownAbortError,
   TeardownMarkerError,
   TeardownScopeError,
   type TeardownPlan,
@@ -48,10 +49,12 @@ const TeardownSection = ({
 
   const [open, setOpen] = useState(false)
   const [plan, setPlan] = useState<TeardownPlan | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  // Whether the current error is the scope wall, so the callout can offer the
-  // elevation the message names.
-  const [scopeWalled, setScopeWalled] = useState(false)
+  // `canElevate` rides with the message so the callout can only offer elevation
+  // for the wall elevation actually fixes; the two are always written together.
+  const [error, setError] = useState<{
+    message: string
+    canElevate: boolean
+  } | null>(null)
   const [done, setDone] = useState<string | null>(null)
 
   const openMutation = usePlanTeardown(org)
@@ -60,17 +63,17 @@ const TeardownSection = ({
       onSuccess: (p) => {
         setPlan(p)
         setError(null)
-        setScopeWalled(false)
         setOpen(true)
       },
       onError: (err) => {
         log.warn("teardown plan failed", { org, err })
-        setScopeWalled(false)
-        setError(
-          err instanceof TeardownMarkerError
-            ? err.message
-            : t("orgSettings.teardown.prepareError"),
-        )
+        setError({
+          message:
+            err instanceof TeardownMarkerError
+              ? err.message
+              : t("orgSettings.teardown.prepareError"),
+          canElevate: false,
+        })
       },
     })
 
@@ -97,8 +100,8 @@ const TeardownSection = ({
     >
       {error && (
         <CalloutDiv className="flex flex-col items-start gap-2 rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error">
-          <span>{error}</span>
-          {scopeWalled && (
+          <span>{error.message}</span>
+          {error.canElevate && (
             // The message names elevation as the remedy, so make it reachable.
             <Button
               variant="warning"
@@ -256,15 +259,17 @@ const TeardownSection = ({
             const localized = localizedMessageOf(err)
             if (localized) {
               const message = resolveLocalizedMessage(t, localized)
-              // An abort can arrive after repositories were already deleted, and
-              // that message is the only record of it. Close the confirmation and
-              // show it as the section callout, which survives — stacking the
-              // elevation dialog over it would hide it, and its first button
-              // navigates the page away.
-              if (err instanceof TeardownScopeError) {
+              // Hoist the message out of the confirmation whenever it is the only
+              // record of real data loss, or whenever elevation is the remedy the
+              // message names. The modal's inline error dies with the modal, and
+              // stacking the elevation dialog over it would hide it (that
+              // dialog's first button navigates the page away).
+              const isScopeWall = err instanceof TeardownScopeError
+              const lostData =
+                err instanceof TeardownAbortError && err.deleted.length > 0
+              if (isScopeWall || lostData) {
                 setOpen(false)
-                setError(message)
-                setScopeWalled(true)
+                setError({ message, canElevate: isScopeWall })
                 return
               }
               throw new Error(message, { cause: err })

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -129,7 +129,7 @@ const TeardownSection = ({
             />
           </span>
           <Button
-            variant="outline"
+            variant="warning"
             size="sm"
             onClick={() => setElevateOpen(true)}
           >

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -4,7 +4,7 @@ import { Trans, useTranslation } from "react-i18next"
 import { TriangleAlert } from "lucide-react"
 
 import { ConfirmModal } from "@/components/modals"
-import { Alert, Button, MonoLtr, cx } from "@/components/ui"
+import { Button, HelpTooltip, MonoLtr, cx } from "@/components/ui"
 import {
   formatTeardownResult,
   TeardownMarkerError,
@@ -114,24 +114,27 @@ const TeardownSection = ({
         // delete_repo is elevated-only and not granted by a normal sign-in, so
         // teardown would 403. Offer the one-shot elevation re-auth up front
         // rather than after a failed attempt (#655).
-        <Alert
-          tone="warning"
+        <div
           className={cx(
-            "flex-col items-start gap-2",
+            "flex flex-wrap items-center gap-2",
             error || done ? "mt-4" : "",
           )}
         >
-          <span className="text-sm">
-            {t("orgSettings.teardown.needsElevation")}
+          <span className="inline-flex items-center gap-1 text-sm text-base-content/70">
+            {t("orgSettings.teardown.insufficientPermission")}
+            <HelpTooltip
+              position="top"
+              help={t("orgSettings.teardown.insufficientPermissionHelp")}
+            />
           </span>
           <Button
-            variant="warning"
+            variant="outline"
             size="sm"
             onClick={() => setElevateOpen(true)}
           >
             {t("orgSettings.teardown.grantButton")}
           </Button>
-        </Alert>
+        </div>
       )}
 
       <ElevatedAccessModal

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -19,7 +19,10 @@ import {
 import { usePlanTeardown } from "@/hooks/mutations/usePlanTeardown"
 import { useExecuteTeardown } from "@/hooks/mutations/useExecuteTeardown"
 import { sectionHighlightClass } from "@/hooks/useHashSectionHighlight"
-import { useHasDeleteRepoScope } from "@/context/github/GitHubProvider"
+import {
+  useHasDeleteRepoScope,
+  useCanElevateInApp,
+} from "@/context/github/GitHubProvider"
 import { ElevatedAccessModal } from "@/auth/ElevatedAccessModal"
 import SettingsSection from "./SettingsSection"
 import { CalloutDiv, CalloutText } from "@/lib/motionComponents"
@@ -45,6 +48,7 @@ const TeardownSection = ({
   const { t } = useTranslation()
   const navigate = useNavigate()
   const hasDeleteRepo = useHasDeleteRepoScope()
+  const canElevateInApp = useCanElevateInApp()
   const [elevateOpen, setElevateOpen] = useState(false)
 
   const [open, setOpen] = useState(false)
@@ -101,16 +105,21 @@ const TeardownSection = ({
       {error && (
         <CalloutDiv className="flex flex-col items-start gap-2 rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error">
           <span>{error.message}</span>
-          {error.canElevate && (
-            // The message names elevation as the remedy, so make it reachable.
-            <Button
-              variant="warning"
-              size="sm"
-              onClick={() => setElevateOpen(true)}
-            >
-              {t("orgSettings.teardown.grantButton")}
-            </Button>
-          )}
+          {error.canElevate &&
+            (canElevateInApp ? (
+              // The message names elevation as the remedy, so make it reachable.
+              <Button
+                variant="warning"
+                size="sm"
+                onClick={() => setElevateOpen(true)}
+              >
+                {t("orgSettings.teardown.grantButton")}
+              </Button>
+            ) : (
+              // A PAT's permissions are fixed at creation, so the only fix is a
+              // replacement token — the elevation flow would swap their session.
+              <span>{t("orgSettings.teardown.needsDeleteScopePat")}</span>
+            ))}
         </CalloutDiv>
       )}
       {done && (
@@ -143,16 +152,26 @@ const TeardownSection = ({
             {t("orgSettings.teardown.insufficientPermission")}
             <HelpTooltip
               position="top"
-              help={t("orgSettings.teardown.insufficientPermissionHelp")}
+              help={
+                canElevateInApp
+                  ? t("orgSettings.teardown.insufficientPermissionHelp")
+                  : t("orgSettings.teardown.insufficientPermissionHelpPat")
+              }
             />
           </span>
-          <Button
-            variant="warning"
-            size="sm"
-            onClick={() => setElevateOpen(true)}
-          >
-            {t("orgSettings.teardown.grantButton")}
-          </Button>
+          {canElevateInApp ? (
+            <Button
+              variant="warning"
+              size="sm"
+              onClick={() => setElevateOpen(true)}
+            >
+              {t("orgSettings.teardown.grantButton")}
+            </Button>
+          ) : (
+            <span className="text-sm text-base-content/70">
+              {t("orgSettings.teardown.needsDeleteScopePat")}
+            </span>
+          )}
         </div>
       )}
 

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -4,7 +4,7 @@ import { Trans, useTranslation } from "react-i18next"
 import { TriangleAlert } from "lucide-react"
 
 import { ConfirmModal } from "@/components/modals"
-import { Button, MonoLtr } from "@/components/ui"
+import { Alert, Button, MonoLtr, cx } from "@/components/ui"
 import {
   formatTeardownResult,
   TeardownMarkerError,
@@ -15,6 +15,8 @@ import {
 import { usePlanTeardown } from "@/hooks/mutations/usePlanTeardown"
 import { useExecuteTeardown } from "@/hooks/mutations/useExecuteTeardown"
 import { sectionHighlightClass } from "@/hooks/useHashSectionHighlight"
+import { useGithubAuth } from "@/auth/useGithubAuth"
+import { useHasDeleteRepoScope } from "@/context/github/GitHubProvider"
 import SettingsSection from "./SettingsSection"
 import { CalloutDiv, CalloutText } from "@/lib/motionComponents"
 import { logger } from "@/lib/logger"
@@ -38,6 +40,8 @@ const TeardownSection = ({
 }) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const { startWebFlow } = useGithubAuth()
+  const hasDeleteRepo = useHasDeleteRepoScope()
 
   const [open, setOpen] = useState(false)
   const [plan, setPlan] = useState<TeardownPlan | null>(null)
@@ -92,19 +96,43 @@ const TeardownSection = ({
         <CalloutText className="text-sm text-success">{done}</CalloutText>
       )}
 
-      <Button
-        variant="error"
-        size="sm"
-        className={error || done ? "mt-4" : ""}
-        disabled={openMutation.isPending}
-        onClick={() => {
-          if (!openMutation.isPending) openTeardown()
-        }}
-      >
-        {openMutation.isPending
-          ? t("orgSettings.teardown.preparing")
-          : t("orgSettings.teardown.button")}
-      </Button>
+      {hasDeleteRepo ? (
+        <Button
+          variant="error"
+          size="sm"
+          className={error || done ? "mt-4" : ""}
+          disabled={openMutation.isPending}
+          onClick={() => {
+            if (!openMutation.isPending) openTeardown()
+          }}
+        >
+          {openMutation.isPending
+            ? t("orgSettings.teardown.preparing")
+            : t("orgSettings.teardown.button")}
+        </Button>
+      ) : (
+        // delete_repo is elevated-only and not granted by a normal sign-in, so
+        // teardown would 403. Offer the one-shot elevation re-auth up front
+        // rather than after a failed attempt (#655).
+        <Alert
+          tone="warning"
+          className={cx(
+            "flex-col items-start gap-2",
+            error || done ? "mt-4" : "",
+          )}
+        >
+          <span className="text-sm">
+            {t("orgSettings.teardown.needsElevation")}
+          </span>
+          <Button
+            variant="warning"
+            size="sm"
+            onClick={() => void startWebFlow({ elevated: true })}
+          >
+            {t("orgSettings.teardown.grantButton")}
+          </Button>
+        </Alert>
+      )}
 
       <ConfirmModal
         open={open}
@@ -199,10 +227,14 @@ const TeardownSection = ({
               },
             })
           } catch (err) {
-            if (
-              err instanceof TeardownScopeError ||
-              err instanceof TeardownRateLimitError
-            ) {
+            if (err instanceof TeardownScopeError) {
+              // Backstop: the up-front gate should have caught this, but a
+              // token that lost the scope mid-session still 403s. Surface the
+              // translated message (domain carries only the i18n key) so the
+              // modal points at the elevation flow.
+              throw new Error(t(err.messageKey), { cause: err })
+            }
+            if (err instanceof TeardownRateLimitError) {
               throw err
             }
             throw new Error(t("orgSettings.teardown.executeError"), {

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -15,8 +15,8 @@ import {
 import { usePlanTeardown } from "@/hooks/mutations/usePlanTeardown"
 import { useExecuteTeardown } from "@/hooks/mutations/useExecuteTeardown"
 import { sectionHighlightClass } from "@/hooks/useHashSectionHighlight"
-import { useGithubAuth } from "@/auth/useGithubAuth"
 import { useHasDeleteRepoScope } from "@/context/github/GitHubProvider"
+import { ElevatedAccessModal } from "@/auth/ElevatedAccessModal"
 import SettingsSection from "./SettingsSection"
 import { CalloutDiv, CalloutText } from "@/lib/motionComponents"
 import { logger } from "@/lib/logger"
@@ -40,8 +40,8 @@ const TeardownSection = ({
 }) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { startWebFlow } = useGithubAuth()
   const hasDeleteRepo = useHasDeleteRepoScope()
+  const [elevateOpen, setElevateOpen] = useState(false)
 
   const [open, setOpen] = useState(false)
   const [plan, setPlan] = useState<TeardownPlan | null>(null)
@@ -127,12 +127,17 @@ const TeardownSection = ({
           <Button
             variant="warning"
             size="sm"
-            onClick={() => void startWebFlow({ elevated: true })}
+            onClick={() => setElevateOpen(true)}
           >
             {t("orgSettings.teardown.grantButton")}
           </Button>
         </Alert>
       )}
+
+      <ElevatedAccessModal
+        open={elevateOpen}
+        onClose={() => setElevateOpen(false)}
+      />
 
       <ConfirmModal
         open={open}

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -49,6 +49,9 @@ const TeardownSection = ({
   const [open, setOpen] = useState(false)
   const [plan, setPlan] = useState<TeardownPlan | null>(null)
   const [error, setError] = useState<string | null>(null)
+  // Whether the current error is the scope wall, so the callout can offer the
+  // elevation the message names.
+  const [scopeWalled, setScopeWalled] = useState(false)
   const [done, setDone] = useState<string | null>(null)
 
   const openMutation = usePlanTeardown(org)
@@ -57,10 +60,12 @@ const TeardownSection = ({
       onSuccess: (p) => {
         setPlan(p)
         setError(null)
+        setScopeWalled(false)
         setOpen(true)
       },
       onError: (err) => {
         log.warn("teardown plan failed", { org, err })
+        setScopeWalled(false)
         setError(
           err instanceof TeardownMarkerError
             ? err.message
@@ -91,8 +96,18 @@ const TeardownSection = ({
       }
     >
       {error && (
-        <CalloutDiv className="rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error">
-          {error}
+        <CalloutDiv className="flex flex-col items-start gap-2 rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error">
+          <span>{error}</span>
+          {scopeWalled && (
+            // The message names elevation as the remedy, so make it reachable.
+            <Button
+              variant="warning"
+              size="sm"
+              onClick={() => setElevateOpen(true)}
+            >
+              {t("orgSettings.teardown.grantButton")}
+            </Button>
+          )}
         </CalloutDiv>
       )}
       {done && (
@@ -237,19 +252,22 @@ const TeardownSection = ({
             })
           } catch (err) {
             // Backstop: the up-front gate should have caught the scope case, but
-            // a token that lost the scope mid-session still 403s. Domain errors
-            // carry a LocalizedMessage, so resolve it here rather than showing a
-            // raw key or English assembled below the view.
+            // a token that lost the scope mid-session still 403s.
             const localized = localizedMessageOf(err)
             if (localized) {
-              // The scope wall tells the user to request elevated permissions,
-              // so make that reachable instead of only naming it.
+              const message = resolveLocalizedMessage(t, localized)
+              // An abort can arrive after repositories were already deleted, and
+              // that message is the only record of it. Close the confirmation and
+              // show it as the section callout, which survives — stacking the
+              // elevation dialog over it would hide it, and its first button
+              // navigates the page away.
               if (err instanceof TeardownScopeError) {
-                setElevateOpen(true)
+                setOpen(false)
+                setError(message)
+                setScopeWalled(true)
+                return
               }
-              throw new Error(resolveLocalizedMessage(t, localized), {
-                cause: err,
-              })
+              throw new Error(message, { cause: err })
             }
             throw new Error(t("orgSettings.teardown.executeError"), {
               cause: err,

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -336,11 +336,13 @@ Classroom 50 authenticates the same way the GitHub CLI does, using GitHub's
 to a single organization's repositories — so the grant covers your repos even
 though Classroom 50 only acts on classroom ones. This matches the CLI's behavior.
 
-### Why does signing in ask for permission to "Delete repositories"?
+### Why does tearing down an organization ask for an extra permission?
 
-One feature uses it: **Tear down organization**, which resets an organization
-by deleting the repositories Classroom 50 manages, and only after you type an
-explicit confirmation. Nothing else ever deletes a repository. See
+Signing in does not request permission to delete repositories. One feature needs
+it: **Tear down organization**, which resets an organization by deleting every
+repository in it, and only after you type an explicit confirmation. When you use
+it, Classroom 50 asks you to request that permission and sign in again. Nothing
+else ever deletes a repository. See
 [the full explanation](GitHub-Integration#2-teacher-authentication) in GitHub
 Integration.
 

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -73,14 +73,15 @@ warns and asks for confirmation before proceeding. See
 | `workflow` | Committing the `classroom50` repository's workflow files during `init` (GitHub 404s the write without it). |
 
 > [!NOTE]
-> **Why the web app's sign-in asks for "Delete repositories".** Signing in at
-> classroom50.org requests `delete_repo` in addition to the set above. It is
-> used by exactly one feature: **Tear down organization** (org settings →
-> Danger zone), which resets an org by deleting the repositories Classroom 50
-> manages — and it only runs when you type an explicit confirmation. Nothing
-> else deletes repositories. Classroom 50 has no server: the token stays in
-> your browser, so nobody but you can act on your org with it. If you prefer,
-> the CLIs never request `delete_repo` unless you opt in with
+> **Tearing down an organization needs an extra permission.** Signing in does
+> not request `delete_repo`. Exactly one feature needs it: **Tear down
+> organization** (org settings → Danger zone), which resets an org by deleting
+> the repositories Classroom 50 manages. When you use it, Classroom 50 asks you
+> to request elevated permissions and sign in again, and teardown still runs
+> only after you type an explicit confirmation. Nothing else deletes
+> repositories. Classroom 50 has no server: the token stays in your browser, so
+> nobody but you can act on your org with it. The CLIs work the same way — they
+> never request `delete_repo` unless you opt in with
 > `gh teacher login -s delete_repo`.
 
 ### 3. Student authentication

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -83,6 +83,12 @@ warns and asks for confirmation before proceeding. See
 > no server: the token stays in your browser, so nobody but you can act on your
 > organization with it. The CLIs work the same way: they never request
 > `delete_repo` unless you opt in with `gh teacher login -s delete_repo`.
+>
+> **If you signed in with a personal access token**, Classroom 50 can't add the
+> permission for you — a token's permissions are fixed when you create it on
+> GitHub. Create one that allows deleting repositories (the `delete_repo` scope
+> on a classic token, or **Administration: read and write** on a fine-grained
+> one) and sign in again.
 
 ### 3. Student authentication
 

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -75,14 +75,14 @@ warns and asks for confirmation before proceeding. See
 > [!NOTE]
 > **Tearing down an organization needs an extra permission.** Signing in does
 > not request `delete_repo`. Exactly one feature needs it: **Tear down
-> organization** (org settings → Danger zone), which resets an org by deleting
-> the repositories Classroom 50 manages. When you use it, Classroom 50 asks you
-> to request elevated permissions and sign in again, and teardown still runs
-> only after you type an explicit confirmation. Nothing else deletes
-> repositories. Classroom 50 has no server: the token stays in your browser, so
-> nobody but you can act on your org with it. The CLIs work the same way — they
-> never request `delete_repo` unless you opt in with
-> `gh teacher login -s delete_repo`.
+> organization**, in the organization's settings under **Danger zone**. It
+> resets an organization by deleting **every** repository in it, not only the
+> ones Classroom 50 created. When you use it, Classroom 50 asks you to request
+> that permission and sign in again, and teardown still runs only after you type
+> an explicit confirmation. Nothing else deletes repositories. Classroom 50 has
+> no server: the token stays in your browser, so nobody but you can act on your
+> organization with it. The CLIs work the same way: they never request
+> `delete_repo` unless you opt in with `gh teacher login -s delete_repo`.
 
 ### 3. Student authentication
 


### PR DESCRIPTION
## Summary

Signing in no longer requests `delete_repo`. The web app's scopes are now split into a base set requested at every sign-in and an elevated set (`delete_repo`) requested only on demand, so a student authorizing the app never grants repository deletion and a teacher's day-to-day session cannot wipe an organization. This brings the web app in line with the CLIs, which have always kept `delete_repo` opt-in.

Exactly one feature needs the elevated scope: **Tear down organization**. A teacher who reaches it without the permission is offered an in-place re-auth rather than a dead end — either a browser redirect or a device code, so the flow also works on localhost where the OAuth callback cannot complete — and is returned to the page they were working on afterwards. Settings gains an **Elevated permissions** section that reports what the current session can do, requests or drops the permission, and links to GitHub where the grant itself is revoked.

Teardown's `403` handling now tells a real scope gap apart from a SAML SSO gate, an organization policy or protected repository, and a secondary rate limit, so the app only offers an elevation when elevation is actually the remedy. Every abort reports how many repositories were already permanently deleted, and a run that hits a token-wide wall stops issuing deletes that are guaranteed to fail instead of burning rate limit on hundreds of doomed requests.

A personal-access-token session is handled separately: a token's permissions are fixed when it is created on GitHub, so it is pointed at creating a replacement token rather than offered an OAuth re-auth that would silently swap its session without adding the scope.

Also corrects the documentation, which understated the blast radius: teardown deletes **every** repository in the organization, not only the ones Classroom 50 created.

Part of #655 — this removes `delete_repo` from the login grant; the broader `repo` and `admin:org` scopes requested at student sign-in are still open there.

## Test plan

- [ ] `npm run check` in `web/` passes (`tsc -b`, `eslint`, `prettier`, `arch:validate`, `vitest`).
- [ ] `go build ./...` and `go test ./...` in `cli/shared` pass.
- [ ] Sign in fresh and confirm GitHub's consent screen does **not** list "Delete repositories".
- [ ] As an owner of a Classroom 50 org, open **Danger zone** and confirm teardown is replaced by an "Insufficient permission" prompt with a request action.
- [ ] Elevate via **Continue in browser** and confirm you land back on the org settings page, not the dashboard, with teardown now available.
- [ ] Elevate via **Use a device code** on `localhost` and confirm the prompt renders inline, completes, and closes the dialog.
- [ ] Cancel a device flow, and separately decline it on GitHub, and confirm the dialog stays open and reports what happened rather than closing silently.
- [ ] In **Settings → Elevated permissions**, confirm the status line matches the session, that requesting is disabled once the permission is observed, and that dropping it re-auths at base scope.
- [ ] Run teardown on a scratch org and confirm every repository is deleted, the marker repo goes last, and classroom teams are removed.
- [ ] Sign in with a classic personal access token lacking `delete_repo` and confirm teardown explains that the token must be replaced, with no elevation button offered.