### PR TITLE
fix(web): warn live when a manual slug exceeds the repo-name budget

### DIFF
--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -207,6 +207,25 @@ describe("assignment slug field", () => {
     expect(slugInput(container).value).toBe("loops-2")
   })
 
+  // #691: a manual slug over the classroom's composed repo-name budget warns
+  // as-you-type, before any submit; shrinking back within budget clears it.
+  it("create: warns live when a manual slug exceeds the classroom's budget", async () => {
+    const user = userEvent.setup()
+    const { container } = renderForm(
+      <CreateAssignmentForm classroom="cs" onSubmit={() => {}} />,
+    )
+    // "cs" leaves a 57-char budget (59 - 2); 58 exceeds it.
+    await user.click(slugInput(container))
+    await user.paste("s".repeat(58))
+    expect(
+      screen.getByText("assignments.form.validation.slugOverBudget"),
+    ).not.toBeNull()
+    await user.type(slugInput(container), "{backspace}")
+    expect(
+      screen.queryByText("assignments.form.validation.slugOverBudget"),
+    ).toBeNull()
+  })
+
   it("create: blurring an emptied slug restores a unique name-derived default", async () => {
     const user = userEvent.setup()
     const { container } = renderForm(

--- a/web/src/pages/assignments/sections/DetailsSection.tsx
+++ b/web/src/pages/assignments/sections/DetailsSection.tsx
@@ -1,6 +1,9 @@
 import { useTranslation } from "react-i18next"
 import { nextAvailableSlug, slugify } from "@/util/slug"
-import { assignmentSlugBudget } from "@/util/repoNameBudget"
+import {
+  GITHUB_REPO_NAME_MAX_LEN,
+  assignmentSlugBudget,
+} from "@/util/repoNameBudget"
 import { Alert, FormField, Input, Textarea } from "@/components/ui"
 import { GROUP_SIZE_MAX, GROUP_SIZE_MIN } from "@/types/classroom"
 import { FieldLabel } from "../AdvancedRuntimeFields"
@@ -88,10 +91,28 @@ export function DetailsSection({
 
         <form.Field name="slug">
           {(field) => {
-            const slugError =
+            const submitError =
               !edit && field.state.meta.errors.length > 0
                 ? String(field.state.meta.errors[0])
                 : undefined
+            // Live budget check (#691) so a manual override warns as-you-type
+            // rather than only at submit (which stays authoritative). The
+            // auto-fill is already budget-bounded, so this fires only on a
+            // deliberate over-long slug.
+            const liveSlug = slugify(field.state.value)
+            const liveError =
+              !edit &&
+              classroom &&
+              slugBudget !== undefined &&
+              liveSlug.length > slugBudget
+                ? t("assignments.form.validation.slugOverBudget", {
+                    classroom,
+                    budget: slugBudget,
+                    length: liveSlug.length,
+                    limit: GITHUB_REPO_NAME_MAX_LEN,
+                  })
+                : undefined
+            const slugError = submitError ?? liveError
             return (
               <FormField
                 htmlFor={field.name}

--- a/web/src/pages/classes/CreateClassroomForm.test.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.test.tsx
@@ -82,6 +82,20 @@ describe("CreateClassroomForm slug validation", () => {
     ).not.toBeNull()
   })
 
+  // The cap warning is live: it shows while typing a manual override, before
+  // any submit, and clears once the slug is back within the cap.
+  it("warns live when a manual slug exceeds the creation cap", async () => {
+    const user = userEvent.setup()
+    const { container } = render(<CreateClassroomForm onSubmit={vi.fn()} />)
+
+    await user.click(slugInput(container))
+    await user.paste("a".repeat(41))
+    expect(screen.getByText("validation.classroomSlugTooLong")).not.toBeNull()
+
+    await user.type(slugInput(container), "{backspace}")
+    expect(screen.queryByText("validation.classroomSlugTooLong")).toBeNull()
+  })
+
   // Regression guard: the collision check must compare the SLUGIFIED value, not
   // the raw input. A raw "CS 50" slugifies to "cs-50"; if the check compared the
   // raw string it would miss an existing "cs-50" and overwrite its roster/scores.

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -184,34 +184,48 @@ const CreateClassroomForm = ({
         </form.Field>
 
         <form.Field name="slug">
-          {(field) => (
-            <FormField
-              label={t("classes.form.slug")}
-              htmlFor={field.name}
-              required
-              error={
-                field.state.meta.errors.length > 0
-                  ? field.state.meta.errors[0]
-                  : undefined
-              }
-              className="mb-4"
-            >
-              {({ id, describedById, invalid }) => (
-                <Input
-                  id={id}
-                  name={field.name}
-                  required
-                  aria-required="true"
-                  aria-describedby={describedById}
-                  invalid={invalid}
-                  placeholder={t("classes.form.slugPlaceholder")}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-              )}
-            </FormField>
-          )}
+          {(field) => {
+            const submitError =
+              field.state.meta.errors.length > 0
+                ? field.state.meta.errors[0]
+                : undefined
+            // Live cap check (#691) so a manual override warns as-you-type
+            // rather than only at submit. The submit validator stays
+            // authoritative (pattern, collision, cap).
+            const liveSlug = slugify(field.state.value)
+            const liveError =
+              liveSlug.length > CLASSROOM_SHORT_NAME_MAX_LEN
+                ? t("validation.classroomSlugTooLong", {
+                    length: liveSlug.length,
+                    max: CLASSROOM_SHORT_NAME_MAX_LEN,
+                    limit: GITHUB_REPO_NAME_MAX_LEN,
+                  })
+                : undefined
+            return (
+              <FormField
+                label={t("classes.form.slug")}
+                htmlFor={field.name}
+                required
+                error={submitError ?? liveError}
+                className="mb-4"
+              >
+                {({ id, describedById, invalid }) => (
+                  <Input
+                    id={id}
+                    name={field.name}
+                    required
+                    aria-required="true"
+                    aria-describedby={describedById}
+                    invalid={invalid}
+                    placeholder={t("classes.form.slugPlaceholder")}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                  />
+                )}
+              </FormField>
+            )
+          }}
         </form.Field>
 
         <form.Field name="term">


### PR DESCRIPTION
## Summary

Follow-up to #706: typing a manual slug override past the length budget in the create-classroom form (40-char cap) or the create-assignment form (the classroom's composed repo-name budget) now shows the budget error live, as-you-type, instead of only on submit. The warning clears as soon as the slug fits again; the submit-time validator remains authoritative (pattern, collision, budget). Auto-derived slugs are already budget-trimmed, so the live warning only ever fires on a deliberate override. Edit forms are untouched: an assignment's slug is edit-locked and exempt from slug validation, and the classroom settings page shows the slug as a disabled display, so legacy over-budget slugs stay fully editable.

## Test plan

- [x] New tests: live warning appears without submit and clears on backspace, in both `CreateClassroomForm.test.tsx` and `CreateAssignmentForm.test.tsx`
- [x] `npm run check` (4335 tests)