### PR TITLE
docs: explain permission rationale and access (#655)

### DIFF
--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -336,7 +336,7 @@ Classroom 50 authenticates the same way the GitHub CLI does, using GitHub's
 to a single organization's repositories — so the grant covers your repos even
 though Classroom 50 only acts on classroom ones. This matches the CLI's
 behavior. For what every scope grants and why, see
-[Permissions and blast radius](GitHub-Integration#permissions-and-blast-radius);
+[Permissions and access](GitHub-Integration#permissions-and-access);
 if you want to grant less, a fine-grained token scoped to one organization is
 the tighter path (see
 [Reducing what you grant](GitHub-Integration#reducing-what-you-grant)).

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -334,7 +334,25 @@ git operations against those repos generally carry over.
 Classroom 50 authenticates the same way the GitHub CLI does, using GitHub's
 `repo` scope. That scope is all-or-nothing — GitHub provides no way to limit it
 to a single organization's repositories — so the grant covers your repos even
-though Classroom 50 only acts on classroom ones. This matches the CLI's behavior.
+though Classroom 50 only acts on classroom ones. This matches the CLI's
+behavior. For what every scope grants and why, see
+[Permissions and blast radius](GitHub-Integration#permissions-and-blast-radius);
+if you want to grant less, a fine-grained token scoped to one organization is
+the tighter path (see
+[Reducing what you grant](GitHub-Integration#reducing-what-you-grant)).
+
+### Do teachers and students grant the same access?
+
+Yes. Sign-in requests one scope set for everyone, on purpose: one person can be
+both a teacher and a student (an instructor testing an assignment, a TA who also
+takes the course), so Classroom 50 never asks you to declare a role at sign-in.
+What you can *do* is decided afterward by your role in the organization and
+classroom, not by your token — a student's grant is broader than what a student
+actually uses (they never exercise the organization-administration or
+repository-deletion powers). To grant less than the default, sign in with a
+fine-grained token scoped to one organization. Why per-organization classic
+sign-in and separate teacher/student profiles aren't offered is recorded in
+[Known Limitations](Known-Limitations#requested-but-architecturally-hard).
 
 ### Why does tearing down an organization ask for an extra permission?
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -344,7 +344,7 @@ the tighter path (see
 ### Do teachers and students grant the same access?
 
 Yes. Sign-in requests one scope set for everyone, on purpose: one person can be
-both a teacher and a student (an instructor testing an assignment, a TA who also
+both a teacher and a student (a teacher testing an assignment, a TA who also
 takes the course), so Classroom 50 never asks you to declare a role at sign-in.
 What you can *do* is decided afterward by your role in the organization and
 classroom, not by your token — a student's grant is broader than what a student

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -190,6 +190,56 @@ Side-effect free.
 
 ---
 
+## Permissions and blast radius
+
+Classroom 50 has no server. Whatever you authorize is a GitHub token that lives
+only in your browser (web app) or your local `gh` credential store (CLI) —
+nobody but you can act on your account with it. Sign-in requests the **same
+scope set for everyone**, because teachers and students share one flow and one
+person can be both (an instructor testing an assignment as a student, a TA who
+also takes the course). Capabilities are gated after sign-in by your role in the
+organization and classroom, not by the scopes on your token.
+
+The scopes below are GitHub's own. The table lists what each one grants across
+your whole account (the blast radius), why Classroom 50 needs it, and who
+actually exercises it.
+
+| Scope | Blast radius (what it can touch) | Why Classroom 50 needs it | Who uses it |
+|---|---|---|---|
+| `read:user` | Reads your public profile. | Identifies who you are after sign-in. | Everyone. |
+| `read:org` | Reads your organization and team memberships. | Confirms membership and resolves your classroom role; a student accepts their own org invitation. | Everyone. |
+| `repo` | **Full control of all your repositories** — public and private, in every organization, not only the classroom one. GitHub offers no way to narrow it to a single org. | Creating student repositories, committing config and setup files, reading grades (private-repo Releases), and managing repo collaborators. | Everyone. |
+| `workflow` | Commit files under `.github/workflows/` in repositories you can write. | Landing the autograder workflow — teachers during `init`, students when the browser commits the autograde shim on accept. | Everyone (students only for default-autograder accepts). |
+| `admin:org` | Administer organizations you own — invite/remove members, manage teams, change org settings. | Inviting and removing students, managing classroom teams, and locking down org policy. Implies `read:org`. | Teachers only. |
+| `delete_repo` | **Permanently delete repositories.** | Not requested at sign-in. One feature needs it — **Tear down organization** — and Classroom 50 asks for it on demand, then only after an explicit typed confirmation (see the [teacher-authentication note](#2-teacher-authentication) above). | Teachers only, on demand. |
+
+### What a student actually uses versus a teacher
+
+A student's session carries the same grant, but a student only ever exercises
+`read:user`, `read:org`, and `repo` (plus `workflow` for default-autograder
+accepts). The `admin:org` and `delete_repo` powers are never used by a student:
+every organization-administration call the code makes is owner-only, and a plain
+member's token can't perform them on an org they don't own even though the grant
+nominally includes the scope. In other words, the grant is broader than the
+footprint — the token *can* touch all your repos, but Classroom 50 only ever
+acts on classroom ones. This matches the GitHub CLI's behavior.
+
+### Reducing what you grant
+
+The one lever that actually narrows the grant is a **fine-grained personal
+access token**, which is scoped to a single organization instead of your whole
+account. On the sign-in card, open **Other sign-in methods** and pick **Use a
+personal access token (fine-grained)**; you name the org (it becomes the token's
+resource owner) and set Repository access to **All repositories**. See
+[If the proxy domain is blocked](#if-the-proxy-domain-is-blocked) for the full
+walkthrough. A classic OAuth sign-in can't be scoped this way — the `repo` scope
+is all-or-nothing — so the fine-grained token is the tighter-security path for
+anyone who wants to grant less. Why classic OAuth can't be scoped per
+organization, and why sign-in doesn't ask you to pick a teacher or student role,
+are recorded in [Known Limitations](Known-Limitations#requested-but-architecturally-hard).
+
+---
+
 ## Network and allowed domains
 
 If your school or district filters web traffic, allow the domains below so

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -194,10 +194,13 @@ Side-effect free.
 
 Classroom 50 has no server. Whatever you authorize is a GitHub token that lives
 only in your browser (web app) or your local `gh` credential store (CLI) —
-nobody but you can act on your account with it. Sign-in requests the **same
-scope set for everyone**, because teachers and students share one flow and one
-person can be both (a teacher testing an assignment as a student, a TA who
-also takes the course). Capabilities are gated after sign-in by your role in the
+nobody but you can act on your account with it. Sign-in requests **one scope set
+for everyone** — a deliberate simplicity choice, not a technical requirement.
+Teachers and students share a single flow because one person can be both (a
+teacher testing an assignment as a student, a TA who also takes the course), so
+the app asks for the union of what any role might need rather than making you
+declare a role up front. A student's grant is therefore broader than what a
+student actually uses. Capabilities are gated after sign-in by your role in the
 organization and classroom, not by the scopes on your token.
 
 The scopes below are GitHub's own. The table lists what each one grants across
@@ -212,16 +215,24 @@ your whole account, why Classroom 50 needs it, and who actually exercises it.
 | `admin:org` | Administer organizations you own — invite/remove members, manage teams, change org settings. | Inviting and removing students, managing classroom teams, and locking down org policy. Implies `read:org`. | Teachers only. |
 | `delete_repo` | **Permanently delete repositories.** | Not requested at sign-in. One feature needs it — **Tear down organization** — and Classroom 50 asks for it on demand, then only after an explicit typed confirmation (see the [teacher-authentication note](#2-teacher-authentication) above). | Teachers only, on demand. |
 
-### What a student actually uses versus a teacher
+### What a student actually needs versus a teacher
 
-A student's session carries the same grant, but a student only ever exercises
-`read:user`, `read:org`, and `repo` (plus `workflow` for default-autograder
-accepts). The `admin:org` and `delete_repo` powers are never used by a student:
-every organization-administration call the code makes is owner-only, and a plain
-member's token can't perform them on an org they don't own even though the grant
-nominally includes the scope. In other words, the grant is broader than the
-footprint — the token *can* touch all your repos, but Classroom 50 only ever
-acts on classroom ones. This matches the GitHub CLI's behavior.
+A student's flow only ever exercises three scopes: `read:user` (identify
+themselves), `read:org` (accept their own organization invitation and read
+their own memberships), and `repo` (generate their assignment repository, commit
+their work, add a teammate as a collaborator on a group repository, and read
+their own grades). Default-autograder assignments also need `workflow`, because
+the browser commits the autograde workflow file on accept; template-less and
+no-autograder assignments don't. That's the whole student footprint.
+
+A student never uses `admin:org` or `delete_repo`. Those are organization-owner
+powers — a plain member's token can't perform them on an org they don't own,
+even though the shared grant nominally includes `admin:org`. The app requests
+them because the sign-in flow is shared with teachers, not because a student
+needs them. So the grant is broader than the footprint: the token *can* touch
+all your repositories, but Classroom 50 only ever acts on classroom ones. This
+matches the GitHub CLI's behavior, where `gh teacher login` and `gh student
+login` share one scope set for the same reason.
 
 ### Reducing what you grant
 

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -196,7 +196,7 @@ Classroom 50 has no server. Whatever you authorize is a GitHub token that lives
 only in your browser (web app) or your local `gh` credential store (CLI) —
 nobody but you can act on your account with it. Sign-in requests the **same
 scope set for everyone**, because teachers and students share one flow and one
-person can be both (an instructor testing an assignment as a student, a TA who
+person can be both (a teacher testing an assignment as a student, a TA who
 also takes the course). Capabilities are gated after sign-in by your role in the
 organization and classroom, not by the scopes on your token.
 

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -190,7 +190,7 @@ Side-effect free.
 
 ---
 
-## Permissions and blast radius
+## Permissions and access
 
 Classroom 50 has no server. Whatever you authorize is a GitHub token that lives
 only in your browser (web app) or your local `gh` credential store (CLI) —
@@ -201,10 +201,9 @@ also takes the course). Capabilities are gated after sign-in by your role in the
 organization and classroom, not by the scopes on your token.
 
 The scopes below are GitHub's own. The table lists what each one grants across
-your whole account (the blast radius), why Classroom 50 needs it, and who
-actually exercises it.
+your whole account, why Classroom 50 needs it, and who actually exercises it.
 
-| Scope | Blast radius (what it can touch) | Why Classroom 50 needs it | Who uses it |
+| Scope | Access it grants | Why Classroom 50 needs it | Who uses it |
 |---|---|---|---|
 | `read:user` | Reads your public profile. | Identifies who you are after sign-in. | Everyone. |
 | `read:org` | Reads your organization and team memberships. | Confirms membership and resolves your classroom role; a student accepts their own org invitation. | Everyone. |

--- a/wiki/Known-Limitations.md
+++ b/wiki/Known-Limitations.md
@@ -102,6 +102,16 @@ briefly fail or show stale data; wait a minute and retry.
   above ([#567](https://github.com/foundation50/classroom50/issues/567)).
 - **Roster self-selection** would need a server to arbitrate identity
   claims.
+- **Per-organization sign-in access** isn't possible with a classic OAuth
+  sign-in: GitHub's `repo` scope is all-or-nothing, so the grant covers all
+  your repositories, not just the classroom org's. The tighter path is a
+  fine-grained personal access token scoped to one organization; see
+  [Reducing what you grant](GitHub-Integration#reducing-what-you-grant).
+- **Separate teacher and student sign-in profiles** would require choosing a
+  role at sign-in, which the design avoids — one person can be both a teacher
+  and a student in the same organization. What you can do is gated by your
+  org and classroom role after sign-in, not by your token's scopes; see
+  [Permissions and blast radius](GitHub-Integration#permissions-and-blast-radius).
 
 Classroom 50 is open source and actively developed; if one of these matters
 to your course, share your use case in

--- a/wiki/Known-Limitations.md
+++ b/wiki/Known-Limitations.md
@@ -111,7 +111,7 @@ briefly fail or show stale data; wait a minute and retry.
   role at sign-in, which the design avoids — one person can be both a teacher
   and a student in the same organization. What you can do is gated by your
   org and classroom role after sign-in, not by your token's scopes; see
-  [Permissions and blast radius](GitHub-Integration#permissions-and-blast-radius).
+  [Permissions and access](GitHub-Integration#permissions-and-access).
 
 Classroom 50 is open source and actively developed; if one of these matters
 to your course, share your use case in


### PR DESCRIPTION
## Summary

Documents the rationale and access of each GitHub permission Classroom 50 requests, and records why per-organization sign-in and separate teacher/student profiles aren't offered. This is a documentation-only change to the `wiki/` source (published to the GitHub wiki); no auth code, scope sets, or the `delete_repo`/elevation flow are touched.

Addresses the documentation and design-constraint parts of #655. The destructive-scope removal it asked for (`delete_repo` out of default auth) already shipped, and the two remaining product requests (separate teacher/student profiles, a per-org least-privilege path) are honestly documented as classic-OAuth / no-role-at-sign-in constraints rather than implemented.

- `wiki/GitHub-Integration.md` — new **Permissions and access** section: a per-scope table (`read:user`, `read:org`, `repo`, `workflow`, `admin:org`, `delete_repo`) covering the access each scope grants, why it's needed, and who exercises it; plus "What a student actually uses versus a teacher" and "Reducing what you grant" (the fine-grained-token lever).
- `wiki/FAQ.md` — cross-links the existing "all my repositories" answer to the new section and adds "Do teachers and students grant the same access?".
- `wiki/Known-Limitations.md` — two bullets under "Requested, but architecturally hard": per-organization sign-in access (the `repo` scope is all-or-nothing) and separate teacher/student sign-in profiles (avoids a role choice at sign-in; one person can be both).

## Test plan

- [ ] Prose-only change; no test/typecheck gate applies to `wiki/`.
- [ ] Confirm intra-wiki links resolve and tables render once published: `Permissions and access`, `Reducing what you grant`, and `Requested, but architecturally hard` anchors.