### PR TITLE
fix(web): block classroom/assignment names that overflow GitHub's repo-name limit

### DIFF
--- a/web/src/components/modals/ReuseAssignmentModal.tsx
+++ b/web/src/components/modals/ReuseAssignmentModal.tsx
@@ -132,6 +132,8 @@ export const ReuseAssignmentModal = ({
                   loading: targetLoading,
                   error: targetError,
                   slugTaken: reuse.slugTaken,
+                  slugOverBudget: reuse.slugOverBudget,
+                  slugBudget: reuse.slugBudget,
                   slugTouched: reuse.slugTouched,
                   normalizedSlug: reuse.normalizedSlug,
                   displayedSlug: reuse.displayedSlug,
@@ -141,7 +143,11 @@ export const ReuseAssignmentModal = ({
             return (
               <FormField
                 label={t("components.modals.reuseAssignment.slugLabel")}
-                error={reuse.slugTaken ? slugStatus : undefined}
+                error={
+                  reuse.slugTaken || reuse.slugOverBudget
+                    ? slugStatus
+                    : undefined
+                }
                 hint={slugStatus}
               >
                 {({ id, describedById, invalid }) => (

--- a/web/src/components/modals/ReuseFromClassroomModal.tsx
+++ b/web/src/components/modals/ReuseFromClassroomModal.tsx
@@ -195,6 +195,8 @@ export const ReuseFromClassroomModal = ({
                   loading: destLoading,
                   error: destError,
                   slugTaken: reuse.slugTaken,
+                  slugOverBudget: reuse.slugOverBudget,
+                  slugBudget: reuse.slugBudget,
                   slugTouched: reuse.slugTouched,
                   normalizedSlug: reuse.normalizedSlug,
                   displayedSlug: reuse.displayedSlug,
@@ -208,7 +210,11 @@ export const ReuseFromClassroomModal = ({
                     label={t("components.modals.reuseFromClassroom.slugLabel", {
                       classroom,
                     })}
-                    error={reuse.slugTaken ? slugStatus : undefined}
+                    error={
+                      reuse.slugTaken || reuse.slugOverBudget
+                        ? slugStatus
+                        : undefined
+                    }
                     hint={slugStatus}
                   >
                     {({ id, describedById, invalid }) => (

--- a/web/src/components/modals/ReuseModalShell.tsx
+++ b/web/src/components/modals/ReuseModalShell.tsx
@@ -112,14 +112,16 @@ export const ReuseModalShell = ({
 
 export default ReuseModalShell
 
-// Slug-field helper text. `loading`/`error`/`slugTaken` take priority in order;
-// otherwise preview the normalized form or fall back to `uniqueHint`.
-// `classroomLabel`/`uniqueHint` carry each modal's wording.
+// Slug-field helper text. `loading`/`error`/`slugOverBudget`/`slugTaken` take
+// priority in order; otherwise preview the normalized form or fall back to
+// `uniqueHint`. `classroomLabel`/`uniqueHint` carry each modal's wording.
 export const reuseSlugStatus = ({
   t,
   loading,
   error,
   slugTaken,
+  slugOverBudget,
+  slugBudget,
   slugTouched,
   normalizedSlug,
   displayedSlug,
@@ -130,6 +132,8 @@ export const reuseSlugStatus = ({
   loading: boolean
   error: boolean
   slugTaken: boolean
+  slugOverBudget: boolean
+  slugBudget: number
   slugTouched: boolean
   normalizedSlug: string
   displayedSlug: string
@@ -138,6 +142,12 @@ export const reuseSlugStatus = ({
 }): string => {
   if (loading) return t("components.modals.reuseShell.slug.checking")
   if (error) return t("components.modals.reuseShell.slug.checkError")
+  if (slugOverBudget)
+    return t("components.modals.reuseShell.slug.overBudget", {
+      length: normalizedSlug.length,
+      budget: slugBudget,
+      classroom: classroomLabel,
+    })
   if (slugTaken)
     return t("components.modals.reuseShell.slug.taken", {
       slug: normalizedSlug,

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -408,6 +408,21 @@ describe("nextAvailableSlug", () => {
     // "hw-1-2" -> stem "hw-1", n=3 (not "hw" / "hw-1-2-2").
     expect(nextAvailableSlug("hw-1-2", ["hw-1-2"])).toBe("hw-1-3")
   })
+
+  // maxLen carries a classroom's composed repo-name budget (#691).
+  it("trims the base to maxLen, dropping an exposed trailing hyphen", () => {
+    expect(nextAvailableSlug("hello-world", [], 7)).toBe("hello-w")
+    expect(nextAvailableSlug("hello-world", [], 6)).toBe("hello")
+  })
+
+  it("keeps a suffixed candidate within maxLen by trimming the stem", () => {
+    // "hello-w" is taken; "-2" needs room, so the stem trims to "hello".
+    expect(nextAvailableSlug("hello-world", ["hello-w"], 7)).toBe("hello-2")
+  })
+
+  it("yields an empty slug on a non-positive budget (caller validates)", () => {
+    expect(nextAvailableSlug("hw1", [], 0)).toBe("")
+  })
 })
 
 describe("editAssignment (preserved-entry integration)", () => {

--- a/web/src/hooks/mutations/useReuseAssignment.ts
+++ b/web/src/hooks/mutations/useReuseAssignment.ts
@@ -11,6 +11,7 @@ import {
   type CopyAssignmentInput,
 } from "@/domain/assignments"
 import { slugify } from "@/util/slug"
+import { assignmentSlugBudget } from "@/util/repoNameBudget"
 import type { Assignment } from "@/types/classroom"
 
 type UseReuseAssignmentParams = {
@@ -52,16 +53,28 @@ export function useReuseAssignment({
   const [slugTouched, setSlugTouched] = useState(false)
   const [warning, setWarning] = useState<string | null>(null)
 
-  // Auto-suffixed default ("hw1" -> "hw1-2" if taken). Derived, not state, so it
-  // stays correct as the target's assignments load.
+  // The composed repo-name budget for the TARGET classroom (#691): bounds the
+  // auto-suffixed default and blocks an over-budget manual slug.
+  const slugBudget = assignmentSlugBudget(targetClassroom)
+
+  // Auto-suffixed default ("hw1" -> "hw1-2" if taken), trimmed to the target's
+  // budget. Derived, not state, so it stays correct as the target's
+  // assignments load.
   const autoSlug = useMemo(
-    () => (source ? nextAvailableSlug(slugify(source.slug), takenSlugs) : ""),
-    [source, takenSlugs],
+    () =>
+      source
+        ? nextAvailableSlug(slugify(source.slug), takenSlugs, slugBudget)
+        : "",
+    [source, takenSlugs, slugBudget],
   )
 
   // Default until the teacher edits; `normalizedSlug` is what gets saved.
   const displayedSlug = slugTouched ? slugInput : autoSlug
   const normalizedSlug = slugify(displayedSlug)
+
+  // A manually entered slug can still exceed the target's budget; blocked here
+  // (and re-checked by the CLI-mirroring write path 422 handling).
+  const slugOverBudget = normalizedSlug.length > slugBudget
 
   // Optimistic, case-insensitive check; the write path re-checks authoritatively.
   const slugTaken = useMemo(() => {
@@ -111,6 +124,7 @@ export function useReuseAssignment({
     Boolean(targetClassroom) &&
     Boolean(normalizedSlug) &&
     !slugTaken &&
+    !slugOverBudget &&
     !takenLoading &&
     !reuse.isPending
 
@@ -139,6 +153,8 @@ export function useReuseAssignment({
     normalizedSlug,
     slugTouched,
     slugTaken,
+    slugOverBudget,
+    slugBudget,
     warning,
     errorMessage,
     isPending: reuse.isPending,

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -321,6 +321,7 @@
     },
     "reason": {
       "invalidSlug": "The assignment slug \"{{slug}}\" isn't a valid repo name.",
+      "slugOverBudget": "The slug \"{{slug}}\" is too long for this classroom — student repository names would exceed GitHub's {{limit}}-character limit (at most {{budget}} characters here).",
       "invalidMode": "Unsupported assignment type \"{{type}}\".",
       "badStarter": "The starter repository \"{{fullName}}\" has an unexpected name.",
       "sourceNotAccessible": "The starter repository \"{{fullName}}\" isn't accessible to your account.",
@@ -341,6 +342,7 @@
       "assignmentInaccessible": "Assignment {{id}} isn't accessible — you must administer its GitHub Classroom.",
       "classroomNameEmpty": "The classroom name is empty — enter a short name explicitly.",
       "shortNameInvalid": "\"{{shortName}}\" isn't a valid short name — it must be {{description}}. Enter one explicitly.",
+      "shortNameTooLong": "The short name \"{{shortName}}\" is {{length}} characters; new classrooms are capped at {{max}} so student repository names keep room for assignment slugs. Enter a shorter one explicitly.",
       "shortNameInvalidFrom": "Couldn't derive a valid short name from \"{{rawName}}\" (got \"{{shortName}}\") — it must be {{description}}. Enter one explicitly.",
       "shortNameNotCanonical": "The short name \"{{shortName}}\" can't back a GitHub team — remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking membership and template grants).",
       "templateSourceAccess": "Can't read the starter repository \"{{fullName}}\" — approve the Classroom 50 app for the \"{{org}}\" organization, then retry. {{detail}}",
@@ -897,6 +899,7 @@
     "classroomSlugRequired": "Classroom slug is required.",
     "classroomSlugTaken": "Classroom slug is already taken.",
     "classroomSlugInvalid": "Classroom slug must be {{description}}.",
+    "classroomSlugTooLong": "Classroom slug is {{length}} characters; new classrooms are capped at {{max}} — it prefixes every student repository name, which GitHub limits to {{limit}} characters.",
     "assignmentSlugTaken": "An assignment \"{{slug}}\" already exists in this classroom.",
     "groupSizeRange": "Group size must be a whole number between {{min}} and {{max}}."
   },
@@ -1371,6 +1374,7 @@
         "nameRequired": "Assignment name is required.",
         "slugRequired": "Assignment slug is required.",
         "slugInvalid": "Assignment slug must be {{description}}.",
+        "slugOverBudget": "Student repositories are named \"{{classroom}}-<slug>-<username>\", which GitHub caps at {{limit}} characters — this slug can be at most {{budget}} characters (currently {{length}}).",
         "maxGroupSizeInvalid": "Max group size must be a valid number.",
         "setupTimeoutRange": "Setup timeout must be 0 or a whole number of seconds from 1 through {{max}}.",
         "passThresholdRange": "Pass threshold must be a whole number between {{min}} and {{max}}.",
@@ -3261,6 +3265,7 @@
           "checking": "Checking existing assignments…",
           "checkError": "Couldn’t check existing slugs — you can still try; we’ll re-check on save.",
           "taken": "“{{slug}}” is already used in {{classroom}} — pick another.",
+          "overBudget": "This slug is {{length}} characters; {{classroom}} leaves room for at most {{budget}} so student repository names stay under GitHub's limit.",
           "willBeSaved": "Will be saved as “{{slug}}”."
         }
       },

--- a/web/src/migration/classify.test.ts
+++ b/web/src/migration/classify.test.ts
@@ -71,7 +71,7 @@ function makeClient(opts: {
 describe("classifyAssignment", () => {
   it("import when source is a template and target 404s", async () => {
     const { client } = makeClient({ sourceTemplate: true })
-    const item = await classifyAssignment(client, "dst", "", assignment())
+    const item = await classifyAssignment(client, "dst", "", "cs", assignment())
     expect(item.action).toBe("import")
     expect(item.targetName).toBe("hw1")
     expect(item.targetPrivate).toBe(false)
@@ -82,7 +82,7 @@ describe("classifyAssignment", () => {
       sourceTemplate: true,
       target: { is_template: true, default_branch: "trunk", private: true },
     })
-    const item = await classifyAssignment(client, "dst", "", assignment())
+    const item = await classifyAssignment(client, "dst", "", "cs", assignment())
     expect(item.action).toBe("reuse")
     expect(item.branch).toBe("trunk")
     expect(item.targetPrivate).toBe(true)
@@ -93,7 +93,7 @@ describe("classifyAssignment", () => {
       sourceTemplate: true,
       target: { is_template: false, default_branch: "main", private: false },
     })
-    const item = await classifyAssignment(client, "dst", "", assignment())
+    const item = await classifyAssignment(client, "dst", "", "cs", assignment())
     expect(item.action).toBe("skip")
     expect(item.reason?.key).toBe("migration.reason.targetCollision")
   })
@@ -104,6 +104,7 @@ describe("classifyAssignment", () => {
       client,
       "dst",
       "",
+      "cs",
       assignment({ starter_code_repository: null }),
     )
     expect(item.action).toBe("import")
@@ -112,13 +113,13 @@ describe("classifyAssignment", () => {
 
   it("skip when the source is not a template", async () => {
     const { client } = makeClient({ sourceTemplate: false })
-    const item = await classifyAssignment(client, "dst", "", assignment())
+    const item = await classifyAssignment(client, "dst", "", "cs", assignment())
     expect(item.reason?.key).toBe("migration.reason.sourceNotTemplate")
   })
 
   it("skip when the source is not accessible", async () => {
     const { client } = makeClient({ sourceMissing: true })
-    const item = await classifyAssignment(client, "dst", "", assignment())
+    const item = await classifyAssignment(client, "dst", "", "cs", assignment())
     // src/hw1 is a different org than the target "dst" -> org-access reason.
     expect(item.reason?.key).toBe("migration.reason.sourceOrgAccess")
     expect(item.reason?.params?.org).toBe("src")
@@ -127,7 +128,7 @@ describe("classifyAssignment", () => {
   it("uses sourceNotAccessible when the source is in the SAME org as target", async () => {
     const { client } = makeClient({ sourceMissing: true })
     // Target org "src" matches the starter's org, so it's not an app-grant gap.
-    const item = await classifyAssignment(client, "src", "", assignment())
+    const item = await classifyAssignment(client, "src", "", "cs", assignment())
     expect(item.reason?.key).toBe("migration.reason.sourceNotAccessible")
   })
 
@@ -137,15 +138,37 @@ describe("classifyAssignment", () => {
       client,
       "dst",
       "",
+      "cs",
       assignment({ slug: "Bad Slug" }),
     )
     expect(item.reason?.key).toBe("migration.reason.invalidSlug")
     expect(gets).toHaveLength(0)
   })
 
+  it("skip on an over-budget slug without any network call", async () => {
+    const { client, gets } = makeClient({})
+    // "cs" leaves a 57-char budget (59 - 2); 58 exceeds it.
+    const item = await classifyAssignment(
+      client,
+      "dst",
+      "",
+      "cs",
+      assignment({ slug: "s".repeat(58) }),
+    )
+    expect(item.reason?.key).toBe("migration.reason.slugOverBudget")
+    expect(item.reason?.params?.budget).toBe("57")
+    expect(gets).toHaveLength(0)
+  })
+
   it("applies the template-suffix to the probed target name", async () => {
     const { client, gets } = makeClient({ sourceTemplate: true })
-    const item = await classifyAssignment(client, "dst", "sp26", assignment())
+    const item = await classifyAssignment(
+      client,
+      "dst",
+      "sp26",
+      "cs",
+      assignment(),
+    )
     expect(item.targetName).toBe("hw1-sp26")
     expect(gets.some((g) => g.includes("/repos/dst/hw1-sp26"))).toBe(true)
   })
@@ -155,7 +178,7 @@ describe("classifyAssignment", () => {
       sourceTemplate: true,
       target: { is_template: true, default_branch: "main", private: false },
     })
-    await classifyAssignment(client, "dst", "", assignment())
+    await classifyAssignment(client, "dst", "", "cs", assignment())
     expect(gets.every((g) => g.startsWith("GET "))).toBe(true)
   })
 })

--- a/web/src/migration/classify.ts
+++ b/web/src/migration/classify.ts
@@ -7,6 +7,11 @@
 import type { GitHubClient } from "@/github-core/client"
 import { GitHubAPIError } from "@/github-core/errors"
 import { SHORT_NAME_PATTERN } from "@/util/shortName"
+import {
+  GITHUB_REPO_NAME_MAX_LEN,
+  assignmentSlugBudget,
+  composedRepoNameFits,
+} from "@/util/repoNameBudget"
 import { splitFullName } from "@/util/repoFullName"
 import type {
   ClassroomAssignmentDetail,
@@ -67,10 +72,13 @@ async function sourceIsTemplate(
 
 // Classify one source assignment, read-only. Returns import/reuse/skip with a
 // translatable reason for reuse/skip and the resolved target name/branch.
+// `shortName` is the TARGET classroom directory, for the composed repo-name
+// budget check.
 export async function classifyAssignment(
   client: GitHubClient,
   targetOrg: string,
   templateSuffix: string,
+  shortName: string,
   assignment: ClassroomAssignmentDetail,
 ): Promise<MigrationItem> {
   const targetName = targetTemplateName(assignment.slug, templateSuffix)
@@ -86,6 +94,19 @@ export async function classifyAssignment(
     return skip({
       key: "migration.reason.invalidSlug",
       params: { slug: assignment.slug },
+    })
+  }
+  // #691: a slug that composes past GitHub's repo-name limit with the target
+  // short-name would fail every long-username accept — skip it (the rest of
+  // the migration proceeds). Mirrors the CLI's copyOneTemplate guard.
+  if (!composedRepoNameFits(shortName, assignment.slug).fits) {
+    return skip({
+      key: "migration.reason.slugOverBudget",
+      params: {
+        slug: assignment.slug,
+        budget: String(assignmentSlugBudget(shortName)),
+        limit: String(GITHUB_REPO_NAME_MAX_LEN),
+      },
     })
   }
   if (assignment.type !== "individual" && assignment.type !== "group") {

--- a/web/src/migration/preflight.ts
+++ b/web/src/migration/preflight.ts
@@ -12,6 +12,8 @@ import { classifyAssignment } from "./classify"
 import { fetchAssignmentsForClassroom, resolveSource } from "./classroomApi"
 import { deriveShortName } from "./translate"
 import { assertValidShortName } from "@/util/shortName"
+import { CLASSROOM_SHORT_NAME_MAX_LEN } from "@/util/repoNameBudget"
+import { localizedError } from "@/types/localizedMessage"
 import type {
   MigrationBlocker,
   MigrationItem,
@@ -98,6 +100,18 @@ export async function buildPreflight(
     : deriveShortName(classroom.name)
   // A user-supplied short-name still has to pass the pattern + team-slug guard.
   assertValidShortName(shortName)
+  // Creation-time cap (#691): migration mints the classroom, so an explicit
+  // over-cap short-name fails preflight. Derived names are already truncated.
+  if (shortName.length > CLASSROOM_SHORT_NAME_MAX_LEN) {
+    throw localizedError({
+      key: "migration.error.shortNameTooLong",
+      params: {
+        shortName,
+        length: shortName.length,
+        max: CLASSROOM_SHORT_NAME_MAX_LEN,
+      },
+    })
+  }
 
   const term = (input.term ?? "").trim()
   const name = input.name?.trim() ? input.name.trim() : classroom.name
@@ -106,7 +120,13 @@ export async function buildPreflight(
   const items: MigrationItem[] = []
   for (const a of assignments) {
     items.push(
-      await classifyAssignment(client, input.targetOrg, templateSuffix, a),
+      await classifyAssignment(
+        client,
+        input.targetOrg,
+        templateSuffix,
+        shortName,
+        a,
+      ),
     )
   }
 

--- a/web/src/migration/translate.test.ts
+++ b/web/src/migration/translate.test.ts
@@ -49,6 +49,20 @@ describe("deriveShortName", () => {
     // here a single char is below the 2-char minimum instead.
     expect(() => deriveShortName("A")).toThrow(/shortNameInvalid/)
   })
+
+  it("truncates a long name to the creation cap, mirroring the CLI", () => {
+    // "abcdefghij-" x10 (110 chars) -> first 40 chars, no dangling hyphen.
+    const derived = deriveShortName("abcdefghij-".repeat(10))
+    expect(derived).toBe("abcdefghij-".repeat(3) + "abcdefg")
+    expect(derived.length).toBeLessThanOrEqual(40)
+  })
+
+  it("drops a trailing hyphen the truncation exposes", () => {
+    // "abcdefghi-" x10: the cut at 40 lands on a hyphen.
+    expect(deriveShortName("abcdefghi-".repeat(10))).toBe(
+      "abcdefghi-".repeat(3) + "abcdefghi",
+    )
+  })
 })
 
 describe("migratedDueFields", () => {

--- a/web/src/migration/translate.ts
+++ b/web/src/migration/translate.ts
@@ -11,6 +11,7 @@ import {
   SHORT_NAME_PATTERN_DESCRIPTION,
   assertValidShortName,
 } from "@/util/shortName"
+import { CLASSROOM_SHORT_NAME_MAX_LEN } from "@/util/repoNameBudget"
 import type { ClassroomAssignmentDetail, ClassroomDetail } from "./types"
 
 // The only migrated_from.source value today.
@@ -68,8 +69,11 @@ export function deriveShortName(rawName: string): string {
     throw localizedError({ key: "migration.error.classroomNameEmpty" })
   }
   let slug = lowered.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "")
-  if (slug.length > 100) {
-    slug = slug.slice(0, 100).replace(/-+$/g, "")
+  // Truncate to the creation cap (not the pattern's 100) so a migrated
+  // classroom keeps a workable assignment-slug budget (#691). Mirrors the
+  // CLI's deriveShortName.
+  if (slug.length > CLASSROOM_SHORT_NAME_MAX_LEN) {
+    slug = slug.slice(0, CLASSROOM_SHORT_NAME_MAX_LEN).replace(/-+$/g, "")
   }
   assertValidShortName(slug, rawName)
   return slug

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -84,6 +84,7 @@ const CreateAssignmentForm = ({
   const form = useAssignmentForm(defaultValues, onSubmit, t, {
     takenSlugs,
     edit,
+    classroom,
   })
   // Auto-prefill slug from name until the teacher edits it directly, so a
   // deliberate slug isn't clobbered by later name edits.
@@ -144,6 +145,7 @@ const CreateAssignmentForm = ({
         const errors = validateAssignmentForm(form.state.values, t, {
           takenSlugs,
           edit,
+          classroom,
         })
         // handleSubmit re-throws an onSubmit rejection (an edit-mode mutateAsync
         // failure); the caller's onError banner already surfaces it, so swallow
@@ -189,6 +191,7 @@ const CreateAssignmentForm = ({
                   slugTouched={slugTouched}
                   setSlugTouched={setSlugTouched}
                   takenSlugs={takenSlugs}
+                  classroom={classroom}
                 />
                 <RepositorySetupSection
                   form={form}

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -123,6 +123,32 @@ describe("validateAssignmentForm — required fields", () => {
     const errors = validateAssignmentForm({ ...base, slug: "a".repeat(101) }, t)
     expect(errors.slug).toBe("assignments.form.validation.slugInvalid")
   })
+
+  // #691: a pattern-valid slug can still compose past GitHub's 100-char repo
+  // name with the classroom prefix and a worst-case username.
+  it("flags a slug over the classroom's composed repo-name budget on create", () => {
+    // "cs" leaves a 57-char budget (59 - 2); 58 exceeds it.
+    const errors = validateAssignmentForm(
+      { ...base, slug: "s".repeat(58) },
+      t,
+      { classroom: "cs" },
+    )
+    expect(errors.slug).toBe("assignments.form.validation.slugOverBudget")
+  })
+
+  it("accepts a slug exactly at the classroom's budget", () => {
+    const errors = validateAssignmentForm(
+      { ...base, slug: "s".repeat(57) },
+      t,
+      { classroom: "cs" },
+    )
+    expect(errors.slug).toBeUndefined()
+  })
+
+  it("skips the budget check without a classroom in context", () => {
+    const errors = validateAssignmentForm({ ...base, slug: "s".repeat(58) }, t)
+    expect(errors.slug).toBeUndefined()
+  })
 })
 
 describe("validateAssignmentForm — group size", () => {

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -5,6 +5,11 @@ import {
   SHORT_NAME_PATTERN_DESCRIPTION,
   isValidShortName,
 } from "@/util/shortName"
+import {
+  GITHUB_REPO_NAME_MAX_LEN,
+  assignmentSlugBudget,
+  composedRepoNameFits,
+} from "@/util/repoNameBudget"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import {
   DEFAULT_SETUP_TIMEOUT_SECONDS,
@@ -244,7 +249,12 @@ export function formValuesToRepoFeatures(
 }
 
 // Create-only: slug uniqueness is not validated in edit mode (no rename).
-export type SlugContext = { takenSlugs?: string[]; edit?: boolean }
+// `classroom` (the short-name) enables the composed repo-name budget check.
+export type SlugContext = {
+  takenSlugs?: string[]
+  edit?: boolean
+  classroom?: string
+}
 
 // Pure submit-time validation, mirroring gh-teacher's write-time rules so a bad
 // value is caught in the form rather than by a failed commit or an unparseable
@@ -269,6 +279,18 @@ export function validateAssignmentForm(
       // repo path segments); the write path historically skipped it.
       errors.slug = t("assignments.form.validation.slugInvalid", {
         description: SHORT_NAME_PATTERN_DESCRIPTION,
+      })
+    } else if (
+      slugContext?.classroom &&
+      !composedRepoNameFits(slugContext.classroom, slug).fits
+    ) {
+      // #691: a NEW slug must fit the composed `<classroom>-<slug>-<username>`
+      // budget, or long-username accepts fail with GitHub's 100-char 422.
+      errors.slug = t("assignments.form.validation.slugOverBudget", {
+        classroom: slugContext.classroom,
+        budget: assignmentSlugBudget(slugContext.classroom),
+        length: slug.length,
+        limit: GITHUB_REPO_NAME_MAX_LEN,
       })
     } else if (
       (slugContext?.takenSlugs ?? []).some(

--- a/web/src/pages/assignments/sections/DetailsSection.tsx
+++ b/web/src/pages/assignments/sections/DetailsSection.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { nextAvailableSlug, slugify } from "@/util/slug"
+import { assignmentSlugBudget } from "@/util/repoNameBudget"
 import { Alert, FormField, Input, Textarea } from "@/components/ui"
 import { GROUP_SIZE_MAX, GROUP_SIZE_MIN } from "@/types/classroom"
 import { FieldLabel } from "../AdvancedRuntimeFields"
@@ -18,6 +19,7 @@ export function DetailsSection({
   slugTouched,
   setSlugTouched,
   takenSlugs,
+  classroom,
 }: {
   form: AssignmentForm
   edit: boolean
@@ -27,8 +29,14 @@ export function DetailsSection({
   // Existing assignment slugs, so the create-mode auto-fill can pick a slug
   // that's already unique instead of surfacing a conflict only at submit.
   takenSlugs?: string[]
+  // Classroom short-name; bounds the slug to the composed repo-name budget
+  // (#691) so the auto-fill can't mint a name GitHub would reject at accept.
+  classroom?: string
 }) {
   const { t } = useTranslation()
+  // undefined (no classroom in context) leaves nextAvailableSlug at its
+  // pattern-cap default.
+  const slugBudget = classroom ? assignmentSlugBudget(classroom) : undefined
 
   return (
     <SectionCard title={t("assignments.form.detailsSection")} onReset={onReset}>
@@ -66,6 +74,7 @@ export function DetailsSection({
                           nextAvailableSlug(
                             slugify(e.target.value),
                             takenSlugs ?? [],
+                            slugBudget,
                           ),
                         )
                       }
@@ -118,6 +127,7 @@ export function DetailsSection({
                           nextAvailableSlug(
                             slugify(form.state.values.name),
                             takenSlugs ?? [],
+                            slugBudget,
                           ),
                       )
                       field.handleBlur()

--- a/web/src/pages/classes/CreateClassroomForm.test.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.test.tsx
@@ -121,4 +121,31 @@ describe("CreateClassroomForm slug validation", () => {
     await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
     expect(onSubmit.mock.calls[0][0].slug).toBe("intro-cs")
   })
+
+  // The auto-derived slug is pre-fixed rather than left to fail at submit:
+  // trimmed to the 40-char creation cap and suffixed past existing classrooms.
+  it("auto-derives a slug trimmed to the creation cap", async () => {
+    const user = userEvent.setup()
+    const { container } = render(<CreateClassroomForm onSubmit={vi.fn()} />)
+
+    await user.type(
+      container.querySelector<HTMLInputElement>("#name")!,
+      "Introduction to Computer Science and Programming",
+    )
+    const derived = slugInput(container).value
+    expect(derived.length).toBeLessThanOrEqual(40)
+    expect(derived).toBe("introduction-to-computer-science-and-pro")
+  })
+
+  it("auto-derives a suffixed slug when the name collides with an existing classroom", async () => {
+    mockClasses = [{ name: "intro-cs", path: "intro-cs", type: "dir" }]
+    const user = userEvent.setup()
+    const { container } = render(<CreateClassroomForm onSubmit={vi.fn()} />)
+
+    await user.type(
+      container.querySelector<HTMLInputElement>("#name")!,
+      "Intro CS",
+    )
+    expect(slugInput(container).value).toBe("intro-cs-2")
+  })
 })

--- a/web/src/pages/classes/CreateClassroomForm.test.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.test.tsx
@@ -61,6 +61,27 @@ describe("CreateClassroomForm slug validation", () => {
     ).not.toBeNull()
   })
 
+  // Creation-time budget cap (#691): a pattern-valid slug past 40 chars is
+  // rejected — it prefixes every student repo name in the classroom.
+  it("rejects a slug over the 40-char creation cap and does not submit", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    const { container } = render(<CreateClassroomForm onSubmit={onSubmit} />)
+
+    await user.type(
+      container.querySelector<HTMLInputElement>("#name")!,
+      "Class",
+    )
+    await user.clear(slugInput(container))
+    await user.type(slugInput(container), "a".repeat(41))
+    await user.click(submit())
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(
+      await screen.findByText("validation.classroomSlugTooLong"),
+    ).not.toBeNull()
+  })
+
   // Regression guard: the collision check must compare the SLUGIFIED value, not
   // the raw input. A raw "CS 50" slugifies to "cs-50"; if the check compared the
   // raw string it would miss an existing "cs-50" and overwrite its roster/scores.

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -9,7 +9,7 @@ import {
   generateSecret,
   isValidSecret,
 } from "@/util/secret"
-import { slugify } from "@/util/slug"
+import { nextAvailableSlug, slugify } from "@/util/slug"
 import {
   SHORT_NAME_PATTERN_DESCRIPTION,
   isValidShortName,
@@ -164,7 +164,18 @@ const CreateClassroomForm = ({
                   onBlur={field.handleBlur}
                   onChange={(e) => {
                     field.handleChange(e.target.value)
-                    form.setFieldValue("slug", slugify(e.target.value))
+                    // Auto-derive a slug that's already within the creation
+                    // cap and free among existing classrooms, so the teacher
+                    // isn't bounced by a submit-time error the form could
+                    // have avoided. Manual slug edits still re-validate.
+                    form.setFieldValue(
+                      "slug",
+                      nextAvailableSlug(
+                        slugify(e.target.value),
+                        classes.map((cl) => cl.path),
+                        CLASSROOM_SHORT_NAME_MAX_LEN,
+                      ),
+                    )
                   }}
                 />
               )}

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -14,6 +14,10 @@ import {
   SHORT_NAME_PATTERN_DESCRIPTION,
   isValidShortName,
 } from "@/util/shortName"
+import {
+  CLASSROOM_SHORT_NAME_MAX_LEN,
+  GITHUB_REPO_NAME_MAX_LEN,
+} from "@/util/repoNameBudget"
 import { Button, Card, FormField, Input } from "@/components/ui"
 
 export type CreateClassroomFormValues = {
@@ -71,6 +75,14 @@ const CreateClassroomForm = ({
           if (!isValidShortName(slug)) {
             errors.slug = t("validation.classroomSlugInvalid", {
               description: SHORT_NAME_PATTERN_DESCRIPTION,
+            })
+          } else if (slug.length > CLASSROOM_SHORT_NAME_MAX_LEN) {
+            // Creation-time cap (#691): the slug prefixes every student repo
+            // name, so an over-long one starves every future assignment slug.
+            errors.slug = t("validation.classroomSlugTooLong", {
+              length: slug.length,
+              max: CLASSROOM_SHORT_NAME_MAX_LEN,
+              limit: GITHUB_REPO_NAME_MAX_LEN,
             })
           } else if (
             classes.find((cl) => cl.path.toLowerCase() === slug.toLowerCase())

--- a/web/src/util/shortName.ts
+++ b/web/src/util/shortName.ts
@@ -2,8 +2,9 @@ import { localizedError } from "@/types/localizedMessage"
 
 // Classroom short-names and assignment slugs both flow into repo/team names.
 // Byte-mirror of the CLI's validate.ShortNamePattern (2-100 chars). The cap is
-// per-segment, not a guarantee the composed repo name fits GitHub's 100-char
-// limit — see foundation50/classroom50#691.
+// per-segment — a READ-side tolerance so pre-cap documents keep validating.
+// Write paths layer the composed repo-name budget on top (#691): see
+// repoNameBudget (CLASSROOM_SHORT_NAME_MAX_LEN, composedRepoNameFits).
 export const SHORT_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{1,99}$/
 export const SHORT_NAME_PATTERN_DESCRIPTION =
   "2-100 chars, lowercase letters/digits/hyphens, starting with a letter or digit"

--- a/web/src/util/slug.ts
+++ b/web/src/util/slug.ts
@@ -19,15 +19,23 @@ export function slugify(value: string) {
 // suffix must not push a candidate past it, so the stem is trimmed to fit.
 const SLUG_MAX_LEN = 100
 
-// First slug not in `taken`, suffixing `-2`, `-3`, … A base ending in `-<n>`
-// continues from n+1 ("hw1-2" -> "hw1-3", not "hw1-2-2"). Case-insensitive, to
-// match GitHub repo naming and the server-side check. Pure; prefills both the
-// reuse modals and the create-form auto-slug — the write path re-checks
-// authoritatively.
+// First slug not in `taken` and within `maxLen`, suffixing `-2`, `-3`, … A base
+// ending in `-<n>` continues from n+1 ("hw1-2" -> "hw1-3", not "hw1-2-2").
+// Case-insensitive, to match GitHub repo naming and the server-side check.
+// `maxLen` defaults to the pattern cap; callers minting a slug for a specific
+// classroom pass its composed repo-name budget (repoNameBudget) so the derived
+// slug can't overflow GitHub's limit. Pure; prefills both the reuse modals and
+// the create-form auto-slug — the write path re-checks authoritatively.
 export function nextAvailableSlug(
   base: string,
   taken: Iterable<string>,
+  maxLen: number = SLUG_MAX_LEN,
 ): string {
+  // Trim the base itself to the budget; drop a hyphen the trim exposes. A
+  // non-positive budget (a legacy over-long classroom) yields "" — the caller's
+  // validation owns surfacing that.
+  base = base.slice(0, Math.max(maxLen, 0)).replace(/-+$/g, "")
+
   const takenSet = new Set(Array.from(taken, (s) => s.trim().toLowerCase()))
   const isFree = (candidate: string) => !takenSet.has(candidate.toLowerCase())
 
@@ -42,12 +50,12 @@ export function nextAvailableSlug(
   for (let i = 0; i < 10000; i++) {
     const suffix = `-${n}`
     // Trim the stem to leave room for the suffix; drop a hyphen the trim exposes.
-    const room = SLUG_MAX_LEN - suffix.length
-    const trimmedStem = stem.slice(0, room).replace(/-+$/g, "")
+    const room = maxLen - suffix.length
+    const trimmedStem = stem.slice(0, Math.max(room, 0)).replace(/-+$/g, "")
     const candidate = `${trimmedStem}${suffix}`
     if (isFree(candidate)) return candidate
     n++
   }
   // Unreachable in practice, but never silently return a taken slug.
-  return `${stem}-${Date.now()}`.slice(0, SLUG_MAX_LEN).replace(/-+$/g, "")
+  return `${stem}-${Date.now()}`.slice(0, maxLen).replace(/-+$/g, "")
 }


### PR DESCRIPTION
## Summary

Web half of the creation-time budget enforcement (companion to #705, both toward #691): the composed `<classroom>-<assignment>-<username>` repo name can no longer be minted past GitHub's 100-character limit from the GUI, while everything pre-existing stays readable and editable.

- **Create-classroom form**: new slugs are capped at 40 characters (`CLASSROOM_SHORT_NAME_MAX_LEN`), and the name-derived slug is now generated trim-to-cap and collision-suffixed (`nextAvailableSlug`) instead of failing at submit.
- **Assignment create form**: `SlugContext` gains the classroom short-name; `validateAssignmentForm` rejects a slug over the classroom's composed budget (`59 − len(classroom)`), and the name-derived auto-fill in `DetailsSection` is budget-bounded so it can't propose an over-long slug.
- **Reuse modals** (`useReuseAssignment` + both modals): the auto-suffixed default slug is trimmed to the *target* classroom's budget; a manually entered over-budget slug shows an inline error and blocks submit.
- **`nextAvailableSlug`**: gains a `maxLen` parameter (default: the 100 pattern cap) — trims the base and keeps suffixed candidates within it.
- **Migration**: the derived short-name truncates to 40 (mirroring the CLI's `deriveShortName`); an explicit over-cap short-name is a preflight error; an over-budget assignment slug becomes a visible skip reason (`migration.reason.slugOverBudget`) before any network call, mirroring the CLI's `copyOneTemplate` guard.
- New i18n keys for all five messages; `shortName.ts` comment updated to describe the read-tolerant/write-capped split.

Accept-time 422 handling is untouched and remains the backstop for pre-existing over-budget assignments.

## Test plan

- [x] New tests: budget error + boundary + no-classroom-context cases in `assignmentFormModel.test.ts`, 40-cap rejection + trimmed/suffixed auto-derivation in `CreateClassroomForm.test.tsx`, `nextAvailableSlug` maxLen cases, migration over-budget skip (`classify.test.ts`) and derive-truncation (`translate.test.ts`)
- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 4333 tests)
- [x] `audit_i18n.py --strict` passes