### PR TITLE
fix: raise the classroom and assignment slug cap to 100 characters

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -864,6 +864,23 @@ func is422AlreadyExists(httpErr *githubapi.HTTPError) bool {
 	return has422Message(httpErr, "already exists")
 }
 
+// is422NameTooLong matches GitHub's 422 for a repo name over its 100-char
+// limit. The composed `<classroom>-<assignment>-<username>` name can exceed 100
+// even when each part is individually legal (foundation50/classroom50#691), so
+// it must be told apart from the "already exists" 422 (whose recovery GET would
+// otherwise 404 on the never-created repo).
+func is422NameTooLong(httpErr *githubapi.HTTPError) bool {
+	return has422Message(httpErr, "too long")
+}
+
+// repoNameTooLongError names the cause and the fix (a shorter classroom or
+// assignment slug) rather than surfacing GitHub's raw validation error.
+func repoNameTooLongError(repoName string, cause error) error {
+	return fmt.Errorf("the repository name %q is %d characters, over GitHub's 100-character "+
+		"limit, so it couldn't be created. Ask your teacher to shorten the classroom or "+
+		"assignment slug, then run accept again: %w", repoName, len(repoName), cause)
+}
+
 // has422Message gates httpErrorMentions on a 422 status, so a caller that isn't
 // already switching on the status can't accept the same wording arriving from an
 // unrelated failure.
@@ -1204,6 +1221,9 @@ func createTemplatedPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI
 		if httpErr, ok := errors.AsType[*githubapi.HTTPError](err); ok {
 			switch httpErr.StatusCode {
 			case http.StatusUnprocessableEntity:
+				if is422NameTooLong(httpErr) {
+					return "", "", "", false, repoNameTooLongError(newRepoName, err)
+				}
 				if is422AlreadyExists(httpErr) {
 					getPath := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(newRepoName))
 					if getErr := client.Get(getPath, &created); getErr != nil {
@@ -1329,6 +1349,9 @@ func createEmptyPrivateAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, ve
 		if httpErr, ok := errors.AsType[*githubapi.HTTPError](err); ok {
 			switch httpErr.StatusCode {
 			case http.StatusUnprocessableEntity:
+				if is422NameTooLong(httpErr) {
+					return "", "", "", false, repoNameTooLongError(newRepoName, err)
+				}
 				if is422AlreadyExists(httpErr) {
 					getPath := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(newRepoName))
 					if getErr := client.Get(getPath, &created); getErr != nil {

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -864,11 +864,9 @@ func is422AlreadyExists(httpErr *githubapi.HTTPError) bool {
 	return has422Message(httpErr, "already exists")
 }
 
-// is422NameTooLong matches GitHub's 422 for a repo name over its 100-char
-// limit. The composed `<classroom>-<assignment>-<username>` name can exceed 100
-// even when each part is individually legal (foundation50/classroom50#691), so
-// it must be told apart from the "already exists" 422 (whose recovery GET would
-// otherwise 404 on the never-created repo).
+// is422NameTooLong matches GitHub's 422 for an over-100-char repo name. Told
+// apart from the "already exists" 422 whose recovery GET would otherwise 404 on
+// the never-created repo (foundation50/classroom50#691).
 func is422NameTooLong(httpErr *githubapi.HTTPError) bool {
 	return has422Message(httpErr, "too long")
 }

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -228,6 +228,38 @@ func TestCreateTemplatedPrivateAssignmentRepoInOrg(t *testing.T) {
 		}
 	})
 
+	// #691: a composed repo name over GitHub's 100-char limit must surface a
+	// legible "too long" error, NOT be mistaken for already-exists (whose
+	// follow-up GET would 404 on the never-created repo).
+	t.Run("422 name-too-long returns an actionable error, no follow-up GET", func(t *testing.T) {
+		var getAttempted bool
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/cs50/hello-template/generate", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"Repository creation failed:","errors":[{"resource":"Repository","field":"name","code":"custom","message":"name is too long (maximum is 100 characters)"}]}`))
+		})
+		mux.HandleFunc("/repos/o/cs-principles-hello-alice", func(w http.ResponseWriter, r *http.Request) {
+			getAttempted = true
+			http.NotFound(w, r)
+		})
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+		client := newTestRESTClient(t, server)
+
+		var out bytes.Buffer
+		_, _, _, already, err := createTemplatedPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "hello", "o", tmpl, nil, false)
+		if err == nil || !strings.Contains(err.Error(), "too long") {
+			t.Fatalf("err = %v, want a 'too long' error", err)
+		}
+		if already {
+			t.Error("alreadyExisted = true, want false on a name-too-long 422")
+		}
+		if getAttempted {
+			t.Error("no follow-up GET should run on the name-too-long path")
+		}
+	})
+
 	t.Run("404 on generate → cross-org visibility message", func(t *testing.T) {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/repos/cs50/hello-template/generate", func(w http.ResponseWriter, r *http.Request) {
@@ -461,6 +493,37 @@ func TestCreateEmptyPrivateAssignmentRepoInOrg(t *testing.T) {
 		}
 		if fullName != "o/cs-principles-solo-alice" {
 			t.Errorf("fullName = %q, want the existing repo from the follow-up GET", fullName)
+		}
+	})
+
+	// #691: an over-100-char composed repo name must surface a legible "too
+	// long" error, not be mistaken for already-exists.
+	t.Run("422 name-too-long returns an actionable error, no follow-up GET", func(t *testing.T) {
+		var getAttempted bool
+		mux := http.NewServeMux()
+		mux.HandleFunc("/orgs/o/repos", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"Repository creation failed:","errors":[{"resource":"Repository","field":"name","code":"custom","message":"name is too long (maximum is 100 characters)"}]}`))
+		})
+		mux.HandleFunc("/repos/o/cs-principles-solo-alice", func(w http.ResponseWriter, r *http.Request) {
+			getAttempted = true
+			http.NotFound(w, r)
+		})
+		server := httptest.NewServer(mux)
+		t.Cleanup(server.Close)
+		client := newTestRESTClient(t, server)
+
+		var out bytes.Buffer
+		_, _, _, already, err := createEmptyPrivateAssignmentRepoInOrg(client, ui.NewForced(&out, false), false, "alice", "cs-principles", "solo", "o", true, nil)
+		if err == nil || !strings.Contains(err.Error(), "too long") {
+			t.Fatalf("err = %v, want a 'too long' error", err)
+		}
+		if already {
+			t.Error("alreadyExisted = true, want false on a name-too-long 422")
+		}
+		if getAttempted {
+			t.Error("no follow-up GET should run on the name-too-long path")
 		}
 	})
 }

--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -789,10 +789,10 @@ func SlugExistsFold(entries []AssignmentEntry, slug string) bool {
 	return false
 }
 
-// slugMaxLen is the max slug length validate.ShortName accepts (39 chars).
+// slugMaxLen is the max slug length validate.ShortName accepts (100 chars).
 // Duplicated here (not imported) so the pure data layer stays free of the
 // command seam.
-const slugMaxLen = 39
+const slugMaxLen = 100
 
 // slugSuffixRe splits a slug into base + optional trailing `-N` (N >= 1):
 // `hello` → ("hello", 0); `hello-2` → ("hello", 2).

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -1903,9 +1903,9 @@ func TestNextAvailableSlug(t *testing.T) {
 }
 
 // TestNextAvailableSlug_OverflowsCap pins that an auto-suffix exceeding the
-// 39-char cap returns an actionable error rather than a too-long candidate.
+// 100-char cap returns an actionable error rather than a too-long candidate.
 func TestNextAvailableSlug_OverflowsCap(t *testing.T) {
-	base := strings.Repeat("a", 39) // already at the cap; any "-N" overflows
+	base := strings.Repeat("a", 100) // already at the cap; any "-N" overflows
 	entries := entriesWithSlugs(base)
 	if _, err := NextAvailableSlug(entries, base); err == nil {
 		t.Fatal("expected an over-cap auto-suffix error, got nil")

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -993,6 +993,16 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			"Warning: %s/%s/%s is %d bytes — approaching GitHub's ~1 MiB contents-API ceiling. Past that, the API returns encoding:\"none\" and future `gh teacher assignment add/remove` calls will fail to read the file. Consider splitting the classroom or shrinking per-entry fields.\n",
 			org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), lastEncodedSize)
 	}
+	// #691: the classroom+slug can each be individually valid yet compose into
+	// a `<classroom>-<assignment>-<username>` student-repo name past GitHub's
+	// 100-char limit, which fails at every student's accept. Warn the teacher
+	// now — nothing budgets the segments against each other, so this is the
+	// only pre-accept signal.
+	if worst, overflows := validate.ComposedRepoNameOverflows(classroom, slug); overflows {
+		_, _ = fmt.Fprintf(errOut,
+			"Warning: student repos are named `<classroom>-<assignment>-<username>`; %q + %q reaches %d characters with a 39-char username, over GitHub's %d-char repo-name limit. Students with long usernames won't be able to accept. Shorten the classroom short-name or the assignment slug.\n",
+			classroom, slug, worst, validate.GitHubRepoNameMaxLen)
+	}
 	_, _ = fmt.Fprintf(errOut, "Students can now run: gh student accept %s %s %s\n", org, classroom, slug)
 	return nil
 }

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -993,10 +993,9 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			"Warning: %s/%s/%s is %d bytes — approaching GitHub's ~1 MiB contents-API ceiling. Past that, the API returns encoding:\"none\" and future `gh teacher assignment add/remove` calls will fail to read the file. Consider splitting the classroom or shrinking per-entry fields.\n",
 			org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), lastEncodedSize)
 	}
-	// #691: the classroom+slug can each be individually valid yet compose into
-	// a `<classroom>-<assignment>-<username>` student-repo name past GitHub's
-	// 100-char limit, which fails at every student's accept. Warn the teacher
-	// now — nothing budgets the segments against each other, so this is the
+	// #691: classroom and slug can each be valid yet compose into a
+	// `<classroom>-<assignment>-<username>` name past GitHub's 100-char limit,
+	// failing every accept. Nothing budgets the segments, so warn here — the
 	// only pre-accept signal.
 	if worst, overflows := validate.ComposedRepoNameOverflows(classroom, slug); overflows {
 		_, _ = fmt.Fprintf(errOut,

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -90,7 +90,7 @@ func assignmentAddCmd() *cobra.Command {
 		Short: "Add or upsert an assignment in assignments.json",
 		Long: "Register an assignment — its template repo and the autograder it\n" +
 			"runs against — in <org>/classroom50/<classroom>/assignments.json.\n\n" +
-			"`<slug>` must match ^[a-z0-9][a-z0-9-]{1,38}$ (the same shape as\n" +
+			"`<slug>` must match ^[a-z0-9][a-z0-9-]{1,99}$ (the same shape as\n" +
 			"classroom short-names) because student repos are named\n" +
 			"`<classroom>-<slug>-<username>`. Only --name is required;\n" +
 			"--template is optional (omit it for a template-less assignment).\n" +

--- a/cli/gh-teacher/internal/classroom/classroom.go
+++ b/cli/gh-teacher/internal/classroom/classroom.go
@@ -85,8 +85,8 @@ func classroomAddCmd() *cobra.Command {
 		Long: "Create the directory <short-name>/ inside <org>/classroom50\n" +
 			"and populate it with a four-file scaffold: classroom.json,\n" +
 			"assignments.json, roster.csv, and scores.json.\n\n" +
-			"Short-name rules (must match ^[a-z0-9][a-z0-9-]{1,38}$):\n" +
-			"  - 2-39 characters total\n" +
+			"Short-name rules (must match ^[a-z0-9][a-z0-9-]{1,99}$):\n" +
+			"  - 2-100 characters total\n" +
 			"  - lowercase letters, digits, or hyphens\n" +
 			"  - must start with a letter or digit (not a hyphen)\n\n" +
 			"These mirror GitHub's repo-name constraints because the\n" +

--- a/cli/gh-teacher/internal/classroom/classroom_test.go
+++ b/cli/gh-teacher/internal/classroom/classroom_test.go
@@ -57,13 +57,14 @@ func TestShortNamePattern(t *testing.T) {
 		{"intro-java", true},
 		{"a1", true},
 		{"0class", true},
-		{"abcdefghijklmnopqrstuvwxyz0123456789-ab", true}, // 39 chars (max)
+		// 100 chars (max): 1 leading alnum + 99 following.
+		{"a" + strings.Repeat("b", 99), true},
 		// Invalid — first char must be alnum.
 		{"-cs50", false},
-		// Invalid — single char (regex requires 2-39).
+		// Invalid — single char (regex requires 2-100).
 		{"a", false},
-		// Invalid — 40 chars.
-		{"abcdefghijklmnopqrstuvwxyz0123456789-abc", false},
+		// Invalid — 101 chars.
+		{"a" + strings.Repeat("b", 100), false},
 		// Invalid — uppercase.
 		{"CS-50", false},
 		{"Cs-principles", false},

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -57,7 +57,7 @@ func classroomMigrateCmd() *cobra.Command {
 			"--short-name overrides the auto-derived classroom directory\n" +
 			"name. Migrate slugifies the source classroom name (lowercase,\n" +
 			"non-alnum → '-', collapsed, trimmed) and validates against\n" +
-			"^[a-z0-9][a-z0-9-]{1,38}$. Pass --short-name explicitly if\n" +
+			"^[a-z0-9][a-z0-9-]{1,99}$. Pass --short-name explicitly if\n" +
 			"the derived value fails validation.\n\n" +
 			"--template-suffix appends a string to every target template\n" +
 			"repo name (e.g., --template-suffix migrated → readability-migrated).\n" +

--- a/cli/gh-teacher/internal/classroom/migrate_translate.go
+++ b/cli/gh-teacher/internal/classroom/migrate_translate.go
@@ -22,7 +22,7 @@ var shortNameDeriveReplace = regexp.MustCompile(`[^a-z0-9]+`)
 
 // deriveShortName slugifies a free-form classroom name into a value that passes
 // ShortNamePattern (lowercase → replace non-alnum with `-` → collapse → trim →
-// truncate to 39 → validate). On failure returns an error asking for an
+// truncate to 100 → validate). On failure returns an error asking for an
 // explicit --short-name.
 func deriveShortName(raw string) (string, error) {
 	lowered := strings.ToLower(strings.TrimSpace(raw))
@@ -31,8 +31,8 @@ func deriveShortName(raw string) (string, error) {
 	}
 	slug := shortNameDeriveReplace.ReplaceAllString(lowered, "-")
 	slug = strings.Trim(slug, "-")
-	if len(slug) > 39 {
-		slug = strings.TrimRight(slug[:39], "-")
+	if len(slug) > 100 {
+		slug = strings.TrimRight(slug[:100], "-")
 	}
 	if !validate.ShortNamePattern.MatchString(slug) {
 		return "", fmt.Errorf("could not derive a valid short-name from %q (got %q after slugify, fails %s) — pass --short-name <name> explicitly", raw, slug, validate.ShortNamePatternDescription)

--- a/cli/gh-teacher/internal/classroom/migrate_translate_test.go
+++ b/cli/gh-teacher/internal/classroom/migrate_translate_test.go
@@ -26,7 +26,7 @@ func TestDeriveShortName(t *testing.T) {
 		{"real-export name 2", "CS50 Stress Test-classroom-1", "cs50-stress-test-classroom-1", false},
 		{"slashes and spaces", "Intro to CS / Section 1", "intro-to-cs-section-1", false},
 		{"apostrophe + em-dash", "Spring '26 — Honors", "spring-26-honors", false},
-		{"too long, truncates cleanly", "abcdefghij-abcdefghij-abcdefghij-abcdefghij", "abcdefghij-abcdefghij-abcdefghij-abcdef", false},
+		{"too long, truncates cleanly", strings.Repeat("abcdefghij-", 10), strings.Repeat("abcdefghij-", 9) + "a", false},
 		{"leading and trailing punctuation", "—Hello—", "hello", false},
 		{"empty", "", "", true},
 		{"whitespace only", "   ", "", true},

--- a/cli/gh-teacher/internal/validate/validate.go
+++ b/cli/gh-teacher/internal/validate/validate.go
@@ -75,6 +75,28 @@ func OrgClassroom(args []string) (org, classroom string, err error) {
 	return org, classroom, nil
 }
 
+// GitHubRepoNameMaxLen is GitHub's hard limit on a repository name. The
+// student-repo name is `<classroom>-<assignment>-<username>`, so a classroom
+// and slug that each individually pass ShortName can still compose past this.
+const GitHubRepoNameMaxLen = 100
+
+// GitHubLoginMaxLen is GitHub's maximum account/org login length, used as the
+// worst-case `<username>` when budgeting the composed student-repo name.
+const GitHubLoginMaxLen = 39
+
+// ComposedRepoNameOverflows reports whether the longest student-repo name a
+// classroom+assignment pair can produce — `<classroom>-<assignment>-<username>`
+// with a worst-case 39-char username and the two joining hyphens — exceeds
+// GitHub's repo-name limit. Both parts can be individually valid yet compose
+// past the ceiling (foundation50/classroom50#691); callers warn the teacher at
+// create time rather than letting every student's accept fail. Returns the
+// worst-case length alongside the boolean so the caller can report it.
+func ComposedRepoNameOverflows(classroom, slug string) (worstCase int, overflows bool) {
+	// classroom + "-" + slug + "-" + <=39-char username.
+	worstCase = len(classroom) + 1 + len(slug) + 1 + GitHubLoginMaxLen
+	return worstCase, worstCase > GitHubRepoNameMaxLen
+}
+
 // ScopeListContains reports whether the comma-separated OAuth scope
 // list (an X-OAuth-Scopes header value) includes want.
 func ScopeListContains(scopes, want string) bool {

--- a/cli/gh-teacher/internal/validate/validate.go
+++ b/cli/gh-teacher/internal/validate/validate.go
@@ -16,12 +16,11 @@ import (
 // student-repo names and the contents/tree API. Exposed for the few call sites
 // that match directly; most callers should use ShortName for the standard error.
 //
-// The cap is 100 per segment, matching GitHub's repo-name limit. It is NOT a
-// full guarantee: `<classroom>-<assignment>-<username>` can exceed 100 even
-// though each part is legal, and nothing here budgets the three against each
-// other. Deciding that split (a combined pre-flight check, an asymmetric cap,
-// or a shorter derived repo name) is open — see foundation50/classroom50#691.
-// Until then an overflow surfaces as a legible "name too long" error at accept.
+// The cap is 100 per segment, matching GitHub's repo-name limit — NOT a full
+// guarantee: `<classroom>-<assignment>-<username>` can exceed 100 even when each
+// part is legal. Budgeting the segments against each other is open work
+// (foundation50/classroom50#691); until then an overflow surfaces as a legible
+// "name too long" error at accept.
 var ShortNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,99}$`)
 
 // ShortNamePatternDescription: human-readable summary of ShortNamePattern,
@@ -75,22 +74,18 @@ func OrgClassroom(args []string) (org, classroom string, err error) {
 	return org, classroom, nil
 }
 
-// GitHubRepoNameMaxLen is GitHub's hard limit on a repository name. The
-// student-repo name is `<classroom>-<assignment>-<username>`, so a classroom
-// and slug that each individually pass ShortName can still compose past this.
+// GitHubRepoNameMaxLen is GitHub's hard limit on a repository name; the
+// student-repo name `<classroom>-<assignment>-<username>` is measured against it.
 const GitHubRepoNameMaxLen = 100
 
-// GitHubLoginMaxLen is GitHub's maximum account/org login length, used as the
-// worst-case `<username>` when budgeting the composed student-repo name.
+// GitHubLoginMaxLen is GitHub's maximum login length — the worst-case
+// `<username>` when budgeting the composed student-repo name.
 const GitHubLoginMaxLen = 39
 
 // ComposedRepoNameOverflows reports whether the longest student-repo name a
-// classroom+assignment pair can produce — with a worst-case 39-char username —
-// exceeds GitHub's repo-name limit. Both parts can be individually valid yet
-// compose past the ceiling (foundation50/classroom50#691); callers warn the
-// teacher at create time rather than letting every student's accept fail. The
-// name shape is single-sourced through contract.AssignmentRepoPrefix so it can't
-// drift from the real one. Returns the worst-case length alongside the boolean.
+// classroom+assignment pair can produce (worst-case 39-char username) exceeds
+// GitHub's repo-name limit; see ShortNamePattern and #691. The name shape comes
+// from contract.AssignmentRepoPrefix so it can't drift from the real one.
 func ComposedRepoNameOverflows(classroom, slug string) (worstCase int, overflows bool) {
 	worstCase = len(contract.AssignmentRepoPrefix(classroom, slug)) + GitHubLoginMaxLen
 	return worstCase, worstCase > GitHubRepoNameMaxLen

--- a/cli/gh-teacher/internal/validate/validate.go
+++ b/cli/gh-teacher/internal/validate/validate.go
@@ -85,15 +85,14 @@ const GitHubRepoNameMaxLen = 100
 const GitHubLoginMaxLen = 39
 
 // ComposedRepoNameOverflows reports whether the longest student-repo name a
-// classroom+assignment pair can produce — `<classroom>-<assignment>-<username>`
-// with a worst-case 39-char username and the two joining hyphens — exceeds
-// GitHub's repo-name limit. Both parts can be individually valid yet compose
-// past the ceiling (foundation50/classroom50#691); callers warn the teacher at
-// create time rather than letting every student's accept fail. Returns the
-// worst-case length alongside the boolean so the caller can report it.
+// classroom+assignment pair can produce — with a worst-case 39-char username —
+// exceeds GitHub's repo-name limit. Both parts can be individually valid yet
+// compose past the ceiling (foundation50/classroom50#691); callers warn the
+// teacher at create time rather than letting every student's accept fail. The
+// name shape is single-sourced through contract.AssignmentRepoPrefix so it can't
+// drift from the real one. Returns the worst-case length alongside the boolean.
 func ComposedRepoNameOverflows(classroom, slug string) (worstCase int, overflows bool) {
-	// classroom + "-" + slug + "-" + <=39-char username.
-	worstCase = len(classroom) + 1 + len(slug) + 1 + GitHubLoginMaxLen
+	worstCase = len(contract.AssignmentRepoPrefix(classroom, slug)) + GitHubLoginMaxLen
 	return worstCase, worstCase > GitHubRepoNameMaxLen
 }
 

--- a/cli/gh-teacher/internal/validate/validate.go
+++ b/cli/gh-teacher/internal/validate/validate.go
@@ -15,11 +15,18 @@ import (
 // ShortNamePattern: classroom short-names and assignment slugs both flow into
 // student-repo names and the contents/tree API. Exposed for the few call sites
 // that match directly; most callers should use ShortName for the standard error.
-var ShortNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,38}$`)
+//
+// The cap is 100 per segment, matching GitHub's repo-name limit. It is NOT a
+// full guarantee: `<classroom>-<assignment>-<username>` can exceed 100 even
+// though each part is legal, and nothing here budgets the three against each
+// other. Deciding that split (a combined pre-flight check, an asymmetric cap,
+// or a shorter derived repo name) is open — see foundation50/classroom50#691.
+// Until then an overflow surfaces as a legible "name too long" error at accept.
+var ShortNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,99}$`)
 
 // ShortNamePatternDescription: human-readable summary of ShortNamePattern,
 // embedded in every "invalid <thing>" error.
-const ShortNamePatternDescription = "^[a-z0-9][a-z0-9-]{1,38}$ (2-39 chars, lowercase letters/digits/hyphens, starting with a letter or digit)"
+const ShortNamePatternDescription = "^[a-z0-9][a-z0-9-]{1,99}$ (2-100 chars, lowercase letters/digits/hyphens, starting with a letter or digit)"
 
 // ShortName checks name against ShortNamePattern with a label-prefixed error.
 // Same rule for classroom short-names and slugs (both flow into repo names) and

--- a/cli/gh-teacher/internal/validate/validate_test.go
+++ b/cli/gh-teacher/internal/validate/validate_test.go
@@ -162,3 +162,33 @@ func TestOrgName(t *testing.T) {
 		}
 	}
 }
+
+func TestComposedRepoNameOverflows(t *testing.T) {
+	cases := []struct {
+		name          string
+		classroom     string
+		slug          string
+		wantWorstCase int
+		wantOverflow  bool
+	}{
+		// 2 + 1 + 2 + 1 + 39 = 45, well under 100.
+		{"short pair", "cs", "hw", 45, false},
+		// Exactly at the limit: classroom(30) + 1 + slug(29) + 1 + 39 = 100.
+		{"exactly 100", strings.Repeat("a", 30), strings.Repeat("b", 29), 100, false},
+		// One over: classroom(30) + 1 + slug(30) + 1 + 39 = 101.
+		{"one over", strings.Repeat("a", 30), strings.Repeat("b", 30), 101, true},
+		// Two max-length segments: 100 + 1 + 100 + 1 + 39 = 241.
+		{"both maxed", strings.Repeat("a", 100), strings.Repeat("b", 100), 241, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			worst, overflows := ComposedRepoNameOverflows(tc.classroom, tc.slug)
+			if worst != tc.wantWorstCase {
+				t.Errorf("worstCase = %d, want %d", worst, tc.wantWorstCase)
+			}
+			if overflows != tc.wantOverflow {
+				t.Errorf("overflows = %v, want %v", overflows, tc.wantOverflow)
+			}
+		})
+	}
+}

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py
@@ -31,7 +31,7 @@ TESTS_FILENAME = "tests.json"
 # Mirror validate.ShortNamePattern in cli/gh-teacher/internal/validate/validate.go.
 # The slug becomes a directory path here, so a traversal-style slug must be
 # rejected before it reaches mkdir.
-SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,38}$")
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,99}$")
 
 
 def materialize(root: pathlib.Path) -> int:

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
@@ -177,7 +177,7 @@ jobs:
           import urllib.error, urllib.request
           import yaml
 
-          _SLUG = re.compile(r"^[a-z0-9][a-z0-9-]{1,38}$")
+          _SLUG = re.compile(r"^[a-z0-9][a-z0-9-]{1,99}$")
           _SECRET = re.compile(r"^[a-z0-9]{4,64}$")
           _LANG = re.compile(r"^[A-Za-z0-9._+-]{1,32}$")
           _APT  = re.compile(r"^[a-z0-9][a-z0-9.+-]{0,63}$")

--- a/cli/gh-teacher/skeleton_tests/test_short_name_parity.py
+++ b/cli/gh-teacher/skeleton_tests/test_short_name_parity.py
@@ -1,0 +1,66 @@
+"""Pins the classroom/assignment short-name (slug) pattern across every mirror.
+
+The regex `^[a-z0-9][a-z0-9-]{1,99}$` is hand-copied into seven places with no
+compile-time link between them (Go, Python, a workflow YAML, three JSON Schemas,
+and TypeScript). A drift here is exactly how the web create path silently fell
+out of the contract (foundation50/classroom50#691), so assert byte-identical
+copies and fail CI on the next drift.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+# The one authoritative pattern. Every mirror must match this literal exactly.
+_EXPECTED = r"^[a-z0-9][a-z0-9-]{1,99}$"
+
+
+def _schema_short_name_pattern(rel: str) -> str:
+    schema = json.loads((_REPO_ROOT / rel).read_text())
+    return schema["$defs"]["shortName"]["pattern"]
+
+
+def _extract(rel: str, pattern: str) -> str:
+    text = (_REPO_ROOT / rel).read_text()
+    m = re.search(pattern, text)
+    assert m, f"{rel}: could not find the short-name pattern (regex {pattern!r})"
+    return m.group(1)
+
+
+def test_all_short_name_mirrors_match() -> None:
+    found = {
+        "schemas/classroom-v1.schema.json": _schema_short_name_pattern(
+            "schemas/classroom-v1.schema.json"
+        ),
+        "schemas/assignments-v1.schema.json": _schema_short_name_pattern(
+            "schemas/assignments-v1.schema.json"
+        ),
+        "schemas/scores-v1.schema.json": _schema_short_name_pattern(
+            "schemas/scores-v1.schema.json"
+        ),
+        "cli/gh-teacher/internal/validate/validate.go": _extract(
+            "cli/gh-teacher/internal/validate/validate.go",
+            r"ShortNamePattern = regexp\.MustCompile\(`([^`]+)`\)",
+        ),
+        "cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py": _extract(
+            "cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py",
+            r'SLUG_RE = re\.compile\(r"([^"]+)"\)',
+        ),
+        "cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml": _extract(
+            "cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml",
+            r'_SLUG = re\.compile\(r"([^"]+)"\)',
+        ),
+        "web/src/util/shortName.ts": _extract(
+            "web/src/util/shortName.ts",
+            r"SHORT_NAME_PATTERN = /([^/]+)/",
+        ),
+    }
+
+    drifted = {rel: pat for rel, pat in found.items() if pat != _EXPECTED}
+    assert not drifted, (
+        f"short-name pattern drift (expected {_EXPECTED!r}): {drifted!r}"
+    )

--- a/schemas/assignments-v1.schema.json
+++ b/schemas/assignments-v1.schema.json
@@ -16,7 +16,7 @@
   "$defs": {
     "shortName": {
       "type": "string",
-      "pattern": "^[a-z0-9][a-z0-9-]{1,38}$"
+      "pattern": "^[a-z0-9][a-z0-9-]{1,99}$"
     },
     "assignment": {
       "type": "object",

--- a/schemas/classroom-v1.schema.json
+++ b/schemas/classroom-v1.schema.json
@@ -67,7 +67,8 @@
   "$defs": {
     "shortName": {
       "type": "string",
-      "pattern": "^[a-z0-9][a-z0-9-]{1,38}$"
+      "description": "URL/path-safe slug (2-100 chars). The cap matches GitHub's repo-name limit; it is per-segment, not a guarantee that the derived `<classroom>-<assignment>-<username>` student-repo name stays under 100 — budgeting the three against each other is an open question (foundation50/classroom50#691).",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,99}$"
     },
     "teamRef": {
       "type": "object",

--- a/schemas/scores-v1.schema.json
+++ b/schemas/scores-v1.schema.json
@@ -18,7 +18,7 @@
   "$defs": {
     "shortName": {
       "type": "string",
-      "pattern": "^[a-z0-9][a-z0-9-]{1,38}$"
+      "pattern": "^[a-z0-9][a-z0-9-]{1,99}$"
     },
     "assignmentBucket": {
       "type": "object",

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -3335,7 +3335,8 @@ describe("createAssignmentRepo", () => {
             new GitHubAPIError({
               status: 422,
               url: path,
-              message: "Unprocessable",
+              message:
+                "Repository creation failed: name already exists on this account",
               body: null,
               rateLimit: {
                 limit: null,
@@ -3825,14 +3826,14 @@ describe("createAssignmentRepo destination-org refusal (#413)", () => {
     ).rejects.toMatchObject({ name: "GitHubAPIError", status: 403 })
   })
 
-  it("still returns already-accepted on a 422 for both paths", async () => {
+  it("still returns already-accepted on an already-exists 422 for both paths", async () => {
     const templated = await createAssignmentRepo({
       client: clientRejecting(
         generatePath,
         new GitHubAPIError({
           status: 422,
           url: generatePath,
-          message: "Unprocessable",
+          message: "Repository creation failed: name already exists on this account",
           body: null,
           rateLimit: {
             limit: null,
@@ -3858,7 +3859,7 @@ describe("createAssignmentRepo destination-org refusal (#413)", () => {
         new GitHubAPIError({
           status: 422,
           url: orgReposPath,
-          message: "Unprocessable",
+          message: "Repository creation failed: name already exists on this account",
           body: null,
           rateLimit: {
             limit: null,
@@ -3876,6 +3877,45 @@ describe("createAssignmentRepo destination-org refusal (#413)", () => {
       bare: true,
     })
     expect(templateless.kind).toBe("already-accepted")
+  })
+
+  it("throws a name-too-long error on a 'too long' 422 for both paths", async () => {
+    const tooLong = (url: string) =>
+      new GitHubAPIError({
+        status: 422,
+        url,
+        message: "name is too long (maximum is 100 characters)",
+        body: null,
+        rateLimit: {
+          limit: null,
+          remaining: null,
+          used: null,
+          reset: null,
+          resource: null,
+          retryAfter: null,
+        },
+      })
+
+    await expect(
+      createAssignmentRepo({
+        client: clientRejecting(generatePath, tooLong(generatePath)),
+        templateOwner: "tpl",
+        templateRepo: "starter",
+        owner: "cs50",
+        name: "hw1-alice",
+        fallbackBranch: "main",
+      }),
+    ).rejects.toMatchObject({ name: "TemplateAccessError" })
+
+    await expect(
+      createAssignmentRepo({
+        client: clientRejecting(orgReposPath, tooLong(orgReposPath)),
+        owner: "cs50",
+        name: "hw1-alice",
+        fallbackBranch: "main",
+        bare: true,
+      }),
+    ).rejects.toMatchObject({ name: "TemplateAccessError" })
   })
 })
 

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -3833,7 +3833,8 @@ describe("createAssignmentRepo destination-org refusal (#413)", () => {
         new GitHubAPIError({
           status: 422,
           url: generatePath,
-          message: "Repository creation failed: name already exists on this account",
+          message:
+            "Repository creation failed: name already exists on this account",
           body: null,
           rateLimit: {
             limit: null,
@@ -3859,7 +3860,8 @@ describe("createAssignmentRepo destination-org refusal (#413)", () => {
         new GitHubAPIError({
           status: 422,
           url: orgReposPath,
-          message: "Repository creation failed: name already exists on this account",
+          message:
+            "Repository creation failed: name already exists on this account",
           body: null,
           rateLimit: {
             limit: null,

--- a/web/src/domain/assignments/repoCreation.ts
+++ b/web/src/domain/assignments/repoCreation.ts
@@ -6,7 +6,11 @@ import type {
   SubmissionMode,
   Grading,
 } from "@/types/classroom"
-import { GitHubAPIError } from "@/github-core/errors"
+import {
+  GitHubAPIError,
+  is422AlreadyExists,
+  is422NameTooLong,
+} from "@/github-core/errors"
 import { getRepo } from "@/github-core/repoReads"
 import { DEFAULT_BRANCH } from "@/util/configRepo"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
@@ -16,6 +20,7 @@ import {
   isOrgRepoCreationDenied,
   orgRepoCreationDeniedError,
   outOfOrgTemplateError,
+  repoNameTooLongError,
 } from "@/util/templateAccessError"
 import { log } from "./accessPrimitives"
 import { withGitConflictRetry } from "../classrooms"
@@ -129,7 +134,11 @@ export async function createAssignmentRepo(params: {
         throw err
       }
 
-      if (err.status === 422) {
+      if (is422NameTooLong(err)) {
+        throw repoNameTooLongError(name, err.status, err.message)
+      }
+
+      if (is422AlreadyExists(err)) {
         const existing = await client.request<GitHubRepo>(
           `/repos/${owner}/${name}`,
         )
@@ -276,7 +285,11 @@ async function createEmptyAssignmentRepo(params: {
       },
     })
   } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 422) {
+    if (err instanceof GitHubAPIError && is422NameTooLong(err)) {
+      throw repoNameTooLongError(name, err.status, err.message)
+    }
+
+    if (err instanceof GitHubAPIError && is422AlreadyExists(err)) {
       const existing = await client.request<GitHubRepo>(
         `/repos/${owner}/${name}`,
       )

--- a/web/src/github-core/errors.ts
+++ b/web/src/github-core/errors.ts
@@ -300,10 +300,10 @@ export function is422NoCommitsBetween(err: unknown): boolean {
   return is422Mentioning(err, "no commits between")
 }
 
-// GitHub rejects a repo name over its 100-char limit with a 422 whose body says
-// the name is "too long". Distinct from "already exists" so a slug that composes
-// into an over-long `<classroom>-<assignment>-<username>` repo name surfaces a
-// legible error instead of being mistaken for an already-accepted repo.
+// GitHub rejects an over-100-char repo name with a "too long" 422. Distinct
+// from "already exists" so an over-long composed
+// `<classroom>-<assignment>-<username>` surfaces a legible error instead of
+// being mistaken for an already-accepted repo (foundation50/classroom50#691).
 export function is422NameTooLong(err: unknown): boolean {
   return is422Mentioning(err, "too long")
 }

--- a/web/src/github-core/errors.ts
+++ b/web/src/github-core/errors.ts
@@ -300,6 +300,14 @@ export function is422NoCommitsBetween(err: unknown): boolean {
   return is422Mentioning(err, "no commits between")
 }
 
+// GitHub rejects a repo name over its 100-char limit with a 422 whose body says
+// the name is "too long". Distinct from "already exists" so a slug that composes
+// into an over-long `<classroom>-<assignment>-<username>` repo name surfaces a
+// legible error instead of being mistaken for an already-accepted repo.
+export function is422NameTooLong(err: unknown): boolean {
+  return is422Mentioning(err, "too long")
+}
+
 // The workflow_dispatch 422 for inputs the workflow file doesn't declare
 // ("Unexpected inputs provided") — the signal that the org's config repo
 // carries an older workflow than this app expects.

--- a/web/src/github-core/mutations/teams.ts
+++ b/web/src/github-core/mutations/teams.ts
@@ -5,6 +5,7 @@ import type { StaffRole } from "@/types/classroom"
 import { STAFF_ROLES } from "@/types/classroom"
 import { createTeam, type TeamNotificationSetting } from "../teamWrites"
 import { CONFIG_REPO } from "@/util/configRepo"
+import { isCanonicalTeamShortName } from "@/util/shortName"
 import { classroomTeamSlug } from "@/util/teamSlug"
 
 // Minimal team identity persisted in classroom.json. The slug is authoritative
@@ -30,12 +31,6 @@ export function isDeletableClassroomTeamRef(
     Number.isInteger(team.id) &&
     (team.id as number) > 0
   )
-}
-
-// A short-name with consecutive/trailing hyphens slugifies to something other
-// than `classroom50-<short>`, breaking team ops that re-derive the slug.
-function isCanonicalTeamShortName(shortName: string): boolean {
-  return !shortName.endsWith("-") && !shortName.includes("--")
 }
 
 // Create (or adopt) a `secret` team by exact name. Idempotent: adopts a

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -892,6 +892,7 @@
     "classroomNameRequired": "Classroom name is required.",
     "classroomSlugRequired": "Classroom slug is required.",
     "classroomSlugTaken": "Classroom slug is already taken.",
+    "classroomSlugInvalid": "Classroom slug must be {{description}}.",
     "assignmentSlugTaken": "An assignment \"{{slug}}\" already exists in this classroom.",
     "groupSizeRange": "Group size must be a whole number between {{min}} and {{max}}."
   },
@@ -1371,6 +1372,7 @@
       "validation": {
         "nameRequired": "Assignment name is required.",
         "slugRequired": "Assignment slug is required.",
+        "slugInvalid": "Assignment slug must be {{description}}.",
         "maxGroupSizeInvalid": "Max group size must be a valid number.",
         "setupTimeoutRange": "Setup timeout must be 0 or a whole number of seconds from 1 through {{max}}.",
         "passThresholdRange": "Pass threshold must be a whole number between {{min}} and {{max}}.",
@@ -2295,7 +2297,9 @@
       "forkParentRestricted": "Couldn't copy the template {{owner}}/{{repo}} (HTTP {{status}}).{{detail}} This template is a fork of a repository in the {{parentOwner}} organization, and copying a fork is governed by that organization's third-party app restrictions. Ask your teacher to approve the Classroom 50 app for {{parentOwner}}, or to use a fresh (non-fork) template repository, then accept again.",
       "forkParentRestrictedStep": "{{parentOwner}} hasn't approved Classroom 50 for the fork's upstream (HTTP {{status}}).",
       "orgRepoCreationDeniedStep": "{{org}} wouldn't let your repository be created (HTTP {{status}}).",
-      "orgRepoCreationDenied": "{{org}} may not allow members to create private repositories, so your repository couldn't be created (HTTP {{status}}). Ask your teacher to enable it, then accept again."
+      "orgRepoCreationDenied": "{{org}} may not allow members to create private repositories, so your repository couldn't be created (HTTP {{status}}). Ask your teacher to enable it, then accept again.",
+      "repoNameTooLongStep": "The repository name \"{{name}}\" is too long ({{length}} characters).",
+      "repoNameTooLong": "Your repository name \"{{name}}\" is {{length}} characters, over GitHub's 100-character limit, so it couldn't be created (HTTP {{status}}).{{detail}} Ask your teacher to shorten the classroom or assignment slug, then accept again."
     },
     "notFound": {
       "badge": "Assignment unavailable",

--- a/web/src/migration/classify.ts
+++ b/web/src/migration/classify.ts
@@ -6,7 +6,7 @@
 
 import type { GitHubClient } from "@/github-core/client"
 import { GitHubAPIError } from "@/github-core/errors"
-import { SHORT_NAME_PATTERN } from "./translate"
+import { SHORT_NAME_PATTERN } from "@/util/shortName"
 import { splitFullName } from "@/util/repoFullName"
 import type {
   ClassroomAssignmentDetail,

--- a/web/src/migration/preflight.ts
+++ b/web/src/migration/preflight.ts
@@ -10,7 +10,8 @@ import { GitHubAPIError } from "@/github-core/errors"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { classifyAssignment } from "./classify"
 import { fetchAssignmentsForClassroom, resolveSource } from "./classroomApi"
-import { assertValidShortName, deriveShortName } from "./translate"
+import { deriveShortName } from "./translate"
+import { assertValidShortName } from "@/util/shortName"
 import type {
   MigrationBlocker,
   MigrationItem,

--- a/web/src/migration/translate.ts
+++ b/web/src/migration/translate.ts
@@ -10,18 +10,8 @@ import {
   SHORT_NAME_PATTERN,
   SHORT_NAME_PATTERN_DESCRIPTION,
   assertValidShortName,
-  isCanonicalTeamShortName,
 } from "@/util/shortName"
 import type { ClassroomAssignmentDetail, ClassroomDetail } from "./types"
-
-// Re-exported from the shared leaf so migration importers keep their path; the
-// pattern itself now lives in @/util/shortName (used by the create forms too).
-export {
-  SHORT_NAME_PATTERN,
-  SHORT_NAME_PATTERN_DESCRIPTION,
-  assertValidShortName,
-  isCanonicalTeamShortName,
-}
 
 // The only migrated_from.source value today.
 export const MIGRATE_SOURCE_GITHUB_CLASSROOM = "github_classroom"
@@ -42,10 +32,6 @@ export function clampMigratedGroupSize(maxTeams: number | null): number {
     ? maxTeams
     : GROUP_SIZE_MAX
 }
-
-// classroom short-names and assignment slugs both flow into repo/team names.
-// The pattern + canonical-team guard live in @/util/shortName (re-exported
-// above); this module keeps only the migration-specific derivation.
 
 // classroom-level migrated_from block for classroom.json. (The web Classroom
 // type doesn't type this field, so it rides through as an extra key on write.)

--- a/web/src/migration/translate.ts
+++ b/web/src/migration/translate.ts
@@ -6,7 +6,22 @@
 import type { Assignment, DueMeta, MigratedFrom } from "@/types/classroom"
 import { GROUP_SIZE_MAX, GROUP_SIZE_MIN } from "@/types/classroom"
 import { localizedError } from "@/types/localizedMessage"
+import {
+  SHORT_NAME_PATTERN,
+  SHORT_NAME_PATTERN_DESCRIPTION,
+  assertValidShortName,
+  isCanonicalTeamShortName,
+} from "@/util/shortName"
 import type { ClassroomAssignmentDetail, ClassroomDetail } from "./types"
+
+// Re-exported from the shared leaf so migration importers keep their path; the
+// pattern itself now lives in @/util/shortName (used by the create forms too).
+export {
+  SHORT_NAME_PATTERN,
+  SHORT_NAME_PATTERN_DESCRIPTION,
+  assertValidShortName,
+  isCanonicalTeamShortName,
+}
 
 // The only migrated_from.source value today.
 export const MIGRATE_SOURCE_GITHUB_CLASSROOM = "github_classroom"
@@ -29,17 +44,8 @@ export function clampMigratedGroupSize(maxTeams: number | null): number {
 }
 
 // classroom short-names and assignment slugs both flow into repo/team names.
-// Byte-mirror of the CLI's validate.ShortNamePattern.
-export const SHORT_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{1,38}$/
-export const SHORT_NAME_PATTERN_DESCRIPTION =
-  "2-39 chars, lowercase letters/digits/hyphens, starting with a letter or digit"
-
-// A short-name with consecutive/trailing hyphens slugifies to something other
-// than `classroom50-<short>`, breaking the team slug. Mirrors the CLI's
-// CanonicalTeamSlugShortName / the web isCanonicalTeamShortName.
-export function isCanonicalTeamShortName(shortName: string): boolean {
-  return !shortName.endsWith("-") && !shortName.includes("--")
-}
+// The pattern + canonical-team guard live in @/util/shortName (re-exported
+// above); this module keeps only the migration-specific derivation.
 
 // classroom-level migrated_from block for classroom.json. (The web Classroom
 // type doesn't type this field, so it rides through as an extra key on write.)
@@ -68,7 +74,7 @@ export function classroomMigratedFrom(
 
 // Slugify a free-form classroom name into a valid short-name, or throw asking
 // for an explicit one. lowercase -> non-alnum to '-' -> collapse -> trim ->
-// truncate to 39 -> validate pattern AND canonical-team-slug. Mirrors the CLI's
+// truncate to 100 -> validate pattern AND canonical-team-slug. Mirrors the CLI's
 // deriveShortName plus the up-front canonical-team-slug guard.
 export function deriveShortName(rawName: string): string {
   const lowered = rawName.trim().toLowerCase()
@@ -76,37 +82,11 @@ export function deriveShortName(rawName: string): string {
     throw localizedError({ key: "migration.error.classroomNameEmpty" })
   }
   let slug = lowered.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "")
-  if (slug.length > 39) {
-    slug = slug.slice(0, 39).replace(/-+$/g, "")
+  if (slug.length > 100) {
+    slug = slug.slice(0, 100).replace(/-+$/g, "")
   }
   assertValidShortName(slug, rawName)
   return slug
-}
-
-// Validate a short-name (derived or user-supplied) for both the schema pattern
-// and the team-slug canonical form. Throws an actionable error otherwise.
-export function assertValidShortName(
-  shortName: string,
-  rawName?: string,
-): void {
-  if (!SHORT_NAME_PATTERN.test(shortName)) {
-    throw localizedError({
-      key: rawName
-        ? "migration.error.shortNameInvalidFrom"
-        : "migration.error.shortNameInvalid",
-      params: {
-        shortName,
-        rawName: rawName ?? "",
-        description: SHORT_NAME_PATTERN_DESCRIPTION,
-      },
-    })
-  }
-  if (!isCanonicalTeamShortName(shortName)) {
-    throw localizedError({
-      key: "migration.error.shortNameNotCanonical",
-      params: { shortName },
-    })
-  }
 }
 
 // A deadline is kept only if it parses as RFC 3339 WITH an explicit offset

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -118,6 +118,11 @@ describe("validateAssignmentForm — required fields", () => {
     })
     expect(errors.slug).toBe("validation.assignmentSlugTaken")
   })
+
+  it("flags a slug over the 100-char cap on create", () => {
+    const errors = validateAssignmentForm({ ...base, slug: "a".repeat(101) }, t)
+    expect(errors.slug).toBe("assignments.form.validation.slugInvalid")
+  })
 })
 
 describe("validateAssignmentForm — group size", () => {

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -2,9 +2,8 @@ import { useForm } from "@tanstack/react-form"
 import type { TFunction } from "i18next"
 import { slugify } from "@/util/slug"
 import {
-  SHORT_NAME_PATTERN,
   SHORT_NAME_PATTERN_DESCRIPTION,
-  isCanonicalTeamShortName,
+  isValidShortName,
 } from "@/util/shortName"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import {
@@ -265,10 +264,7 @@ export function validateAssignmentForm(
     const slug = slugify(value.slug)
     if (!slug) {
       errors.slug = t("assignments.form.validation.slugRequired")
-    } else if (
-      !SHORT_NAME_PATTERN.test(slug) ||
-      !isCanonicalTeamShortName(slug)
-    ) {
+    } else if (!isValidShortName(slug)) {
       // Same cross-tool short-name contract as classroom slugs (both become
       // repo path segments); the write path historically skipped it.
       errors.slug = t("assignments.form.validation.slugInvalid", {

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -1,6 +1,11 @@
 import { useForm } from "@tanstack/react-form"
 import type { TFunction } from "i18next"
 import { slugify } from "@/util/slug"
+import {
+  SHORT_NAME_PATTERN,
+  SHORT_NAME_PATTERN_DESCRIPTION,
+  isCanonicalTeamShortName,
+} from "@/util/shortName"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import {
   DEFAULT_SETUP_TIMEOUT_SECONDS,
@@ -260,6 +265,15 @@ export function validateAssignmentForm(
     const slug = slugify(value.slug)
     if (!slug) {
       errors.slug = t("assignments.form.validation.slugRequired")
+    } else if (
+      !SHORT_NAME_PATTERN.test(slug) ||
+      !isCanonicalTeamShortName(slug)
+    ) {
+      // Same cross-tool short-name contract as classroom slugs (both become
+      // repo path segments); the write path historically skipped it.
+      errors.slug = t("assignments.form.validation.slugInvalid", {
+        description: SHORT_NAME_PATTERN_DESCRIPTION,
+      })
     } else if (
       (slugContext?.takenSlugs ?? []).some(
         (s) => s.trim().toLowerCase() === slug.toLowerCase(),

--- a/web/src/pages/classes/CreateClassroomForm.test.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+// Match on stable i18n keys rather than English copy.
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+// The form reads the org from the route and the existing classrooms from a
+// GitHub query; both are irrelevant to the slug-validation logic under test, so
+// stub them. `mockClasses` lets each test control the taken-slug set.
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    useParams: () => ({ org: "cs50" }),
+  }
+})
+
+let mockClasses: { name: string; path: string; type: string }[] = []
+vi.mock("@/hooks/useGetClasses", () => ({
+  default: () => ({ classes: mockClasses, isLoading: false }),
+}))
+
+import CreateClassroomForm from "./CreateClassroomForm"
+
+afterEach(() => {
+  cleanup()
+  mockClasses = []
+})
+
+const slugInput = (container: HTMLElement) =>
+  container.querySelector<HTMLInputElement>("#slug")!
+const submit = () =>
+  screen.getByRole("button", { name: "classes.form.createButton" })
+
+describe("CreateClassroomForm slug validation", () => {
+  it("rejects a slug over the 100-char cap and does not submit", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    const { container } = render(<CreateClassroomForm onSubmit={onSubmit} />)
+
+    await user.type(
+      container.querySelector<HTMLInputElement>("#name")!,
+      "Class",
+    )
+    // Overwrite the auto-derived slug with a 101-char value.
+    await user.clear(slugInput(container))
+    await user.type(slugInput(container), "a".repeat(101))
+    await user.click(submit())
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(
+      await screen.findByText("validation.classroomSlugInvalid"),
+    ).not.toBeNull()
+  })
+
+  // Regression guard: the collision check must compare the SLUGIFIED value, not
+  // the raw input. A raw "CS 50" slugifies to "cs-50"; if the check compared the
+  // raw string it would miss an existing "cs-50" and overwrite its roster/scores.
+  it("flags a raw input that slugifies onto an existing classroom as taken", async () => {
+    mockClasses = [{ name: "cs-50", path: "cs-50", type: "dir" }]
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    const { container } = render(<CreateClassroomForm onSubmit={onSubmit} />)
+
+    // Type a name (auto-derives a slug), then overwrite the slug with a raw
+    // value that slugifies onto the existing "cs-50".
+    await user.type(
+      container.querySelector<HTMLInputElement>("#name")!,
+      "Class",
+    )
+    await user.clear(slugInput(container))
+    await user.type(slugInput(container), "CS 50")
+    await user.click(submit())
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(
+      await screen.findByText("validation.classroomSlugTaken"),
+    ).not.toBeNull()
+  })
+
+  it("submits the slugified value for a valid, non-colliding slug", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { container } = render(<CreateClassroomForm onSubmit={onSubmit} />)
+
+    await user.type(
+      container.querySelector<HTMLInputElement>("#name")!,
+      "Intro CS",
+    )
+    await user.click(submit())
+
+    await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(onSubmit.mock.calls[0][0].slug).toBe("intro-cs")
+  })
+})

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -10,6 +10,11 @@ import {
   isValidSecret,
 } from "@/util/secret"
 import { slugify } from "@/util/slug"
+import {
+  SHORT_NAME_PATTERN,
+  SHORT_NAME_PATTERN_DESCRIPTION,
+  isCanonicalTeamShortName,
+} from "@/util/shortName"
 import { Button, Card, FormField, Input } from "@/components/ui"
 
 export type CreateClassroomFormValues = {
@@ -58,6 +63,19 @@ const CreateClassroomForm = ({
 
         if (!value.slug.trim()) {
           errors.slug = t("validation.classroomSlugRequired")
+        } else {
+          // Validate the value that will actually be written (post-slugify),
+          // matching the cross-tool short-name contract the CLI and schemas
+          // enforce; the web create path historically skipped this.
+          const slug = slugify(value.slug)
+          if (
+            !SHORT_NAME_PATTERN.test(slug) ||
+            !isCanonicalTeamShortName(slug)
+          ) {
+            errors.slug = t("validation.classroomSlugInvalid", {
+              description: SHORT_NAME_PATTERN_DESCRIPTION,
+            })
+          }
         }
 
         if (classes.find((cl) => cl.path === value.slug.trim())) {

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -63,12 +63,10 @@ const CreateClassroomForm = ({
         if (!value.slug.trim()) {
           errors.slug = t("validation.classroomSlugRequired")
         } else {
-          // Validate and check collisions against the value that will actually
-          // be written (post-slugify), matching the cross-tool short-name
-          // contract; the create path historically skipped the shape check and
-          // compared the raw input for collisions, so a raw value slugifying to
-          // an existing classroom (e.g. "CS 50" -> "cs-50") slipped past and
-          // overwrote its roster/scores. One slug value drives all three.
+          // Validate AND collision-check the slugified value (what actually
+          // gets written): comparing the raw input for collisions let a raw
+          // value slugifying onto an existing classroom (e.g. "CS 50" ->
+          // "cs-50") slip past and overwrite its roster/scores.
           const slug = slugify(value.slug)
           if (!isValidShortName(slug)) {
             errors.slug = t("validation.classroomSlugInvalid", {

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -64,9 +64,12 @@ const CreateClassroomForm = ({
         if (!value.slug.trim()) {
           errors.slug = t("validation.classroomSlugRequired")
         } else {
-          // Validate the value that will actually be written (post-slugify),
-          // matching the cross-tool short-name contract the CLI and schemas
-          // enforce; the web create path historically skipped this.
+          // Validate and check collisions against the value that will actually
+          // be written (post-slugify), matching the cross-tool short-name
+          // contract; the create path historically skipped the shape check and
+          // compared the raw input for collisions, so a raw value slugifying to
+          // an existing classroom (e.g. "CS 50" -> "cs-50") slipped past and
+          // overwrote its roster/scores. One slug value drives all three.
           const slug = slugify(value.slug)
           if (
             !SHORT_NAME_PATTERN.test(slug) ||
@@ -75,11 +78,11 @@ const CreateClassroomForm = ({
             errors.slug = t("validation.classroomSlugInvalid", {
               description: SHORT_NAME_PATTERN_DESCRIPTION,
             })
+          } else if (
+            classes.find((cl) => cl.path.toLowerCase() === slug.toLowerCase())
+          ) {
+            errors.slug = t("validation.classroomSlugTaken")
           }
-        }
-
-        if (classes.find((cl) => cl.path === value.slug.trim())) {
-          errors.slug = t("validation.classroomSlugTaken")
         }
 
         // Only validate the secret when protection is on; a disabled toggle

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -11,9 +11,8 @@ import {
 } from "@/util/secret"
 import { slugify } from "@/util/slug"
 import {
-  SHORT_NAME_PATTERN,
   SHORT_NAME_PATTERN_DESCRIPTION,
-  isCanonicalTeamShortName,
+  isValidShortName,
 } from "@/util/shortName"
 import { Button, Card, FormField, Input } from "@/components/ui"
 
@@ -71,10 +70,7 @@ const CreateClassroomForm = ({
           // an existing classroom (e.g. "CS 50" -> "cs-50") slipped past and
           // overwrote its roster/scores. One slug value drives all three.
           const slug = slugify(value.slug)
-          if (
-            !SHORT_NAME_PATTERN.test(slug) ||
-            !isCanonicalTeamShortName(slug)
-          ) {
+          if (!isValidShortName(slug)) {
             errors.slug = t("validation.classroomSlugInvalid", {
               description: SHORT_NAME_PATTERN_DESCRIPTION,
             })

--- a/web/src/util/shortName.test.ts
+++ b/web/src/util/shortName.test.ts
@@ -3,6 +3,7 @@ import {
   SHORT_NAME_PATTERN,
   assertValidShortName,
   isCanonicalTeamShortName,
+  isValidShortName,
 } from "./shortName"
 
 describe("SHORT_NAME_PATTERN", () => {
@@ -30,6 +31,15 @@ describe("isCanonicalTeamShortName", () => {
     expect(isCanonicalTeamShortName("cs-")).toBe(false)
     expect(isCanonicalTeamShortName("cs--50")).toBe(false)
     expect(isCanonicalTeamShortName("cs-50")).toBe(true)
+  })
+})
+
+describe("isValidShortName", () => {
+  it("is true only when the pattern and the canonical-team form both hold", () => {
+    expect(isValidShortName("cs-50")).toBe(true)
+    expect(isValidShortName("a".repeat(101))).toBe(false) // over cap
+    expect(isValidShortName("cs--50")).toBe(false) // non-canonical
+    expect(isValidShortName("CS-50")).toBe(false) // uppercase
   })
 })
 

--- a/web/src/util/shortName.test.ts
+++ b/web/src/util/shortName.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import {
+  SHORT_NAME_PATTERN,
+  assertValidShortName,
+  isCanonicalTeamShortName,
+} from "./shortName"
+
+describe("SHORT_NAME_PATTERN", () => {
+  it("accepts a slug at the 100-char cap", () => {
+    expect(SHORT_NAME_PATTERN.test("a" + "b".repeat(99))).toBe(true)
+  })
+
+  it("rejects a 101-char slug", () => {
+    expect(SHORT_NAME_PATTERN.test("a" + "b".repeat(100))).toBe(false)
+  })
+
+  it("rejects a single char (2-char minimum)", () => {
+    expect(SHORT_NAME_PATTERN.test("a")).toBe(false)
+  })
+
+  it("rejects uppercase, punctuation, and a leading hyphen", () => {
+    expect(SHORT_NAME_PATTERN.test("CS-50")).toBe(false)
+    expect(SHORT_NAME_PATTERN.test("cs_50")).toBe(false)
+    expect(SHORT_NAME_PATTERN.test("-cs50")).toBe(false)
+  })
+})
+
+describe("isCanonicalTeamShortName", () => {
+  it("rejects trailing or consecutive hyphens", () => {
+    expect(isCanonicalTeamShortName("cs-")).toBe(false)
+    expect(isCanonicalTeamShortName("cs--50")).toBe(false)
+    expect(isCanonicalTeamShortName("cs-50")).toBe(true)
+  })
+})
+
+describe("assertValidShortName", () => {
+  it("passes a valid slug", () => {
+    expect(() => assertValidShortName("cs-principles")).not.toThrow()
+  })
+
+  it("throws on an over-cap slug", () => {
+    expect(() => assertValidShortName("a".repeat(101))).toThrow(
+      /shortNameInvalid/,
+    )
+  })
+})

--- a/web/src/util/shortName.ts
+++ b/web/src/util/shortName.ts
@@ -1,13 +1,9 @@
 import { localizedError } from "@/types/localizedMessage"
 
 // Classroom short-names and assignment slugs both flow into repo/team names.
-// Byte-mirror of the CLI's validate.ShortNamePattern.
-//
-// The cap is 100 per segment, matching GitHub's repo-name limit. It is NOT a
-// full guarantee: `<classroom>-<assignment>-<username>` can exceed 100 even
-// though each part is legal, and nothing here budgets the three against each
-// other. Deciding that split is open — see foundation50/classroom50#691. Until
-// then an overflow surfaces as a legible "name too long" error at accept.
+// Byte-mirror of the CLI's validate.ShortNamePattern (2-100 chars). The cap is
+// per-segment, not a guarantee the composed repo name fits GitHub's 100-char
+// limit — see foundation50/classroom50#691.
 export const SHORT_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{1,99}$/
 export const SHORT_NAME_PATTERN_DESCRIPTION =
   "2-100 chars, lowercase letters/digits/hyphens, starting with a letter or digit"
@@ -19,9 +15,8 @@ export function isCanonicalTeamShortName(shortName: string): boolean {
   return !shortName.endsWith("-") && !shortName.includes("--")
 }
 
-// Whether a short-name is well-shaped for both the schema pattern and the
-// team-slug canonical form. The boolean form the create-form validators need
-// (assertValidShortName throws a localized error, which they can't consume).
+// Boolean well-shaped check (pattern + canonical-team form) for the create-form
+// validators, which can't consume assertValidShortName's thrown localized error.
 export function isValidShortName(shortName: string): boolean {
   return (
     SHORT_NAME_PATTERN.test(shortName) && isCanonicalTeamShortName(shortName)

--- a/web/src/util/shortName.ts
+++ b/web/src/util/shortName.ts
@@ -1,0 +1,48 @@
+import { localizedError } from "@/types/localizedMessage"
+
+// Classroom short-names and assignment slugs both flow into repo/team names.
+// Byte-mirror of the CLI's validate.ShortNamePattern.
+//
+// The cap is 100 per segment, matching GitHub's repo-name limit. It is NOT a
+// full guarantee: `<classroom>-<assignment>-<username>` can exceed 100 even
+// though each part is legal, and nothing here budgets the three against each
+// other. Deciding that split is open — see foundation50/classroom50#691. Until
+// then an overflow surfaces as a legible "name too long" error at accept.
+export const SHORT_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{1,99}$/
+export const SHORT_NAME_PATTERN_DESCRIPTION =
+  "2-100 chars, lowercase letters/digits/hyphens, starting with a letter or digit"
+
+// A short-name with consecutive/trailing hyphens slugifies to something other
+// than `classroom50-<short>`, breaking the team slug. Mirrors the CLI's
+// CanonicalTeamSlugShortName.
+export function isCanonicalTeamShortName(shortName: string): boolean {
+  return !shortName.endsWith("-") && !shortName.includes("--")
+}
+
+// Validate a short-name (derived or user-supplied) for both the schema pattern
+// and the team-slug canonical form. Throws an actionable error otherwise.
+// `rawName`, when given, names the free-form source in the error (the migration
+// case that slugified it).
+export function assertValidShortName(
+  shortName: string,
+  rawName?: string,
+): void {
+  if (!SHORT_NAME_PATTERN.test(shortName)) {
+    throw localizedError({
+      key: rawName
+        ? "migration.error.shortNameInvalidFrom"
+        : "migration.error.shortNameInvalid",
+      params: {
+        shortName,
+        rawName: rawName ?? "",
+        description: SHORT_NAME_PATTERN_DESCRIPTION,
+      },
+    })
+  }
+  if (!isCanonicalTeamShortName(shortName)) {
+    throw localizedError({
+      key: "migration.error.shortNameNotCanonical",
+      params: { shortName },
+    })
+  }
+}

--- a/web/src/util/shortName.ts
+++ b/web/src/util/shortName.ts
@@ -19,6 +19,15 @@ export function isCanonicalTeamShortName(shortName: string): boolean {
   return !shortName.endsWith("-") && !shortName.includes("--")
 }
 
+// Whether a short-name is well-shaped for both the schema pattern and the
+// team-slug canonical form. The boolean form the create-form validators need
+// (assertValidShortName throws a localized error, which they can't consume).
+export function isValidShortName(shortName: string): boolean {
+  return (
+    SHORT_NAME_PATTERN.test(shortName) && isCanonicalTeamShortName(shortName)
+  )
+}
+
 // Validate a short-name (derived or user-supplied) for both the schema pattern
 // and the team-slug canonical form. Throws an actionable error otherwise.
 // `rawName`, when given, names the free-form source in the error (the migration

--- a/web/src/util/slug.test.ts
+++ b/web/src/util/slug.test.ts
@@ -30,4 +30,11 @@ describe("nextAvailableSlug", () => {
   it("matches case-insensitively (slugs are repo path segments)", () => {
     expect(nextAvailableSlug("hw1", ["HW1"])).toBe("hw1-2")
   })
+
+  it("keeps a suffixed candidate within the 100-char cap", () => {
+    const base = "a".repeat(100)
+    const result = nextAvailableSlug(base, [base])
+    expect(result.length).toBeLessThanOrEqual(100)
+    expect(result).toMatch(/-2$/)
+  })
 })

--- a/web/src/util/slug.ts
+++ b/web/src/util/slug.ts
@@ -39,8 +39,7 @@ export function nextAvailableSlug(
   // Bounded defensively; a classroom never has thousands of same-stem slugs.
   for (let i = 0; i < 10000; i++) {
     const suffix = `-${n}`
-    // Trim the stem so stem+suffix stays within the cap; a trailing hyphen left
-    // by the trim is dropped so the result stays a valid slug.
+    // Trim the stem to leave room for the suffix; drop a hyphen the trim exposes.
     const room = SLUG_MAX_LEN - suffix.length
     const trimmedStem = stem.slice(0, room).replace(/-+$/g, "")
     const candidate = `${trimmedStem}${suffix}`

--- a/web/src/util/slug.ts
+++ b/web/src/util/slug.ts
@@ -12,9 +12,8 @@ export function slugify(value: string) {
     .replace(/^-+|-+$/g, "")
 }
 
-// Max slug length, matching validate.ShortNamePattern's cap (2-100 chars). A
-// derived `-<n>` suffix must not push a candidate past it, so the stem is
-// trimmed to leave room. The write path re-checks authoritatively.
+// Max slug length, mirroring validate.ShortNamePattern's cap. A derived `-<n>`
+// suffix must not push a candidate past it, so the stem is trimmed to fit.
 const SLUG_MAX_LEN = 100
 
 // First slug not in `taken`, suffixing `-2`, `-3`, … A base ending in `-<n>`

--- a/web/src/util/slug.ts
+++ b/web/src/util/slug.ts
@@ -12,6 +12,11 @@ export function slugify(value: string) {
     .replace(/^-+|-+$/g, "")
 }
 
+// Max slug length, matching validate.ShortNamePattern's cap (2-100 chars). A
+// derived `-<n>` suffix must not push a candidate past it, so the stem is
+// trimmed to leave room. The write path re-checks authoritatively.
+const SLUG_MAX_LEN = 100
+
 // First slug not in `taken`, suffixing `-2`, `-3`, … A base ending in `-<n>`
 // continues from n+1 ("hw1-2" -> "hw1-3", not "hw1-2-2"). Case-insensitive, to
 // match GitHub repo naming and the server-side check. Pure; prefills both the
@@ -33,10 +38,15 @@ export function nextAvailableSlug(
 
   // Bounded defensively; a classroom never has thousands of same-stem slugs.
   for (let i = 0; i < 10000; i++) {
-    const candidate = `${stem}-${n}`
+    const suffix = `-${n}`
+    // Trim the stem so stem+suffix stays within the cap; a trailing hyphen left
+    // by the trim is dropped so the result stays a valid slug.
+    const room = SLUG_MAX_LEN - suffix.length
+    const trimmedStem = stem.slice(0, room).replace(/-+$/g, "")
+    const candidate = `${trimmedStem}${suffix}`
     if (isFree(candidate)) return candidate
     n++
   }
   // Unreachable in practice, but never silently return a taken slug.
-  return `${stem}-${Date.now()}`
+  return `${stem}-${Date.now()}`.slice(0, SLUG_MAX_LEN).replace(/-+$/g, "")
 }

--- a/web/src/util/templateAccessError.ts
+++ b/web/src/util/templateAccessError.ts
@@ -104,6 +104,33 @@ export function forkParentRestrictedError(
   )
 }
 
+// GitHub rejects a repo name over its 100-char limit with a 422. The composed
+// student-repo name `<classroom>-<assignment>-<username>` can exceed 100 even
+// when each part is individually legal (foundation50/classroom50#691), so name
+// the cause and the fix (shorter classroom/assignment slug) rather than letting
+// it fall through to a confusing not-found from the "already exists" recovery.
+export function repoNameTooLongError(
+  repoName: string,
+  status: number,
+  githubMessage?: string,
+): TemplateAccessError {
+  return new TemplateAccessError(
+    {
+      key: "accept.templateErrors.repoNameTooLong",
+      params: {
+        name: repoName,
+        length: repoName.length,
+        status,
+        detail: githubSaid(githubMessage),
+      },
+    },
+    {
+      key: "accept.templateErrors.repoNameTooLongStep",
+      params: { name: repoName, length: repoName.length },
+    },
+  )
+}
+
 // The one 403 message GitHub was observed to return when the *destination* org
 // refuses the create (issue #413). Matched as a substring, case-insensitively.
 const ORG_REPO_CREATION_DENIED_SIGNATURE = "admin access to the organization"

--- a/web/src/util/templateAccessError.ts
+++ b/web/src/util/templateAccessError.ts
@@ -104,11 +104,10 @@ export function forkParentRestrictedError(
   )
 }
 
-// GitHub rejects a repo name over its 100-char limit with a 422. The composed
-// student-repo name `<classroom>-<assignment>-<username>` can exceed 100 even
-// when each part is individually legal (foundation50/classroom50#691), so name
-// the cause and the fix (shorter classroom/assignment slug) rather than letting
-// it fall through to a confusing not-found from the "already exists" recovery.
+// An over-100-char composed `<classroom>-<assignment>-<username>` repo name is
+// rejected with a 422 (foundation50/classroom50#691). Name the cause and the
+// fix rather than letting it fall through to the "already exists" recovery's
+// confusing not-found.
 export function repoNameTooLongError(
   repoName: string,
   status: number,

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -231,7 +231,7 @@ gh teacher classroom add <org> <short-name> --name "<full name>" --term <term>
 gh teacher classroom add cs50-fall-2026 cs-principles --name "CS Principles" --term Fall-2026
 ```
 
-The `<short-name>` must match `^[a-z0-9][a-z0-9-]{1,38}$` (2–39 characters,
+The `<short-name>` must match `^[a-z0-9][a-z0-9-]{1,99}$` (2–100 characters,
 lowercase letters/digits/hyphens, starting with a letter or digit), because it
 becomes part of student repo names like `<short-name>-<assignment>-<username>`.
 `--name` and `--term` are optional but recommended.
@@ -536,7 +536,7 @@ gh teacher assignment add cs50-fall-2026 cs-principles reflection --name "Reflec
 
 **`--name` is required; `--template` is optional.** Omit `--template` for a
 template-less assignment (students get an initialized repository with a README
-and the autograding setup). The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
+and the autograding setup). The slug must match `^[a-z0-9][a-z0-9-]{1,99}$`.
 
 **Optional flags:**
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -169,7 +169,7 @@ gh teacher classroom add <org> <short-name> [--name "<full name>"] [--term <term
 gh teacher classroom add cs50-fall-2026 cs-principles --name "CS Principles" --term Fall-2026
 ```
 
-**Short-name rules:** `^[a-z0-9][a-z0-9-]{1,38}$` — 2–39 characters, lowercase
+**Short-name rules:** `^[a-z0-9][a-z0-9-]{1,99}$` — 2–100 characters, lowercase
 letters/digits/hyphens, starting with a letter or digit. It becomes part of
 student repo names (`<short-name>-<assignment>-<username>`).
 
@@ -581,7 +581,7 @@ gh teacher assignment add cs50-fall-2026 cs-principles actions-lab --name "Actio
 
 Registers or upserts one assignment. Re-running with the same slug replaces the
 entry wholesale (dropping tests or a template you don't re-pass — the CLI warns).
-The slug must match `^[a-z0-9][a-z0-9-]{1,38}$`.
+The slug must match `^[a-z0-9][a-z0-9-]{1,99}$`.
 
 **Required:** `--name`.
 


### PR DESCRIPTION
## Summary

Resolves #691. A teacher created a classroom whose slug was longer than 39 characters; the autograding workflow then failed at setup with `.classroom50.yaml field 'classroom' has invalid value ... (must match '^[a-z0-9][a-z0-9-]{1,38}$')`. The root cause is that the 2–39 short-name contract is a cross-tool rule, but the web GUI create path never enforced it — so an over-long slug committed fine, students accepted fine, and the first strict reader downstream (the autograder's inline validator) rejected it.

This raises the classroom short-name / assignment slug cap from 39 to 100 characters (`^[a-z0-9][a-z0-9-]{1,99}$`) consistently across every mirror, makes the web create forms actually enforce the contract, and makes a still-too-long composed repo name fail with an actionable error instead of a confusing not-found.

## What changed

- **Widened the cap to 100 across all seven regex mirrors and three numeric truncation sites:** the three JSON Schemas (source of truth), Go (`validate.ShortNamePattern`, `slugMaxLen`, `deriveShortName`, CLI help text), the Python `materialize_tests.py` `SLUG_RE`, and the inline `_SLUG` validator in `autograde-runner.yaml` (the line that actually unblocks the reporter). `orgNamePattern` stays at 39 — GitHub org logins really are capped there.
- **Enforced the contract in the web GUI create path**, which previously skipped it: `CreateClassroomForm` and `assignmentFormModel` now reject invalid/over-cap slugs, and `nextAvailableSlug` is capped so an auto `-N` suffix can't overflow. The pattern moved into a shared leaf `web/src/util/shortName.ts` (which also owns the shared `isValidShortName` predicate and the `isCanonicalTeamShortName` guard the migration module and `teams.ts` previously duplicated).
- **Made an over-long composed repo name fail legibly.** `<classroom>-<assignment>-<username>` can still exceed GitHub's 100-char repo-name limit even when each segment is legal (open question — the cross-segment budget is deferred to #691). Both `web/src/domain/assignments/repoCreation.ts` and `cli/gh-student/accept.go` now distinguish GitHub's "name too long" 422 from "already exists" and surface an actionable error, instead of the old "any 422 = already accepted" path that then 404'd on recovery.
- **Added a cross-language drift test** (`test_short_name_parity.py`) pinning all seven pattern mirrors identical — the gap that let the web path drift out of the contract in the first place.
- Updated the boundary tests and the wiki.

## Follow-ups from code review

- **Fixed a latent data-loss bug on the create form.** `CreateClassroomForm` validated the slugified value but collision-checked the raw input, so a raw value that slugifies onto an existing classroom (e.g. `CS 50` -> `cs-50`) slipped past the "already taken" guard; the write path then overwrote that classroom's `roster.csv`/`scores.json` with empty scaffolds. The check now runs on the slugified value.
- **Warn the teacher early about an un-acceptable pair.** `gh teacher assignment add` now emits a non-blocking warning when the classroom + slug compose to a `<classroom>-<assignment>-<username>` name over GitHub's 100-char limit, so the teacher shortens it at create time instead of every student's accept failing.
- Added the missing `CreateClassroomForm` and Go "name too long" 422 tests, plus a `validate.ComposedRepoNameOverflows` boundary test.

## Propagation note (for anyone closing the issue)

Deploying classroom50.org is necessary but not sufficient: the rejecting regex lives inside each teacher's own config-repo workflow, so an org owner must re-commit the skeleton — one click via the owner-only "Classroom workflow files are out of date" banner the deploy surfaces, or `gh teacher init <org>` on the new CLI. Students do nothing; their shim resolves `@<default-branch>` at workflow-call time.

## Test plan

- [x] web: `tsc -b`, `eslint` (0 errors), `prettier --check`, i18n strict audit, node vitest suite passes (incl. new `CreateClassroomForm` tests)
- [x] cli: `go build`/`go test`/`golangci-lint run` clean across gh-teacher, gh-student, shared
- [x] python: skeleton_tests + autograders_tests pass (incl. the new parity test)
- [ ] Playwright browser suite (not runnable in this environment; unaffected by these changes)
- [ ] Manual: create a classroom with a >39-char slug in the web GUI, accept as a student, push, and confirm the autograde run reaches grading