### PR TITLE
refactor(cli): single-source repo-name budget constants in contract

### DIFF
--- a/cli/gh-teacher/internal/validate/validate.go
+++ b/cli/gh-teacher/internal/validate/validate.go
@@ -74,21 +74,20 @@ func OrgClassroom(args []string) (org, classroom string, err error) {
 	return org, classroom, nil
 }
 
-// GitHubRepoNameMaxLen is GitHub's hard limit on a repository name; the
-// student-repo name `<classroom>-<assignment>-<username>` is measured against it.
-const GitHubRepoNameMaxLen = 100
-
-// GitHubLoginMaxLen is GitHub's maximum login length — the worst-case
-// `<username>` when budgeting the composed student-repo name.
-const GitHubLoginMaxLen = 39
+// GitHubRepoNameMaxLen and GitHubLoginMaxLen alias the single source in
+// cli/shared/contract, kept here so existing call sites read naturally.
+const (
+	GitHubRepoNameMaxLen = contract.GitHubRepoNameMaxLen
+	GitHubLoginMaxLen    = contract.GitHubLoginMaxLen
+)
 
 // ComposedRepoNameOverflows reports whether the longest student-repo name a
 // classroom+assignment pair can produce (worst-case 39-char username) exceeds
-// GitHub's repo-name limit; see ShortNamePattern and #691. The name shape comes
-// from contract.AssignmentRepoPrefix so it can't drift from the real one.
+// GitHub's repo-name limit; see ShortNamePattern and #691. Thin negation of
+// the single source, contract.ComposedRepoNameFits.
 func ComposedRepoNameOverflows(classroom, slug string) (worstCase int, overflows bool) {
-	worstCase = len(contract.AssignmentRepoPrefix(classroom, slug)) + GitHubLoginMaxLen
-	return worstCase, worstCase > GitHubRepoNameMaxLen
+	worstCase, fits := contract.ComposedRepoNameFits(classroom, slug)
+	return worstCase, !fits
 }
 
 // ScopeListContains reports whether the comma-separated OAuth scope

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -350,6 +350,47 @@ func AssignmentRepoName(classroom, assignment, username string) string {
 	return AssignmentRepoPrefix(classroom, assignment) + strings.ToLower(username)
 }
 
+// Repo-name budget: GitHub caps a repository name at 100 characters and a
+// login at 39, so the two slug segments of `<classroom>-<assignment>-<username>`
+// share what's left. Cross-tool with NO compile-time link — mirrored in the web
+// GUI (web/src/util/repoNameBudget.ts) and pinned on both sides by the shared
+// fixture cli/shared/testdata/repo_name_budget_cases.json.
+const (
+	// GitHubRepoNameMaxLen is GitHub's hard limit on a repository name; the
+	// composed student-repo name is measured against it.
+	GitHubRepoNameMaxLen = 100
+
+	// GitHubLoginMaxLen is GitHub's maximum login length — the worst-case
+	// `<username>` segment, used because a teacher can't control who enrolls.
+	GitHubLoginMaxLen = 39
+
+	// RepoNameSlugBudget is what the classroom short-name and assignment slug
+	// may spend TOGETHER: the repo-name cap minus the worst-case login and the
+	// two joining hyphens.
+	RepoNameSlugBudget = GitHubRepoNameMaxLen - GitHubLoginMaxLen - 2
+
+	// ClassroomShortNameMaxLen caps a NEW classroom short-name at creation so
+	// every future assignment keeps a workable slug budget (>= RepoNameSlugBudget
+	// - ClassroomShortNameMaxLen chars). A write-time rule only: existing
+	// classrooms up to ShortNamePattern's 100 stay readable.
+	ClassroomShortNameMaxLen = 40
+)
+
+// AssignmentSlugBudget is how many characters remain for an assignment slug in
+// classroom. Can be <= 0 for a pre-cap over-long classroom.
+func AssignmentSlugBudget(classroom string) int {
+	return RepoNameSlugBudget - len(classroom)
+}
+
+// ComposedRepoNameFits reports whether the longest student-repo name a
+// classroom+slug pair can produce (worst-case GitHubLoginMaxLen username) fits
+// GitHub's repo-name limit. The shape comes from AssignmentRepoPrefix so it
+// can't drift from the real one.
+func ComposedRepoNameFits(classroom, slug string) (worstCase int, fits bool) {
+	worstCase = len(AssignmentRepoPrefix(classroom, slug)) + GitHubLoginMaxLen
+	return worstCase, worstCase <= GitHubRepoNameMaxLen
+}
+
 // FeedbackOpenCommitMessage is the empty commit `gh student accept` / the web
 // accept flow pushes so the accept-time Feedback PR has a commit to hang on
 // (GitHub rejects a zero-diff PR with "No commits between ..."). The `[skip

--- a/cli/shared/contract/contract_test.go
+++ b/cli/shared/contract/contract_test.go
@@ -250,6 +250,81 @@ func TestAssignmentRepoName_SharedFixtureParity(t *testing.T) {
 	}
 }
 
+// sharedBudgetCasesPath locates the cross-language repo-name-budget fixture,
+// also consumed by the web mirror's vitest (repoNameBudget.test.ts).
+const sharedBudgetCasesPath = "../testdata/repo_name_budget_cases.json"
+
+// TestRepoNameBudget_SharedFixtureParity pins the budget constants and the
+// composed-name math to the shared fixture so the Go source and the web mirror
+// can't drift: a one-sided edit fails on the other language's copy.
+func TestRepoNameBudget_SharedFixtureParity(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Clean(sharedBudgetCasesPath))
+	if err != nil {
+		t.Fatalf("read shared fixture: %v", err)
+	}
+	var doc struct {
+		RepoNameMaxLen        int `json:"github_repo_name_max_len"`
+		LoginMaxLen           int `json:"github_login_max_len"`
+		SlugBudget            int `json:"repo_name_slug_budget"`
+		ClassroomShortNameMax int `json:"classroom_short_name_max_len"`
+		Cases                 []struct {
+			Classroom string `json:"classroom"`
+			Slug      string `json:"slug"`
+			WorstCase int    `json:"worst_case"`
+			Fits      bool   `json:"fits"`
+		} `json:"cases"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse shared fixture: %v", err)
+	}
+	if doc.RepoNameMaxLen != GitHubRepoNameMaxLen {
+		t.Errorf("fixture github_repo_name_max_len = %d, want %d", doc.RepoNameMaxLen, GitHubRepoNameMaxLen)
+	}
+	if doc.LoginMaxLen != GitHubLoginMaxLen {
+		t.Errorf("fixture github_login_max_len = %d, want %d", doc.LoginMaxLen, GitHubLoginMaxLen)
+	}
+	if doc.SlugBudget != RepoNameSlugBudget {
+		t.Errorf("fixture repo_name_slug_budget = %d, want %d", doc.SlugBudget, RepoNameSlugBudget)
+	}
+	if doc.ClassroomShortNameMax != ClassroomShortNameMaxLen {
+		t.Errorf("fixture classroom_short_name_max_len = %d, want %d", doc.ClassroomShortNameMax, ClassroomShortNameMaxLen)
+	}
+	if len(doc.Cases) == 0 {
+		t.Fatal("shared fixture has no cases")
+	}
+	for _, c := range doc.Cases {
+		worst, fits := ComposedRepoNameFits(c.Classroom, c.Slug)
+		if worst != c.WorstCase || fits != c.Fits {
+			t.Errorf("ComposedRepoNameFits(%q,%q) = (%d,%t), want (%d,%t)",
+				c.Classroom, c.Slug, worst, fits, c.WorstCase, c.Fits)
+		}
+		// The two budget views must agree: a slug fits exactly when it spends
+		// no more than the classroom's remaining budget.
+		if budgetFits := len(c.Slug) <= AssignmentSlugBudget(c.Classroom); budgetFits != c.Fits {
+			t.Errorf("AssignmentSlugBudget(%q) = %d disagrees with fits=%t for slug %q",
+				c.Classroom, AssignmentSlugBudget(c.Classroom), c.Fits, c.Slug)
+		}
+	}
+}
+
+// TestRepoNameBudgetConstants pins the budget derivation so a constant edit
+// that breaks the `<classroom>-<assignment>-<username>` arithmetic fails
+// loudly, and the classroom cap keeps a workable slug budget.
+func TestRepoNameBudgetConstants(t *testing.T) {
+	if RepoNameSlugBudget != GitHubRepoNameMaxLen-GitHubLoginMaxLen-2 {
+		t.Errorf("RepoNameSlugBudget = %d, want max-len minus worst-case login minus two hyphens (%d)",
+			RepoNameSlugBudget, GitHubRepoNameMaxLen-GitHubLoginMaxLen-2)
+	}
+	if ClassroomShortNameMaxLen >= RepoNameSlugBudget {
+		t.Errorf("ClassroomShortNameMaxLen = %d must leave slug room under the %d budget",
+			ClassroomShortNameMaxLen, RepoNameSlugBudget)
+	}
+	// A cap-length classroom must keep room for a real slug.
+	if got := AssignmentSlugBudget(strings.Repeat("a", ClassroomShortNameMaxLen)); got < 19 {
+		t.Errorf("cap-length classroom leaves %d slug chars, want >= 19", got)
+	}
+}
+
 // TestRequiredOAuthScopes pins the unified CLI scope set (issue #246): both
 // binaries request exactly these, and delete_repo stays out (opt-in for
 // teardown). This list is the behavior oracle for the login command and the

--- a/cli/shared/testdata/repo_name_budget_cases.json
+++ b/cli/shared/testdata/repo_name_budget_cases.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Shared golden fixture pinning the composed repo-name budget across every implementation: Go contract.ComposedRepoNameFits / AssignmentSlugBudget (cli/shared/contract) and the web mirror (web/src/util/repoNameBudget.ts). There is NO compile-time link across languages, so each side asserts these same constants and cases and a one-sided edit fails on the other side. worst_case is the composed `<classroom>-<slug>-<username>` length with a maximum-length (39-char) username; fits means it is within GitHub's 100-char repo-name limit.",
+  "github_repo_name_max_len": 100,
+  "github_login_max_len": 39,
+  "repo_name_slug_budget": 59,
+  "classroom_short_name_max_len": 40,
+  "cases": [
+    { "classroom": "cs101", "slug": "hw1", "worst_case": 49, "fits": true },
+    { "classroom": "CS101", "slug": "HW1", "worst_case": 49, "fits": true },
+    { "classroom": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "slug": "bbbbbbbbbbbbbbbbbbb", "worst_case": 100, "fits": true },
+    { "classroom": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "slug": "bbbbbbbbbbbbbbbbbbbb", "worst_case": 101, "fits": false },
+    { "classroom": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "slug": "bb", "worst_case": 100, "fits": true },
+    { "classroom": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "slug": "bb", "worst_case": 101, "fits": false }
+  ]
+}

--- a/web/src/util/repoNameBudget.test.ts
+++ b/web/src/util/repoNameBudget.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+import {
+  CLASSROOM_SHORT_NAME_MAX_LEN,
+  GITHUB_LOGIN_MAX_LEN,
+  GITHUB_REPO_NAME_MAX_LEN,
+  REPO_NAME_SLUG_BUDGET,
+  assignmentSlugBudget,
+  composedRepoNameFits,
+} from "./repoNameBudget"
+
+// Same golden constants and cases the Go contract test asserts
+// (contract_test.go TestRepoNameBudget_SharedFixtureParity), so this mirror
+// can't drift from the single source in cli/shared/contract.
+const fixtureUrl = new URL(
+  "../../../cli/shared/testdata/repo_name_budget_cases.json",
+  import.meta.url,
+)
+const doc = JSON.parse(readFileSync(fileURLToPath(fixtureUrl), "utf8")) as {
+  github_repo_name_max_len: number
+  github_login_max_len: number
+  repo_name_slug_budget: number
+  classroom_short_name_max_len: number
+  cases: {
+    classroom: string
+    slug: string
+    worst_case: number
+    fits: boolean
+  }[]
+}
+
+describe("repo-name budget — shared fixture parity", () => {
+  it("pins the constants to the fixture", () => {
+    expect(GITHUB_REPO_NAME_MAX_LEN).toBe(doc.github_repo_name_max_len)
+    expect(GITHUB_LOGIN_MAX_LEN).toBe(doc.github_login_max_len)
+    expect(REPO_NAME_SLUG_BUDGET).toBe(doc.repo_name_slug_budget)
+    expect(CLASSROOM_SHORT_NAME_MAX_LEN).toBe(doc.classroom_short_name_max_len)
+  })
+
+  it("has cases", () => {
+    expect(doc.cases.length).toBeGreaterThan(0)
+  })
+
+  it.each(doc.cases)("composedRepoNameFits($classroom, $slug)", (c) => {
+    expect(composedRepoNameFits(c.classroom, c.slug)).toEqual({
+      worstCase: c.worst_case,
+      fits: c.fits,
+    })
+    // The two budget views must agree: a slug fits exactly when it spends no
+    // more than the classroom's remaining budget.
+    expect(c.slug.length <= assignmentSlugBudget(c.classroom)).toBe(c.fits)
+  })
+})

--- a/web/src/util/repoNameBudget.ts
+++ b/web/src/util/repoNameBudget.ts
@@ -1,0 +1,45 @@
+// Repo-name budget for the composed `<classroom>-<assignment>-<username>`
+// student-repo name: GitHub caps a repo name at 100 characters and a login at
+// 39, so the two slug segments share what's left. A byte-mirror of the CLI's
+// cli/shared/contract (GitHubRepoNameMaxLen, GitHubLoginMaxLen,
+// RepoNameSlugBudget, ClassroomShortNameMaxLen, AssignmentSlugBudget,
+// ComposedRepoNameFits) — a cross-tool contract with no compile-time link, so
+// keep in lockstep (pinned by the shared fixture in repoNameBudget.test.ts).
+
+import { studentRepoName } from "@/util/studentRepo"
+
+export const GITHUB_REPO_NAME_MAX_LEN = 100
+
+// Worst-case `<username>` segment; a teacher can't control who enrolls.
+export const GITHUB_LOGIN_MAX_LEN = 39
+
+// What the classroom short-name and assignment slug may spend TOGETHER: the
+// repo-name cap minus the worst-case login and the two joining hyphens.
+export const REPO_NAME_SLUG_BUDGET =
+  GITHUB_REPO_NAME_MAX_LEN - GITHUB_LOGIN_MAX_LEN - 2
+
+// Write-time cap for a NEW classroom short-name, reserving a workable slug
+// budget for every future assignment; existing classrooms up to the
+// SHORT_NAME_PATTERN 100 stay readable.
+export const CLASSROOM_SHORT_NAME_MAX_LEN = 40
+
+// Characters remaining for an assignment slug in `classroom`; can be <= 0 for
+// a pre-cap over-long classroom.
+export function assignmentSlugBudget(classroom: string): number {
+  return REPO_NAME_SLUG_BUDGET - classroom.length
+}
+
+// Whether the longest student-repo name a classroom+slug pair can produce
+// (worst-case GITHUB_LOGIN_MAX_LEN username) fits GitHub's repo-name limit.
+// Measured through studentRepoName so it can't drift from the real shape.
+export function composedRepoNameFits(
+  classroom: string,
+  slug: string,
+): { worstCase: number; fits: boolean } {
+  const worstCase = studentRepoName(
+    classroom,
+    slug,
+    "a".repeat(GITHUB_LOGIN_MAX_LEN),
+  ).length
+  return { worstCase, fits: worstCase <= GITHUB_REPO_NAME_MAX_LEN }
+}


### PR DESCRIPTION
## Summary

- Adds the composed repo-name budget to `cli/shared/contract` as the single source: `GitHubRepoNameMaxLen` (100), `GitHubLoginMaxLen` (39), `RepoNameSlugBudget` (59 — what classroom + assignment slugs share once a worst-case login and the two hyphens are reserved), `ClassroomShortNameMaxLen` (40), plus `AssignmentSlugBudget` and `ComposedRepoNameFits` built on `AssignmentRepoPrefix` so the math can't drift from the real name shape.
- `gh-teacher`'s `validate` package now aliases those constants and delegates `ComposedRepoNameOverflows` to the contract; no behavior change.
- Adds the web byte-mirror `web/src/util/repoNameBudget.ts` (measured through `studentRepoName`) and a shared golden fixture `cli/shared/testdata/repo_name_budget_cases.json` pinned by both `contract_test.go` and a vitest, following the `assignment_repo_name_cases.json` pattern.

Groundwork for #691: the next PRs enforce this budget at classroom/assignment creation in the CLI and web. Pure refactor — nothing consumes the new helpers yet beyond the existing warn path.

## Test plan

- [x] `go build ./... && go test ./...` in `cli/shared` and `cli/gh-teacher`
- [x] `golangci-lint run` in both Go modules (0 issues)
- [x] `npm run check` in `web/` (tsc, eslint, prettier, arch:validate, vitest — 4321 tests)