### PR TITLE
fix(web): keep custom template branch in the edit form (#673)

### DIFF
--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -719,6 +719,26 @@ describe("toSubmitValues — runtime field clearing", () => {
     expect(out.template_repo).toBe("acme/starter")
   })
 
+  it("surfaces a non-main stored template branch as owner/repo@branch (#673)", () => {
+    const custom = assignmentToFormValues({
+      slug: "hw",
+      name: "HW",
+      mode: "individual",
+      autograder: "default",
+      template: { owner: "acme", repo: "starter", branch: "spring-2026" },
+    })
+    expect(custom.template_repo).toBe("acme/starter@spring-2026")
+    // The overwhelming default ("main") is omitted so the common case stays clean.
+    const mainBranch = assignmentToFormValues({
+      slug: "hw2",
+      name: "HW2",
+      mode: "individual",
+      autograder: "default",
+      template: { owner: "acme", repo: "starter", branch: "main" },
+    })
+    expect(mainBranch.template_repo).toBe("acme/starter")
+  })
+
   it("include_all_branches passes through for a template source, clears otherwise", () => {
     const templated = toSubmitValues({
       ...base,

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -719,8 +719,15 @@ export const assignmentToFormValues = (
     slug: assignment.slug,
     description: assignment.description ?? "",
     mode: assignment.mode === "group" ? "group" : "individual",
+    // Surface a non-default stored branch as `owner/repo@branch` so an edit
+    // doesn't silently drop it (#673). We can't know the template's live default
+    // branch from stored state, so we omit the suffix only for "main" (GitHub's
+    // overwhelming default, matching the CLI's own non-main warning); any other
+    // stored branch round-trips visibly instead of appearing to reset.
     template_repo: assignment.template
-      ? `${assignment.template.owner}/${assignment.template.repo}`
+      ? assignment.template.branch && assignment.template.branch !== "main"
+        ? `${assignment.template.owner}/${assignment.template.repo}@${assignment.template.branch}`
+        : `${assignment.template.owner}/${assignment.template.repo}`
       : "",
     due_date: utcIsoToDatetimeLocalValue(assignment.due),
     available_from_date: utcIsoToDatetimeLocalValue(assignment.available_from),


### PR DESCRIPTION
## Summary

Fixes the visible half of #673: editing an assignment whose template used a custom branch (`ORG/REPO@CUSTOMBRANCH`) silently dropped the `@branch` suffix, so the Template Repository field always appeared to reset to `ORG/REPO`.

`assignmentToFormValues` rebuilt the field as `owner/repo` only. It now surfaces a non-default stored branch as `owner/repo@branch`. Because this function has only stored state (not live GitHub data), it can't know the template's real default branch, so it omits the suffix only for `main` — GitHub's overwhelming default, matching the same `!= "main"` convention the teacher CLI already uses for its non-main warning. The common case stays clean; any other stored branch round-trips visibly.

This also makes the save round-trip more robust: with the branch now present in the field, `templateRefUnchanged` matches on `parsed.branch === existing.branch` rather than relying on the omitted-branch fallback.

## Scope

This addresses only the "suffix disappears in the edit form" symptom. The other half of #673 — a custom branch not actually being used when generating student repos — is a GitHub API limitation (`POST /repos/{owner}/{repo}/generate` has no source-branch parameter, only `include_all_branches`) and is intentionally left out of this PR.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest) — all node tests pass (4083)
- [x] Added a unit test: a `spring-2026` branch renders as `acme/starter@spring-2026`; `main` stays `acme/starter`
- [ ] Manually edit an assignment with a `@custom-branch` template and confirm the field shows the branch and preserves it on save