### PR TITLE
fix: point no-room slug budgets at a shorter classroom, not negative counts

### DIFF
--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -824,6 +824,12 @@ func NextAvailableSlug(entries []AssignmentEntry, slug string, maxLen int) (stri
 			slug, maxLen, slugMaxLen)
 	}
 	base := trimSlugTo(slug, maxLen)
+	if len(base) < 2 {
+		// A hyphen just inside the cut can trim the base below ShortName's
+		// 2-char minimum even when maxLen >= 2 (e.g. "a-..." at budget 2).
+		return "", fmt.Errorf("cannot derive a slug for %q within the %d-character budget (trimming leaves less than the 2-character minimum) — pass an explicit, shorter --slug",
+			slug, maxLen)
+	}
 	if !SlugExistsFold(entries, base) {
 		return base, nil
 	}
@@ -840,7 +846,7 @@ func NextAvailableSlug(entries []AssignmentEntry, slug string, maxLen int) (stri
 	for n := start; ; n++ {
 		suffix := fmt.Sprintf("-%d", n)
 		room := maxLen - len(suffix)
-		if room < 1 {
+		if room < 1 || len(trimSlugTo(stem, room)) < 1 {
 			return "", fmt.Errorf("cannot auto-suffix slug %q within the %d-character budget — pass an explicit, shorter --slug", slug, maxLen)
 		}
 		candidate := trimSlugTo(stem, room) + suffix

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -1912,12 +1912,19 @@ func TestNextAvailableSlug(t *testing.T) {
 
 // TestNextAvailableSlug_NoRoom pins that a budget below ShortName's 2-char
 // minimum (a legacy over-long classroom) is an actionable error rather than a
-// degenerate slug.
+// degenerate slug — whether the budget itself is too small or the trim lands
+// just past a hyphen and leaves a single character.
 func TestNextAvailableSlug_NoRoom(t *testing.T) {
 	if _, err := NextAvailableSlug(entriesWithSlugs(), "hello", 1); err == nil {
 		t.Fatal("expected a no-room error, got nil")
 	} else if !strings.Contains(err.Error(), "shorter short-name") {
 		t.Errorf("error should point at a shorter classroom, got %v", err)
+	}
+	// maxLen 2 is nominally viable, but "a-bcd" trims to the 1-char "a".
+	if _, err := NextAvailableSlug(entriesWithSlugs(), "a-bcd", 2); err == nil {
+		t.Fatal("expected a sub-minimum trim error, got nil")
+	} else if !strings.Contains(err.Error(), "--slug") {
+		t.Errorf("error should point at --slug, got %v", err)
 	}
 }
 

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -142,8 +142,10 @@ type reuseAssignmentParams struct {
 	AsJSON       bool
 }
 
-// reuseResult is the --json shape. `slug` is the FINAL slug (after any
-// auto-suffix), which is why --json exists — the suffix isn't knowable ahead.
+// reuseResult is the --json shape. `slug` is the FINAL slug — after any
+// auto-suffix or budget trim, which is why --json exists (neither is knowable
+// ahead). `auto_suffixed` is true whenever the final slug differs from the
+// source slug, whether from a collision suffix or a budget trim.
 type reuseResult struct {
 	Org          string                  `json:"org"`
 	Classroom    string                  `json:"classroom"`

--- a/web/src/components/modals/ReuseModalShell.tsx
+++ b/web/src/components/modals/ReuseModalShell.tsx
@@ -143,11 +143,17 @@ export const reuseSlugStatus = ({
   if (loading) return t("components.modals.reuseShell.slug.checking")
   if (error) return t("components.modals.reuseShell.slug.checkError")
   if (slugOverBudget)
-    return t("components.modals.reuseShell.slug.overBudget", {
-      length: normalizedSlug.length,
-      budget: slugBudget,
-      classroom: classroomLabel,
-    })
+    // A budget below the 2-char slug minimum means NO slug can fit (a legacy
+    // over-long classroom) — point at a different classroom, not a shorter slug.
+    return slugBudget < 2
+      ? t("components.modals.reuseShell.slug.noRoom", {
+          classroom: classroomLabel,
+        })
+      : t("components.modals.reuseShell.slug.overBudget", {
+          length: normalizedSlug.length,
+          budget: slugBudget,
+          classroom: classroomLabel,
+        })
   if (slugTaken)
     return t("components.modals.reuseShell.slug.taken", {
       slug: normalizedSlug,

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -423,6 +423,11 @@ describe("nextAvailableSlug", () => {
   it("yields an empty slug on a non-positive budget (caller validates)", () => {
     expect(nextAvailableSlug("hw1", [], 0)).toBe("")
   })
+
+  it("yields an empty slug when trimming lands below the 2-char minimum", () => {
+    // maxLen 2 is nominally viable, but "a-bcd" trims to the 1-char "a".
+    expect(nextAvailableSlug("a-bcd", [], 2)).toBe("")
+  })
 })
 
 describe("editAssignment (preserved-entry integration)", () => {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1375,6 +1375,7 @@
         "slugRequired": "Assignment slug is required.",
         "slugInvalid": "Assignment slug must be {{description}}.",
         "slugOverBudget": "Student repositories are named \"{{classroom}}-<slug>-<username>\", which GitHub caps at {{limit}} characters — this slug can be at most {{budget}} characters (currently {{length}}).",
+        "slugNoRoom": "The classroom \"{{classroom}}\" leaves no room for any assignment slug — its short-name plus a username can exceed GitHub's {{limit}}-character repository-name cap. Create a classroom with a shorter slug (at most {{max}} characters) and add the assignment there.",
         "maxGroupSizeInvalid": "Max group size must be a valid number.",
         "setupTimeoutRange": "Setup timeout must be 0 or a whole number of seconds from 1 through {{max}}.",
         "passThresholdRange": "Pass threshold must be a whole number between {{min}} and {{max}}.",
@@ -3266,6 +3267,7 @@
           "checkError": "Couldn’t check existing slugs — you can still try; we’ll re-check on save.",
           "taken": "“{{slug}}” is already used in {{classroom}} — pick another.",
           "overBudget": "This slug is {{length}} characters; {{classroom}} leaves room for at most {{budget}} so student repository names stay under GitHub's limit.",
+          "noRoom": "{{classroom}} leaves no room for any assignment slug — its name is too long for GitHub's repository-name limit. Reuse into a classroom with a shorter name.",
           "willBeSaved": "Will be saved as “{{slug}}”."
         }
       },

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -145,6 +145,15 @@ describe("validateAssignmentForm — required fields", () => {
     expect(errors.slug).toBeUndefined()
   })
 
+  // A legacy classroom whose short-name eats the whole budget points at a NEW
+  // classroom, not an impossible "at most -N characters" slug.
+  it("uses the no-room message when the classroom leaves no slug budget", () => {
+    const errors = validateAssignmentForm({ ...base, slug: "hw" }, t, {
+      classroom: "a".repeat(58),
+    })
+    expect(errors.slug).toBe("assignments.form.validation.slugNoRoom")
+  })
+
   it("skips the budget check without a classroom in context", () => {
     const errors = validateAssignmentForm({ ...base, slug: "s".repeat(58) }, t)
     expect(errors.slug).toBeUndefined()

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -6,6 +6,7 @@ import {
   isValidShortName,
 } from "@/util/shortName"
 import {
+  CLASSROOM_SHORT_NAME_MAX_LEN,
   GITHUB_REPO_NAME_MAX_LEN,
   assignmentSlugBudget,
   composedRepoNameFits,
@@ -256,6 +257,33 @@ export type SlugContext = {
   classroom?: string
 }
 
+// The composed repo-name budget error for `slug` in `classroom`, or undefined
+// when it fits (#691). The single recipe shared by the submit validator and
+// the live as-you-type check (DetailsSection). A classroom leaving no room for
+// any slug (a legacy over-long short-name) points at a new classroom instead
+// of an impossible shorter slug, mirroring the CLI's ComposedRepoNameBudget.
+export function slugBudgetError(
+  t: TFunction,
+  classroom: string,
+  slug: string,
+): string | undefined {
+  if (composedRepoNameFits(classroom, slug).fits) return undefined
+  const budget = assignmentSlugBudget(classroom)
+  if (budget < 2) {
+    return t("assignments.form.validation.slugNoRoom", {
+      classroom,
+      max: CLASSROOM_SHORT_NAME_MAX_LEN,
+      limit: GITHUB_REPO_NAME_MAX_LEN,
+    })
+  }
+  return t("assignments.form.validation.slugOverBudget", {
+    classroom,
+    budget,
+    length: slug.length,
+    limit: GITHUB_REPO_NAME_MAX_LEN,
+  })
+}
+
 // Pure submit-time validation, mirroring gh-teacher's write-time rules so a bad
 // value is caught in the form rather than by a failed commit or an unparseable
 // file. Returns a field->message map ({} when valid) so it's testable without a
@@ -280,26 +308,23 @@ export function validateAssignmentForm(
       errors.slug = t("assignments.form.validation.slugInvalid", {
         description: SHORT_NAME_PATTERN_DESCRIPTION,
       })
-    } else if (
-      slugContext?.classroom &&
-      !composedRepoNameFits(slugContext.classroom, slug).fits
-    ) {
+    } else {
       // #691: a NEW slug must fit the composed `<classroom>-<slug>-<username>`
       // budget, or long-username accepts fail with GitHub's 100-char 422.
-      errors.slug = t("assignments.form.validation.slugOverBudget", {
-        classroom: slugContext.classroom,
-        budget: assignmentSlugBudget(slugContext.classroom),
-        length: slug.length,
-        limit: GITHUB_REPO_NAME_MAX_LEN,
-      })
-    } else if (
-      (slugContext?.takenSlugs ?? []).some(
-        (s) => s.trim().toLowerCase() === slug.toLowerCase(),
-      )
-    ) {
-      // Case-insensitive collision (slugs become repo path segments); write
-      // path re-checks authoritatively (nextAvailableSlug).
-      errors.slug = t("validation.assignmentSlugTaken", { slug })
+      const budgetError = slugContext?.classroom
+        ? slugBudgetError(t, slugContext.classroom, slug)
+        : undefined
+      if (budgetError) {
+        errors.slug = budgetError
+      } else if (
+        (slugContext?.takenSlugs ?? []).some(
+          (s) => s.trim().toLowerCase() === slug.toLowerCase(),
+        )
+      ) {
+        // Case-insensitive collision (slugs become repo path segments); write
+        // path re-checks authoritatively (nextAvailableSlug).
+        errors.slug = t("validation.assignmentSlugTaken", { slug })
+      }
     }
   }
   if (!Number(value.max_group_size)) {

--- a/web/src/pages/assignments/sections/DetailsSection.tsx
+++ b/web/src/pages/assignments/sections/DetailsSection.tsx
@@ -1,13 +1,10 @@
 import { useTranslation } from "react-i18next"
 import { nextAvailableSlug, slugify } from "@/util/slug"
-import {
-  GITHUB_REPO_NAME_MAX_LEN,
-  assignmentSlugBudget,
-} from "@/util/repoNameBudget"
+import { assignmentSlugBudget } from "@/util/repoNameBudget"
 import { Alert, FormField, Input, Textarea } from "@/components/ui"
 import { GROUP_SIZE_MAX, GROUP_SIZE_MIN } from "@/types/classroom"
 import { FieldLabel } from "../AdvancedRuntimeFields"
-import type { AssignmentForm } from "../assignmentFormModel"
+import { slugBudgetError, type AssignmentForm } from "../assignmentFormModel"
 import { deriveFormShape } from "../formShape"
 import { SectionCard } from "./SectionCard"
 
@@ -99,28 +96,24 @@ export function DetailsSection({
             // as-you-type rather than only at submit (which stays
             // authoritative). The auto-fill is already budget-bounded and
             // collision-suffixed, so these fire only on a deliberate override.
+            // The budget message comes from the same recipe as the submit
+            // validator (slugBudgetError) so the two can't drift.
             const liveSlug = slugify(field.state.value)
-            const liveOverBudget =
-              !edit &&
-              classroom &&
-              slugBudget !== undefined &&
-              liveSlug.length > slugBudget
+            const liveBudgetError =
+              !edit && classroom && liveSlug
+                ? slugBudgetError(t, classroom, liveSlug)
+                : undefined
             const liveTaken =
               !edit &&
               Boolean(liveSlug) &&
               (takenSlugs ?? []).some(
                 (s) => s.trim().toLowerCase() === liveSlug.toLowerCase(),
               )
-            const liveError = liveOverBudget
-              ? t("assignments.form.validation.slugOverBudget", {
-                  classroom,
-                  budget: slugBudget,
-                  length: liveSlug.length,
-                  limit: GITHUB_REPO_NAME_MAX_LEN,
-                })
-              : liveTaken
+            const liveError =
+              liveBudgetError ??
+              (liveTaken
                 ? t("validation.assignmentSlugTaken", { slug: liveSlug })
-                : undefined
+                : undefined)
             const slugError = submitError ?? liveError
             return (
               <FormField

--- a/web/src/util/slug.ts
+++ b/web/src/util/slug.ts
@@ -32,9 +32,11 @@ export function nextAvailableSlug(
   maxLen: number = SLUG_MAX_LEN,
 ): string {
   // Trim the base itself to the budget; drop a hyphen the trim exposes. A
-  // non-positive budget (a legacy over-long classroom) yields "" — the caller's
-  // validation owns surfacing that.
+  // result below the pattern's 2-char minimum (a non-positive or tiny budget —
+  // a legacy over-long classroom) yields "" — the caller's validation owns
+  // surfacing that.
   base = base.slice(0, Math.max(maxLen, 0)).replace(/-+$/g, "")
+  if (base.length < 2) return ""
 
   const takenSet = new Set(Array.from(taken, (s) => s.trim().toLowerCase()))
   const isFree = (candidate: string) => !takenSet.has(candidate.toLowerCase())
@@ -49,9 +51,11 @@ export function nextAvailableSlug(
   // Bounded defensively; a classroom never has thousands of same-stem slugs.
   for (let i = 0; i < 10000; i++) {
     const suffix = `-${n}`
-    // Trim the stem to leave room for the suffix; drop a hyphen the trim exposes.
+    // Trim the stem to leave room for the suffix; drop a hyphen the trim
+    // exposes. No stem room at all means no valid candidate can exist.
     const room = maxLen - suffix.length
     const trimmedStem = stem.slice(0, Math.max(room, 0)).replace(/-+$/g, "")
+    if (!trimmedStem) return ""
     const candidate = `${trimmedStem}${suffix}`
     if (isFree(candidate)) return candidate
     n++


### PR DESCRIPTION
## Summary

Self-review fixes across the #704–#709 repo-name budget workstream, all in the legacy over-long-classroom corner (slug budget < 2):

- **Web no-room messages**: creating or reusing an assignment in a pre-cap classroom whose short-name eats the whole budget rendered "this slug can be at most −1 characters (currently 0)". New `slugNoRoom` / `slug.noRoom` messages now point at creating a classroom with a shorter name — in the create form (live and submit) and both reuse modals — mirroring the CLI's existing `ComposedRepoNameBudget` no-room phrasing.
- **One budget-message recipe**: the live check in `DetailsSection` hand-built the same message as `validateAssignmentForm`; both now call a single exported `slugBudgetError`, so the copies can't drift.
- **Sub-minimum trims refused in both derivers**: `trimSlugTo("a-bcd", 2)` yields the 1-char "a", below the slug pattern's 2-char minimum. Go's `NextAvailableSlug` now returns the actionable `--slug` error for that (and for a suffix stem that trims to empty); the web's `nextAvailableSlug` yields `""` (blocked by the existing empty-slug validation) instead of a degenerate 1-char slug.
- Stale `reuseResult` docstring updated: `auto_suffixed` also covers budget trims since #707.

## Test plan

- [x] New tests: Go no-room + sub-minimum-trim errors, web sub-minimum trim yields empty, `slugNoRoom` selection in the form validator
- [x] `go build ./... && go test ./...`, `golangci-lint run`, `golangci-lint fmt --diff` clean
- [x] `npm run check` (4339 tests) and `audit_i18n.py --strict` pass