### PR TITLE
fix(cli): scope collect-scores staff-team grant to who needs it

### DIFF
--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -1333,14 +1333,11 @@ def grant_classroom_team_access(
     deferral rather than a failure. A classroom with no mapped staff team is a
     no-op.
 
-    A staff team with no members is skipped (its grants would benefit nobody),
-    so an empty ta/hta team no longer sweeps every student repo — the common
-    case behind the "granting to repos that don't exist" reports. The skip is
-    per-slug: a classroom with TAs but no HTAs still grants the TA team.
+    A staff team with no members is skipped per-slug (its grants would benefit
+    nobody), so an empty ta team still lets a populated hta team grant.
 
     `assignment_filter` scopes the grant to one assignment (its student repos
-    and its private template) so a per-assignment "Sync now" doesn't sweep the
-    whole classroom; blank grants every assignment as before.
+    and its private template); blank grants every assignment as before.
     """
     role_slugs = resolve_staff_team_slugs(classroom_meta)
     grant_slugs = [
@@ -1356,12 +1353,9 @@ def grant_classroom_team_access(
     # still need access to review them.
     slugs = all_assignment_slugs(assignments)
     if assignment_filter:
-        # A per-assignment run touches only that assignment's repos/template.
-        # Skip a classroom that lacks the slug SILENTLY, mirroring
-        # collect_classroom's per-classroom skip — main()'s run-level
-        # assignment_filter_matched guard owns the single loud "no classroom
-        # has this slug" failure, so warning here would spam N-1 times in a
-        # multi-classroom org where the slug lives in one classroom.
+        # Skip a classroom lacking the slug silently, like collect_classroom:
+        # main()'s run-level guard owns the single loud "no such slug" error,
+        # so warning here would spam once per non-matching classroom.
         if assignment_filter not in slugs:
             return
         slugs = [assignment_filter]
@@ -1411,12 +1405,10 @@ def grant_classroom_team_access(
         return
 
     for team_slug, permission in grant_slugs:
-        # Skip a staff team that has no members: its grants would benefit
-        # nobody, and an empty ta/hta team otherwise sweeps every student repo
-        # (the "granting to repos that don't exist" reports). Follows the same
-        # SKIPPABLE-warn-and-skip contract as the student-team read above —
-        # any non-401/403/599/throttle (404 = team not created yet, 422, …)
-        # skips this team for the run; the add-only pass re-affirms next run.
+        # Read this staff team's members to skip it when empty (see docstring).
+        # Same SKIPPABLE-warn-and-skip contract as the student read above: any
+        # non-401/403/599/throttle (404 = team not created yet, 422, …) skips
+        # this team for the run; the add-only pass re-affirms it next run.
         try:
             staff_logins = (
                 team_members.logins(team_slug)
@@ -1500,8 +1492,7 @@ def private_template_targets(
     `repo_index` already knows each in-org repo's `private` flag from the org
     listing, so the per-template read only happens when it can't say.
 
-    `assignment_filter` scopes to one assignment's template (mirrors the
-    student-repo scoping in grant_classroom_team_access); blank keeps them all."""
+    `assignment_filter` scopes to one assignment's template; blank keeps all."""
     targets: list[tuple[str, str]] = []
     # Deduped on the REF, not the kept targets: assignments commonly share one
     # starter template, and only private ones are kept — so deduping on the

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -258,6 +258,7 @@ def main() -> int:
                 service_token=service_token,
                 repo_index=repo_index,
                 team_members=team_members,
+                assignment_filter=assignment_filter,
             )
         except GrantThrottled as exc:
             # NOT a failure: collection is untouched, the pass is idempotent, and
@@ -1316,6 +1317,7 @@ def grant_classroom_team_access(
     service_token: str,
     repo_index: RepoIndex | None = None,
     team_members: "TeamMembers | None" = None,
+    assignment_filter: str = "",
 ) -> None:
     """Grant each classroom staff team its mapped repo permission (see
     STAFF_TEAM_PERMISSIONS) on every EXISTING student assignment repo and on each
@@ -1330,6 +1332,15 @@ def grant_classroom_team_access(
     main() aborts; a throttle raises GrantThrottled, which main() reports as a
     deferral rather than a failure. A classroom with no mapped staff team is a
     no-op.
+
+    A staff team with no members is skipped (its grants would benefit nobody),
+    so an empty ta/hta team no longer sweeps every student repo — the common
+    case behind the "granting to repos that don't exist" reports. The skip is
+    per-slug: a classroom with TAs but no HTAs still grants the TA team.
+
+    `assignment_filter` scopes the grant to one assignment (its student repos
+    and its private template) so a per-assignment "Sync now" doesn't sweep the
+    whole classroom; blank grants every assignment as before.
     """
     role_slugs = resolve_staff_team_slugs(classroom_meta)
     grant_slugs = [
@@ -1344,6 +1355,16 @@ def grant_classroom_team_access(
     # skipped by collection but their student repos still exist and staff
     # still need access to review them.
     slugs = all_assignment_slugs(assignments)
+    if assignment_filter:
+        # A per-assignment run touches only that assignment's repos/template.
+        # Skip a classroom that lacks the slug SILENTLY, mirroring
+        # collect_classroom's per-classroom skip — main()'s run-level
+        # assignment_filter_matched guard owns the single loud "no classroom
+        # has this slug" failure, so warning here would spam N-1 times in a
+        # multi-classroom org where the slug lives in one classroom.
+        if assignment_filter not in slugs:
+            return
+        slugs = [assignment_filter]
     if not slugs:
         return
 
@@ -1382,13 +1403,43 @@ def grant_classroom_team_access(
             targets.append((org, repo_name))
     targets.extend(
         private_template_targets(
-            api_url, org, assignments, service_token, repo_index=repo_index
+            api_url, org, assignments, service_token, repo_index=repo_index,
+            assignment_filter=assignment_filter,
         )
     )
     if not targets:
         return
 
     for team_slug, permission in grant_slugs:
+        # Skip a staff team that has no members: its grants would benefit
+        # nobody, and an empty ta/hta team otherwise sweeps every student repo
+        # (the "granting to repos that don't exist" reports). Follows the same
+        # SKIPPABLE-warn-and-skip contract as the student-team read above —
+        # any non-401/403/599/throttle (404 = team not created yet, 422, …)
+        # skips this team for the run; the add-only pass re-affirms next run.
+        try:
+            staff_logins = (
+                team_members.logins(team_slug)
+                if team_members is not None
+                else list_team_member_logins(api_url, org, team_slug, service_token)
+            )
+        except urllib.error.HTTPError as exc:
+            if classify(exc) is not SKIPPABLE:
+                raise
+            emit_warning(
+                f"{classroom_short}: could not read staff team {team_slug!r} members: "
+                f"HTTP {exc.code} ({exc.reason or 'no reason'}); skipping its grant this run."
+            )
+            continue
+        except (json.JSONDecodeError, ValueError) as exc:
+            emit_warning(
+                f"{classroom_short}: staff team {team_slug!r} member listing malformed "
+                f"({exc}); skipping its grant this run."
+            )
+            continue
+        if not staff_logins:
+            continue
+
         # One bulk read replaces grant_team_repo's per-repo access check: after
         # the first run nearly every target is already granted, so that check —
         # not the PUT — is the request that dominates. None means "unknown".
@@ -1436,6 +1487,7 @@ def private_template_targets(
     assignments: dict[str, Any],
     service_token: str,
     repo_index: RepoIndex | None = None,
+    assignment_filter: str = "",
 ) -> list[tuple[str, str]]:
     """The private, in-org assignment templates (starter code the staff team
     should also be able to read), as (owner, repo) pairs.
@@ -1446,14 +1498,21 @@ def private_template_targets(
     once for all staff roles — the read doesn't depend on the team.
 
     `repo_index` already knows each in-org repo's `private` flag from the org
-    listing, so the per-template read only happens when it can't say."""
+    listing, so the per-template read only happens when it can't say.
+
+    `assignment_filter` scopes to one assignment's template (mirrors the
+    student-repo scoping in grant_classroom_team_access); blank keeps them all."""
     targets: list[tuple[str, str]] = []
     # Deduped on the REF, not the kept targets: assignments commonly share one
     # starter template, and only private ones are kept — so deduping on the
     # output would re-read every public template once per assignment.
     seen: set[tuple[str, str]] = set()
     for entry in assignments.get("assignments") or []:
-        ref = assignment_template_ref(entry) if isinstance(entry, dict) else None
+        if not isinstance(entry, dict):
+            continue
+        if assignment_filter and entry.get("slug") != assignment_filter:
+            continue
+        ref = assignment_template_ref(entry)
         if ref is None:
             continue
         t_owner, t_repo = ref

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -3376,7 +3376,11 @@ class TestGrantClassroomTeamAccess:
 
     def test_grants_private_in_org_template_skips_public_and_out_of_org(self, monkeypatch):
         grants = self._capture_grants(monkeypatch)
-        monkeypatch.setattr(cs, "list_team_member_logins", lambda *a, **k: [])  # no students
+        # No students, but the TA team has a member — templates must still be
+        # granted so a TA can read the starter code before anyone accepts.
+        stub_team_members_by_slug(
+            monkeypatch, {"classroom50-cs": [], "classroom50-cs-ta": ["ta1"]}
+        )
         assignments = {
             "schema": cs.ASSIGNMENTS_SCHEMA_V1,
             "assignments": [
@@ -3452,6 +3456,167 @@ class TestGrantClassroomTeamAccess:
                 service_token="tok",
             )
         assert ei.value.code == 403
+
+    # --- empty-staff-team skip (change 1) ---
+
+    META_TA_HTA = {
+        "schema": cs.CLASSROOM_SCHEMA_V1,
+        "short_name": "cs",
+        "team": {"id": 1, "slug": "classroom50-cs"},
+        "teams": {
+            "ta": {"id": 2, "slug": "classroom50-cs-ta"},
+            "hta": {"id": 3, "slug": "classroom50-cs-hta"},
+        },
+    }
+
+    def test_empty_staff_team_grants_nothing_and_stays_green(self, monkeypatch, capsys):
+        # A ta team with no members must not sweep any student repo. The bulk
+        # known_team_repos read and every PUT are skipped, and the run is green.
+        grants = self._capture_grants(monkeypatch)
+        known_read = {"hit": False}
+
+        def fake_known(*a, **k):
+            known_read["hit"] = True
+            return None
+
+        monkeypatch.setattr(cs, "known_team_repos", fake_known)
+        stub_team_members_by_slug(
+            monkeypatch, {"classroom50-cs": ["alice", "bob"], "classroom50-cs-ta": []}
+        )
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
+        )
+        assert grants == []
+        assert known_read["hit"] is False  # no bulk read for an empty team
+
+    def test_empty_team_skip_is_per_slug_not_all_or_nothing(self, monkeypatch):
+        # ta is empty, hta is populated: the hta team still gets its grants.
+        grants = self._capture_grants(monkeypatch)
+        stub_team_members_by_slug(
+            monkeypatch,
+            {
+                "classroom50-cs": ["alice"],
+                "classroom50-cs-ta": [],
+                "classroom50-cs-hta": ["prof"],
+            },
+        )
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta=self.META_TA_HTA, assignments=self.ASSIGNMENTS, service_token="tok",
+        )
+        granted_teams = {team for team, _, _, _ in grants}
+        assert granted_teams == {"classroom50-cs-hta"}  # ta skipped, hta granted
+
+    def test_non_404_skippable_staff_read_skips_that_team(self, monkeypatch, capsys):
+        # A 422 (not 401/403/599/throttle) reading staff membership is SKIPPABLE:
+        # skip that team for the run without failing, and don't grant.
+        grants = self._capture_grants(monkeypatch)
+
+        def fake_members(api_url, org, team_slug, token):
+            if team_slug == "classroom50-cs-ta":
+                raise cs.urllib.error.HTTPError(url="u", code=422, msg="unproc", hdrs=None, fp=None)
+            return ["alice"]
+
+        monkeypatch.setattr(cs, "list_team_member_logins", fake_members)
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
+        )
+        assert grants == []
+        assert "::warning::" in capsys.readouterr().err
+
+    def test_hard_error_on_staff_read_propagates(self, monkeypatch):
+        # A 403 (missing Members scope) reading staff membership is FATAL and
+        # must abort so main() reports it.
+        self._capture_grants(monkeypatch)
+
+        def fake_members(api_url, org, team_slug, token):
+            if team_slug == "classroom50-cs-ta":
+                raise cs.urllib.error.HTTPError(url="u", code=403, msg="forbidden", hdrs=None, fp=None)
+            return ["alice"]
+
+        monkeypatch.setattr(cs, "list_team_member_logins", fake_members)
+        with pytest.raises(cs.urllib.error.HTTPError) as ei:
+            cs.grant_classroom_team_access(
+                api_url="https://api.github.com", org="cs50", classroom_short="cs",
+                classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
+            )
+        assert ei.value.code == 403
+
+    def test_throttled_staff_read_propagates_for_deferral(self, monkeypatch):
+        # A throttle reading staff membership is NOT SKIPPABLE, so it re-raises;
+        # main() turns a raw throttled HTTPError from the grant pass into a
+        # deferral (see test_raw_throttled_httperror_from_grant_pass_defers).
+        self._capture_grants(monkeypatch)
+
+        def fake_members(api_url, org, team_slug, token):
+            if team_slug == "classroom50-cs-ta":
+                raise http_error(403, {"Retry-After": "30"})
+            return ["alice"]
+
+        monkeypatch.setattr(cs, "list_team_member_logins", fake_members)
+        with pytest.raises(cs.urllib.error.HTTPError) as ei:
+            cs.grant_classroom_team_access(
+                api_url="https://api.github.com", org="cs50", classroom_short="cs",
+                classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
+            )
+        assert cs.classify(ei.value) is cs.THROTTLED
+
+    def test_malformed_staff_member_listing_warns_and_skips(self, monkeypatch, capsys):
+        grants = self._capture_grants(monkeypatch)
+
+        def fake_members(api_url, org, team_slug, token):
+            if team_slug == "classroom50-cs-ta":
+                raise ValueError("bad JSON")
+            return ["alice"]
+
+        monkeypatch.setattr(cs, "list_team_member_logins", fake_members)
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
+        )
+        assert grants == []
+        assert "::warning::" in capsys.readouterr().err
+
+    # --- per-assignment scoping (change 2) ---
+
+    def test_assignment_filter_scopes_student_repos_and_template(self, monkeypatch):
+        grants = self._capture_grants(monkeypatch)
+        stub_team_members_by_slug(
+            monkeypatch, {"classroom50-cs": ["alice"], "classroom50-cs-ta": ["ta1"]}
+        )
+        assignments = {
+            "schema": cs.ASSIGNMENTS_SCHEMA_V1,
+            "assignments": [
+                {"slug": "hw1", "mode": "individual", "template": {"owner": "cs50", "repo": "hw1-tmpl"}},
+                {"slug": "hw2", "mode": "individual", "template": {"owner": "cs50", "repo": "hw2-tmpl"}},
+            ],
+        }
+        monkeypatch.setattr(cs, "get_repo", lambda *a, **k: {"private": True})
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta=self.META, assignments=assignments, service_token="tok",
+            assignment_filter="hw1",
+        )
+        repos = {repo for _, _, repo, _ in grants}
+        assert repos == {"cs-hw1-alice", "hw1-tmpl"}  # hw2 repo + template untouched
+
+    def test_assignment_filter_unknown_slug_is_a_silent_noop(self, monkeypatch, capsys):
+        # Mirrors collect_classroom: a classroom lacking the scoped slug is
+        # skipped silently (main's run-level guard owns the single loud error),
+        # so a multi-classroom Sync now doesn't spam per-classroom warnings.
+        grants = self._capture_grants(monkeypatch)
+        stub_team_members_by_slug(
+            monkeypatch, {"classroom50-cs": ["alice"], "classroom50-cs-ta": ["ta1"]}
+        )
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
+            assignment_filter="does-not-exist",
+        )
+        assert grants == []
+        assert "::warning::" not in capsys.readouterr().err
 
 
 # Throttling vs. refusal ------------------------------------------------------
@@ -4147,6 +4312,21 @@ class TestTemplatePrivacyFromTheIndex:
         )
         assert targets == [("cs50", "priv-tmpl")]
         assert read == ["priv-tmpl", "pub-tmpl"]
+
+    def test_assignment_filter_limits_to_one_assignments_template(self, monkeypatch):
+        read: list[str] = []
+
+        def fake_get_repo(api_url, owner, repo, token):
+            read.append(repo)
+            return {"private": True}
+
+        monkeypatch.setattr(cs, "get_repo", fake_get_repo)
+        targets = cs.private_template_targets(
+            "https://api.github.com", "cs50", self.ASSIGNMENTS, "tok",
+            assignment_filter="hw1",
+        )
+        assert targets == [("cs50", "priv-tmpl")]  # hw2's template not read at all
+        assert read == ["priv-tmpl"]
 
 
 class TestRepoIndexLatch:


### PR DESCRIPTION
## Summary

The collect-scores staff-team grant pass re-affirmed TA/HTA `pull` access on **every assignment repo × every student on every run** — even when a classroom had no TAs/HTAs at all, and even for a per-assignment "Sync now". This burned Actions minutes and emitted a `404`/`422` warning for every not-yet-accepted student repo (and a `403` that marked the classroom failed when the token lacked Administration scope). It is the shared cause behind several open discussions.

This scopes the grant to who actually needs it, with two independent, add-only changes in `grant_classroom_team_access` ([`cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py`](cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py)):

- **Skip a staff team with no members.** A new per-staff-slug membership read gates each grant: an empty `ta`/`hta` team no longer sweeps every student repo. The skip is per-slug (a classroom with TAs but no HTAs still grants the TA team) and follows the existing student-team `SKIPPABLE`-warn-and-skip contract — a `401`/`403`/`599` still propagates so `main` reports it, a throttle re-raises for deferral, and a `404`/`422`/malformed listing warns and skips that team for the run. The pass is add-only (never revokes), so a mis-skip self-heals on the next full run.
- **Honor `ASSIGNMENT_FILTER`.** The `assignment` workflow input already scoped collection; now it also scopes the grant, threaded through `grant_classroom_team_access` and `private_template_targets`. A per-assignment "Sync now" touches only that assignment's student repos and private template. A classroom lacking the scoped slug is skipped silently, mirroring `collect_classroom`'s per-classroom skip, so `main`'s run-level guard still owns the single loud "no classroom has this slug" error.

The parity-pinned `STAFF_TEAM_PERMISSIONS` map is unchanged.

## Scope / what this does and does not solve

Populated classrooms (that do have TAs/HTAs) still run the full `student-members × all-assignments` sweep and still emit `404` warnings for not-yet-accepted repos on an unfiltered run — that runtime is a deferred follow-up. The membership skip eliminates the sweep only when there are no staff; the per-assignment scoping is what shrinks the "Sync now" path.

Known behavior change (add-only, intended): after the membership skip, a newly added TA gains student-repo read only at the next full (non-scoped) collect run; the accept-time eager grant covers only the template. Neither change ever revokes existing access.

## Test plan

- [x] `python3 -m pytest cli/gh-teacher/skeleton_tests -q` — 864 pass (9 new: empty-team no-op with no bulk read, per-slug skip, `422` skip, `403` propagate, throttle defer, malformed-JSON skip, per-assignment repo+template scoping, silent unknown-slug no-op, `private_template_targets` filter unit)
- [x] `python3 -m pytest cli/gh-teacher/autograders_tests -q` — 388 pass
- [x] `go build ./...` && `go vet ./...` && `go test ./...` in `cli/gh-teacher` — pass, including the `init_skeleton_test.go` skeleton-embed parity test
- Code review: `ce-code-review` receipt `status: complete` (run 20260822-122553-e9ceefcf), verdict "Ready with fixes"; the one P2 (per-classroom warning divergence) was applied as a silent skip and its two flagged staff-read error-path test gaps are now covered. No open actionable residuals.

## Post-Deploy Monitoring & Validation

This change ships as a skeleton script embedded into each org's `classroom50` repo at `gh teacher init`; existing classrooms pick it up when their skeleton is refreshed. To validate after a Collect Scores run:

- **Log query (Actions run):** in the "Collect scores" step output, confirm classrooms with no TAs/HTAs no longer emit `could not grant ... HTTP 404` lines, and a per-assignment "Sync now" only logs `granted <team> pull on N repo(s)` for the scoped assignment.
- **Healthy signal:** shorter Collect Scores runtime for no-staff classrooms; grant warnings only for classrooms that actually have staff and not-yet-accepted repos.
- **Failure signal / rollback trigger:** a staffed classroom stops granting (TAs report losing repo access) or a `403` "staff-team access grant failed" appears where it did not before → revert this commit and re-run.
- **Validation window/owner:** first scheduled/manual Collect Scores run after rollout; repo maintainer.