### PR TITLE
fix(web): stop the classroom migration from stamping grading: auto (#680)

### DIFF
--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -4093,7 +4093,7 @@ describe("migrateClassroomAssignments", () => {
     ...extra,
   })
 
-  it("writes explicit submission_mode + grading:auto onto every legacy entry in one commit", async () => {
+  it("writes explicit submission_mode onto every legacy entry in one commit, nothing else", async () => {
     const { client, committed } = makeMigrateClient([
       legacyEntry("hw1"),
       legacyEntry("hw2"),
@@ -4107,9 +4107,11 @@ describe("migrateClassroomAssignments", () => {
     expect(result.alreadyMigratedCount).toBe(0)
     const written = committed()!
     // Every entry now carries an explicit tag mode (preserving pre-1.28
-    // submit/*-release counting) and auto grading.
+    // submit/*-release counting). grading stays absent: the schema reads
+    // absent as auto and every other writer omits the block for plain auto,
+    // so stamping an explicit auto here would be the lone writer doing so.
     expect(written.match(/"submission_mode": "tag"/g)).toHaveLength(3)
-    expect(written.match(/"mode": "auto"/g)).toHaveLength(3)
+    expect(written).not.toContain(`"grading"`)
   })
 
   it("no-ops when every entry is already migrated (no commit)", async () => {

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -1519,8 +1519,12 @@ function isSubmissionTrackingMigrated(entry: Assignment): boolean {
 }
 
 // Normalize an unmigrated entry into the new canonical shape by writing the
-// fields that pre-1.28 left absent: submission_mode = "tag" and, when grading
-// is absent, an explicit grading: { mode: "auto" } so the file self-documents.
+// one field that pre-1.28 left absent: submission_mode = "tag". Nothing else
+// is stamped on — in particular NOT an explicit grading: { mode: "auto" }:
+// the schema reads an absent grading as auto and every writer (CLI omitempty,
+// buildAssignmentEntry above) omits the block for plain auto, so writing it
+// here would only produce a shape no other path preserves (the next edit
+// would drop it again) and a noisy diff in the config repo.
 // "tag" (NOT "every-push") is what preserves pre-1.28 counting: before 1.28 a
 // submission was a submit/* release, and tag-mode detection counts exactly the
 // always-unioned submit/* namespace — every-push would instead start counting
@@ -1530,19 +1534,12 @@ function isSubmissionTrackingMigrated(entry: Assignment): boolean {
 // entry unchanged when already migrated.
 function normalizeEntryForMigration(entry: Assignment): Assignment {
   if (isSubmissionTrackingMigrated(entry)) return entry
-  const migrated: Assignment = {
-    ...entry,
-    submission_mode: "tag",
-  }
-  if (migrated.grading === undefined) {
-    migrated.grading = { mode: "auto" }
-  }
-  return migrated
+  return { ...entry, submission_mode: "tag" }
 }
 
 // Migrate every eligible assignment in a classroom's assignments.json to the
 // new submission-configuration semantics in ONE commit: write an explicit
-// submission_mode: "tag" (and grading: auto) onto each legacy entry so the
+// submission_mode: "tag" onto each legacy entry so the
 // detection overlay opts in while PRESERVING pre-1.28 counting — a submission
 // was a submit/* release before 1.28, and tag mode counts exactly the
 // always-unioned submit/* namespace. This is a content normalization WITHIN v1

--- a/web/src/hooks/mutations/useMigrateClassroomAssignments.ts
+++ b/web/src/hooks/mutations/useMigrateClassroomAssignments.ts
@@ -13,7 +13,7 @@ import { CONFIG_REPO } from "@/util/configRepo"
 // pre-1.28 assignments.json files. Safe to remove in a future version once no
 // legacy files remain. Greppable tag: MIGRATION(v1.28).
 // Migrate a classroom's assignments.json to the new submission-tracking
-// semantics (write an explicit submission_mode + grading:auto onto every legacy
+// semantics (write an explicit submission_mode onto every legacy
 // entry, opting the detection overlay in without changing behavior). The hook
 // owns the assignments.json listing invalidate (unmount-safe — the migrate
 // banner must clear even if the teacher navigates away). A content


### PR DESCRIPTION
Closes #680

## What

`normalizeEntryForMigration` stamped an explicit `grading: { mode: "auto" }` onto every legacy entry that had no `grading` block. This PR drops that write; the migration now sets `submission_mode` and nothing else.

## Why

Every other writer omits the block for plain auto — the CLI (`omitempty`, no `--grading` flag) and the web's own `buildAssignmentEntry` ("mirroring the CLI's omitempty"). The schema reads absent as `auto` and documents "writers omit the default" for every defaulted field; `submission_mode` is the one deliberate exception because its presence is the migration signal, and `grading` has no such exemption.

Net effect of the old behavior: the first web edit after migration dropped the block again (shape flip without teacher intent), and the migration commit carried a `grading` diff nobody asked for. `isSubmissionTrackingMigrated` keys off `submission_mode` only, so `grading` never mattered for the signal.

## Scope

Deliberately narrow — three files, no schema change:

- `createEdit.ts`: remove the `grading` write + update the two comments.
- `assignments.test.ts`: the migration test now asserts `grading` stays absent (the "preserves existing grading verbatim" test is unchanged and still covers the manual case).
- `useMigrateClassroomAssignments.ts`: comment.

Independent of #654 / the `tag` → `every-push` question; touches only the `grading` lines, so the two can land in either order.

## Verification

- `vitest run src/domain/assignments.test.ts` — 182 passed
- `tsc -b`, `eslint`, `prettier --check` on the touched files — clean