### PR TITLE
fix(web): eliminate loading flashes and redundant entrance animations

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -31,6 +31,12 @@
     />
     <meta name="twitter:image" content="https://classroom50.org/og-image.jpg" />
     <title>Classroom 50</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Noto+Sans+JP:wght@400;500;700&display=swap"
+    />
     <script>
       // Anti-flash: apply the persisted (or OS-preferred) theme before the app
       // renders so there's no light->dark flicker. Mirrors resolveInitialTheme
@@ -81,6 +87,17 @@
         } catch (e) {}
       })()
     </script>
+    <style>
+      /* Anti-flash: paint the themed canvas before the CSS bundle arrives so a
+         dark-mode first load never flashes white. Hand-mirrors --color-base-100
+         for each theme in src/index.css — keep in sync. */
+      html {
+        background-color: #fafafa;
+      }
+      html[data-theme="sumi-dark"] {
+        background-color: #1b1b1d;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -103,11 +103,13 @@ export function NoSearchResults({
   )
 }
 
-// Placeholder rows for a list/table body while its data loads. Shared so list
-// pages skeleton-in consistently (content fades into place) instead of a
-// centered spinner that content then jumps to replace. Decorative — hidden from
+// Placeholder rows for a list body while its data loads. Shared so list pages
+// skeleton-in consistently (content fades into place) instead of a centered
+// spinner that content then jumps to replace. Decorative — hidden from
 // assistive tech; the surrounding container carries the aria-busy signal.
-export function SkeletonRows({
+// Named ListSkeletonRows to keep it distinct from the <tr>-based SkeletonRows
+// in components/ui/TableShell.
+export function ListSkeletonRows({
   rows = 5,
   className = "divide-y divide-base-200",
 }: {

--- a/web/src/components/org/StudentAssignmentList.tsx
+++ b/web/src/components/org/StudentAssignmentList.tsx
@@ -421,7 +421,8 @@ export function StudentAssignmentList({
 
   if (isLoading) {
     return (
-      <TableShell padded ariaBusy>
+      // animate={false}: PageTransition already animates the page in.
+      <TableShell animate={false} padded ariaBusy>
         <TableHead sort={sortKey} onSortChange={changeSort} />
         <tbody>
           <SkeletonRows rows={3} bars={SKELETON_BARS} />
@@ -485,16 +486,18 @@ export function StudentAssignmentList({
         />
       ) : (
         // Same table shell as the teacher assignments list, so the two
-        // surfaces read as one design.
-        <TableShell padded>
+        // surfaces read as one design. Its entrance is off — the tbody
+        // blockEnter below is the data-arrival cue.
+        <TableShell animate={false} padded>
           <caption className="sr-only">
             {t("assignments.discover.tableCaption")}
           </caption>
           <TableHead sort={sortKey} onSortChange={changeSort} />
           {/* Same recipe as the teacher table: the body enters as one block
-              (blockEnter) and replays when the visible set changes. */}
+              (blockEnter) and replays when the view changes (filter/sort — not
+              per search keystroke, which would remount the rows mid-typing). */}
           <motion.tbody
-            key={visible.map((a) => a.slug).join("|")}
+            key={`${JSON.stringify(filters)}|${sortKey}`}
             variants={blockEnter}
             initial="initial"
             animate="animate"

--- a/web/src/components/status/ActionsBanner.tsx
+++ b/web/src/components/status/ActionsBanner.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
-import {
-  AnimatePresence,
-  motion,
-  useMotionValue,
-  useMotionValueEvent,
-} from "motion/react"
+import { AnimatePresence, motion } from "motion/react"
 import {
   AlertTriangle,
   CheckCircle2,
@@ -341,10 +336,10 @@ export function ActionsBanner() {
   const showList = canExpand && expanded
 
   // Reserve body padding equal to banner height so it PUSHES the app down
-  // rather than overlaying it (the fixed bar is out of normal flow). During
-  // enter/exit, padding = height + y tracks the banner's bottom edge frame-for-
-  // frame so the app slides with it. Height is measured from the inner content
-  // (unaffected by the slide) via a ResizeObserver so expanding stays in sync.
+  // rather than overlaying it (the fixed bar is out of normal flow). The
+  // padding transitions in step with the banner's slide so the app moves with
+  // it. Height is measured from the inner content (unaffected by the slide)
+  // via a ResizeObserver so expanding stays in sync.
   const contentRef = useRef<HTMLDivElement | null>(null)
   const [bannerHeight, setBannerHeight] = useState(0)
   useLayoutEffect(() => {
@@ -357,24 +352,32 @@ export function ActionsBanner() {
     return () => observer.disconnect()
   }, [visible])
 
-  // `y` (animated on enter/exit) drives body padding = height + y. onExitComplete
-  // below hard-clears the gap so a reduced-motion or interrupted exit can't
-  // strand a permanent top gap.
-  const y = useMotionValue(-bannerHeight)
-  useMotionValueEvent(y, "change", (value) => {
-    const px = Math.max(0, bannerHeight + value)
-    document.body.style.paddingTop = px > 0 ? `${px}px` : ""
-  })
+  // The padding animates via a CSS transition timed to the banner's slide —
+  // NOT per-frame JS writes (the previous motion-value listener wrote
+  // body.style.paddingTop every animation frame, forcing a full-page style
+  // recalc + layout per frame). The reduced-motion safety net in index.css
+  // collapses this transition alongside the Motion slide. onExitComplete below
+  // hard-clears the gap so an interrupted exit can't strand a permanent top gap.
   useEffect(() => {
-    if (!visible) return
-    const px = Math.max(0, bannerHeight + y.get())
-    document.body.style.paddingTop = px > 0 ? `${px}px` : ""
+    const body = document.body
+    if (!visible || bannerHeight <= 0) return
+    body.style.transitionProperty = "padding-top"
+    body.style.transitionTimingFunction = "var(--ease-out-soft)"
+    body.style.transitionDuration = `${DURATION.slow}s`
+    body.style.paddingTop = `${bannerHeight}px`
     return () => {
-      document.body.style.paddingTop = ""
+      // Exit (or a height change, which immediately re-applies): transition
+      // back at the banner's exit pace.
+      body.style.transitionDuration = `${DURATION.base}s`
+      body.style.paddingTop = ""
     }
-  }, [visible, bannerHeight, y])
+  }, [visible, bannerHeight])
   const clearReservedGap = () => {
-    document.body.style.paddingTop = ""
+    const body = document.body
+    body.style.paddingTop = ""
+    body.style.transitionProperty = ""
+    body.style.transitionTimingFunction = ""
+    body.style.transitionDuration = ""
   }
 
   const body = (
@@ -418,7 +421,6 @@ export function ActionsBanner() {
       <AnimatePresence onExitComplete={clearReservedGap}>
         {visible && bannerHeight > 0 && (
           <motion.div
-            style={{ y }}
             initial={{ y: -bannerHeight }}
             animate={{
               y: 0,

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Noto+Sans+JP:wght@400;500;700&display=swap");
 @import "tailwindcss";
 @plugin "daisyui/index.js" {
   themes: sumi --default;

--- a/web/src/lib/motion.ts
+++ b/web/src/lib/motion.ts
@@ -76,10 +76,13 @@ export const blockEnter: Variants = {
   },
 }
 
-// Hover affordance for clickable list rows: a subtle lift + shadow (the former
-// `clickable-row` CSS utility). Pair with a `bg` hover via className.
+// Hover affordance for clickable list rows: a subtle lift (the former
+// `clickable-row` CSS utility). Pair with a `bg` hover via className — the bg
+// carries the affordance. No shadow tween: animating box-shadow repaints the
+// row every frame, a visible stutter cost on long tables for a barely
+// perceptible 1px shadow.
 export const rowHover = {
-  whileHover: { y: -1, boxShadow: "0 1px 3px rgb(0 0 0 / 0.08)" },
+  whileHover: { y: -1 },
   transition: { duration: DURATION.base, ease: EASE_OUT },
 } as const
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -548,7 +548,6 @@
     "resendFailed": "Re-sending the invite for {{username}} failed ({{error}}).",
     "resend": "Re-send",
     "dismiss": "Dismiss",
-    "loadingRoster": "Loading roster...",
     "rosterLoadError": "Couldn't load the roster from GitHub. The enrolled list may be incomplete — this is a load error, not an empty classroom.",
     "rosterRetry": "Retry",
     "rosterParseError": "roster.csv is malformed and couldn't be fully read. Fix these lines so the roster stays accurate:",
@@ -1045,7 +1044,6 @@
     "serviceTokens": {
       "heading": "Manage Service Tokens",
       "subheading": "Service-token status across every organization you own. Rotate a token before it expires so score collection keeps working.",
-      "loading": "Checking your organizations…",
       "empty": "No organizations with Classroom 50 set up yet.",
       "expires": "Expires {{date}}",
       "manage": "Manage"
@@ -1762,7 +1760,6 @@
     "serviceToken": {
       "title": "Service token",
       "help": "A fine-grained GitHub token that lets Classroom 50 collect scores and regrade across your student repositories. Stored as a secret on your classroom50 repository.",
-      "checking": "Checking…",
       "statusPresent": "Token set",
       "statusMissing": "No service token set",
       "expiresOn": "Expires {{date}}",

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -246,6 +246,9 @@ export const TeacherAssignmentsView = ({
           canAuthor={canAuthor}
           sort={sort}
           onSortChange={setSort}
+          // Replay the row entrance on filter/sort changes; search is excluded
+          // so typing doesn't remount the rows on every keystroke.
+          viewSignature={`${JSON.stringify(filters)}|${sort}`}
         />
       )}
     </div>

--- a/web/src/pages/OrgActivityPage.tsx
+++ b/web/src/pages/OrgActivityPage.tsx
@@ -8,7 +8,7 @@ import { Activity } from "lucide-react"
 import { AnimatedAlert, Card, Button } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
-import { EmptyState, SkeletonRows } from "@/components/list"
+import { EmptyState, ListSkeletonRows } from "@/components/list"
 import RequireRole from "@/components/RequireRole"
 import { DiagnosticsDialog } from "@/components/DiagnosticsDialog"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -155,7 +155,7 @@ const OrgActivityPage = () => {
         {items.length === 0 ? (
           loading ? (
             <Card className="mt-4 w-full overflow-hidden" aria-busy>
-              <SkeletonRows rows={6} />
+              <ListSkeletonRows rows={6} />
             </Card>
           ) : (
             <EmptyState

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -19,7 +19,7 @@ import {
   Select,
   rtlFlip,
 } from "@/components/ui"
-import { SkeletonRows } from "@/components/list"
+import { ListSkeletonRows } from "@/components/list"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -457,7 +457,7 @@ const OrgMembersPage = () => {
 
           <Card className="mt-4 w-full overflow-hidden" aria-busy={isLoading}>
             {isLoading ? (
-              <SkeletonRows rows={6} />
+              <ListSkeletonRows rows={6} />
             ) : isError ? (
               <div className="px-6 py-10 text-center text-sm text-error">
                 {t("orgMembers.loadError")}

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -499,9 +499,19 @@ export const OrgSettingsPane = ({ highlighted }: { highlighted?: boolean }) => {
       className={sectionHighlightClass(highlighted ?? false)}
     >
       {tokenStatusLoading ? (
-        <p className="text-sm text-base-content/60">
-          {t("orgSettings.serviceToken.checking")}
-        </p>
+        <div
+          className="flex flex-wrap items-center justify-between gap-3"
+          aria-busy="true"
+        >
+          <span
+            aria-hidden="true"
+            className="skeleton skeleton-shimmer h-5 w-48"
+          />
+          <span
+            aria-hidden="true"
+            className="skeleton skeleton-shimmer h-8 w-24 rounded-field"
+          />
+        </div>
       ) : !present ? (
         <div className="flex flex-wrap items-center justify-between gap-3">
           <span className="inline-flex items-center gap-2 text-sm text-error">

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -241,10 +241,20 @@ function ClassroomResources({
 }) {
   const { t } = useTranslation()
   const base = pagesBaseUrl(org)
-  const { data: classroomData } = useGetClassroom(org, classroom)
+  const { data: classroomData, isLoading: classroomLoading } = useGetClassroom(
+    org,
+    classroom,
+  )
   const secret = classroomData?.secret
-  const { data: assignments } = usePagesAssignments(org, classroom, secret)
+  // Gate on the classroom read: fetching before the secret resolves would hit
+  // the unprotected path and 404 a protected classroom.
+  const { data: assignments, isPending: assignmentsPending } =
+    usePagesAssignments(org, classroom, secret, { enabled: !classroomLoading })
   const [open, setOpen] = useState(true)
+
+  // Hold skeletons until both reads settle so the resource rows and the "N
+  // resources" count don't pop in one by one as each query resolves.
+  const loading = classroomLoading || assignmentsPending
 
   // When protected, everything is served under the capability-URL segment; else
   // the plain classroom path. Same segment builder the Pages URL helpers use.
@@ -301,6 +311,7 @@ function ClassroomResources({
       initial="initial"
       animate="animate"
       transition={staggerTransition(index)}
+      aria-busy={loading || undefined}
     >
       <button
         type="button"
@@ -311,7 +322,12 @@ function ClassroomResources({
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <h3 className="truncate font-semibold">{classroom}</h3>
-            {secret ? (
+            {loading ? (
+              <span
+                aria-hidden="true"
+                className="skeleton skeleton-shimmer h-5 w-16 rounded-full"
+              />
+            ) : secret ? (
               <Badge tone="warning" className="gap-1">
                 <ShieldAlert aria-hidden="true" className="size-3" />
                 {t("published.unlisted")}
@@ -321,8 +337,17 @@ function ClassroomResources({
             )}
           </div>
           <p className="text-xs text-base-content/70">
-            {t("published.resourceCount", { count: resources.length })}
-            {secret ? t("published.servedUnlistedNote") : ""}
+            {loading ? (
+              <span
+                aria-hidden="true"
+                className="skeleton skeleton-shimmer inline-block h-3 w-32 align-middle"
+              />
+            ) : (
+              <>
+                {t("published.resourceCount", { count: resources.length })}
+                {secret ? t("published.servedUnlistedNote") : ""}
+              </>
+            )}
           </p>
         </div>
         <ChevronDown
@@ -334,18 +359,30 @@ function ClassroomResources({
       </button>
       {open && (
         <div className="flex flex-col gap-3 border-t border-base-200 p-5">
-          {secret && (
-            <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 p-3 text-xs text-base-content/70">
-              <ShieldAlert
+          {loading ? (
+            Array.from({ length: 2 }).map((_, i) => (
+              <div
+                key={i}
                 aria-hidden="true"
-                className="mt-0.5 size-4 shrink-0 text-warning"
+                className="skeleton skeleton-shimmer h-24 rounded-xl"
               />
-              <span>{t("published.unlistedWarning")}</span>
-            </div>
+            ))
+          ) : (
+            <>
+              {secret && (
+                <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 p-3 text-xs text-base-content/70">
+                  <ShieldAlert
+                    aria-hidden="true"
+                    className="mt-0.5 size-4 shrink-0 text-warning"
+                  />
+                  <span>{t("published.unlistedWarning")}</span>
+                </div>
+              )}
+              {resources.map((r) => (
+                <ResourceRow key={r.url} resource={r} />
+              ))}
+            </>
           )}
-          {resources.map((r) => (
-            <ResourceRow key={r.url} resource={r} />
-          ))}
         </div>
       )}
     </motion.div>
@@ -355,7 +392,7 @@ function ClassroomResources({
 export const PublishedResourcesPane = ({ org }: { org: string }) => {
   const { t } = useTranslation()
   const base = pagesBaseUrl(org)
-  const { classes } = useGetClasses(org)
+  const { classes, isLoading: classesLoading } = useGetClasses(org)
 
   // Org-level resources are classroom-independent: the public index and the two
   // generic engine scripts served at the Pages site root.
@@ -424,7 +461,20 @@ export const PublishedResourcesPane = ({ org }: { org: string }) => {
         <p className="mt-1 text-sm text-base-content/70">
           {t("published.perClassroomDescription")}
         </p>
-        {classes.length === 0 ? (
+        {/* Hold the skeleton while the class list loads — the empty-while-
+            loading array is indistinguishable from a genuinely empty org, so
+            rendering on it flashes the "no classrooms" empty state. */}
+        {classesLoading ? (
+          <div className="mt-4 flex flex-col gap-4" aria-busy="true">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <div
+                key={i}
+                aria-hidden="true"
+                className="skeleton skeleton-shimmer h-20 rounded-2xl"
+              />
+            ))}
+          </div>
+        ) : classes.length === 0 ? (
           <div className="mt-4 rounded-xl border border-dashed border-base-300 bg-base-100 p-6 text-center text-sm text-base-content/70">
             {t("published.noClassrooms")}
           </div>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -57,9 +57,15 @@ function ServiceTokensSection({ highlighted }: { highlighted?: boolean }) {
       highlighted={highlighted}
     >
       {isLoading ? (
-        <p className="text-sm text-base-content/60">
-          {t("settings.serviceTokens.loading")}
-        </p>
+        <ul className="flex flex-col gap-2" aria-busy="true">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <li
+              key={i}
+              aria-hidden="true"
+              className="skeleton skeleton-shimmer h-16 rounded-lg"
+            />
+          ))}
+        </ul>
       ) : ownedReady.length === 0 ? (
         <p className="text-sm text-base-content/60">
           {t("settings.serviceTokens.empty")}

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -225,7 +225,7 @@ const CsvRosterContent = ({
   classroom: string
 }) => {
   const { t } = useTranslation()
-  const { students } = useGetStudents(org, classroom)
+  const { students, isLoading } = useGetStudents(org, classroom)
 
   return (
     <>
@@ -241,7 +241,7 @@ const CsvRosterContent = ({
           </span>
         }
       />
-      <CsvRosterView students={students} />
+      <CsvRosterView students={students} loading={isLoading} />
     </>
   )
 }

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -365,6 +365,10 @@ const SubmissionsPageContent = () => {
     setLastViewSignature(viewSignature)
     setPage(0)
   }
+  // The animation signature drops the search text: re-keying the rows on every
+  // keystroke would remount and replay the whole tbody entrance while typing.
+  // Filter/sort/size/assignment changes still re-stagger.
+  const animationSignature = `${JSON.stringify(filters)}|${sort}|${pageSize}|${assignment ?? ""}`
 
   // Section filtering: distinct sections for the dropdown, plus a username ->
   // section lookup so submitted rows (which carry only logins) can be matched.
@@ -1473,9 +1477,10 @@ const SubmissionsPageContent = () => {
           onPageSizeChange={setPageSize}
           sort={sort}
           onSortChange={setSort}
-          // Re-stagger the row entrance whenever the visible set changes (search/
-          // filter/sort/size/assignment). Combined with `page` inside the table.
-          viewSignature={viewSignature}
+          // Re-stagger the row entrance whenever the view changes (filter/sort/
+          // size/assignment — search deliberately excluded). Combined with
+          // `page` inside the table.
+          viewSignature={animationSignature}
           // The current page's live/detected data is still resolving, so the
           // count + last-submitted cells shimmer until they settle. Gated on
           // overlayCapable so a snapshot-only view never shows a settling

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -365,6 +365,7 @@ const AssignmentsTable = ({
   canAuthor = false,
   sort,
   onSortChange,
+  viewSignature = "",
 }: {
   org: string
   classroom: string
@@ -391,6 +392,10 @@ const AssignmentsTable = ({
   // render as static text.
   sort?: AssignmentSort
   onSortChange?: (sort: AssignmentSort) => void
+  // A signature of the current view (filter/sort — NOT the search text, which
+  // changes per keystroke and would remount the rows mid-typing). Keys the row
+  // container so the rows replay their entrance when the view changes.
+  viewSignature?: string
 }) => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
@@ -439,7 +444,10 @@ const AssignmentsTable = ({
   const canMutate = !archived && canAuthor
 
   return (
-    <TableShell key={loading ? "loading" : "loaded"} padded ariaBusy={loading}>
+    // The shell's own entrance is off: the page-level PageTransition already
+    // animates navigation, and the tbody blockEnter below is the data-arrival
+    // cue — a third nested entrance reads as a double pop.
+    <TableShell animate={false} padded ariaBusy={loading}>
       <caption className="sr-only">{t("assignments.table.caption")}</caption>
       <thead>
         <tr>
@@ -469,9 +477,10 @@ const AssignmentsTable = ({
         </tr>
       </thead>
       {/* Same recipe as the submissions table: the body enters as one block
-            (blockEnter) and replays when the visible set changes. */}
+            (blockEnter) and replays when the view changes (data arrival, filter,
+            sort — not per search keystroke, which the signature excludes). */}
       <motion.tbody
-        key={assignments?.map((a) => a.slug).join("|") ?? ""}
+        key={`${loading}:${viewSignature}`}
         variants={blockEnter}
         initial="initial"
         animate="animate"

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Info } from "lucide-react"
 
-import { Alert, Toolbar } from "@/components/ui"
+import { Alert, SkeletonRows, Toolbar } from "@/components/ui"
 import { RoleBadges } from "./RoleBadges"
 import { StudentSortSelect } from "./StudentSortSelect"
 import { coerceImportRole } from "./rosterImportParse"
@@ -26,7 +26,16 @@ function displayName(student: Student): string {
 // isn't on the classroom's secret student team, so the team-members API 403s for
 // them — roster.csv (readable via config-repo access) is the stand-in:
 // teacher-maintained, not live, no invites or management actions.
-const CsvRosterView = ({ students }: { students: Student[] }) => {
+const CsvRosterView = ({
+  students,
+  loading = false,
+}: {
+  students: Student[]
+  // Hold skeleton rows while roster.csv loads — the empty-while-loading array
+  // is indistinguishable from a genuinely empty roster, so rendering on it
+  // flashes the "empty roster" row.
+  loading?: boolean
+}) => {
   const { t } = useTranslation()
   const [sortMode, setSortMode] =
     useState<StudentSortMode>(DEFAULT_STUDENT_SORT)
@@ -50,7 +59,7 @@ const CsvRosterView = ({ students }: { students: Student[] }) => {
       ) : null}
 
       <div className="overflow-x-auto rounded-box border border-base-content/5 bg-base-100">
-        <table className="table">
+        <table className="table" aria-busy={loading || undefined}>
           <caption className="sr-only">
             {t("students.csvRoster.caption")}
           </caption>
@@ -62,7 +71,9 @@ const CsvRosterView = ({ students }: { students: Student[] }) => {
             </tr>
           </thead>
           <tbody>
-            {rows.length === 0 ? (
+            {loading ? (
+              <SkeletonRows rows={3} bars={["w-40", "w-16", "w-20"]} />
+            ) : rows.length === 0 ? (
               <tr>
                 <td colSpan={3} className="text-center">
                   {t("students.csvRoster.empty")}

--- a/web/src/pages/students/EnrolledStudents.smoke.test.tsx
+++ b/web/src/pages/students/EnrolledStudents.smoke.test.tsx
@@ -125,14 +125,15 @@ afterEach(() => {
 })
 
 describe("EnrolledStudents — rendered phase views", () => {
-  it("shows the loading spinner while the roster loads", () => {
+  it("shows skeleton rows while the roster loads", () => {
     useTeamRoster.mockReturnValue({
       ...emptyRoster,
       isLoading: true,
       isEmpty: false,
     })
-    render(renderView())
-    expect(screen.getByText("students.loadingRoster")).not.toBeNull()
+    const { container } = render(renderView())
+    expect(container.querySelector("[aria-busy='true']")).not.toBeNull()
+    expect(container.querySelector(".skeleton")).not.toBeNull()
   })
 
   it("shows the empty state when the roster has no rows", () => {

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -6,9 +6,9 @@ import {
   Badge,
   Button,
   Card,
-  Spinner,
   Toolbar,
 } from "@/components/ui"
+import { ListSkeletonRows } from "@/components/list"
 import type { Student } from "@/types/classroom"
 import { useQueryClient } from "@tanstack/react-query"
 import type { RosterCsvProblem } from "@/domain/students"
@@ -644,12 +644,11 @@ const EnrolledStudents = ({
       ) : null}
 
       {/* The list card. */}
-      <Card className="w-full overflow-hidden">
+      <Card className="w-full overflow-hidden" aria-busy={isLoading}>
         {isLoading ? (
-          <div className="flex items-center justify-center gap-3 px-6 py-12 text-base-content/70">
-            <Spinner size="md" />
-            <span className="text-sm">{t("students.loadingRoster")}</span>
-          </div>
+          // Skeleton rows shaped like the roster rows, so content fades into
+          // place instead of jumping in to replace a centered spinner.
+          <ListSkeletonRows className="divide-y divide-base-300" />
         ) : isError ? (
           <div
             role="alert"

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -346,9 +346,10 @@ const SubmissionsTable = ({
   // toggles recent/oldest). Omitted, the headers render as static text and
   // the toolbar select stays the only sort control.
   onSortChange?: (sort: SubmissionSort) => void
-  // A signature of the current view (search/filter/sort/size/assignment) from
-  // the page. Combined with `page` it keys the row container, so the rows
-  // re-stagger their entrance whenever the visible set changes. Empty (the
+  // A signature of the current view (filter/sort/size/assignment — NOT the
+  // search text, which changes per keystroke and would remount the rows mid-
+  // typing) from the page. Combined with `page` it keys the row container, so
+  // the rows re-stagger their entrance whenever the view changes. Empty (the
   // default) means the container never re-keys — fine for tests that render a
   // single static page.
   viewSignature?: string
@@ -664,7 +665,10 @@ const SubmissionsTable = ({
 
   return (
     <>
+      {/* The shell's own entrance is off: PageTransition already animates
+          navigation and the tbody blockEnter is the data-arrival cue. */}
       <TableShell
+        animate={false}
         ariaBusy={initialLoading}
         footer={
           showPager ? (


### PR DESCRIPTION
## Summary

- **White flash on first load**: `index.html` now paints the themed canvas (`--color-base-100` per theme, hand-mirrored with a keep-in-sync comment) via an inline style before the CSS bundle arrives, and the render-blocking Google Fonts `@import` moved out of `index.css` into `<link rel="preconnect">` + `<link rel="stylesheet">` so font CSS loads in parallel.
- **Empty-state flashes on cold load**: PublishedResources holds skeletons instead of flashing "No classrooms" (and `ClassroomResources` gates its Pages read on the classroom read, fixing a wasted 404 on protected classrooms); the non-owner CSV roster skeletons instead of flashing "empty roster"; the Settings/Org-settings token sections swap layout-shifting loading text for content-shaped skeletons; EnrolledStudents uses list skeleton rows instead of a centered spinner.
- **Redundant animation replays**: the three data tables pass `animate={false}` to `TableShell` so their entrance no longer stacks with `PageTransition` on navigation (the tbody `blockEnter` stays as the data-arrival cue), and the tbody animation keys now exclude the search text so typing no longer remounts and re-staggers every row per keystroke (filter/sort/size/page replays kept).
- **Stutter (low-risk fixes)**: `ActionsBanner` no longer writes `body.style.paddingTop` on every animation frame — the reserved gap transitions via CSS timed to the banner's slide; the row-hover `boxShadow` tween (per-row repaint) is dropped, keeping the lift + bg hover.
- Cleanup: the div-based list `SkeletonRows` is renamed `ListSkeletonRows` to resolve the name collision with the `<tr>`-based `SkeletonRows` in `TableShell`; dead locale keys removed.

## Test plan

- [x] `npm run check` green (tsc, eslint, prettier, arch:validate, 4271 vitest tests)
- [x] `audit_i18n.py --strict` passes (no dead/missing keys)
- [ ] Dark-mode hard reload shows no white flash
- [ ] Cold loads of Published resources and the non-owner roster show skeletons, not empty states
- [ ] Typing in the submissions/assignments search does not replay the row entrance
- [ ] Actions banner slide-in/out still pushes the page smoothly (incl. reduced motion)