### PR TITLE
fix: ignore a custom template branch, warning it won't take effect (#673)

### DIFF
--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -107,11 +107,13 @@ func assignmentAddCmd() *cobra.Command {
 			"Mutually exclusive with --template, --tests, --feedback-pr,\n" +
 			"--allowed-files, --pass-threshold, --submission-mode, and\n" +
 			"--submission-tag.\n\n" +
-			"--template parses `<owner>/<repo>` or `<owner>/<repo>@<branch>`.\n" +
-			"When the branch is omitted, the template repo's default branch is\n" +
-			"used. The template repo must be marked `is_template: true` (set\n" +
-			"in Settings → \"Template repository\"); if your account can't see\n" +
-			"the repo, the CLI returns the cross-org visibility message.\n\n" +
+			"--template parses `<owner>/<repo>` (or `<owner>/<repo>@<branch>`).\n" +
+			"A custom source branch is tolerated but IGNORED — the assignment\n" +
+			"uses the template repo's default branch. To use a different branch,\n" +
+			"change the template repository's default branch first. The template\n" +
+			"repo must be marked `is_template: true` (set in Settings →\n" +
+			"\"Template repository\"); if your account can't see the repo, the CLI\n" +
+			"returns the cross-org visibility message.\n\n" +
 			"--runtime points at a JSON file describing the runtime\n" +
 			"environment for this assignment's autograde job: which\n" +
 			"runner label(s), optional language toolchains\n" +
@@ -147,7 +149,7 @@ func assignmentAddCmd() *cobra.Command {
 			"      --name \"Hello\" --template cs50/hello-template \\\n" +
 			"      --due 2026-09-15T23:59:00-04:00\n" +
 			"  gh teacher assignment add cs50-fall-2026 cs-principles intro \\\n" +
-			"      --name \"Intro\" --template cs50/intro-template@main\n" +
+			"      --name \"Intro\" --template cs50/intro-template\n" +
 			"  gh teacher assignment add cs50-fall-2026 cs-principles greet \\\n" +
 			"      --name \"Greet\" --template cs50/greet-template \\\n" +
 			"      --runtime ./runtime-c.json",
@@ -247,6 +249,14 @@ func assignmentAddCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				// A `@branch` is tolerated but ignored (#673): the assignment
+				// uses the template's default branch. Warn so a teacher isn't
+				// surprised the branch had no effect.
+				if parsed.IgnoredBranch != "" {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"warning: --template branch %q is ignored — the assignment uses %s/%s's default branch. To use a different branch, change the template repository's default branch.\n",
+						parsed.IgnoredBranch, parsed.Owner, parsed.Repo)
+				}
 				tmplArg = &parsed
 			}
 			runtime, err := assignment.ParseRuntimeFile(strings.TrimSpace(runtimeFile))
@@ -293,7 +303,7 @@ func assignmentAddCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", `Display name written into the assignment entry (e.g., "Hello") (required)`)
-	cmd.Flags().StringVar(&template, "template", "", "Optional template repo as <owner>/<repo> or <owner>/<repo>@<branch>. Omit for a template-less assignment (students get an initialized repo: a README plus the autograding setup).")
+	cmd.Flags().StringVar(&template, "template", "", "Optional template repo as <owner>/<repo> (or <owner>/<repo>@<branch>). Omit for a template-less assignment (students get an initialized repo: a README plus the autograding setup). A custom source branch (@<branch>) is tolerated but ignored — the assignment uses the template's default branch; change the template repo's default branch to use a different one.")
 	cmd.Flags().StringVar(&description, "description", "", "Optional one-line description")
 	cmd.Flags().StringVar(&due, "due", "", "Optional due date (e.g., 2026-09-15T23:59:00-04:00); stored as UTC. Omit the offset to use the machine's local timezone")
 	cmd.Flags().StringVar(&availableFrom, "available-from", "", "Optional release date (e.g., 2026-09-15T00:00:00-04:00); stored as UTC. Assignments are hidden from the student list by default (invite-link accept only); set this to list it for everyone once the date passes. Students who already accepted always see it (listing-only, not access control). Omit the offset to use the machine's local timezone.")
@@ -1052,17 +1062,24 @@ func ensureClassroomActive(client githubapi.Client, org, classroom, ref string) 
 	return nil
 }
 
-// templateArg is the parsed `--template` flag. Branch is empty if `@branch` is
-// omitted; validateTemplateRepo then fills it from default_branch. Kept
-// distinct from assignment.TemplateRef because on-disk Branch must be populated.
+// templateArg is the parsed `--template` flag. A custom `@branch` is TOLERATED
+// but IGNORED (#673 — GitHub's create-from-template API can't select a source
+// branch, and changing a generated repo's default branch is blocked by org
+// branch rulesets); the assignment always uses the template repo's
+// default_branch, resolved by validateTemplateRepo. IgnoredBranch carries a
+// specified branch so the caller can warn it won't take effect. Kept distinct
+// from assignment.TemplateRef because on-disk Branch must be populated.
 type templateArg struct {
-	Owner  string
-	Repo   string
-	Branch string // empty → use the repo's default_branch
+	Owner         string
+	Repo          string
+	IgnoredBranch string // a specified `@branch` we tolerate but ignore; "" when absent
 }
 
-// parseTemplateRef parses `<owner>/<repo>[@branch]`. Rejects empty
-// parts and extra `/` or `@` (e.g., `cs50//hello`, `cs50/hello@@main`).
+// parseTemplateRef parses `<owner>/<repo>[@branch]`. A custom `@branch` is
+// tolerated but ignored (#673) — carried as IgnoredBranch so the caller can
+// warn — and the assignment uses the template's default branch. Rejects an
+// empty ref, a malformed `@` (multiple, or empty after `@`), or a malformed
+// `<owner>/<repo>`.
 func parseTemplateRef(raw string) (templateArg, error) {
 	if raw == "" {
 		return templateArg{}, errors.New("--template must not be empty")
@@ -1079,9 +1096,9 @@ func parseTemplateRef(raw string) (templateArg, error) {
 		return templateArg{}, fmt.Errorf("invalid --template %q: expected <owner>/<repo>[@branch]", raw)
 	}
 	return templateArg{
-		Owner:  parts[0],
-		Repo:   parts[1],
-		Branch: branch,
+		Owner:         parts[0],
+		Repo:          parts[1],
+		IgnoredBranch: branch,
 	}, nil
 }
 
@@ -1221,10 +1238,10 @@ func templateInOrg(templateOwner, org string) bool {
 }
 
 // resolveTemplateBranch picks the final assignment.TemplateRef from
-// --template + repo fields: not-a-template, empty (commitless), explicit
-// @branch, default_branch fallback, or empty-default_branch guard. Emptiness is
-// passed in as a resolved `hasCommits` (the HTTP-aware caller owns the branches
-// probe) so this stays a pure, unit-testable function.
+// --template + repo fields: not-a-template, empty (commitless), or the repo's
+// default_branch (a custom `@branch` is tolerated but ignored — #673). Emptiness
+// is passed in as a resolved `hasCommits` (the HTTP-aware caller owns the
+// branches probe) so this stays a pure, unit-testable function.
 func resolveTemplateBranch(t templateArg, isTemplate, hasCommits bool, defaultBranch string) (assignment.TemplateRef, error) {
 	if !isTemplate {
 		return assignment.TemplateRef{}, fmt.Errorf("`%s/%s` is not a template repository — toggle Settings → \"Template repository\" on the repo, then re-run", t.Owner, t.Repo)
@@ -1238,14 +1255,11 @@ func resolveTemplateBranch(t templateArg, isTemplate, hasCommits bool, defaultBr
 	if !hasCommits {
 		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no commits — add at least one commit (e.g. a README) so students can generate from it, then re-run", t.Owner, t.Repo)
 	}
-	branch := t.Branch
-	if branch == "" {
-		branch = defaultBranch
-	}
+	branch := defaultBranch
 	if branch == "" {
 		// Not expected once size > 0, but a blank on-disk Branch would trip
 		// `student accept`, so guard it anyway.
-		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no default branch — pass --template %s/%s@<branch> explicitly", t.Owner, t.Repo, t.Owner, t.Repo)
+		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no default branch — push a commit to it, then re-run", t.Owner, t.Repo)
 	}
 	return assignment.TemplateRef{Owner: t.Owner, Repo: t.Repo, Branch: branch}, nil
 }

--- a/cli/gh-teacher/internal/assignmentcmd/assignment_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment_test.go
@@ -14,17 +14,17 @@ import (
 )
 
 func TestParseTemplateRef_HappyPaths(t *testing.T) {
-	// Empty branch is the sentinel for "use template's default_branch"
-	// (resolveTemplateBranch fills it in).
+	// A `@branch` is tolerated but ignored (#673): it parses to owner/repo with
+	// the branch captured in IgnoredBranch (the caller warns; the assignment
+	// uses the template's default branch).
 	cases := []struct {
-		in         string
-		wantOwner  string
-		wantRepo   string
-		wantBranch string
+		in            string
+		wantOwner     string
+		wantRepo      string
+		wantIgnoredBr string
 	}{
 		{"cs50/hello-template", "cs50", "hello-template", ""},
 		{"cs50/hello-template@main", "cs50", "hello-template", "main"},
-		// Branch with `/` is legal — refs/heads/feature/foo is valid.
 		{"cs50/hello-template@feature/foo", "cs50", "hello-template", "feature/foo"},
 		{"cs50/hello-template@v0.1-beta", "cs50", "hello-template", "v0.1-beta"},
 	}
@@ -34,9 +34,10 @@ func TestParseTemplateRef_HappyPaths(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parseTemplateRef(%q): %v", tc.in, err)
 			}
-			if got.Owner != tc.wantOwner || got.Repo != tc.wantRepo || got.Branch != tc.wantBranch {
-				t.Errorf("parseTemplateRef(%q) = %#v, want owner=%q repo=%q branch=%q",
-					tc.in, got, tc.wantOwner, tc.wantRepo, tc.wantBranch)
+			if got.Owner != tc.wantOwner || got.Repo != tc.wantRepo ||
+				got.IgnoredBranch != tc.wantIgnoredBr {
+				t.Errorf("parseTemplateRef(%q) = %#v, want owner=%q repo=%q ignoredBranch=%q",
+					tc.in, got, tc.wantOwner, tc.wantRepo, tc.wantIgnoredBr)
 			}
 		})
 	}
@@ -54,6 +55,7 @@ func TestParseTemplateRef_Rejects(t *testing.T) {
 		{"empty repo", "cs50/", "expected"},
 		{"empty repo with branch", "cs50/@main", "expected"},
 		{"too many slashes outside branch", "cs50/foo/bar", "expected"},
+		// A `@branch` is tolerated, but a MALFORMED `@` is still rejected.
 		{"empty branch after @", "cs50/hello-template@", "branch is empty"},
 		{"double @", "cs50/hello-template@main@v2", "@"},
 	}
@@ -170,10 +172,12 @@ func TestResolveTemplateBranch(t *testing.T) {
 	// Each row covers one branch of the post-HTTP decision tree so a
 	// change to validateTemplateRepo's response handling can't
 	// silently drop a guard: not-a-template, empty-template,
-	// explicit-@branch retention, default_branch fallback,
-	// empty-default_branch error. Emptiness is now an input (hasCommits);
-	// the fork exemption (#528) and the size-0 branches probe (#544) are
-	// resolved by templateHasCommits and covered by TestTemplateHasCommits.
+	// default_branch resolution, empty-default_branch error. A custom
+	// `@branch` is tolerated but ignored (#673) — resolveTemplateBranch never
+	// sees it (parseTemplateRef captures it as IgnoredBranch), so branch always
+	// comes from default_branch. Emptiness is now an input (hasCommits); the
+	// fork exemption (#528) and the size-0 branches probe (#544) are resolved
+	// by templateHasCommits and covered by TestTemplateHasCommits.
 	cases := []struct {
 		name        string
 		arg         templateArg
@@ -208,14 +212,6 @@ func TestResolveTemplateBranch(t *testing.T) {
 			hasCommits: true,
 			defaultBr:  "main",
 			wantRef:    assignment.TemplateRef{Owner: "cs50", Repo: "cross-org-fork-template", Branch: "main"},
-		},
-		{
-			name:       "explicit @branch retained even when default_branch differs",
-			arg:        templateArg{Owner: "cs50", Repo: "hello-template", Branch: "feature/foo"},
-			isTemplate: true,
-			hasCommits: true,
-			defaultBr:  "main",
-			wantRef:    assignment.TemplateRef{Owner: "cs50", Repo: "hello-template", Branch: "feature/foo"},
 		},
 		{
 			name:       "no @branch falls back to default_branch (master)",

--- a/cli/gh-teacher/internal/assignmentcmd/lock_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/lock_test.go
@@ -325,7 +325,7 @@ func TestRunAssignmentAdd_PreservesLockAndSkipsGrant(t *testing.T) {
 		Classroom:  "dst",
 		Slug:       "hello",
 		Name:       "Hello",
-		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template", Branch: "main"},
+		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template"},
 		Mode:       assignment.ModeIndividual,
 		Autograder: "default",
 	})
@@ -364,7 +364,7 @@ func TestRunAssignmentAdd_PreservesClosed(t *testing.T) {
 		Classroom:  "dst",
 		Slug:       "hello",
 		Name:       "Hello",
-		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template", Branch: "main"},
+		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template"},
 		Mode:       assignment.ModeIndividual,
 		Autograder: "default",
 	})
@@ -413,7 +413,7 @@ func TestRunAssignmentAdd_PreservesSubmissionMode(t *testing.T) {
 		Classroom:  "dst",
 		Slug:       "hello",
 		Name:       "Hello",
-		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template", Branch: "main"},
+		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template"},
 		Mode:       assignment.ModeIndividual,
 		Autograder: "default",
 		// --submission-mode omitted: SubmissionMode is the normalized zero value
@@ -444,7 +444,7 @@ func TestRunAssignmentAdd_ExplicitEveryPushResetsSubmissionMode(t *testing.T) {
 		Classroom:  "dst",
 		Slug:       "hello",
 		Name:       "Hello",
-		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template", Branch: "main"},
+		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template"},
 		Mode:       assignment.ModeIndividual,
 		Autograder: "default",
 		// An explicit --submission-mode every-push normalizes to "" with
@@ -491,7 +491,7 @@ func TestRunAssignmentAdd_PreservesSubmissionTags(t *testing.T) {
 		Classroom:  "dst",
 		Slug:       "hello",
 		Name:       "Hello",
-		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template", Branch: "main"},
+		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template"},
 		Mode:       assignment.ModeIndividual,
 		Autograder: "default",
 		// --submission-tag omitted: the prior patterns must carry forward.
@@ -515,7 +515,7 @@ func TestRunAssignmentAdd_PreservesSubmissionTags(t *testing.T) {
 		Classroom:             "dst",
 		Slug:                  "hello",
 		Name:                  "Hello",
-		Tmpl:                  &templateArg{Owner: "o", Repo: "hello-template", Branch: "main"},
+		Tmpl:                  &templateArg{Owner: "o", Repo: "hello-template"},
 		Mode:                  assignment.ModeIndividual,
 		Autograder:            "default",
 		SubmissionTags:        []string{"final"},
@@ -564,7 +564,7 @@ func TestRunAssignmentAdd_PreservesIncludeAllBranches(t *testing.T) {
 		Classroom:  "dst",
 		Slug:       "hello",
 		Name:       "Hello",
-		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template", Branch: "main"},
+		Tmpl:       &templateArg{Owner: "o", Repo: "hello-template"},
 		Mode:       assignment.ModeIndividual,
 		Autograder: "default",
 	})

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -1386,6 +1386,89 @@ describe("editAssignment (preserved-entry integration)", () => {
     )
   })
 
+  it("heals a legacy non-default stored branch to the template default on an unchanged-ref edit (#673)", async () => {
+    // A pre-#673 assignment whose stored template.branch is a NON-default
+    // branch (written when @branch was honored). Editing without changing the
+    // ref must re-resolve to the template's CURRENT default branch, not
+    // re-persist the stale one — a custom branch can't be honored.
+    const legacyEntry: Assignment = {
+      slug: SLUG,
+      name: "Homework 1",
+      mode: "individual",
+      autograder: "default",
+      feedback_pr: true,
+      template: { owner: ORG, repo: "hw1", branch: "legacy-branch" },
+    }
+    const assignmentsFile = {
+      schema: "classroom50/assignments/v1",
+      assignments: [legacyEntry],
+    }
+    const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64")
+    let committed = ""
+    const request = vi.fn(
+      async (url: string, init?: { method?: string; body?: unknown }) => {
+        const method = init?.method ?? "GET"
+        if (/\/repos\/[^/]+\/classroom50$/.test(url))
+          return { default_branch: "main" }
+        if (url.includes("/git/ref/heads/main")) return { object: { sha: "s" } }
+        if (url.includes("/git/commits/s")) return { tree: { sha: "t" } }
+        if (url.includes("/contents/cs50/assignments.json")) {
+          return {
+            type: "file",
+            encoding: "base64",
+            content: b64(JSON.stringify(assignmentsFile)),
+          }
+        }
+        // The template repo's LIVE default branch is `main`, not the stored
+        // `legacy-branch`.
+        if (url.includes(`/repos/${ORG}/hw1`) && !url.includes("classroom50")) {
+          return {
+            name: "hw1",
+            full_name: `${ORG}/hw1`,
+            private: false,
+            is_template: true,
+            default_branch: "main",
+          }
+        }
+        if (method === "POST" && url.endsWith("/git/trees")) {
+          committed = (init as { body?: { tree: { content: string }[] } }).body!
+            .tree[0].content
+          return { sha: "newtree" }
+        }
+        if (url.endsWith("/git/commits")) return { sha: "newcommit" }
+        if (url.endsWith("/git/refs/heads/main"))
+          return { object: { sha: "nc" } }
+        throw new Error(`unexpected request: ${method} ${url}`)
+      },
+    )
+    const requestRaw = vi.fn(async () => {
+      throw new GitHubAPIError({
+        status: 404,
+        url: "classroom.json",
+        message: "Not Found",
+        body: null,
+        rateLimit: {
+          limit: null,
+          remaining: null,
+          used: null,
+          reset: null,
+          resource: null,
+          retryAfter: null,
+        },
+      })
+    })
+    const client = { request, requestRaw } as unknown as GitHubClient
+
+    await editAssignment(
+      client,
+      editInput({ slug: SLUG, template_repo: "hw1" }),
+    )
+
+    const written = JSON.parse(committed) as { assignments: Assignment[] }
+    const entry = written.assignments.find((a) => a.slug === SLUG)!
+    expect(entry.template).toEqual({ owner: ORG, repo: "hw1", branch: "main" })
+  })
+
   // buildAssignmentEntry's student_permission branch (clamp group up to admin,
   // omit when it equals the mode default) is exercised through editAssignment's
   // write, asserting the entry that lands in the committed assignments.json —
@@ -2058,7 +2141,6 @@ describe("parseTemplateRef", () => {
     expect(parseTemplateRef("acme/starter", ORG)).toEqual({
       owner: "acme",
       repo: "starter",
-      branch: undefined,
     })
   })
 
@@ -2066,11 +2148,11 @@ describe("parseTemplateRef", () => {
     expect(parseTemplateRef("starter", ORG)).toEqual({
       owner: ORG,
       repo: "starter",
-      branch: undefined,
     })
   })
 
-  it("parses owner/repo@branch", () => {
+  it("accepts owner/repo@branch but carries the branch as advisory (#673)", () => {
+    // Tolerated but ignored — the assignment uses the template's default branch.
     expect(parseTemplateRef("acme/starter@spring-2026", ORG)).toEqual({
       owner: "acme",
       repo: "starter",
@@ -2093,23 +2175,22 @@ describe("parseTemplateRef", () => {
     expect(parseTemplateRef(raw, ORG)).toEqual({
       owner: "acme",
       repo: "starter",
-      branch: undefined,
     })
   })
 
-  it("reads the branch from a /tree/<branch> URL", () => {
+  it("carries a /tree/<branch> URL branch as advisory (tolerated, #673)", () => {
     expect(
       parseTemplateRef("https://github.com/acme/starter/tree/spring-2026", ORG),
     ).toEqual({ owner: "acme", repo: "starter", branch: "spring-2026" })
   })
 
-  it("keeps a slash-bearing branch from a /tree/ URL", () => {
+  it("carries a slash-bearing /tree/ branch as advisory (#673)", () => {
     expect(
       parseTemplateRef("https://github.com/acme/starter/tree/release/1.0", ORG),
     ).toEqual({ owner: "acme", repo: "starter", branch: "release/1.0" })
   })
 
-  it("accepts an @branch suffix on a URL", () => {
+  it("carries an @branch suffix on a URL as advisory (#673)", () => {
     expect(
       parseTemplateRef("https://github.com/acme/starter@spring-2026", ORG),
     ).toEqual({ owner: "acme", repo: "starter", branch: "spring-2026" })
@@ -2168,7 +2249,7 @@ describe("parseTemplateRef", () => {
 
   it("decodes a percent-encoded URL segment to the real name", () => {
     expect(parseTemplateRef("https://github.com/acme/star%2Dter", ORG)).toEqual(
-      { owner: "acme", repo: "star-ter", branch: undefined },
+      { owner: "acme", repo: "star-ter" },
     )
   })
 
@@ -2182,15 +2263,15 @@ describe("parseTemplateRef", () => {
     expect(localizedFor("   ")?.key).toBe("assignments.template.invalid.empty")
   })
 
-  it("localizes a branch containing '@'", () => {
+  it("rejects a multiple-@ ref as a shape error (#673)", () => {
     expect(localizedFor("acme/starter@a@b")?.key).toBe(
-      "assignments.template.invalid.branchHasAt",
+      "assignments.template.invalid.shape",
     )
   })
 
-  it("localizes an empty branch after '@'", () => {
+  it("rejects an empty branch after '@' as a shape error (#673)", () => {
     expect(localizedFor("acme/starter@  ")?.key).toBe(
-      "assignments.template.invalid.branchEmpty",
+      "assignments.template.invalid.shape",
     )
   })
 
@@ -2220,22 +2301,14 @@ describe("formatTemplateRef", () => {
     )
   })
 
-  it("keeps a branch the user typed", () => {
+  it("drops the advisory branch — a custom branch is ignored (#673)", () => {
     expect(
       formatTemplateRef({ owner: "acme", repo: "starter", branch: "dev" }),
-    ).toBe("acme/starter@dev")
+    ).toBe("acme/starter")
   })
 
   it("round-trips through parseTemplateRef", () => {
     const parsed = parseTemplateRef("https://github.com/acme/starter", "cs50")
-    expect(parseTemplateRef(formatTemplateRef(parsed), "cs50")).toEqual(parsed)
-  })
-
-  it("round-trips a branch-bearing ref", () => {
-    const parsed = parseTemplateRef(
-      "https://github.com/acme/starter/tree/dev",
-      "cs50",
-    )
     expect(parseTemplateRef(formatTemplateRef(parsed), "cs50")).toEqual(parsed)
   })
 })

--- a/web/src/domain/assignments/accessPrimitives.ts
+++ b/web/src/domain/assignments/accessPrimitives.ts
@@ -151,10 +151,16 @@ export async function withAcceptStep<T>(
 }
 
 // Parse a `--template` ref — `<owner>/<repo>[@<branch>]`, a bare `<repo>`
-// (owner defaults to the org), or a pasted GitHub URL. The `<owner>/<repo>`
-// form mirrors the CLI's parseTemplateRef so both write the same template
-// block; the bare name and the URL form are web-only (the CLI rejects both, and
-// nobody pastes a browser URL into a shell flag).
+// (owner defaults to the org), or a pasted GitHub URL. A `@branch` suffix (or a
+// `/tree/<branch>` URL) is TOLERATED but IGNORED (#673): GitHub's
+// create-from-template API can't select a source branch, and changing the
+// generated repo's default branch is blocked by org branch rulesets — so the
+// assignment always uses the template's own default branch. The parsed
+// `branch` is advisory only (the form warns it will be ignored, and a future
+// release may act on it); resolve/store never use it. To target a different
+// branch today, change the template repo's own default branch. The
+// `<owner>/<repo>` form mirrors the CLI's parseTemplateRef; the bare name and
+// the URL form are web-only.
 export type ParsedTemplate = { owner: string; repo: string; branch?: string }
 
 const GITHUB_URL_HOSTS = new Set(["github.com", "www.github.com"])
@@ -221,17 +227,18 @@ function parseGitHubUrl(raw: string): ParsedTemplate | null {
   if (!owner || !repoSegment) throw urlShapeError
   if (GITHUB_RESERVED_OWNERS.has(owner.toLowerCase())) throw urlShapeError
 
-  // A copied URL sometimes carries the branch as `repo@branch` rather than a
-  // `/tree/` path, so honor that suffix here too.
+  // A `@branch` suffix (or `/tree/<branch>`) is tolerated but ignored — carry
+  // it as an advisory `branch` (see ParsedTemplate, #673). A malformed `@`
+  // (multiple, or empty after `@`) is still a shape error.
   const [repoName, atBranch, ...extraAt] = repoSegment.split("@")
   if (extraAt.length > 0) throw urlShapeError
   const repo = repoName.replace(/\.git$/i, "")
   if (!repo) throw urlShapeError
   if (atBranch !== undefined && !atBranch) throw urlShapeError
 
-  // A branch may itself contain slashes (`release/1.0`), so everything after
-  // `/tree/` is the branch. Any other deep path (blob, pull, issues) isn't a
-  // template ref we can trust.
+  // A branch may contain slashes (`release/1.0`), so everything after `/tree/`
+  // is the branch. Any other deep path (blob, pull, issues) isn't a template
+  // ref we trust.
   let branch = atBranch || undefined
   if (rest.length > 0) {
     if (branch) throw urlShapeError
@@ -270,18 +277,19 @@ export function parseTemplateRef(
   const fromUrl = parseGitHubUrl(trimmed)
   if (fromUrl) return fromUrl
 
+  // Split off a tolerated-but-ignored `@branch` (see ParsedTemplate, #673). A
+  // malformed `@` (multiple, or empty after `@`) is a shape error.
   const [ownerRepo, branch, ...extraAt] = trimmed.split("@")
   if (extraAt.length > 0) {
     throw localizedError({
-      key: "assignments.template.invalid.branchHasAt",
+      key: "assignments.template.invalid.shape",
       params: { raw },
     })
   }
-  // A branch given as `@<whitespace>` is empty after trimming.
   const trimmedBranch = branch?.trim()
   if (trimmed.includes("@") && !trimmedBranch) {
     throw localizedError({
-      key: "assignments.template.invalid.branchEmpty",
+      key: "assignments.template.invalid.shape",
       params: { raw },
     })
   }
@@ -306,11 +314,10 @@ export function parseTemplateRef(
   )
 }
 
-// Render a parsed ref back to field text; the branch is appended only when one
-// is present.
+// Render a parsed ref back to field text. The advisory branch is dropped: a
+// custom branch is ignored (#673), so the canonical form is always owner/repo.
 export function formatTemplateRef(parsed: ParsedTemplate): string {
-  const ref = `${parsed.owner}/${parsed.repo}`
-  return parsed.branch ? `${ref}@${parsed.branch}` : ref
+  return `${parsed.owner}/${parsed.repo}`
 }
 
 // Advisory pre-flight verdict for a template ref: mirrors resolveTemplate's
@@ -527,7 +534,7 @@ export async function verifyTemplateAccess(
     return { kind: "private-out-of-org", ...canonical }
   }
 
-  const branch = parsed.branch || repo.default_branch
+  const branch = repo.default_branch
   if (!branch) {
     return { kind: "no-branch", ...canonical }
   }
@@ -607,10 +614,10 @@ export async function resolveTemplate(
     )
   }
 
-  const branch = parsed.branch || repo.default_branch
+  const branch = repo.default_branch
   if (!branch) {
     throw new Error(
-      `Template "${parsed.owner}/${parsed.repo}" has no default branch — specify one as ${parsed.owner}/${parsed.repo}@<branch>.`,
+      `Template "${parsed.owner}/${parsed.repo}" has no default branch — push a commit to it, then retry.`,
     )
   }
 
@@ -637,8 +644,7 @@ export async function resolveTemplate(
 
 // True when a parsed ref still points at the assignment's stored template, so
 // an edit can reuse the stored block instead of re-resolving live. Owner/repo
-// case-insensitive (per GitHub); an omitted @branch means "keep the stored
-// branch". Edit only.
+// case-insensitive (per GitHub). Edit only.
 export function templateRefUnchanged(
   parsed: ParsedTemplate,
   existing: Assignment["template"] | undefined,
@@ -646,8 +652,7 @@ export function templateRefUnchanged(
   if (!existing) return false
   const sameOwner = parsed.owner.toLowerCase() === existing.owner.toLowerCase()
   const sameRepo = parsed.repo.toLowerCase() === existing.repo.toLowerCase()
-  const sameBranch = !parsed.branch || parsed.branch === existing.branch
-  return sameOwner && sameRepo && sameBranch
+  return sameOwner && sameRepo
 }
 
 // 404 -> false, 200 -> true, else throws. Wraps repoContentsPathExists for the

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -532,14 +532,16 @@ async function buildAssignmentEntry(
   if (input.template_repo.trim()) {
     const parsedTemplate = parseTemplateRef(input.template_repo, input.org)
     if (templateRefUnchanged(parsedTemplate, existingTemplate)) {
-      // Ref unchanged, but still re-validate live via resolveTemplate — it
-      // still fails closed before any commit on a template that went truly
-      // unusable (deleted, no longer a template, out-of-org private). Reuse its
-      // needsTeamGrant so an unchanged-ref save re-affirms the (idempotent) team
-      // read: a grant GitHub or a prior failure dropped is repaired on the next
-      // edit, not left stranded.
+      // Ref unchanged, but still re-resolve live via resolveTemplate — it fails
+      // closed before any commit on a template that went truly unusable
+      // (deleted, no longer a template, out-of-org private). Use the RESOLVED
+      // block (not the stored one) so an edit heals a legacy non-default
+      // `branch` down to the template's current default (#673): a custom branch
+      // can't be honored, so an unrelated edit shouldn't re-persist a stale one.
+      // Reuse needsTeamGrant so the unchanged-ref save re-affirms the
+      // (idempotent) team read a prior failure may have dropped.
       const resolved = await resolveTemplate(client, input.org, parsedTemplate)
-      template = existingTemplate!
+      template = resolved.template
       needsTeamGrant = resolved.needsTeamGrant
     } else {
       const resolved = await resolveTemplate(client, input.org, parsedTemplate)

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1508,9 +1508,7 @@
         "empty": "Enter a template repository.",
         "shape": "\"{{raw}}\" isn't a repository reference. Use <owner>/<repo>, a repository name, or paste a GitHub repository URL.",
         "urlShape": "\"{{raw}}\" isn't a GitHub repository URL. Link to the repository itself, like https://github.com/<owner>/<repo>.",
-        "notGithubHost": "\"{{raw}}\" is on {{host}}, not github.com. Classroom 50 can only copy templates hosted on GitHub.",
-        "branchHasAt": "\"{{raw}}\" has more than one \"@\". Use <owner>/<repo>@<branch>.",
-        "branchEmpty": "\"{{raw}}\" is missing a branch name after \"@\"."
+        "notGithubHost": "\"{{raw}}\" is on {{host}}, not github.com. Classroom 50 can only copy templates hosted on GitHub."
       },
       "search": {
         "loading": "Loading templates…",
@@ -1531,6 +1529,7 @@
       "okPublicInOrg": "Public template, branch <branch>{{branch}}</branch>. Students can access it.",
       "okPrivateInOrg": "Private template, branch <branch>{{branch}}</branch>. Students can access it.",
       "nonMainBranch": "This template's default branch is <branch>{{branch}}</branch>, not \"main\". The assignment will use it, and student autograding keys off that branch.",
+      "branchIgnored": "A custom branch (<branch>{{branch}}</branch>) was specified and will be ignored — the assignment copies the template's default branch. To use a different branch, change the template repository's default branch.",
       "okVerify": "Reachable in {{owner}} (branch <branch>{{branch}}</branch>). If {{owner}} restricts third-party apps, students can't copy it until an owner approves Classroom 50.",
       "notVisible": "{{owner}}/{{repo}} isn't visible to you. Make it public or copy it into {{org}}.",
       "notTemplate": "{{owner}}/{{repo}} isn't a template repo. Enable it in the repo's Settings.",
@@ -1549,7 +1548,7 @@
       "privateForkNoParent": "{{owner}}/{{repo}} is a private fork (branch <branch>{{branch}}</branch>). <important>Important: the fork's upstream org must keep Classroom 50 approved — if that approval is ever removed, students will fail to accept (HTTP 403).</important> To avoid depending on the upstream org, use a fresh (non-fork) repo: create a new repo and copy the fork's contents into it.",
       "unknown": "Couldn't verify {{owner}}/{{repo}} now. It's rechecked when students accept.",
       "privateOutOfOrg": "{{owner}}/{{repo}} is private and outside {{org}}. Make it public or copy it into {{org}}.",
-      "noBranch": "{{owner}}/{{repo}} has no default branch. Push a commit, or add <hint/>.",
+      "noBranch": "{{owner}}/{{repo}} has no default branch. Push a commit to it, then retry.",
       "rateLimited": "GitHub rate limit hit. Try again shortly.",
       "policyLink": "Check {{owner}}'s OAuth app policy",
       "reconcile": {

--- a/web/src/pages/assignments/TemplateField.test.tsx
+++ b/web/src/pages/assignments/TemplateField.test.tsx
@@ -17,9 +17,16 @@ vi.mock("react-i18next", async (importOriginal) => {
 })
 
 const verifyTemplateAccess = vi.fn()
-vi.mock("@/domain/assignments", () => ({
-  verifyTemplateAccess: (...a: unknown[]) => verifyTemplateAccess(...a),
-}))
+vi.mock("@/domain/assignments", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/domain/assignments")>()
+  return {
+    // parseTemplateRef/formatTemplateRef are pure — keep the real ones so
+    // canonicalTemplateRef (used by the rendered picker) resolves owner/repo.
+    parseTemplateRef: actual.parseTemplateRef,
+    formatTemplateRef: actual.formatTemplateRef,
+    verifyTemplateAccess: (...a: unknown[]) => verifyTemplateAccess(...a),
+  }
+})
 
 const teamHasRepoAccess = vi.fn()
 // The field now renders TemplateRepoPicker, which reaches for the org template
@@ -129,6 +136,32 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   __resetGitHubHealthForTest()
+})
+
+describe("TemplateField — custom branch ignored (#673)", () => {
+  const okPublic = {
+    kind: "ok",
+    owner: "acme",
+    repo: "starter",
+    branch: "main",
+    visibility: "public",
+    inOrg: false,
+  }
+
+  it("warns that a typed @branch will be ignored", async () => {
+    verifyTemplateAccess.mockResolvedValue(okPublic)
+    renderField({ field: fakeField("acme/starter@dev") })
+    expect(
+      await screen.findByText("assignments.template.branchIgnored"),
+    ).toBeTruthy()
+  })
+
+  it("shows no branch-ignored warning for a plain owner/repo", async () => {
+    verifyTemplateAccess.mockResolvedValue(okPublic)
+    renderField({ field: fakeField("acme/starter") })
+    await screen.findByText("assignments.template.okPublic", { exact: false })
+    expect(screen.queryByText("assignments.template.branchIgnored")).toBeNull()
+  })
 })
 
 describe("TemplateField — inline Fix template access", () => {

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -16,6 +16,7 @@ import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
 import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import {
+  parseTemplateRef,
   verifyTemplateAccess,
   type TemplateAccessVerification,
 } from "@/domain/assignments"
@@ -63,6 +64,19 @@ export const TemplateField = ({
   const rawValue = field.state.value
   const trimmedValue = rawValue.trim()
   const debouncedValue = useDebouncedValue(trimmedValue, 500)
+
+  // A `@branch` (or `/tree/<branch>`) suffix is tolerated but ignored (#673):
+  // the assignment uses the template's own default branch. Surface the branch
+  // the teacher typed so the note can warn it won't take effect. Parse is
+  // best-effort — an unparseable ref has no branch to warn about.
+  let ignoredBranch: string | undefined
+  if (org && trimmedValue) {
+    try {
+      ignoredBranch = parseTemplateRef(trimmedValue, org).branch
+    } catch {
+      ignoredBranch = undefined
+    }
+  }
 
   // viewerLogin decides ok vs ok-verify, so wait for it — verifying mid-load
   // would show a verdict that flips once the profile resolves.
@@ -171,6 +185,7 @@ export const TemplateField = ({
         verification={verification}
         pending={pending}
         org={org}
+        ignoredBranch={ignoredBranch}
         teamHasAccess={teamHasAccess}
         onRecheck={() => verificationQuery.refetch()}
         isRechecking={verificationQuery.isFetching}
@@ -244,6 +259,7 @@ const TemplateVerificationNote = ({
   verification,
   pending,
   org,
+  ignoredBranch,
   teamHasAccess,
   onRecheck,
   isRechecking,
@@ -252,6 +268,10 @@ const TemplateVerificationNote = ({
   verification: TemplateAccessVerification | null
   pending: boolean
   org?: string
+  // A `@branch` (or `/tree/<branch>`) the teacher typed. Tolerated but ignored
+  // (#673) — the assignment uses the template's default branch — so warn
+  // without blocking. Undefined when no branch was specified.
+  ignoredBranch?: string
   // For an in-org private template: true if the classroom team already has
   // read, false if granted on create, undefined if N/A or unresolved.
   teamHasAccess?: boolean
@@ -277,6 +297,18 @@ const TemplateVerificationNote = ({
   if (!verification || verification.kind === "empty") return null
 
   const fallbackOrg = org ?? t("assignments.template.fallbackOrg")
+
+  // A typed `@branch` is tolerated but ignored (#673): warn it won't take
+  // effect and the template's default branch is used. Non-blocking.
+  const ignoredBranchNote = ignoredBranch ? (
+    <Note tone="warning" icon={Info}>
+      <Trans
+        i18nKey="assignments.template.branchIgnored"
+        values={{ branch: ignoredBranch }}
+        components={{ branch: <Code /> }}
+      />
+    </Note>
+  ) : null
 
   // Working assumption is `main`. When a verified template resolves to another
   // default branch, the assignment (and student autograding) key off that
@@ -306,10 +338,11 @@ const TemplateVerificationNote = ({
     statusDescription,
   })
 
-  if (!nonMainNote) return verdict
+  if (!nonMainNote && !ignoredBranchNote) return verdict
   return (
     <>
       {verdict}
+      {ignoredBranchNote}
       {nonMainNote}
     </>
   )
@@ -600,14 +633,10 @@ function renderTemplateVerdict({
     case "no-branch":
       return (
         <Note tone="error" icon={AlertTriangle}>
-          <Trans
-            i18nKey="assignments.template.noBranch"
-            values={{ owner: verification.owner, repo: verification.repo }}
-            // The literal @<branch> hint lives in the component (not the
-            // translation value) so its angle brackets never collide with the
-            // Trans tag parser.
-            components={{ hint: <Code>@&lt;branch&gt;</Code> }}
-          />
+          {t("assignments.template.noBranch", {
+            owner: verification.owner,
+            repo: verification.repo,
+          })}
         </Note>
       )
 

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -719,7 +719,9 @@ describe("toSubmitValues — runtime field clearing", () => {
     expect(out.template_repo).toBe("acme/starter")
   })
 
-  it("surfaces a non-main stored template branch as owner/repo@branch (#673)", () => {
+  it("surfaces a stored template as owner/repo, dropping any stored branch (#673)", () => {
+    // A custom source branch isn't supported: the edit form always shows just
+    // owner/repo, regardless of the stored (resolved-default) branch.
     const custom = assignmentToFormValues({
       slug: "hw",
       name: "HW",
@@ -727,8 +729,7 @@ describe("toSubmitValues — runtime field clearing", () => {
       autograder: "default",
       template: { owner: "acme", repo: "starter", branch: "spring-2026" },
     })
-    expect(custom.template_repo).toBe("acme/starter@spring-2026")
-    // The overwhelming default ("main") is omitted so the common case stays clean.
+    expect(custom.template_repo).toBe("acme/starter")
     const mainBranch = assignmentToFormValues({
       slug: "hw2",
       name: "HW2",

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -720,15 +720,10 @@ export const assignmentToFormValues = (
     slug: assignment.slug,
     description: assignment.description ?? "",
     mode: assignment.mode === "group" ? "group" : "individual",
-    // Surface a non-default stored branch as `owner/repo@branch` so an edit
-    // doesn't silently drop it (#673). We can't know the template's live default
-    // branch from stored state, so we omit the suffix only for "main" (GitHub's
-    // overwhelming default, matching the CLI's own non-main warning); any other
-    // stored branch round-trips visibly instead of appearing to reset.
+    // A custom source branch isn't supported (#673); the stored branch is always
+    // the template's own default, so surface just `owner/repo`.
     template_repo: assignment.template
-      ? assignment.template.branch && assignment.template.branch !== "main"
-        ? `${assignment.template.owner}/${assignment.template.repo}@${assignment.template.branch}`
-        : `${assignment.template.owner}/${assignment.template.repo}`
+      ? `${assignment.template.owner}/${assignment.template.repo}`
       : "",
     due_date: utcIsoToDatetimeLocalValue(assignment.due),
     available_from_date: utcIsoToDatetimeLocalValue(assignment.available_from),

--- a/web/src/pages/assignments/templateRefNormalize.test.ts
+++ b/web/src/pages/assignments/templateRefNormalize.test.ts
@@ -31,9 +31,9 @@ describe("canonicalTemplateRef", () => {
     )
   })
 
-  it("preserves a branch the teacher typed", () => {
+  it("drops a branch the teacher typed (custom branch unsupported, #673)", () => {
     expect(canonicalTemplateRef(ok(ORG, "starter", "dev"), "starter@dev")).toBe(
-      "cs50/starter@dev",
+      "cs50/starter",
     )
   })
 

--- a/web/src/pages/assignments/templateRefNormalize.ts
+++ b/web/src/pages/assignments/templateRefNormalize.ts
@@ -50,20 +50,11 @@ export function canonicalTemplateRef(
   const trimmed = typed.trim()
   if (!trimmed) return null
 
-  let typedBranch: string | undefined
-  try {
-    // The branch comes from what was typed, never from the verdict: a verdict's
-    // `branch` may be the repo's resolved default, and echoing that back would
-    // silently pin the assignment to today's default branch (#673).
-    typedBranch = parseTemplateRef(trimmed, verification.owner).branch
-  } catch {
-    return null
-  }
-
+  // A custom source branch isn't supported (#673), so the canonical form is
+  // always just `owner/repo`; the parse rejects any `@branch` before we get here.
   const canonical = formatTemplateRef({
     owner: verification.owner,
     repo: verification.repo,
-    branch: typedBranch,
   })
   // Returning null when nothing changes keeps callers from writing the value
   // back to the form on every render.


### PR DESCRIPTION
## Summary

Closes #673. A template's custom source branch (`owner/repo@branch`, a `repo@branch` URL, or a `/tree/<branch>` URL) is now **tolerated but ignored**, with a clear warning that it won't take effect. Assignments always use the template repository's own default branch. This applies consistently to both the web app and the `gh-teacher` CLI.

A custom source branch can't be honored in this product: GitHub's create-from-template API has no source-branch parameter, and changing a generated student repo's default branch is blocked by organization branch rulesets (the accept flow acts as a repo admin, not an org admin). Rather than reject a `@branch` (a valid thing to type) or silently drop it, we accept it, ignore it, and warn — leaving a clean seam for a future release that may act on it. To use a different branch today, change the template repository's default branch.

## Changes

**Web**

- `parseTemplateRef` / `parseGitHubUrl` accept `owner/repo@branch`, `repo@branch`, and `/tree/<branch>` again, carrying the branch as an advisory field only; a malformed `@` (empty branch or multiple `@`) is still rejected. `resolveTemplate` / `verifyTemplateAccess` always use the template's `default_branch`, and `formatTemplateRef` canonicalizes to `owner/repo`.
- The assignment form shows a non-blocking warning when a branch is specified (`assignments.template.branchIgnored`).
- On edit, an unchanged-ref save re-resolves to the template's current default branch, healing a legacy non-default stored branch instead of re-persisting it.

**CLI (gh-teacher)**

- `--template owner/repo@branch` is accepted; the branch is ignored and a warning is printed to stderr. A malformed `@` is still rejected. Help text updated. Web and CLI now behave identically.

No schema change: `template.branch` stays required and is always the resolved default branch.

## Test plan

- [x] Web: `tsc`, `eslint`, `prettier`, `arch:validate`, node vitest suite (4205 tests), and `audit_i18n.py --strict` all pass
- [x] CLI: `gh-teacher` (+ shared, gh-student) build; `gh-teacher` tests pass; `golangci-lint` clean (0 issues) and `golangci-lint fmt` clean
- [x] New tests: web accepts `@branch` as advisory + shows the ignored-branch warning + heals a legacy branch on edit; CLI parses `@branch` and captures the ignored branch, rejecting only a malformed `@`
- [ ] Manual (web): entering `owner/repo@branch` shows the \"branch will be ignored\" warning and the assignment uses the template default; a plain `owner/repo` shows no warning
- [ ] Manual (CLI): `gh teacher assignment add … --template owner/repo@branch` prints the ignored-branch warning and stores the template's default branch