### PR TITLE
fix(cli): block classroom/assignment names that overflow GitHub's repo-name limit

### DIFF
--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -764,6 +764,16 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		// One lookup of the entry this upsert replaces, shared by the
 		// wholesale-replace footgun checks and the Extra carry-forward.
 		prevIdx, hasPrev := assignment.FindAssignment(file.Assignments, slug)
+		// #691: a NEW slug must fit the composed repo-name budget, or every
+		// long-username accept fails after the fact. Checked inside the build
+		// (before the commit) so a blocked add leaves nothing behind. A
+		// same-slug replace stays allowed — the rule is creation-time only, and
+		// a pre-cap over-budget entry must remain editable.
+		if !hasPrev {
+			if err := validate.ComposedRepoNameBudget(classroom, slug); err != nil {
+				return nil, err
+			}
+		}
 		// no_autograder is owned by the gradebook GUI, not `assignment add`
 		// (there is no --no-autograder flag), so `entry`/`attemptEntry` rebuilt
 		// from flags never carry it. Carry it forward from the prior entry
@@ -993,13 +1003,12 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			"Warning: %s/%s/%s is %d bytes — approaching GitHub's ~1 MiB contents-API ceiling. Past that, the API returns encoding:\"none\" and future `gh teacher assignment add/remove` calls will fail to read the file. Consider splitting the classroom or shrinking per-entry fields.\n",
 			org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), lastEncodedSize)
 	}
-	// #691: classroom and slug can each be valid yet compose into a
-	// `<classroom>-<assignment>-<username>` name past GitHub's 100-char limit,
-	// failing every accept. Nothing budgets the segments, so warn here — the
-	// only pre-accept signal.
+	// #691: a NEW over-budget slug is blocked in the build above, so reaching
+	// here over budget means a pre-cap entry was REPLACED (kept editable on
+	// purpose). Warn so the standing accept risk stays visible on every edit.
 	if worst, overflows := validate.ComposedRepoNameOverflows(classroom, slug); overflows {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: student repos are named `<classroom>-<assignment>-<username>`; %q + %q reaches %d characters with a 39-char username, over GitHub's %d-char repo-name limit. Students with long usernames won't be able to accept. Shorten the classroom short-name or the assignment slug.\n",
+			"Warning: student repos are named `<classroom>-<assignment>-<username>`; %q + %q reaches %d characters with a 39-char username, over GitHub's %d-char repo-name limit. Students with long usernames won't be able to accept. Reuse the assignment under a shorter slug or classroom.\n",
 			classroom, slug, worst, validate.GitHubRepoNameMaxLen)
 	}
 	_, _ = fmt.Fprintf(errOut, "Students can now run: gh student accept %s %s %s\n", org, classroom, slug)

--- a/cli/gh-teacher/internal/assignmentcmd/budget_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/budget_test.go
@@ -1,0 +1,121 @@
+package assignmentcmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/foundation50/gh-teacher/internal/assignment"
+	"github.com/foundation50/gh-teacher/internal/githubtest"
+)
+
+// overBudgetSlug composes past GitHub's 100-char repo-name limit with the
+// 3-char test classroom "dst": 3 + 1 + 57 + 1 + 39 = 101.
+var overBudgetSlug = strings.Repeat("s", 57)
+
+// overBudgetAssignmentsBody is a manifest already carrying an over-budget
+// (pre-cap) template-less entry, for the replace-stays-allowed tests.
+func overBudgetAssignmentsBody() string {
+	return `{
+  "schema": "classroom50/assignments/v1",
+  "assignments": [
+    {
+      "slug": "` + overBudgetSlug + `",
+      "name": "Long",
+      "mode": "individual",
+      "autograder": "default"
+    }
+  ]
+}`
+}
+
+// TestRunAssignmentAdd_BlocksNewOverBudgetSlug: a NEW slug whose composed
+// `<classroom>-<slug>-<username>` name can exceed GitHub's 100-char limit is a
+// hard preflight error (#691) — nothing is committed, so no config entry or
+// template grant is left behind.
+func TestRunAssignmentAdd_BlocksNewOverBudgetSlug(t *testing.T) {
+	server, fix := newLockServer(t, lockServerConfig{
+		assignments: lockAssignmentsBody(false),
+		classroom:   lockClassroomBody(),
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	err := runAssignmentAdd(client, &out, &errOut, addAssignmentParams{
+		Org:        "o",
+		Classroom:  "dst",
+		Slug:       overBudgetSlug,
+		Name:       "Long",
+		Mode:       assignment.ModeIndividual,
+		Autograder: "default",
+	})
+	if err == nil || !strings.Contains(err.Error(), "repo-name limit") {
+		t.Fatalf("err = %v, want a repo-name limit error", err)
+	}
+	fix.mu.Lock()
+	committed := fix.committed
+	fix.mu.Unlock()
+	if committed != nil {
+		t.Error("a blocked add must not commit anything")
+	}
+}
+
+// TestRunAssignmentAdd_AllowsReplacingOverBudgetSlug: the budget is a
+// creation-time rule only — a same-slug replace of a pre-cap over-budget entry
+// must keep working (the teacher can still edit it), with the standing accept
+// risk surfaced as a warning.
+func TestRunAssignmentAdd_AllowsReplacingOverBudgetSlug(t *testing.T) {
+	server, fix := newLockServer(t, lockServerConfig{
+		assignments: overBudgetAssignmentsBody(),
+		classroom:   lockClassroomBody(),
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	err := runAssignmentAdd(client, &out, &errOut, addAssignmentParams{
+		Org:        "o",
+		Classroom:  "dst",
+		Slug:       overBudgetSlug,
+		Name:       "Long (edited)",
+		Mode:       assignment.ModeIndividual,
+		Autograder: "default",
+	})
+	if err != nil {
+		t.Fatalf("runAssignmentAdd(replace over-budget): %v", err)
+	}
+	file := decodeLock(t, fix)
+	if len(file.Assignments) != 1 || file.Assignments[0].Name != "Long (edited)" {
+		t.Errorf("replace did not land, got %+v", file.Assignments)
+	}
+	if !strings.Contains(errOut.String(), "repo-name limit") {
+		t.Errorf("errOut = %q, want the over-budget warning", errOut.String())
+	}
+}
+
+// TestRunAssignmentReuse_BlocksOverBudgetSlug: reuse always mints a new slug in
+// the target classroom, so an over-budget --slug is refused inside the build —
+// nothing is committed.
+func TestRunAssignmentReuse_BlocksOverBudgetSlug(t *testing.T) {
+	server, fix := newReuseServer(t, reuseServerConfig{
+		sourceAssignments: sourceAssignmentsBody(),
+		targetAssignments: emptyAssignmentsBody(),
+		targetClassroom:   targetClassroomBody(nil),
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	params := baseReuseParams()
+	params.SlugOverride = overBudgetSlug
+	params.SlugWasSet = true
+
+	var out, errOut bytes.Buffer
+	err := runAssignmentReuse(client, &out, &errOut, params)
+	if err == nil || !strings.Contains(err.Error(), "repo-name limit") {
+		t.Fatalf("err = %v, want a repo-name limit error", err)
+	}
+	fix.mu.Lock()
+	committed := fix.committed
+	fix.mu.Unlock()
+	if committed != nil {
+		t.Error("a blocked reuse must not commit anything")
+	}
+}

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -218,6 +218,12 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 		if p.NameWasSet {
 			copied.Name = p.NameOverride
 		}
+		// #691: reuse always mints a new slug in the TARGET classroom, so the
+		// composed repo-name budget is unconditional (unlike add's replace
+		// path). Covers the auto-suffixed slug too — checked after resolution.
+		if err := validate.ComposedRepoNameBudget(p.To, finalSlug); err != nil {
+			return nil, err
+		}
 
 		if err := assignment.ValidateAssignmentEntry(copied); err != nil {
 			return nil, fmt.Errorf("copied assignment is invalid: %w", err)

--- a/cli/gh-teacher/internal/classroom/classroom.go
+++ b/cli/gh-teacher/internal/classroom/classroom.go
@@ -86,13 +86,15 @@ func classroomAddCmd() *cobra.Command {
 			"and populate it with a four-file scaffold: classroom.json,\n" +
 			"assignments.json, roster.csv, and scores.json.\n\n" +
 			"Short-name rules (must match ^[a-z0-9][a-z0-9-]{1,99}$):\n" +
-			"  - 2-100 characters total\n" +
+			"  - 2-40 characters total for a new classroom\n" +
 			"  - lowercase letters, digits, or hyphens\n" +
 			"  - must start with a letter or digit (not a hyphen)\n\n" +
 			"These mirror GitHub's repo-name constraints because the\n" +
 			"short-name flows into student repo names like\n" +
 			"`<short-name>-<assignment>-<username>` (see `gh student\n" +
-			"accept`).\n\n" +
+			"accept`). GitHub caps repo names at 100 characters, so a new\n" +
+			"classroom's short-name is capped at 40 to leave room for the\n" +
+			"assignment slug and any username.\n\n" +
 			"Unlisted resources (opt-in): pass --unlisted to publish this\n" +
 			"classroom's resources at an unguessable URL path segment\n" +
 			"(`<classroom>/<key>/...`) instead of the guessable default. This\n" +
@@ -114,6 +116,12 @@ func classroomAddCmd() *cobra.Command {
 
 			org, shortName, err := parseOrgShortNameArgs(args)
 			if err != nil {
+				return err
+			}
+			// Creation-time cap only (#691): `add` mints the short-name, so it
+			// must leave slug budget; the other subcommands sharing
+			// parseOrgShortNameArgs operate on existing classrooms of any length.
+			if err := validate.ClassroomShortNameBudget(shortName); err != nil {
 				return err
 			}
 

--- a/cli/gh-teacher/internal/classroom/classroom_test.go
+++ b/cli/gh-teacher/internal/classroom/classroom_test.go
@@ -2,6 +2,7 @@ package classroom
 
 import (
 	"encoding/json"
+	"io"
 	"strings"
 	"testing"
 
@@ -42,6 +43,21 @@ func TestValidateShortName(t *testing.T) {
 				t.Fatalf("validate.ShortName(%q) = nil, want error", tc.in)
 			}
 		})
+	}
+}
+
+// TestClassroomAddShortNameCreationCap: `classroom add` mints the short-name,
+// so it enforces the creation cap (#691) in its preflight — before the key
+// prompt, auth, or any network. The other subcommands sharing
+// parseOrgShortNameArgs stay uncapped (they operate on existing classrooms).
+func TestClassroomAddShortNameCreationCap(t *testing.T) {
+	cmd := classroomAddCmd()
+	cmd.SetArgs([]string{"org", strings.Repeat("a", 41)})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "capped at 40") {
+		t.Fatalf("err = %v, want the creation-cap error", err)
 	}
 }
 

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -56,9 +56,11 @@ func classroomMigrateCmd() *cobra.Command {
 			"doesn't yet exist.\n\n" +
 			"--short-name overrides the auto-derived classroom directory\n" +
 			"name. Migrate slugifies the source classroom name (lowercase,\n" +
-			"non-alnum → '-', collapsed, trimmed) and validates against\n" +
-			"^[a-z0-9][a-z0-9-]{1,99}$. Pass --short-name explicitly if\n" +
-			"the derived value fails validation.\n\n" +
+			"non-alnum → '-', collapsed, trimmed, truncated to 40 chars) and\n" +
+			"validates against ^[a-z0-9][a-z0-9-]{1,99}$. New classrooms are\n" +
+			"capped at 40 characters so `<short-name>-<assignment>-<username>`\n" +
+			"student-repo names stay under GitHub's 100-character limit. Pass\n" +
+			"--short-name explicitly if the derived value fails validation.\n\n" +
 			"--template-suffix appends a string to every target template\n" +
 			"repo name (e.g., --template-suffix migrated → readability-migrated).\n" +
 			"Use to escape collisions with existing target-org repos.\n\n" +
@@ -162,6 +164,12 @@ func discoverMigration(client githubapi.Client, errOut io.Writer, opts migrateOp
 		}
 	}
 	if err := validate.ShortName(shortNameVal, "short-name"); err != nil {
+		return migrationPlan{}, err
+	}
+	// Creation-time cap (#691): migrate mints the classroom, so an explicit
+	// --short-name past the cap fails here, before any template repos are
+	// generated. Auto-derived names are already truncated to the cap.
+	if err := validate.ClassroomShortNameBudget(shortNameVal); err != nil {
 		return migrationPlan{}, err
 	}
 	// A migrated classroom gets a team (classroom50-<short>); reject a

--- a/cli/gh-teacher/internal/classroom/migrate_template.go
+++ b/cli/gh-teacher/internal/classroom/migrate_template.go
@@ -163,7 +163,7 @@ func targetTemplateName(slug, suffix string) string {
 func runTemplateCopy(client githubapi.Client, errOut io.Writer, plan migrationPlan, templateSuffix string) ([]resolvedTemplate, error) {
 	out := make([]resolvedTemplate, 0, len(plan.Assignments))
 	for _, a := range plan.Assignments {
-		r, err := copyOneTemplate(client, errOut, plan.TargetOrg, templateSuffix, plan.Classroom.ID, a)
+		r, err := copyOneTemplate(client, errOut, plan.TargetOrg, templateSuffix, plan.ShortName, plan.Classroom.ID, a)
 		if err != nil {
 			return nil, err
 		}
@@ -182,7 +182,9 @@ func runTemplateCopy(client githubapi.Client, errOut io.Writer, plan migrationPl
 //
 // Skip reasons are recorded on `errOut`. classroomID comes from the discovery
 // context, not `a.Classroom.ID` (unreliable on the assignment-detail response).
-func copyOneTemplate(client githubapi.Client, errOut io.Writer, targetOrg, templateSuffix string, classroomID int64, a classroomAssignmentDetail) (resolvedTemplate, error) {
+// shortName is the TARGET classroom directory, needed for the composed
+// repo-name budget check.
+func copyOneTemplate(client githubapi.Client, errOut io.Writer, targetOrg, templateSuffix, shortName string, classroomID int64, a classroomAssignmentDetail) (resolvedTemplate, error) {
 	skip := func(reason string) resolvedTemplate {
 		_, _ = fmt.Fprintf(errOut, "Skipping %q: %s\n", a.Slug, reason)
 		return resolvedTemplate{Assignment: a, Action: templateActionSkipped, SkipReason: reason}
@@ -192,6 +194,13 @@ func copyOneTemplate(client githubapi.Client, errOut io.Writer, targetOrg, templ
 	// — otherwise a bad slug/mode generates a template repo, then drops the
 	// entry at commit time, orphaning the repo.
 	if err := validate.ShortName(a.Slug, "slug"); err != nil {
+		return skip(err.Error()), nil
+	}
+	// #691: a migrated slug that can't fit the composed repo-name budget would
+	// fail every long-username accept in the new classroom; skip it (the rest
+	// of the migration proceeds) so the teacher can re-add it under a shorter
+	// slug.
+	if err := validate.ComposedRepoNameBudget(shortName, a.Slug); err != nil {
 		return skip(err.Error()), nil
 	}
 	if !assignment.IsValidAssignmentMode(a.Type) {

--- a/cli/gh-teacher/internal/classroom/migrate_template_test.go
+++ b/cli/gh-teacher/internal/classroom/migrate_template_test.go
@@ -290,7 +290,7 @@ func TestCopyOneTemplate(t *testing.T) {
 	t.Run("skipped when no starter_code_repository", func(t *testing.T) {
 		var errOut bytes.Buffer
 		detail := classroomAssignmentDetail{ID: 1, Slug: "noop", Type: "individual"}
-		got, err := copyOneTemplate(nil, &errOut, "tgt", "", 42, detail)
+		got, err := copyOneTemplate(nil, &errOut, "tgt", "", "cs", 42, detail)
 		if err != nil {
 			t.Fatalf("copyOneTemplate: %v", err)
 		}
@@ -308,7 +308,7 @@ func TestCopyOneTemplate(t *testing.T) {
 	t.Run("skipped when slug fails shortNamePattern (pre-validation)", func(t *testing.T) {
 		var errOut bytes.Buffer
 		detail := classroomAssignmentDetail{ID: 1, Slug: "Bad-Slug", Type: "individual"}
-		got, err := copyOneTemplate(nil, &errOut, "tgt", "", 42, detail)
+		got, err := copyOneTemplate(nil, &errOut, "tgt", "", "cs", 42, detail)
 		if err != nil {
 			t.Fatalf("copyOneTemplate: %v", err)
 		}
@@ -323,7 +323,7 @@ func TestCopyOneTemplate(t *testing.T) {
 	t.Run("skipped when type is unknown (pre-validation)", func(t *testing.T) {
 		var errOut bytes.Buffer
 		detail := classroomAssignmentDetail{ID: 1, Slug: "hello", Type: "weird"}
-		got, err := copyOneTemplate(nil, &errOut, "tgt", "", 42, detail)
+		got, err := copyOneTemplate(nil, &errOut, "tgt", "", "cs", 42, detail)
 		if err != nil {
 			t.Fatalf("copyOneTemplate: %v", err)
 		}
@@ -332,6 +332,24 @@ func TestCopyOneTemplate(t *testing.T) {
 		}
 		if !strings.Contains(got.SkipReason, "unknown type") {
 			t.Errorf("skip reason = %q, want 'unknown type'", got.SkipReason)
+		}
+	})
+
+	// #691: a slug that composes past GitHub's repo-name limit with the target
+	// short-name is skipped BEFORE any API write, like the other
+	// pre-validation guards. "cs" leaves a 57-char budget; 58 exceeds it.
+	t.Run("skipped when slug exceeds the composed repo-name budget (pre-validation)", func(t *testing.T) {
+		var errOut bytes.Buffer
+		detail := classroomAssignmentDetail{ID: 1, Slug: strings.Repeat("s", 58), Type: "individual"}
+		got, err := copyOneTemplate(nil, &errOut, "tgt", "", "cs", 42, detail)
+		if err != nil {
+			t.Fatalf("copyOneTemplate: %v", err)
+		}
+		if got.Action != templateActionSkipped {
+			t.Errorf("action = %s, want skipped", got.Action)
+		}
+		if !strings.Contains(got.SkipReason, "repo-name limit") {
+			t.Errorf("skip reason = %q, want 'repo-name limit'", got.SkipReason)
 		}
 	})
 
@@ -369,7 +387,7 @@ func TestCopyOneTemplate(t *testing.T) {
 		})
 		defer cleanup()
 		// a.Classroom.ID stays zero; the caller passes 95884.
-		_, err := copyOneTemplate(githubtest.NewTestClient(t, server), io.Discard, "tgt", "", 95884, a("hello", "src/hello", false))
+		_, err := copyOneTemplate(githubtest.NewTestClient(t, server), io.Discard, "tgt", "", "cs", 95884, a("hello", "src/hello", false))
 		if err != nil {
 			t.Fatalf("copyOneTemplate: %v", err)
 		}
@@ -386,7 +404,7 @@ func TestCopyOneTemplate(t *testing.T) {
 		})
 		defer cleanup()
 		var errOut bytes.Buffer
-		got, err := copyOneTemplate(githubtest.NewTestClient(t, server), &errOut, "tgt", "", 42, a("hello", "src/hello", false))
+		got, err := copyOneTemplate(githubtest.NewTestClient(t, server), &errOut, "tgt", "", "cs", 42, a("hello", "src/hello", false))
 		if err != nil {
 			t.Fatalf("copyOneTemplate: %v", err)
 		}
@@ -409,7 +427,7 @@ func TestCopyOneTemplate(t *testing.T) {
 		})
 		defer cleanup()
 		var errOut bytes.Buffer
-		got, err := copyOneTemplate(githubtest.NewTestClient(t, server), &errOut, "tgt", "", 42, a("hello", "src/hello", false))
+		got, err := copyOneTemplate(githubtest.NewTestClient(t, server), &errOut, "tgt", "", "cs", 42, a("hello", "src/hello", false))
 		if err != nil {
 			t.Fatalf("copyOneTemplate: %v", err)
 		}
@@ -435,7 +453,7 @@ func TestCopyOneTemplate(t *testing.T) {
 		})
 		defer cleanup()
 		var errOut bytes.Buffer
-		got, err := copyOneTemplate(githubtest.NewTestClient(t, server), &errOut, "tgt", "", 42, a("hello", "src/hello", false))
+		got, err := copyOneTemplate(githubtest.NewTestClient(t, server), &errOut, "tgt", "", "cs", 42, a("hello", "src/hello", false))
 		if err != nil {
 			t.Fatalf("copyOneTemplate: %v", err)
 		}
@@ -482,7 +500,7 @@ func TestCopyOneTemplate(t *testing.T) {
 		})
 		defer cleanup()
 		var errOut bytes.Buffer
-		got, err := copyOneTemplate(githubtest.NewTestClient(t, server), &errOut, "tgt", "", 42, a("hello", "src/hello", true))
+		got, err := copyOneTemplate(githubtest.NewTestClient(t, server), &errOut, "tgt", "", "cs", 42, a("hello", "src/hello", true))
 		if err != nil {
 			t.Fatalf("copyOneTemplate: %v", err)
 		}
@@ -533,7 +551,7 @@ func TestCopyOneTemplate(t *testing.T) {
 		})
 		defer cleanup()
 		var errOut bytes.Buffer
-		got, err := copyOneTemplate(githubtest.NewTestClient(t, server), &errOut, "tgt", "migrated", 42, a("hello", "src/hello", false))
+		got, err := copyOneTemplate(githubtest.NewTestClient(t, server), &errOut, "tgt", "migrated", "cs", 42, a("hello", "src/hello", false))
 		if err != nil {
 			t.Fatalf("copyOneTemplate: %v", err)
 		}

--- a/cli/gh-teacher/internal/classroom/migrate_translate.go
+++ b/cli/gh-teacher/internal/classroom/migrate_translate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/foundation50/classroom50-cli-shared/contract"
 	"github.com/foundation50/gh-teacher/internal/assignment"
 	"github.com/foundation50/gh-teacher/internal/configrepo"
 	"github.com/foundation50/gh-teacher/internal/validate"
@@ -21,9 +22,11 @@ const migrateSourceGitHubClassroom = "github_classroom"
 var shortNameDeriveReplace = regexp.MustCompile(`[^a-z0-9]+`)
 
 // deriveShortName slugifies a free-form classroom name into a value that passes
-// ShortNamePattern (lowercase → replace non-alnum with `-` → collapse → trim →
-// truncate to 100 → validate). On failure returns an error asking for an
-// explicit --short-name.
+// ShortNamePattern and the creation cap (lowercase → replace non-alnum with `-`
+// → collapse → trim → truncate to contract.ClassroomShortNameMaxLen →
+// validate). Truncating to the cap (not the pattern's 100) keeps a migrated
+// classroom's slug budget workable (#691). On failure returns an error asking
+// for an explicit --short-name.
 func deriveShortName(raw string) (string, error) {
 	lowered := strings.ToLower(strings.TrimSpace(raw))
 	if lowered == "" {
@@ -31,8 +34,8 @@ func deriveShortName(raw string) (string, error) {
 	}
 	slug := shortNameDeriveReplace.ReplaceAllString(lowered, "-")
 	slug = strings.Trim(slug, "-")
-	if len(slug) > 100 {
-		slug = strings.TrimRight(slug[:100], "-")
+	if len(slug) > contract.ClassroomShortNameMaxLen {
+		slug = strings.TrimRight(slug[:contract.ClassroomShortNameMaxLen], "-")
 	}
 	if !validate.ShortNamePattern.MatchString(slug) {
 		return "", fmt.Errorf("could not derive a valid short-name from %q (got %q after slugify, fails %s) — pass --short-name <name> explicitly", raw, slug, validate.ShortNamePatternDescription)

--- a/cli/gh-teacher/internal/classroom/migrate_translate_test.go
+++ b/cli/gh-teacher/internal/classroom/migrate_translate_test.go
@@ -26,7 +26,10 @@ func TestDeriveShortName(t *testing.T) {
 		{"real-export name 2", "CS50 Stress Test-classroom-1", "cs50-stress-test-classroom-1", false},
 		{"slashes and spaces", "Intro to CS / Section 1", "intro-to-cs-section-1", false},
 		{"apostrophe + em-dash", "Spring '26 — Honors", "spring-26-honors", false},
-		{"too long, truncates cleanly", strings.Repeat("abcdefghij-", 10), strings.Repeat("abcdefghij-", 9) + "a", false},
+		// Truncation cap is the CREATION budget (40), not the pattern's 100.
+		{"too long, truncates to the creation cap", strings.Repeat("abcdefghij-", 10), strings.Repeat("abcdefghij-", 3) + "abcdefg", false},
+		// A cut landing on a hyphen is trimmed, not left dangling.
+		{"truncation exposing a trailing hyphen", strings.Repeat("abcdefghi-", 10), strings.Repeat("abcdefghi-", 3) + "abcdefghi", false},
 		{"leading and trailing punctuation", "—Hello—", "hello", false},
 		{"empty", "", "", true},
 		{"whitespace only", "   ", "", true},

--- a/cli/gh-teacher/internal/validate/validate.go
+++ b/cli/gh-teacher/internal/validate/validate.go
@@ -16,11 +16,12 @@ import (
 // student-repo names and the contents/tree API. Exposed for the few call sites
 // that match directly; most callers should use ShortName for the standard error.
 //
-// The cap is 100 per segment, matching GitHub's repo-name limit — NOT a full
-// guarantee: `<classroom>-<assignment>-<username>` can exceed 100 even when each
-// part is legal. Budgeting the segments against each other is open work
-// (foundation50/classroom50#691); until then an overflow surfaces as a legible
-// "name too long" error at accept.
+// The cap is 100 per segment, matching GitHub's repo-name limit — a READ-side
+// tolerance so pre-cap documents keep validating. Write paths layer the
+// composed budget on top (#691): ClassroomShortNameBudget caps a NEW
+// classroom, and ComposedRepoNameBudget gates every path minting a NEW slug;
+// an existing over-budget pair still surfaces a legible "name too long" error
+// at accept.
 var ShortNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,99}$`)
 
 // ShortNamePatternDescription: human-readable summary of ShortNamePattern,
@@ -88,6 +89,39 @@ const (
 func ComposedRepoNameOverflows(classroom, slug string) (worstCase int, overflows bool) {
 	worstCase, fits := contract.ComposedRepoNameFits(classroom, slug)
 	return worstCase, !fits
+}
+
+// ClassroomShortNameBudget rejects a short-name past the CREATION cap
+// (contract.ClassroomShortNameMaxLen): the short-name prefixes every student
+// repo in the classroom, so an over-long one starves every future assignment
+// slug (#691). Creation-time only — existing classrooms up to
+// ShortNamePattern's 100 stay fully operable.
+func ClassroomShortNameBudget(shortName string) error {
+	if len(shortName) > contract.ClassroomShortNameMaxLen {
+		return fmt.Errorf("classroom short-name %q is %d characters; new classrooms are capped at %d because student repos are named `<short-name>-<assignment>-<username>` and GitHub caps repo names at %d characters — a shorter short-name keeps room for assignment slugs and any username",
+			shortName, len(shortName), contract.ClassroomShortNameMaxLen, contract.GitHubRepoNameMaxLen)
+	}
+	return nil
+}
+
+// ComposedRepoNameBudget rejects a classroom+slug pair whose composed
+// student-repo name can exceed GitHub's limit with a worst-case
+// (contract.GitHubLoginMaxLen) username — the hard write-time gate for every
+// path that mints a NEW assignment slug (#691). Existing over-budget
+// assignments are untouched: readers stay tolerant, and a same-slug replace
+// is allowed so legacy entries remain editable.
+func ComposedRepoNameBudget(classroom, slug string) error {
+	worst, fits := contract.ComposedRepoNameFits(classroom, slug)
+	if fits {
+		return nil
+	}
+	budget := contract.AssignmentSlugBudget(classroom)
+	if budget < 2 {
+		return fmt.Errorf("student repos are named `<classroom>-<assignment>-<username>`; %q + %q reaches %d characters with a %d-char username, over GitHub's %d-char repo-name limit — classroom %q leaves no room for any slug, so create a classroom with a shorter short-name (at most %d characters) and add the assignment there",
+			classroom, slug, worst, contract.GitHubLoginMaxLen, contract.GitHubRepoNameMaxLen, classroom, contract.ClassroomShortNameMaxLen)
+	}
+	return fmt.Errorf("student repos are named `<classroom>-<assignment>-<username>`; %q + %q reaches %d characters with a %d-char username, over GitHub's %d-char repo-name limit — use a slug of at most %d characters, or create a classroom with a shorter short-name",
+		classroom, slug, worst, contract.GitHubLoginMaxLen, contract.GitHubRepoNameMaxLen, budget)
 }
 
 // ScopeListContains reports whether the comma-separated OAuth scope

--- a/cli/gh-teacher/internal/validate/validate_test.go
+++ b/cli/gh-teacher/internal/validate/validate_test.go
@@ -3,6 +3,8 @@ package validate
 import (
 	"strings"
 	"testing"
+
+	"github.com/foundation50/classroom50-cli-shared/contract"
 )
 
 func TestScopeListContains(t *testing.T) {
@@ -160,6 +162,44 @@ func TestOrgName(t *testing.T) {
 		if err := OrgName(org); err == nil {
 			t.Errorf("OrgName(%q) = nil, want an error", org)
 		}
+	}
+}
+
+func TestClassroomShortNameBudget(t *testing.T) {
+	if err := ClassroomShortNameBudget(strings.Repeat("a", contract.ClassroomShortNameMaxLen)); err != nil {
+		t.Errorf("a cap-length short-name must pass, got %v", err)
+	}
+	err := ClassroomShortNameBudget(strings.Repeat("a", contract.ClassroomShortNameMaxLen+1))
+	if err == nil {
+		t.Fatal("an over-cap short-name must fail")
+	}
+	// The error must be actionable: name the cap and the reason.
+	if !strings.Contains(err.Error(), "capped at 40") || !strings.Contains(err.Error(), "<short-name>-<assignment>-<username>") {
+		t.Errorf("err = %q, want the cap and the repo-name shape named", err.Error())
+	}
+}
+
+func TestComposedRepoNameBudget(t *testing.T) {
+	// Exactly at the limit: classroom(30) + 1 + slug(29) + 1 + 39 = 100.
+	if err := ComposedRepoNameBudget(strings.Repeat("a", 30), strings.Repeat("b", 29)); err != nil {
+		t.Errorf("an exactly-100 composition must pass, got %v", err)
+	}
+	// One over: the error names the remaining slug budget (59 - 30 = 29).
+	err := ComposedRepoNameBudget(strings.Repeat("a", 30), strings.Repeat("b", 30))
+	if err == nil {
+		t.Fatal("a 101-char worst case must fail")
+	}
+	if !strings.Contains(err.Error(), "at most 29 characters") {
+		t.Errorf("err = %q, want the remaining slug budget (29) named", err.Error())
+	}
+	// A classroom leaving no room for even a 2-char slug points at a new
+	// classroom instead of an impossible shorter slug.
+	err = ComposedRepoNameBudget(strings.Repeat("a", 58), "bb")
+	if err == nil {
+		t.Fatal("a no-room classroom must fail")
+	}
+	if !strings.Contains(err.Error(), "no room for any slug") {
+		t.Errorf("err = %q, want the no-room phrasing", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

Second PR toward #691 (after #704's shared budget constants): the CLI now enforces the composed `<classroom>-<assignment>-<username>` budget at creation time, while read paths stay tolerant of pre-existing over-budget names.

- **`classroom add` / `classroom migrate`**: a NEW classroom short-name is capped at 40 characters (`validate.ClassroomShortNameBudget`), guaranteeing every future assignment slug at least 19 characters. Subcommands operating on existing classrooms (archive, edit, roster, …) are untouched. Migrate's auto-derived short-name now truncates to the cap instead of 100, and an explicit over-cap `--short-name` fails before any template repos are generated.
- **`assignment add`**: a NEW slug that can compose past 100 chars with a worst-case 39-char username is now a hard error inside the commit build — nothing is written (previously a warning printed *after* the commit). A same-slug replace of a pre-cap over-budget entry stays allowed so legacy assignments remain editable, and keeps the post-commit warning.
- **`assignment reuse`**: the final target slug (explicit `--slug` or auto-suffixed) is validated against the *target* classroom's budget inside the build.
- **`classroom migrate`**: an over-budget source slug is skipped with a reason (like the other pre-validation guards) before any API write, rather than failing the whole migration.
- Errors are actionable: they name the composed shape, the worst case, and the remaining slug budget — or point at creating a shorter-named classroom when no slug could fit.

## Test plan

- [x] New tests: budget validators (boundaries at 100/101 and the no-room case), `classroom add` cap preflight, add blocks new over-budget slug / allows replacing a legacy one (nothing committed on block), reuse blocks over-budget `--slug`, migrate skip, derive-short-name truncation to the cap
- [x] `go build ./... && go test ./...` in `cli/gh-teacher` and `cli/shared`
- [x] `golangci-lint run` and `golangci-lint fmt --diff` (clean)
- [x] Python suites pass (`skeleton_tests` 867, `autograders_tests` 388)