### PR TITLE
fix(web): keep repo actions for no_autograder assignments in manage hub

### DIFF
--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -1271,7 +1271,7 @@ const SubmissionsPageContent = () => {
               regradeAllActive={regradeAllActive}
               canRegradeAll={canRegradeAll}
               emptyRoster={emptyRoster.show}
-              emptyRepo={skipsGrading}
+              skipsGrading={skipsGrading}
               // Metrics summarizes the GRADED snapshot, and computeStats skips
               // every `pending` row — so hide it whenever an overlay is adding
               // those rows, live or detection. Keying this on liveCapable alone
@@ -1400,7 +1400,8 @@ const SubmissionsPageContent = () => {
           thresholdFraction={thresholdFraction}
           filtered={hasActiveFilter}
           onClearFilters={clearFilters}
-          emptyRepo={skipsGrading}
+          emptyRepoAssignment={isEmptyRepoAssignment}
+          skipsGrading={skipsGrading}
           // Per-row trigger retrofit: owner + default-autograder only (teacher-
           // authored shims are never rewritten). Mirrors the bulk-action gate,
           // including assignmentResolved.

--- a/web/src/pages/submissions/ManageSubmissionModal.test.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.test.tsx
@@ -68,7 +68,8 @@ const individualAction = {
   owner: "alice",
   repo: "cs101-hw1-alice",
   hasRepo: true,
-  emptyRepo: false,
+  skipsGrading: false,
+  emptyRepoAssignment: false,
 }
 
 afterEach(() => {

--- a/web/src/pages/submissions/SubmissionsActionsMenu.test.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.test.tsx
@@ -69,16 +69,20 @@ describe("SubmissionsActionsMenu — Open all Feedback PRs item", () => {
     ).not.toBeNull()
   })
 
-  it("hides the item for an empty_repo assignment even if a handler is passed", () => {
+  it("keeps the item for a no_autograder (skipsGrading) assignment when a handler is passed", () => {
     render(
       <SubmissionsActionsMenu
         {...baseProps}
-        emptyRepo
+        skipsGrading
         onOpenAllPrs={() => {}}
       />,
     )
-    // The whole !emptyRepo block (incl. this item) is gone for empty_repo.
-    expect(screen.queryByText("submissions.openAllPrs.menuLabel")).toBeNull()
+    // The page owns the empty_repo gate (handler omitted there); a templated
+    // no_autograder repo permits the Feedback PR, so the item must survive
+    // skipsGrading.
+    expect(
+      screen.queryByText("submissions.openAllPrs.menuLabel"),
+    ).not.toBeNull()
   })
 })
 
@@ -96,8 +100,8 @@ describe("SubmissionsActionsMenu — Download all submissions item", () => {
     expect((item.closest("button") as HTMLButtonElement).disabled).toBe(true)
   })
 
-  it("stays visible for an empty_repo assignment (unlike Open all PRs)", () => {
-    render(<SubmissionsActionsMenu {...baseProps} emptyRepo />)
+  it("stays visible for a non-autograding assignment", () => {
+    render(<SubmissionsActionsMenu {...baseProps} skipsGrading />)
     expect(
       screen.queryByText("submissions.downloadAll.menuLabel"),
     ).not.toBeNull()

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -33,7 +33,7 @@ export function SubmissionsActionsMenu({
   regradeAllActive,
   canRegradeAll = true,
   emptyRoster,
-  emptyRepo = false,
+  skipsGrading = false,
   onMetrics,
   onCollect,
   onRegradeAll,
@@ -64,9 +64,10 @@ export function SubmissionsActionsMenu({
   // that don't gate (the item stays visible).
   canRegradeAll?: boolean
   emptyRoster: boolean
-  // empty_repo assignment: never autogrades, so the grading actions (Collect
-  // now / Regrade all / View workflow) are hidden — only the CSV export stays.
-  emptyRepo?: boolean
+  // The assignment never autogrades (empty_repo OR no_autograder), so the
+  // grading actions (Regrade all / View workflow) are hidden — Collect and the
+  // exports stay.
+  skipsGrading?: boolean
   // Opens the Metrics modal. Omitted (hidden) in live view, where the graded
   // snapshot stats don't apply.
   onMetrics?: () => void
@@ -182,9 +183,10 @@ export function SubmissionsActionsMenu({
             role="separator"
           />
         )}
-        {/* Open all Feedback PRs — the bulk PR action leads the menu. Its own
-            group (owner-only, non-empty_repo), above the grading actions. */}
-        {!emptyRepo && onOpenAllPrs && (
+        {/* Open all Feedback PRs — the bulk PR action leads the menu. The page
+            owns the gate (owner-only, non-empty_repo): a no_autograder repo is
+            templated and PERMITS the PR, so no skipsGrading re-gate here. */}
+        {onOpenAllPrs && (
           <>
             <li>
               <button
@@ -211,7 +213,7 @@ export function SubmissionsActionsMenu({
             />
           </>
         )}
-        {/* Collect stays for empty_repo assignments: it's org-wide and
+        {/* Collect stays for non-autograding assignments: it's org-wide and
             collect_scores.py skips this assignment server-side (see the
             SubmissionsPage comment). Only grading actions hide. */}
         <li>
@@ -231,7 +233,7 @@ export function SubmissionsActionsMenu({
               : t("submissions.collect.label")}
           </button>
         </li>
-        {!emptyRepo && (
+        {!skipsGrading && (
           <>
             {canRegradeAll && (
               <li>

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -298,9 +298,11 @@ export const RepoRowActions = ({
 //
 // Gating mirrors the old cluster: repo-only actions (Review, access, regrade,
 // download) disable only when no repo exists; submission-only links
-// (commit, details) dim until an attempt lands; assignments that skip built-in
-// grading (empty_repo OR no_autograder — this receives skipsGrading) omit the
-// PR/access/details/regrade actions entirely.
+// (commit, details) dim until an attempt lands. Two distinct omission gates:
+// assignments that skip built-in grading (empty_repo OR no_autograder —
+// skipsGrading) omit the grading actions (details/regrade), while only a bare
+// empty_repo also omits the repo actions (Review/access) — a no_autograder
+// repo is templated and keeps the Feedback PR, matching the page's bulk gates.
 export type SubmissionActionListProps = {
   mode: AssignmentMode
   org: string
@@ -315,7 +317,10 @@ export type SubmissionActionListProps = {
   // snapshot from scores.json and can lag a fresh push. Falls back to `commit`.
   latestCommitHref?: string | null
   release?: string | null
-  emptyRepo: boolean
+  // The assignment never autogrades (empty_repo OR no_autograder).
+  skipsGrading: boolean
+  // The narrower bare-repo case (empty_repo alone).
+  emptyRepoAssignment: boolean
   displayName?: string
   // Opens the individual per-student access editor (stacked on the hub);
   // omitted for group rows (access is managed through the group Members editor).
@@ -345,7 +350,8 @@ export const SubmissionActionList = ({
   commit,
   latestCommitHref,
   release,
-  emptyRepo,
+  skipsGrading,
+  emptyRepoAssignment,
   displayName,
   onManageAccess,
   submissionMode,
@@ -370,7 +376,9 @@ export const SubmissionActionList = ({
         disabled={!commitHref}
         external
       />
-      {!emptyRepo && (
+      {/* Repo actions: any templated repo (incl. no_autograder) keeps the
+          Feedback PR and is worth managing; only a bare empty_repo omits them. */}
+      {!emptyRepoAssignment && (
         <>
           <ReviewButton org={org} repo={repo} mode={mode} noRepo={!hasRepo} />
           {onManageAccess && (
@@ -383,6 +391,12 @@ export const SubmissionActionList = ({
               ariaLabel={t("submissions.table.manageAccessAria", { owner })}
             />
           )}
+        </>
+      )}
+      {/* Grading actions: no submit/* releases exist when grading is skipped,
+          so there's nothing to view or regrade. */}
+      {!skipsGrading && (
+        <>
           <ActionListRow
             icon={ScrollText}
             title={t("submissions.table.viewDetails")}

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -244,7 +244,7 @@ describe("SubmissionsTable empty_repo score cell", () => {
         {...baseProps}
         scores={[scoreRow()]}
         acceptedUsernames={new Set(["alice"])}
-        emptyRepo
+        skipsGrading
       />,
     )
     // The score cell shows the placeholder titled noGradingTitle instead of a
@@ -266,7 +266,7 @@ describe("SubmissionsTable empty_repo score cell", () => {
 
 describe("SubmissionsTable score override on a no-autograder manual assignment", () => {
   // A templated manual-graded assignment is written as no_autograder (the
-  // emptyRepo prop here), so manual grading must win over the no-grading
+  // skipsGrading prop here), so manual grading must win over the no-grading
   // em-dash — otherwise a grade entered via the non-submitter row becomes
   // invisible once the student turns into a submitter row.
   const overrideGrade = {
@@ -278,13 +278,13 @@ describe("SubmissionsTable score override on a no-autograder manual assignment",
     maxPoints: 10,
   }
 
-  it("offers the score-override trigger on a submitter row despite emptyRepo", () => {
+  it("offers the score-override trigger on a submitter row despite skipsGrading", () => {
     render(
       <SubmissionsTable
         {...baseProps}
         scores={[scoreRow()]}
         acceptedUsernames={new Set(["alice"])}
-        emptyRepo
+        skipsGrading
         overrideGrade={overrideGrade}
       />,
     )
@@ -302,19 +302,19 @@ describe("SubmissionsTable score override on a no-autograder manual assignment",
         {...baseProps}
         scores={[scoreRow()]}
         acceptedUsernames={new Set(["alice"])}
-        emptyRepo
+        skipsGrading
       />,
     )
     expect(screen.getByTitle("submissions.table.noGradingTitle")).toBeTruthy()
   })
 
-  it("matches the non-submitter row's Add-grade affordance under emptyRepo", () => {
+  it("matches the non-submitter row's Add-grade affordance under skipsGrading", () => {
     render(
       <SubmissionsTable
         {...baseProps}
         nonSubmitters={[student()]}
         acceptedUsernames={new Set(["alice"])}
-        emptyRepo
+        skipsGrading
         overrideGrade={overrideGrade}
       />,
     )
@@ -357,7 +357,7 @@ describe("SubmissionsTable autograded score override", () => {
         {...baseProps}
         scores={[scoreRow()]}
         acceptedUsernames={new Set(["alice"])}
-        emptyRepo
+        skipsGrading
         overrideGrade={overrideGrade}
       />,
     )
@@ -419,7 +419,8 @@ describe("SubmissionsTable per-row download", () => {
         {...baseProps}
         scores={[scoreRow()]}
         acceptedUsernames={new Set(["alice"])}
-        emptyRepo
+        skipsGrading
+        emptyRepoAssignment
       />,
     )
     await openHub(user)
@@ -519,7 +520,8 @@ describe("SubmissionsTable hub action list", () => {
         {...baseProps}
         nonSubmitters={[student()]}
         acceptedUsernames={new Set(["alice"])}
-        emptyRepo
+        skipsGrading
+        emptyRepoAssignment
       />,
     )
     // The Open-repo shortcut stays inline in the row.
@@ -545,6 +547,32 @@ describe("SubmissionsTable hub action list", () => {
     expect(
       screen.getByRole("button", { name: "submissions.rowDownload.aria" }),
     ).toBeTruthy()
+  })
+
+  it("keeps Review and Manage access in the hub for a no_autograder assignment, hiding only the grading actions", async () => {
+    const user = userEvent.setup()
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        scores={[scoreRow()]}
+        acceptedUsernames={new Set(["alice"])}
+        skipsGrading
+      />,
+    )
+    await openHub(user)
+    // no_autograder repos are templated: the Feedback PR and repo access are
+    // real, so their actions stay — only the autograding surfaces hide.
+    expect(
+      screen.getByRole("button", { name: "submissions.table.reviewAria" }),
+    ).toBeTruthy()
+    expect(
+      screen.getByRole("button", {
+        name: "submissions.table.manageAccessAria",
+      }),
+    ).toBeTruthy()
+    expect(
+      screen.queryByRole("button", { name: "submissions.rowRegrade.aria" }),
+    ).toBeNull()
   })
 
   it("shows an em-dash (no Manage trigger) while acceptance data is still loading", () => {

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -211,7 +211,7 @@ function resolveOverrideCell(
   row: Pick<SubmissionRow, "pending" | "max-score">,
   capability: ScoreOverrideCapability | undefined,
   isGroup: boolean,
-  emptyRepo: boolean,
+  skipsGrading: boolean,
 ): { hasGrade: boolean; maxPoints?: number } | null {
   if (!capability) return null
   if (isGroup && row.pending) return null
@@ -222,7 +222,7 @@ function resolveOverrideCell(
   }
 
   // Autograded override. A never-graded empty repo can't produce a score.
-  if (emptyRepo) return null
+  if (skipsGrading) return null
   // A pending row has no collected max yet: the teacher enters it in the modal.
   if (row.pending) return { hasGrade: false, maxPoints: undefined }
   // A collected row uses its own max-score as the bound.
@@ -253,7 +253,8 @@ const SubmissionsTable = ({
   thresholdFraction,
   filtered = false,
   onClearFilters,
-  emptyRepo = false,
+  skipsGrading = false,
+  emptyRepoAssignment = false,
   submissionMode,
   submissionTags,
   assignmentMode = "every-push",
@@ -297,10 +298,12 @@ const SubmissionsTable = ({
   // Clears the active search + filters (wired to the controls' clearAll).
   onClearFilters?: () => void
   // The assignment skips built-in grading (empty_repo OR no_autograder): score
-  // badges and the regrade action are hidden. Fed skipsGrading by the page. Note
-  // no_autograder repos are templated and keep the Feedback PR — the wire flag
-  // this receives is skipsGrading, not empty_repo alone.
-  emptyRepo?: boolean
+  // badges and the grading actions (details/regrade) are hidden.
+  skipsGrading?: boolean
+  // The narrower bare-repo case (empty_repo alone): also hides the hub's repo
+  // actions (Review/Manage access). A no_autograder repo is templated and keeps
+  // the Feedback PR, so it must NOT set this — mirrors the page's bulk gates.
+  emptyRepoAssignment?: boolean
   // The assignment's submission_mode, enabling the per-repo "Update
   // autograding trigger" action in the manage hub. Omitted (action hidden)
   // for custom-autograder assignments and non-owners.
@@ -558,7 +561,7 @@ const SubmissionsTable = ({
               { usernames, score, ...rest } as SubmissionRow,
               overrideGrade,
               isGroup,
-              emptyRepo,
+              skipsGrading,
             )
             if (cell) {
               return (
@@ -588,7 +591,7 @@ const SubmissionsTable = ({
                 />
               )
             }
-            return emptyRepo ? (
+            return skipsGrading ? (
               <span
                 className="text-base-content/50"
                 title={t("submissions.table.noGradingTitle")}
@@ -638,7 +641,7 @@ const SubmissionsTable = ({
               <RepoRowActions
                 owner={rest.owner}
                 release={rest.release}
-                skipsGrading={emptyRepo}
+                skipsGrading={skipsGrading}
                 header={<GroupActionControls repo={repo} repoHref={repoHref} />}
                 onManage={openManage}
               />
@@ -646,7 +649,7 @@ const SubmissionsTable = ({
               <RepoRowActions
                 owner={rest.owner}
                 release={rest.release}
-                skipsGrading={emptyRepo}
+                skipsGrading={skipsGrading}
                 header={
                   <IndividualRowHeader
                     repo={repo}
@@ -852,7 +855,7 @@ const SubmissionsTable = ({
                 actions = (
                   <RepoRowActions
                     owner={student.username}
-                    skipsGrading={emptyRepo}
+                    skipsGrading={skipsGrading}
                     header={
                       <IndividualRowHeader
                         repo={repoName}
@@ -922,7 +925,7 @@ const SubmissionsTable = ({
                 actions={
                   <RepoRowActions
                     owner={owner}
-                    skipsGrading={emptyRepo}
+                    skipsGrading={skipsGrading}
                     header={
                       <GroupActionControls
                         repo={repoName}
@@ -1009,7 +1012,8 @@ const SubmissionsTable = ({
             hasRepo: manageSubmission.hasRepo,
             commit: manageSubmission.commit,
             release: manageSubmission.release,
-            emptyRepo,
+            skipsGrading,
+            emptyRepoAssignment,
             displayName: manageSubmission.displayName,
             onManageAccess: manageSubmission.isGroup
               ? undefined


### PR DESCRIPTION
## Summary

The submissions page treated a `no_autograder` assignment like a bare `empty_repo` one: the per-row manage hub dropped Review (Feedback PR) and Manage repository access, and the bulk Actions menu dropped "Open all Feedback PRs", leaving little beyond commit/download. Those repos are templated and keep the Feedback PR, so the repo actions now stay; only the grading actions (autograder details, regrade, trigger retrofit, pause) still hide when grading is skipped, and only a bare `empty_repo` hides the repo actions — the same distinction the page's bulk-action gates already drew.

The single flag that caused the conflation is also renamed along the path (`emptyRepo` → `skipsGrading`), with the real `emptyRepoAssignment` flag threaded separately, so the two states can't be mixed up again.

Validated with `npm run check` (all 4302 tests green), including new coverage asserting a `no_autograder` assignment keeps Review + Manage access in the hub and "Open all Feedback PRs" in the menu while grading actions stay hidden.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass. (N/A — web-only)
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README). (N/A)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
