### PR TITLE
fix(web): warn live when a manual slug collides with an existing one

### DIFF
--- a/web/src/pages/assignments/CreateAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.test.tsx
@@ -226,6 +226,19 @@ describe("assignment slug field", () => {
     ).toBeNull()
   })
 
+  // Collisions warn live too, case-insensitively against the taken set.
+  it("create: warns live when a manual slug collides with an existing assignment", async () => {
+    const user = userEvent.setup()
+    const { container } = renderForm(
+      <CreateAssignmentForm takenSlugs={["loops"]} onSubmit={() => {}} />,
+    )
+    await user.click(slugInput(container))
+    await user.paste("Loops")
+    expect(screen.getByText("validation.assignmentSlugTaken")).not.toBeNull()
+    await user.type(slugInput(container), "x")
+    expect(screen.queryByText("validation.assignmentSlugTaken")).toBeNull()
+  })
+
   it("create: blurring an emptied slug restores a unique name-derived default", async () => {
     const user = userEvent.setup()
     const { container } = renderForm(

--- a/web/src/pages/assignments/sections/DetailsSection.tsx
+++ b/web/src/pages/assignments/sections/DetailsSection.tsx
@@ -95,22 +95,31 @@ export function DetailsSection({
               !edit && field.state.meta.errors.length > 0
                 ? String(field.state.meta.errors[0])
                 : undefined
-            // Live budget check (#691) so a manual override warns as-you-type
-            // rather than only at submit (which stays authoritative). The
-            // auto-fill is already budget-bounded, so this fires only on a
-            // deliberate over-long slug.
+            // Live budget + collision checks (#691) so a manual override warns
+            // as-you-type rather than only at submit (which stays
+            // authoritative). The auto-fill is already budget-bounded and
+            // collision-suffixed, so these fire only on a deliberate override.
             const liveSlug = slugify(field.state.value)
-            const liveError =
+            const liveOverBudget =
               !edit &&
               classroom &&
               slugBudget !== undefined &&
               liveSlug.length > slugBudget
-                ? t("assignments.form.validation.slugOverBudget", {
-                    classroom,
-                    budget: slugBudget,
-                    length: liveSlug.length,
-                    limit: GITHUB_REPO_NAME_MAX_LEN,
-                  })
+            const liveTaken =
+              !edit &&
+              Boolean(liveSlug) &&
+              (takenSlugs ?? []).some(
+                (s) => s.trim().toLowerCase() === liveSlug.toLowerCase(),
+              )
+            const liveError = liveOverBudget
+              ? t("assignments.form.validation.slugOverBudget", {
+                  classroom,
+                  budget: slugBudget,
+                  length: liveSlug.length,
+                  limit: GITHUB_REPO_NAME_MAX_LEN,
+                })
+              : liveTaken
+                ? t("validation.assignmentSlugTaken", { slug: liveSlug })
                 : undefined
             const slugError = submitError ?? liveError
             return (

--- a/web/src/pages/classes/CreateClassroomForm.test.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.test.tsx
@@ -96,6 +96,21 @@ describe("CreateClassroomForm slug validation", () => {
     expect(screen.queryByText("validation.classroomSlugTooLong")).toBeNull()
   })
 
+  // Collisions warn live too, comparing the SLUGIFIED value case-insensitively
+  // against existing classrooms.
+  it("warns live when a manual slug collides with an existing classroom", async () => {
+    mockClasses = [{ name: "cs-50", path: "cs-50", type: "dir" }]
+    const user = userEvent.setup()
+    const { container } = render(<CreateClassroomForm onSubmit={vi.fn()} />)
+
+    await user.click(slugInput(container))
+    await user.paste("CS 50")
+    expect(screen.getByText("validation.classroomSlugTaken")).not.toBeNull()
+
+    await user.type(slugInput(container), "x")
+    expect(screen.queryByText("validation.classroomSlugTaken")).toBeNull()
+  })
+
   // Regression guard: the collision check must compare the SLUGIFIED value, not
   // the raw input. A raw "CS 50" slugifies to "cs-50"; if the check compared the
   // raw string it would miss an existing "cs-50" and overwrite its roster/scores.

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -189,9 +189,9 @@ const CreateClassroomForm = ({
               field.state.meta.errors.length > 0
                 ? field.state.meta.errors[0]
                 : undefined
-            // Live cap check (#691) so a manual override warns as-you-type
-            // rather than only at submit. The submit validator stays
-            // authoritative (pattern, collision, cap).
+            // Live cap + collision checks (#691) so a manual override warns
+            // as-you-type rather than only at submit. The submit validator
+            // stays authoritative (pattern, cap, collision).
             const liveSlug = slugify(field.state.value)
             const liveError =
               liveSlug.length > CLASSROOM_SHORT_NAME_MAX_LEN
@@ -200,7 +200,12 @@ const CreateClassroomForm = ({
                     max: CLASSROOM_SHORT_NAME_MAX_LEN,
                     limit: GITHUB_REPO_NAME_MAX_LEN,
                   })
-                : undefined
+                : liveSlug &&
+                    classes.some(
+                      (cl) => cl.path.toLowerCase() === liveSlug.toLowerCase(),
+                    )
+                  ? t("validation.classroomSlugTaken")
+                  : undefined
             return (
               <FormField
                 label={t("classes.form.slug")}


### PR DESCRIPTION
## Summary

Companion to #708: a *manual* slug override that collides with an existing classroom or assignment now warns live, as-you-type, in both create forms — previously the collision (like the budget) surfaced only via the submit validator. The live check compares the slugified value case-insensitively (so a raw "CS 50" is flagged against an existing `cs-50`), shows budget-over-taken when both apply, and clears the moment the slug is free. Auto-derived slugs were already collision-free by construction (`nextAvailableSlug`); the reuse modals already had live collision feedback. Submit validation stays authoritative.

## Test plan

- [x] New tests in both form suites: live taken-warning appears without submit (including the raw-input-slugifies-onto-existing case) and clears once the slug is free
- [x] `npm run check` (4337 tests)