### PR TITLE
fix(cli): trim auto-derived reuse slugs to the repo-name budget

### DIFF
--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -798,32 +798,52 @@ const slugMaxLen = 100
 // `hello` → ("hello", 0); `hello-2` → ("hello", 2).
 var slugSuffixRe = regexp.MustCompile(`^(.*)-([1-9][0-9]*)$`)
 
-// NextAvailableSlug returns a slug that doesn't collide (case-insensitively),
-// auto-suffixing `-2`, `-3`, …; a base already ending in `-N` increments from
-// N+1. Returns the input unchanged when already free.
-//
-// A candidate overflowing slugMaxLen returns an actionable error rather than
-// an over-long slug. A free-but-over-cap input is returned unchanged (the
-// caller's validation surfaces it).
-func NextAvailableSlug(entries []AssignmentEntry, slug string) (string, error) {
-	if !SlugExistsFold(entries, slug) {
-		return slug, nil
+// trimSlugTo cuts s to at most n bytes and drops a trailing hyphen the cut
+// exposes (a valid slug never ends with one).
+func trimSlugTo(s string, n int) string {
+	if len(s) > n {
+		s = s[:n]
 	}
-	base := slug
+	return strings.TrimRight(s, "-")
+}
+
+// NextAvailableSlug returns a slug within maxLen that doesn't collide
+// (case-insensitively): the base is trimmed to maxLen, and a collision
+// auto-suffixes `-2`, `-3`, … with the stem re-trimmed so the candidate stays
+// within maxLen; a base already ending in `-N` increments from N+1. Callers
+// pass the target classroom's composed repo-name budget (#691) — or slugMaxLen
+// when unconstrained; anything larger clamps to the pattern cap. Mirrors the
+// web's nextAvailableSlug so both tools derive the same copy names. Errors
+// only when maxLen can't fit ShortName's 2-char minimum.
+func NextAvailableSlug(entries []AssignmentEntry, slug string, maxLen int) (string, error) {
+	if maxLen > slugMaxLen {
+		maxLen = slugMaxLen
+	}
+	if maxLen < 2 {
+		return "", fmt.Errorf("cannot derive a slug for %q: the target classroom leaves %d characters for a slug (student repo names are capped at %d by GitHub) — reuse into a classroom with a shorter short-name",
+			slug, maxLen, slugMaxLen)
+	}
+	base := trimSlugTo(slug, maxLen)
+	if !SlugExistsFold(entries, base) {
+		return base, nil
+	}
+	stem := base
 	start := 2
-	if m := slugSuffixRe.FindStringSubmatch(slug); m != nil {
-		base = m[1]
+	if m := slugSuffixRe.FindStringSubmatch(base); m != nil {
+		stem = m[1]
 		// m[2] is a non-empty digit run with no leading zero, so Atoi always
 		// succeeds; start one past it.
 		n, _ := strconv.Atoi(m[2])
 		start = n + 1
 	}
+	// Terminates: entries are finite and candidates are distinct per n.
 	for n := start; ; n++ {
-		candidate := fmt.Sprintf("%s-%d", base, n)
-		if len(candidate) > slugMaxLen {
-			return "", fmt.Errorf("cannot auto-suffix slug %q: every candidate (e.g., %q) exceeds the %d-character slug cap — pass an explicit, shorter --slug",
-				slug, candidate, slugMaxLen)
+		suffix := fmt.Sprintf("-%d", n)
+		room := maxLen - len(suffix)
+		if room < 1 {
+			return "", fmt.Errorf("cannot auto-suffix slug %q within the %d-character budget — pass an explicit, shorter --slug", slug, maxLen)
 		}
+		candidate := trimSlugTo(stem, room) + suffix
 		if !SlugExistsFold(entries, candidate) {
 			return candidate, nil
 		}

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -1879,19 +1879,27 @@ func TestNextAvailableSlug(t *testing.T) {
 		name    string
 		entries []AssignmentEntry
 		slug    string
+		maxLen  int
 		want    string
 	}{
-		{"free slug unchanged", entriesWithSlugs("other"), "hello", "hello"},
-		{"first collision -> -2", entriesWithSlugs("hello"), "hello", "hello-2"},
-		{"case-insensitive collision -> -2", entriesWithSlugs("Hello"), "hello", "hello-2"},
-		{"skips taken suffixes", entriesWithSlugs("hello", "hello-2", "hello-3"), "hello", "hello-4"},
-		{"base already -N increments from N+1", entriesWithSlugs("hello-2"), "hello-2", "hello-3"},
-		{"base -N skips taken", entriesWithSlugs("hello-2", "hello-3"), "hello-2", "hello-4"},
-		{"non-suffix trailing number is treated as base", entriesWithSlugs("week1"), "week1", "week1-2"},
+		{"free slug unchanged", entriesWithSlugs("other"), "hello", slugMaxLen, "hello"},
+		{"first collision -> -2", entriesWithSlugs("hello"), "hello", slugMaxLen, "hello-2"},
+		{"case-insensitive collision -> -2", entriesWithSlugs("Hello"), "hello", slugMaxLen, "hello-2"},
+		{"skips taken suffixes", entriesWithSlugs("hello", "hello-2", "hello-3"), "hello", slugMaxLen, "hello-4"},
+		{"base already -N increments from N+1", entriesWithSlugs("hello-2"), "hello-2", slugMaxLen, "hello-3"},
+		{"base -N skips taken", entriesWithSlugs("hello-2", "hello-3"), "hello-2", slugMaxLen, "hello-4"},
+		{"non-suffix trailing number is treated as base", entriesWithSlugs("week1"), "week1", slugMaxLen, "week1-2"},
+		// maxLen carries a classroom's composed repo-name budget (#691);
+		// these mirror the web's nextAvailableSlug golden cases.
+		{"trims the base to maxLen", entriesWithSlugs(), "hello-world", 7, "hello-w"},
+		{"drops a hyphen the trim exposes", entriesWithSlugs(), "hello-world", 6, "hello"},
+		{"suffixed candidate stays within maxLen", entriesWithSlugs("hello-w"), "hello-world", 7, "hello-2"},
+		// At the pattern cap a collision trims the stem instead of erroring.
+		{"at-cap collision trims the stem", entriesWithSlugs(strings.Repeat("a", 100)), strings.Repeat("a", 100), slugMaxLen, strings.Repeat("a", 98) + "-2"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := NextAvailableSlug(tc.entries, tc.slug)
+			got, err := NextAvailableSlug(tc.entries, tc.slug, tc.maxLen)
 			if err != nil {
 				t.Fatalf("NextAvailableSlug(%q): unexpected error %v", tc.slug, err)
 			}
@@ -1902,15 +1910,14 @@ func TestNextAvailableSlug(t *testing.T) {
 	}
 }
 
-// TestNextAvailableSlug_OverflowsCap pins that an auto-suffix exceeding the
-// 100-char cap returns an actionable error rather than a too-long candidate.
-func TestNextAvailableSlug_OverflowsCap(t *testing.T) {
-	base := strings.Repeat("a", 100) // already at the cap; any "-N" overflows
-	entries := entriesWithSlugs(base)
-	if _, err := NextAvailableSlug(entries, base); err == nil {
-		t.Fatal("expected an over-cap auto-suffix error, got nil")
-	} else if !strings.Contains(err.Error(), "--slug") {
-		t.Errorf("error should point at --slug, got %v", err)
+// TestNextAvailableSlug_NoRoom pins that a budget below ShortName's 2-char
+// minimum (a legacy over-long classroom) is an actionable error rather than a
+// degenerate slug.
+func TestNextAvailableSlug_NoRoom(t *testing.T) {
+	if _, err := NextAvailableSlug(entriesWithSlugs(), "hello", 1); err == nil {
+		t.Fatal("expected a no-room error, got nil")
+	} else if !strings.Contains(err.Error(), "shorter short-name") {
+		t.Errorf("error should point at a shorter classroom, got %v", err)
 	}
 }
 

--- a/cli/gh-teacher/internal/assignmentcmd/budget_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/budget_test.go
@@ -92,9 +92,8 @@ func TestRunAssignmentAdd_AllowsReplacingOverBudgetSlug(t *testing.T) {
 	}
 }
 
-// TestRunAssignmentReuse_BlocksOverBudgetSlug: reuse always mints a new slug in
-// the target classroom, so an over-budget --slug is refused inside the build —
-// nothing is committed.
+// TestRunAssignmentReuse_BlocksOverBudgetSlug: an EXPLICIT --slug past the
+// target's budget is refused inside the build — nothing is committed.
 func TestRunAssignmentReuse_BlocksOverBudgetSlug(t *testing.T) {
 	server, fix := newReuseServer(t, reuseServerConfig{
 		sourceAssignments: sourceAssignmentsBody(),
@@ -117,5 +116,41 @@ func TestRunAssignmentReuse_BlocksOverBudgetSlug(t *testing.T) {
 	fix.mu.Unlock()
 	if committed != nil {
 		t.Error("a blocked reuse must not commit anything")
+	}
+}
+
+// TestRunAssignmentReuse_TrimsAutoSlugToBudget: the AUTO-derived slug (no
+// --slug) is trimmed to the target classroom's budget instead of erroring,
+// mirroring the web reuse modals, with a note naming why the copy was renamed.
+func TestRunAssignmentReuse_TrimsAutoSlugToBudget(t *testing.T) {
+	// "dst" (3) leaves 59 - 3 = 56 slug chars; the 57-char source slug trims.
+	longSlug := strings.Repeat("s", 57)
+	sourceBody := `{
+  "schema": "classroom50/assignments/v1",
+  "assignments": [
+    { "slug": "` + longSlug + `", "name": "Long", "mode": "individual", "autograder": "default" }
+  ]
+}`
+	server, fix := newReuseServer(t, reuseServerConfig{
+		sourceAssignments: sourceBody,
+		targetAssignments: emptyAssignmentsBody(),
+		targetClassroom:   targetClassroomBody(nil),
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	params := baseReuseParams()
+	params.SourceSlug = longSlug
+
+	var out, errOut bytes.Buffer
+	if err := runAssignmentReuse(client, &out, &errOut, params); err != nil {
+		t.Fatalf("runAssignmentReuse(auto slug): %v", err)
+	}
+	file := decodeReuse(t, fix)
+	want := strings.Repeat("s", 56)
+	if len(file.Assignments) != 1 || file.Assignments[0].Slug != want {
+		t.Errorf("committed slug = %+v, want %q", file.Assignments, want)
+	}
+	if !strings.Contains(errOut.String(), "past GitHub's") {
+		t.Errorf("errOut = %q, want the budget-trim note", errOut.String())
 	}
 }

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -198,8 +198,10 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 		}
 
 		// Resolve the target slug: an explicit --slug must not collide
-		// (case-insensitive); else auto-suffix off the source slug. Reset each
-		// attempt since build re-runs on a rebase retry.
+		// (case-insensitive); else auto-derive off the source slug — trimmed to
+		// the target's composed repo-name budget (#691) and suffixed past
+		// collisions, mirroring the web reuse modals. Reset each attempt since
+		// build re-runs on a rebase retry.
 		autoSuffixed = false
 		if p.SlugWasSet {
 			if assignment.SlugExistsFold(dstFile.Assignments, p.SlugOverride) {
@@ -208,7 +210,7 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 			}
 			finalSlug = p.SlugOverride
 		} else {
-			finalSlug, err = assignment.NextAvailableSlug(dstFile.Assignments, p.SourceSlug)
+			finalSlug, err = assignment.NextAvailableSlug(dstFile.Assignments, p.SourceSlug, contract.AssignmentSlugBudget(p.To))
 			if err != nil {
 				return nil, err
 			}
@@ -270,7 +272,13 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 			p.Org, configrepo.ConfigRepoName, assignmentsFilePath(p.To), p.SourceSlug, finalSlug, templateDesc, copied.Autograder)
 	}
 	if autoSuffixed {
-		_, _ = fmt.Fprintf(errOut, "Note: slug %q already existed in %q, so the copy was named %q.\n", p.SourceSlug, p.To, finalSlug)
+		// The derived name can differ for two reasons; name the right one.
+		if _, fits := contract.ComposedRepoNameFits(p.To, p.SourceSlug); !fits {
+			_, _ = fmt.Fprintf(errOut, "Note: slug %q would push student repo names past GitHub's %d-char limit in %q, so the copy was named %q.\n",
+				p.SourceSlug, contract.GitHubRepoNameMaxLen, p.To, finalSlug)
+		} else {
+			_, _ = fmt.Fprintf(errOut, "Note: slug %q already existed in %q, so the copy was named %q.\n", p.SourceSlug, p.To, finalSlug)
+		}
 	}
 
 	// Re-apply the target classroom's private in-org template team grant. In


### PR DESCRIPTION
## Summary

Follow-up to #705/#706: `gh teacher assignment reuse` *without* `--slug` now derives a slug that both avoids collisions and fits the target classroom's composed `<classroom>-<slug>-<username>` budget — `assignment.NextAvailableSlug` gains a `maxLen` parameter mirroring the web's `nextAvailableSlug` (trim the base, keep suffixed candidates within the budget, drop hyphens the trim exposes), so both tools derive the same copy names. An explicit `--slug` over budget still hard-errors, and the post-copy note now says *why* the copy was renamed (budget vs collision). A budget below the 2-char slug minimum (legacy over-long classroom) is an actionable error pointing at a shorter classroom.

## Test plan

- [x] New `NextAvailableSlug` trim/suffix-within-budget/at-cap/no-room cases (mirroring the web golden cases) and a reuse-level auto-trim test asserting the committed slug and the note
- [x] `go build ./... && go test ./...`, `golangci-lint run`, `golangci-lint fmt --diff` all clean