### PR TITLE
test: guard submission_mode reader-rule and route fallbacks through one resolver

### DIFF
--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -89,23 +89,19 @@ func TestSubmissionModeEnumParity(t *testing.T) {
 	}
 }
 
-// TestSubmissionModeReaderRuleParity guards the PROSE reader rule that the enum
-// parity test above does not: absence is the wire default (resolve to
-// every-push) and no reader may gate behavior on the field being present. That
-// rule lives only as hand-synced free text in three places — the schema
-// submission_mode.description, the Go contract.go comment, and the web
-// types/classroom.ts comment — so an edit to one that silently drops or
-// contradicts it in another is exactly the #654 defect in a new form. Enum
-// values are pinned separately; this pins the invariant's wording. On a
-// reworded rule, update all three copies so the shared phrases survive.
+// TestSubmissionModeReaderRuleParity pins the PROSE reader rule (absence is the
+// wire default; never gate on the field being present) across its three
+// hand-synced copies — the schema submission_mode.description, contract.go, and
+// the web types/classroom.ts comment. Enum parity pins the values, not this
+// wording, and a one-sided drop reintroduces the #654 ambiguity. Update all
+// three copies in lockstep so the shared phrases survive.
 func TestSubmissionModeReaderRuleParity(t *testing.T) {
 	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
 	if err != nil {
 		t.Fatalf("resolve repo root: %v", err)
 	}
 
-	// The two load-bearing clauses of the rule, in the wording all three copies
-	// share. Both must survive verbatim in every mirror.
+	// The load-bearing clauses every copy shares, in their common wording.
 	wantPhrases := []string{
 		"gate behavior on the field being PRESENT",
 		"absence is the wire default",

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -89,6 +89,91 @@ func TestSubmissionModeEnumParity(t *testing.T) {
 	}
 }
 
+// TestSubmissionModeReaderRuleParity guards the PROSE reader rule that the enum
+// parity test above does not: absence is the wire default (resolve to
+// every-push) and no reader may gate behavior on the field being present. That
+// rule lives only as hand-synced free text in three places — the schema
+// submission_mode.description, the Go contract.go comment, and the web
+// types/classroom.ts comment — so an edit to one that silently drops or
+// contradicts it in another is exactly the #654 defect in a new form. Enum
+// values are pinned separately; this pins the invariant's wording. On a
+// reworded rule, update all three copies so the shared phrases survive.
+func TestSubmissionModeReaderRuleParity(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	// The two load-bearing clauses of the rule, in the wording all three copies
+	// share. Both must survive verbatim in every mirror.
+	wantPhrases := []string{
+		"gate behavior on the field being PRESENT",
+		"absence is the wire default",
+	}
+
+	// (source label, path relative to repo root, extractor)
+	sources := []struct {
+		label   string
+		relPath string
+		extract func(raw []byte) (string, error)
+	}{
+		{
+			label:   "schema submission_mode.description",
+			relPath: filepath.Join("schemas", "assignments-v1.schema.json"),
+			extract: func(raw []byte) (string, error) {
+				var schema struct {
+					Defs struct {
+						Assignment struct {
+							Properties struct {
+								SubmissionMode struct {
+									Description string `json:"description"`
+								} `json:"submission_mode"`
+							} `json:"properties"`
+						} `json:"assignment"`
+					} `json:"$defs"`
+				}
+				if err := json.Unmarshal(raw, &schema); err != nil {
+					return "", err
+				}
+				return schema.Defs.Assignment.Properties.SubmissionMode.Description, nil
+			},
+		},
+		{
+			label:   "Go contract.go comment",
+			relPath: filepath.Join("cli", "shared", "contract", "contract.go"),
+			extract: func(raw []byte) (string, error) { return string(raw), nil },
+		},
+		{
+			label:   "web types/classroom.ts comment",
+			relPath: filepath.Join("web", "src", "types", "classroom.ts"),
+			extract: func(raw []byte) (string, error) { return string(raw), nil },
+		},
+	}
+
+	for _, src := range sources {
+		raw, err := os.ReadFile(filepath.Join(root, src.relPath))
+		if err != nil {
+			t.Fatalf("read %s (%s): %v", src.label, src.relPath, err)
+		}
+		text, err := src.extract(raw)
+		if err != nil {
+			t.Fatalf("parse %s (%s): %v", src.label, src.relPath, err)
+		}
+		if text == "" {
+			t.Fatalf("%s is empty; did the shape change?", src.label)
+		}
+		// Collapse whitespace (incl. comment-wrap newlines and `//` prefixes) so a
+		// phrase split across two wrapped comment lines still matches.
+		normalized := strings.Join(strings.Fields(strings.ReplaceAll(text, "//", " ")), " ")
+		for _, phrase := range wantPhrases {
+			if !strings.Contains(normalized, phrase) {
+				t.Errorf("submission_mode reader-rule drift: %s is missing %q — update every mirror in lockstep (schema description, Go contract.go, web types/classroom.ts)",
+					src.label, phrase)
+			}
+		}
+	}
+}
+
 // TestGradingModeEnumParity pins the grading.mode allow-list across its
 // hand-mirrored sources: the JSON schema enum (declared source of truth) and
 // the Go contract.GradingModes (what ValidateGrading enforces). The web mirror

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -74,6 +74,7 @@ import {
 } from "./accessPrimitives"
 import { CONFIG_REPO } from "@/util/configRepo"
 import type { CreateAssignmentInput } from "./repoCreation"
+import { resolveSubmissionMode } from "./submissionDetection"
 
 export type CreateAssignmentResult = CreateClassroomResult & {
   // Set when the assignment saved but the follow-up team read grant on a
@@ -802,7 +803,7 @@ async function buildAssignmentEntry(
   // Absence IS every-push, so no intent is lost. Permitted for every repo shape
   // (including empty_repo / no_autograder): with no shim it carries no trigger,
   // but it still defines what the submissions page counts as a submission.
-  const resolvedSubmissionMode = input.submission_mode ?? "every-push"
+  const resolvedSubmissionMode = resolveSubmissionMode(input.submission_mode)
   if (!SUBMISSION_MODES.includes(resolvedSubmissionMode)) {
     throw new Error(
       `submission_mode: must be one of ${SUBMISSION_MODES.join(", ")} (got "${resolvedSubmissionMode}").`,

--- a/web/src/hooks/useDetectedSubmissions.test.tsx
+++ b/web/src/hooks/useDetectedSubmissions.test.tsx
@@ -310,12 +310,10 @@ describe("useDetectedSubmissions — fan-out contract", () => {
     expect(result.current.isPending).toBe(false)
   })
 
-  // Regression for #654: while the assignment query is unresolved the caller
-  // passes an undefined mode AND enabled:false. If the disabled gate ever leaked,
-  // the undefined mode would resolve to every-push and count a tag-mode
-  // assignment in branch mode. The gate must win — no read fires at all.
+  // Regression for #654: an unresolved assignment passes mode:undefined with
+  // enabled:false. The disabled gate must win before the undefined mode could
+  // resolve to every-push and count a tag-mode assignment in branch mode.
   it("does not fetch while unresolved (mode undefined + disabled)", () => {
-    request.mockImplementation(branchClient({ defaultBranch: "main" }))
     const { result } = renderHook(
       () =>
         useDetectedSubmissions({

--- a/web/src/hooks/useDetectedSubmissions.test.tsx
+++ b/web/src/hooks/useDetectedSubmissions.test.tsx
@@ -310,6 +310,27 @@ describe("useDetectedSubmissions — fan-out contract", () => {
     expect(result.current.isPending).toBe(false)
   })
 
+  // Regression for #654: while the assignment query is unresolved the caller
+  // passes an undefined mode AND enabled:false. If the disabled gate ever leaked,
+  // the undefined mode would resolve to every-push and count a tag-mode
+  // assignment in branch mode. The gate must win — no read fires at all.
+  it("does not fetch while unresolved (mode undefined + disabled)", () => {
+    request.mockImplementation(branchClient({ defaultBranch: "main" }))
+    const { result } = renderHook(
+      () =>
+        useDetectedSubmissions({
+          ...base,
+          mode: undefined,
+          repoOwners: ["a"],
+          enabled: false,
+        }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    expect(request).not.toHaveBeenCalled()
+    expect(result.current.detected).toEqual([])
+    expect(result.current.isPending).toBe(false)
+  })
+
   it("does not fetch when there are no owners", () => {
     renderHook(
       () =>

--- a/web/src/hooks/useDetectedSubmissions.ts
+++ b/web/src/hooks/useDetectedSubmissions.ts
@@ -20,6 +20,7 @@ import {
   detectBranchSubmissions,
   detectTagSubmissions,
   detectedSubmissionCount,
+  resolveSubmissionMode,
   type DetectedSubmission,
 } from "@/domain/assignments/submissionDetection"
 import { studentRepoName } from "@/util/studentRepo"
@@ -93,7 +94,7 @@ export function useDetectedSubmissions({
     [submissionTags],
   )
 
-  const resolvedMode: SubmissionMode = mode ?? "every-push"
+  const resolvedMode = resolveSubmissionMode(mode)
 
   const active =
     enabled && Boolean(org && classroom && assignment) && repoOwners.length > 0

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -43,6 +43,7 @@ import {
   type AutogradingState,
 } from "@/domain/assignments/autogradingState"
 import { deriveFormShape } from "./formShape"
+import { resolveSubmissionMode } from "@/domain/assignments/submissionDetection"
 import type {
   Assignment,
   RepoPermission,
@@ -657,7 +658,7 @@ export const useAssignmentForm = (
       pass_threshold_enabled: defaultValues?.pass_threshold_enabled ?? false,
       pass_threshold: defaultValues?.pass_threshold ?? DEFAULT_PASS_THRESHOLD,
       student_permission: defaultValues?.student_permission ?? "",
-      submission_mode: defaultValues?.submission_mode ?? "every-push",
+      submission_mode: resolveSubmissionMode(defaultValues?.submission_mode),
       submission_tags: defaultValues?.submission_tags || "",
       // Create default is "off" (not graded); the option order is off ->
       // manual -> auto. On edit, assignmentToFormValues supplies the stored
@@ -778,7 +779,7 @@ export const assignmentToFormValues = (
     // path re-omits it. A stored value pins the picker to that level.
     student_permission: assignment.student_permission ?? "",
     // Absent means every-push (the wire default, collapsed by writers).
-    submission_mode: assignment.submission_mode ?? "every-push",
+    submission_mode: resolveSubmissionMode(assignment.submission_mode),
     // Milestone tag patterns, joined one-per-line for the textarea.
     submission_tags: submissionTagsToText(assignment.submission_tags),
     // Grading intent; absent reads as "auto" (today's behavior). A stored


### PR DESCRIPTION
## Summary

Follow-ups from the [#683](https://github.com/foundation50/classroom50/pull/683) code review, addressing the three non-blocking residuals that PR left behind. **No behavior change** — this is a consistency refactor plus two regression/drift guards.

- **One resolver for the wire default.** #683 routed `SubmissionsPage` through `resolveSubmissionMode` but left inline `?? "every-push"` fallbacks elsewhere. This routes the remaining three — the `buildAssignmentEntry` writer (`createEdit.ts`), the `useDetectedSubmissions` read path, and the form-model seeding (`assignmentFormModel.ts`, both create-default and edit-read) — through `resolveSubmissionMode`. The only surviving `?? "every-push"` is now inside the helper itself.
- **Regression guard for the #654 window.** `useDetectedSubmissions.test.tsx` now pins that no read fires while the assignment is unresolved (`mode: undefined` + `enabled: false`) — the exact state where a leaked gate would resolve the absent mode to every-push and count a tag-mode assignment in branch mode. The existing tests only covered the mode once the query is already active.
- **Prose-parity drift guard.** `TestSubmissionModeReaderRuleParity` (in `assignments_json_test.go`, next to the enum-parity test) pins the *wording* of the reader rule — "absence is the wire default; never gate on the field being present" — across all three hand-synced mirrors: the schema `submission_mode.description`, `contract.go`, and `types/classroom.ts`. Enum-value parity was already pinned; the prose that actually encodes the #654 fix was not, so a one-sided edit could silently reintroduce the ambiguity.

## Why these are safe

`resolveSubmissionMode(x)` is exactly `x ?? "every-push"` with a typed return, so every swapped site is behavior-identical; the `createEdit` enum-validation guard still runs unchanged. The drift test normalizes whitespace so a rule that wraps across comment lines still matches.

## Not included (intentional)

The review also noted a missing **page-level** test that `BulkSubmissionTriggerModal` is *unmounted* (not merely closed) while unresolved. `SubmissionsPage` has no existing test harness and a full-render test would be disproportionately brittle for this change; the hook-level regression above guards the same underlying bug at the reads layer. Worth a dedicated follow-up if a `SubmissionsPage` harness lands.

## Test plan

- [x] `cd web && npm run check` — tsc, eslint, prettier, `arch:validate`, and vitest node project (328 files / 4085 tests) all green.
- [x] `npx vitest run --project browser` — 5 files / 18 tests green (Playwright chromium installed locally).
- [x] `go build ./... && go test ./internal/assignment/` in `cli/gh-teacher` — green, including the new `TestSubmissionModeReaderRuleParity` (verified it fails when a phrase is dropped before whitespace normalization was added).
- [x] `golangci-lint run ./internal/assignment/...` and `golangci-lint fmt --diff ./internal/assignment/` — 0 issues, no diff.

## Type of change

- [x] Refactor / maintenance (consistency) + test hardening
- [ ] Bug fix
- [ ] New feature

## Checklist

- [x] Built, tested, and linted the modules touched: web (`npm run check` + browser project) and `cli/gh-teacher` (`go build`/`go test`/`golangci-lint`).
- [x] No cross-binary contract value changed — the enum, types, and reader semantics are untouched; this only adds a test pinning the existing prose and consolidates a fallback behind an existing helper.
- [x] No CLI command or flag changed — n/a for wiki docs.
- [x] Conventional Commits title.