### PR TITLE
fix(web): stop the classroom migration from stamping grading: auto

### DIFF
--- a/web/src/components/modals/MigrateSubmissionTrackingModal.tsx
+++ b/web/src/components/modals/MigrateSubmissionTrackingModal.tsx
@@ -20,10 +20,10 @@ type Phase = "idle" | "working" | "complete" | "error"
 // Greppable tag: MIGRATION(v1.28).
 // Explicit, teacher-triggered migration of a classroom's assignments.json to
 // the new submission-tracking semantics: one confirm writes an explicit
-// submission_mode (+ grading:auto) onto every legacy assignment, opting the
-// submissions-page detection overlay in without changing any grade. Nothing
-// runs until the teacher clicks Migrate. A content normalization within v1 —
-// no schema version bump.
+// submission_mode onto every legacy assignment, opting the submissions-page
+// detection overlay in without changing any grade. Nothing runs until the
+// teacher clicks Migrate. A content normalization within v1 — no schema
+// version bump.
 export function MigrateSubmissionTrackingModal({
   open,
   onClose,

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -4093,12 +4093,9 @@ describe("migrateClassroomAssignments", () => {
     ...extra,
   })
 
-  it("writes explicit submission_mode + grading:auto onto every legacy entry in one commit", async () => {
-    const { client, committed } = makeMigrateClient([
-      legacyEntry("hw1"),
-      legacyEntry("hw2"),
-      legacyEntry("hw3"),
-    ])
+  it("writes explicit submission_mode onto every legacy entry in one commit, nothing else", async () => {
+    const legacy = [legacyEntry("hw1"), legacyEntry("hw2"), legacyEntry("hw3")]
+    const { client, committed } = makeMigrateClient(legacy)
     const result = await migrateClassroomAssignments(client, {
       org: ORG,
       classroom: CLASSROOM,
@@ -4106,10 +4103,12 @@ describe("migrateClassroomAssignments", () => {
     expect(result.migratedCount).toBe(3)
     expect(result.alreadyMigratedCount).toBe(0)
     const written = committed()!
-    // Every entry now carries an explicit tag mode (preserving pre-1.28
-    // submit/*-release counting) and auto grading.
-    expect(written.match(/"submission_mode": "tag"/g)).toHaveLength(3)
-    expect(written.match(/"mode": "auto"/g)).toHaveLength(3)
+    // Each entry gains exactly submission_mode: "tag" (preserving pre-1.28
+    // submit/*-release counting); grading stays absent, as every other writer
+    // leaves it (see normalizeEntryForMigration).
+    expect(JSON.parse(written).assignments).toEqual(
+      legacy.map((e) => ({ ...e, submission_mode: "tag" })),
+    )
   })
 
   it("no-ops when every entry is already migrated (no commit)", async () => {

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -1519,8 +1519,12 @@ function isSubmissionTrackingMigrated(entry: Assignment): boolean {
 }
 
 // Normalize an unmigrated entry into the new canonical shape by writing the
-// fields that pre-1.28 left absent: submission_mode = "tag" and, when grading
-// is absent, an explicit grading: { mode: "auto" } so the file self-documents.
+// one field that pre-1.28 left absent: submission_mode = "tag". Nothing else
+// is stamped on — in particular no explicit grading: { mode: "auto" }: absent
+// reads as auto everywhere, and every writer (CLI omitempty,
+// buildAssignmentEntry above) omits the block for plain auto, so the app's
+// next edit would drop it again and the migration commit would carry a diff
+// nobody asked for.
 // "tag" (NOT "every-push") is what preserves pre-1.28 counting: before 1.28 a
 // submission was a submit/* release, and tag-mode detection counts exactly the
 // always-unioned submit/* namespace — every-push would instead start counting
@@ -1530,25 +1534,18 @@ function isSubmissionTrackingMigrated(entry: Assignment): boolean {
 // entry unchanged when already migrated.
 function normalizeEntryForMigration(entry: Assignment): Assignment {
   if (isSubmissionTrackingMigrated(entry)) return entry
-  const migrated: Assignment = {
-    ...entry,
-    submission_mode: "tag",
-  }
-  if (migrated.grading === undefined) {
-    migrated.grading = { mode: "auto" }
-  }
-  return migrated
+  return { ...entry, submission_mode: "tag" }
 }
 
 // Migrate every eligible assignment in a classroom's assignments.json to the
 // new submission-configuration semantics in ONE commit: write an explicit
-// submission_mode: "tag" (and grading: auto) onto each legacy entry so the
-// detection overlay opts in while PRESERVING pre-1.28 counting — a submission
-// was a submit/* release before 1.28, and tag mode counts exactly the
-// always-unioned submit/* namespace. This is a content normalization WITHIN v1
-// — the schema sentinel is untouched and no version bump occurs. Unknown fields
-// round-trip via the whole-entry spread. Mirrors setAssignmentClosed's no-op
-// short-circuit: an all-migrated file skips the commit.
+// submission_mode: "tag" onto each legacy entry so the detection overlay opts
+// in while PRESERVING pre-1.28 counting — a submission was a submit/* release
+// before 1.28, and tag mode counts exactly the always-unioned submit/*
+// namespace. This is a content normalization WITHIN v1 — the schema sentinel
+// is untouched and no version bump occurs. Unknown fields round-trip via the
+// whole-entry spread. Mirrors setAssignmentClosed's no-op short-circuit: an
+// all-migrated file skips the commit.
 export async function migrateClassroomAssignments(
   client: GitHubClient,
   input: MigrateClassroomAssignmentsInput,

--- a/web/src/hooks/mutations/useMigrateClassroomAssignments.ts
+++ b/web/src/hooks/mutations/useMigrateClassroomAssignments.ts
@@ -13,11 +13,11 @@ import { CONFIG_REPO } from "@/util/configRepo"
 // pre-1.28 assignments.json files. Safe to remove in a future version once no
 // legacy files remain. Greppable tag: MIGRATION(v1.28).
 // Migrate a classroom's assignments.json to the new submission-tracking
-// semantics (write an explicit submission_mode + grading:auto onto every legacy
-// entry, opting the detection overlay in without changing behavior). The hook
-// owns the assignments.json listing invalidate (unmount-safe — the migrate
-// banner must clear even if the teacher navigates away). A content
-// normalization within v1, so there is no schema-version side effect.
+// semantics (write an explicit submission_mode onto every legacy entry, opting
+// the detection overlay in without changing behavior). The hook owns the
+// assignments.json listing invalidate (unmount-safe — the migrate banner must
+// clear even if the teacher navigates away). A content normalization within
+// v1, so there is no schema-version side effect.
 export function useMigrateClassroomAssignments(
   org: string,
   classroom: string,


### PR DESCRIPTION
## Summary

The classroom migration (`normalizeEntryForMigration`) stamped an explicit `grading: { mode: "auto" }` onto every legacy entry without a `grading` block. No other writer does: the CLI has no `--grading` flag and omits the pointer (`omitempty`), and the web's own `buildAssignmentEntry` omits the block for plain auto to mirror it. The schema reads absent as `auto` and documents "writers omit the default" for every defaulted field; only `submission_mode` is exempted, as the migration signal. The explicit auto was therefore a shape no other path preserves (the next edit dropped it again) plus an unasked-for diff in the config repo's history.

This PR drops the `grading` write; the migration now sets `submission_mode` and nothing else. Four files (the function, its test, and two stale comments), no schema change. Independent of #654 — touches only the `grading` lines.

Files migrated by web-v1.28..v1.31 already carry the explicit block; it stays valid (the schema allows it, every reader uses `grading?.mode ?? "auto"`, and `isSubmissionTrackingMigrated` keys off `submission_mode` only, so nothing re-migrates). The app drops it on the next edit of that assignment; the CLI carries an existing block forward as-is.

Closes #680

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`) — not touched
  - Web: `cd web && npm run check` — clean (tsc, eslint, prettier, arch:validate, 4101 tests)
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q` — not touched
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass. — no contract change
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README). — n/a
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
