### PR TITLE
fix(cli): auto-trim over-budget migrated slugs and add --rename

### DIFF
--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -27,6 +27,7 @@ func classroomMigrateCmd() *cobra.Command {
 		shortName       string
 		term            string
 		templateSuffix  string
+		renameFlags     []string
 		includeArchived bool
 		dryRun          bool
 	)
@@ -61,6 +62,14 @@ func classroomMigrateCmd() *cobra.Command {
 			"capped at 40 characters so `<short-name>-<assignment>-<username>`\n" +
 			"student-repo names stay under GitHub's 100-character limit. Pass\n" +
 			"--short-name explicitly if the derived value fails validation.\n\n" +
+			"Assignment slugs import verbatim when they fit. A slug that would\n" +
+			"push composed student-repo names past GitHub's 100-character\n" +
+			"limit is automatically shortened to the classroom's budget\n" +
+			"(suffixed -2, -3, … past collisions), with the mapping reported.\n" +
+			"Pass --rename <source-slug>=<new-slug> (repeatable) to import any\n" +
+			"assignment under a slug of your choice instead; explicit renames\n" +
+			"are validated against the same pattern, budget, and uniqueness\n" +
+			"rules before anything is created.\n\n" +
 			"--template-suffix appends a string to every target template\n" +
 			"repo name (e.g., --template-suffix migrated → readability-migrated).\n" +
 			"Use to escape collisions with existing target-org repos.\n\n" +
@@ -69,7 +78,9 @@ func classroomMigrateCmd() *cobra.Command {
 		Example: "  gh teacher classroom migrate --source 95884 --target cs50-fall-2026 --dry-run\n" +
 			"  gh teacher classroom migrate --source classroom50test --target cs50-fall-2026 --dry-run\n" +
 			"  gh teacher classroom migrate --source 95884 --target cs50-fall-2026 --dry-run \\\n" +
-			"      --short-name cs-principles --term Spring-2026",
+			"      --short-name cs-principles --term Spring-2026\n" +
+			"  gh teacher classroom migrate --source 95884 --target cs50-fall-2026 \\\n" +
+			"      --rename my-very-long-legacy-assignment-prefix=hw1",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
@@ -82,6 +93,10 @@ func classroomMigrateCmd() *cobra.Command {
 			if targetVal == "" {
 				return errors.New("--target is required (destination org owning the classroom50 repository)")
 			}
+			renames, err := parseRenameFlags(renameFlags)
+			if err != nil {
+				return err
+			}
 
 			client, err := githubapi.RequireAuthClient(cmd)
 			if err != nil {
@@ -93,6 +108,7 @@ func classroomMigrateCmd() *cobra.Command {
 				ShortName:       strings.TrimSpace(shortName),
 				Term:            strings.TrimSpace(term),
 				TemplateSuffix:  strings.TrimSpace(templateSuffix),
+				Renames:         renames,
 				IncludeArchived: includeArchived,
 				DryRun:          dryRun,
 			})
@@ -104,18 +120,42 @@ func classroomMigrateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&shortName, "short-name", "", "Override the auto-derived classroom directory name")
 	cmd.Flags().StringVar(&term, "term", "", "Set classroom.json.term (e.g., Spring-2026)")
 	cmd.Flags().StringVar(&templateSuffix, "template-suffix", "", "Suffix appended to every target template repo name (e.g., --template-suffix migrated → readability-migrated)")
+	cmd.Flags().StringArrayVar(&renameFlags, "rename", nil, "Import an assignment under a different slug: <source-slug>=<new-slug> (repeatable; validated against the slug pattern, the repo-name budget, and batch uniqueness)")
 	cmd.Flags().BoolVar(&includeArchived, "include-archived", false, "Include archived classrooms when resolving --source by org name (ignored when --source is a numeric ID)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the discovered migration plan without API writes")
 	return cmd
 }
 
+// parseRenameFlags turns repeated --rename <source>=<new> values into a map,
+// rejecting malformed pairs and duplicate sources.
+func parseRenameFlags(flags []string) (map[string]string, error) {
+	if len(flags) == 0 {
+		return nil, nil
+	}
+	renames := make(map[string]string, len(flags))
+	for _, f := range flags {
+		from, to, ok := strings.Cut(f, "=")
+		from, to = strings.TrimSpace(from), strings.TrimSpace(to)
+		if !ok || from == "" || to == "" {
+			return nil, fmt.Errorf("--rename %q: expected <source-slug>=<new-slug>", f)
+		}
+		if prev, dup := renames[from]; dup {
+			return nil, fmt.Errorf("--rename %s=%s: source slug %q already renamed to %q", from, to, from, prev)
+		}
+		renames[from] = to
+	}
+	return renames, nil
+}
+
 // migrateOptions packages runMigrate's flags so tests can call it directly.
 type migrateOptions struct {
-	Source          string
-	Target          string
-	ShortName       string
-	Term            string
-	TemplateSuffix  string
+	Source         string
+	Target         string
+	ShortName      string
+	Term           string
+	TemplateSuffix string
+	// Import-slug overrides, keyed by source slug (from --rename).
+	Renames         map[string]string
 	IncludeArchived bool
 	DryRun          bool
 }
@@ -185,9 +225,26 @@ func discoverMigration(client githubapi.Client, errOut io.Writer, opts migrateOp
 		return migrationPlan{}, err
 	}
 
+	// Resolve import slugs before anything is named after them: explicit
+	// --rename entries win; over-budget slugs auto-trim to the classroom's
+	// budget instead of being skipped (#691). Surface every rewrite so the
+	// teacher sees the mapping in dry-run and live runs alike.
+	assignments, renames, err := resolveImportSlugs(assignments, shortNameVal, opts.Renames)
+	if err != nil {
+		return migrationPlan{}, err
+	}
+	for _, r := range renames {
+		reason := "over the repo-name budget for classroom " + shortNameVal
+		if r.Explicit {
+			reason = "--rename"
+		}
+		_, _ = fmt.Fprintf(errOut, "Note: importing %q as %q (%s).\n", r.From, r.To, reason)
+	}
+
 	return migrationPlan{
 		Classroom:   detail,
 		Assignments: assignments,
+		Renames:     renames,
 		TargetOrg:   opts.Target,
 		ShortName:   shortNameVal,
 		Term:        opts.Term,
@@ -440,6 +497,11 @@ func printMigrationPlan(out io.Writer, plan migrationPlan) error {
 	if len(plan.Assignments) == 0 {
 		_, _ = fmt.Fprintln(out, "  assignments:   (none)")
 	} else {
+		// Annotate rewritten import slugs so dry-run shows the exact mapping.
+		renamedFrom := make(map[string]string, len(plan.Renames))
+		for _, r := range plan.Renames {
+			renamedFrom[r.To] = r.From
+		}
 		_, _ = fmt.Fprintln(out, "  assignments:")
 		for _, a := range plan.Assignments {
 			starter := "no starter_code_repository — would be skipped"
@@ -451,6 +513,9 @@ func printMigrationPlan(out io.Writer, plan migrationPlan) error {
 				starter = fmt.Sprintf("%s @ %s (%s)", a.StarterCodeRepo.FullName, a.StarterCodeRepo.DefaultBranch, privacy)
 			}
 			line := fmt.Sprintf("    - %-32s mode=%s  starter=%s", a.Slug, a.Type, starter)
+			if from, ok := renamedFrom[a.Slug]; ok {
+				line += "  renamed-from=" + from
+			}
 			if a.Deadline != nil && *a.Deadline != "" {
 				line += "  deadline=" + *a.Deadline
 			}

--- a/cli/gh-teacher/internal/classroom/migrate_translate.go
+++ b/cli/gh-teacher/internal/classroom/migrate_translate.go
@@ -43,6 +43,110 @@ func deriveShortName(raw string) (string, error) {
 	return slug, nil
 }
 
+// slugRename records one import-slug rewrite for reporting: an explicit
+// --rename or an automatic trim to the composed repo-name budget (#691).
+type slugRename struct {
+	From     string
+	To       string
+	Explicit bool
+}
+
+// resolveImportSlugs rewrites each source assignment's slug to its import
+// slug: an explicit rename (from --rename) wins and is validated (pattern,
+// budget, uniqueness); an over-budget slug auto-trims to the classroom's
+// budget, suffixing past batch collisions (the classroom directory is new, so
+// the batch is the whole collision set) — mirroring the web import and the
+// reuse derivers. A fitting slug imports verbatim; a pattern-invalid slug is
+// left untouched for copyOneTemplate's skip. Returns the rewritten slice and
+// the renames applied, in plan order.
+func resolveImportSlugs(
+	assignments []classroomAssignmentDetail,
+	shortName string,
+	renames map[string]string,
+) ([]classroomAssignmentDetail, []slugRename, error) {
+	bySlug := make(map[string]int, len(assignments))
+	for i, a := range assignments {
+		bySlug[a.Slug] = i
+	}
+	for from := range renames {
+		if _, ok := bySlug[from]; !ok {
+			return nil, nil, fmt.Errorf("--rename %s=%s: no source assignment has slug %q", from, renames[from], from)
+		}
+	}
+
+	out := append([]classroomAssignmentDetail(nil), assignments...)
+	var applied []slugRename
+
+	// Final import slugs claimed so far (lowercased), seeding the auto-trim
+	// collision set: explicit renames and verbatim keepers claim their names
+	// first, then over-budget slugs trim around them in plan order.
+	taken := make(map[string]bool, len(out))
+	claim := func(s string) { taken[strings.ToLower(s)] = true }
+
+	budget := contract.AssignmentSlugBudget(shortName)
+	needsTrim := func(a classroomAssignmentDetail) bool {
+		if _, renamed := renames[a.Slug]; renamed {
+			return false
+		}
+		if !validate.ShortNamePattern.MatchString(a.Slug) {
+			return false // copyOneTemplate skips it with the pattern error
+		}
+		_, fits := contract.ComposedRepoNameFits(shortName, a.Slug)
+		return !fits
+	}
+
+	// Verbatim keepers claim their names first, so an explicit rename or an
+	// auto-trim can never silently duplicate one regardless of slice order.
+	for _, a := range assignments {
+		if _, renamed := renames[a.Slug]; !renamed && !needsTrim(a) {
+			claim(a.Slug)
+		}
+	}
+
+	// Explicit renames (validated) claim next.
+	for i := range out {
+		from := assignments[i].Slug
+		to, ok := renames[from]
+		if !ok {
+			continue
+		}
+		if err := validate.ShortName(to, "--rename target"); err != nil {
+			return nil, nil, fmt.Errorf("--rename %s=%s: %w", from, to, err)
+		}
+		if err := validate.ComposedRepoNameBudget(shortName, to); err != nil {
+			return nil, nil, fmt.Errorf("--rename %s=%s: %w", from, to, err)
+		}
+		if taken[strings.ToLower(to)] {
+			return nil, nil, fmt.Errorf("--rename %s=%s: import slug %q is already used by another assignment in this migration (case-insensitive)", from, to, to)
+		}
+		if from != to {
+			applied = append(applied, slugRename{From: from, To: to, Explicit: true})
+		}
+		out[i].Slug = to
+		claim(to)
+	}
+
+	// Auto-trim over-budget slugs around the claimed names, in plan order.
+	for i := range out {
+		if _, renamed := renames[assignments[i].Slug]; renamed || !needsTrim(assignments[i]) {
+			continue
+		}
+		entries := make([]assignment.AssignmentEntry, 0, len(taken))
+		for s := range taken {
+			entries = append(entries, assignment.AssignmentEntry{Slug: s})
+		}
+		trimmed, err := assignment.NextAvailableSlug(entries, assignments[i].Slug, budget)
+		if err != nil {
+			return nil, nil, fmt.Errorf("assignment %q: %w", assignments[i].Slug, err)
+		}
+		applied = append(applied, slugRename{From: assignments[i].Slug, To: trimmed})
+		out[i].Slug = trimmed
+		claim(trimmed)
+	}
+
+	return out, applied, nil
+}
+
 // classroomMigratedFromFromDetail builds the classroom-level
 // migrated_from block from a source classroom and write timestamp.
 func classroomMigratedFromFromDetail(detail classroomDetail, migratedAt time.Time) *configrepo.MigratedFromRef {
@@ -131,10 +235,13 @@ func assignmentToEntry(
 type migrationPlan struct {
 	Classroom   classroomDetail
 	Assignments []classroomAssignmentDetail
-	TargetOrg   string
-	ShortName   string
-	Term        string
-	MigratedAt  time.Time
+	// Import-slug rewrites applied by resolveImportSlugs (explicit --rename or
+	// budget trims), for the plan printout.
+	Renames    []slugRename
+	TargetOrg  string
+	ShortName  string
+	Term       string
+	MigratedAt time.Time
 }
 
 // countsByMode returns (individual, group, other) tallies.

--- a/cli/gh-teacher/internal/classroom/migrate_translate_test.go
+++ b/cli/gh-teacher/internal/classroom/migrate_translate_test.go
@@ -64,6 +64,153 @@ func TestDeriveShortName(t *testing.T) {
 	}
 }
 
+func TestResolveImportSlugs(t *testing.T) {
+	// shortName "cs" leaves a 57-char budget (59 - 2).
+	const shortName = "cs"
+	long := strings.Repeat("s", 58)
+	det := func(slug string) classroomAssignmentDetail {
+		return classroomAssignmentDetail{Slug: slug, Type: "individual"}
+	}
+	slugs := func(out []classroomAssignmentDetail) []string {
+		got := make([]string, len(out))
+		for i, a := range out {
+			got[i] = a.Slug
+		}
+		return got
+	}
+
+	t.Run("fitting slugs import verbatim with no renames", func(t *testing.T) {
+		out, renames, err := resolveImportSlugs(
+			[]classroomAssignmentDetail{det("hw1"), det("hw2")}, shortName, nil)
+		if err != nil {
+			t.Fatalf("resolveImportSlugs: %v", err)
+		}
+		if !reflect.DeepEqual(slugs(out), []string{"hw1", "hw2"}) || len(renames) != 0 {
+			t.Errorf("got %v (%d renames), want verbatim", slugs(out), len(renames))
+		}
+	})
+
+	t.Run("over-budget slug auto-trims to the budget", func(t *testing.T) {
+		out, renames, err := resolveImportSlugs(
+			[]classroomAssignmentDetail{det(long)}, shortName, nil)
+		if err != nil {
+			t.Fatalf("resolveImportSlugs: %v", err)
+		}
+		want := strings.Repeat("s", 57)
+		if out[0].Slug != want {
+			t.Errorf("slug = %q, want %q", out[0].Slug, want)
+		}
+		if len(renames) != 1 || renames[0].From != long || renames[0].To != want || renames[0].Explicit {
+			t.Errorf("renames = %+v, want one implicit %q -> %q", renames, long, want)
+		}
+	})
+
+	t.Run("two same-prefix trims suffix apart", func(t *testing.T) {
+		other := strings.Repeat("s", 59)
+		out, _, err := resolveImportSlugs(
+			[]classroomAssignmentDetail{det(long), det(other)}, shortName, nil)
+		if err != nil {
+			t.Fatalf("resolveImportSlugs: %v", err)
+		}
+		first := strings.Repeat("s", 57)
+		second := strings.Repeat("s", 55) + "-2"
+		if !reflect.DeepEqual(slugs(out), []string{first, second}) {
+			t.Errorf("slugs = %v, want [%q, %q]", slugs(out), first, second)
+		}
+	})
+
+	t.Run("trim avoids a verbatim keeper", func(t *testing.T) {
+		keeper := strings.Repeat("s", 57) // fits, imports verbatim
+		out, _, err := resolveImportSlugs(
+			[]classroomAssignmentDetail{det(long), det(keeper)}, shortName, nil)
+		if err != nil {
+			t.Fatalf("resolveImportSlugs: %v", err)
+		}
+		// The keeper claims s*57 first, so the trim suffixes past it.
+		want := strings.Repeat("s", 55) + "-2"
+		if out[0].Slug != want || out[1].Slug != keeper {
+			t.Errorf("slugs = %v, want [%q, %q]", slugs(out), want, keeper)
+		}
+	})
+
+	t.Run("explicit rename wins over auto-trim and is reported explicit", func(t *testing.T) {
+		out, renames, err := resolveImportSlugs(
+			[]classroomAssignmentDetail{det(long)}, shortName,
+			map[string]string{long: "hw1"})
+		if err != nil {
+			t.Fatalf("resolveImportSlugs: %v", err)
+		}
+		if out[0].Slug != "hw1" {
+			t.Errorf("slug = %q, want %q", out[0].Slug, "hw1")
+		}
+		if len(renames) != 1 || !renames[0].Explicit {
+			t.Errorf("renames = %+v, want one explicit", renames)
+		}
+	})
+
+	t.Run("unknown rename source errors", func(t *testing.T) {
+		_, _, err := resolveImportSlugs(
+			[]classroomAssignmentDetail{det("hw1")}, shortName,
+			map[string]string{"nope": "hw2"})
+		if err == nil || !strings.Contains(err.Error(), "no source assignment") {
+			t.Fatalf("err = %v, want unknown-source error", err)
+		}
+	})
+
+	t.Run("over-budget rename target errors", func(t *testing.T) {
+		_, _, err := resolveImportSlugs(
+			[]classroomAssignmentDetail{det("hw1")}, shortName,
+			map[string]string{"hw1": long})
+		if err == nil || !strings.Contains(err.Error(), "repo-name limit") {
+			t.Fatalf("err = %v, want a repo-name limit error", err)
+		}
+	})
+
+	t.Run("rename colliding with a verbatim keeper errors", func(t *testing.T) {
+		_, _, err := resolveImportSlugs(
+			[]classroomAssignmentDetail{det("hw1"), det("hw2")}, shortName,
+			map[string]string{"hw1": "hw2"})
+		if err == nil || !strings.Contains(err.Error(), "already used") {
+			t.Fatalf("err = %v, want a collision error", err)
+		}
+	})
+
+	t.Run("pattern-invalid slug is left for the skip machinery", func(t *testing.T) {
+		out, renames, err := resolveImportSlugs(
+			[]classroomAssignmentDetail{det("Bad Slug")}, shortName, nil)
+		if err != nil {
+			t.Fatalf("resolveImportSlugs: %v", err)
+		}
+		if out[0].Slug != "Bad Slug" || len(renames) != 0 {
+			t.Errorf("got %q (%d renames), want untouched", out[0].Slug, len(renames))
+		}
+	})
+}
+
+// TestParseRenameFlags pins the --rename parsing: well-formed pairs build the
+// map; malformed values and duplicate sources error before any network.
+func TestParseRenameFlags(t *testing.T) {
+	got, err := parseRenameFlags([]string{"a=b", " c = d "})
+	if err != nil {
+		t.Fatalf("parseRenameFlags: %v", err)
+	}
+	if got["a"] != "b" || got["c"] != "d" {
+		t.Errorf("got %v, want a=b and trimmed c=d", got)
+	}
+	if _, err := parseRenameFlags([]string{"nope"}); err == nil {
+		t.Error("malformed pair must error")
+	}
+	if _, err := parseRenameFlags([]string{"a="}); err == nil {
+		t.Error("empty target must error")
+	}
+	if _, err := parseRenameFlags([]string{"a=b", "a=c"}); err == nil {
+		t.Error("duplicate source must error")
+	}
+	if got, err := parseRenameFlags(nil); err != nil || got != nil {
+		t.Errorf("no flags should be a nil map, got %v (%v)", got, err)
+	}
+}
+
 func TestAssignmentToEntry(t *testing.T) {
 	migratedAt := time.Date(2026, time.May, 25, 20, 21, 0, 0, time.UTC)
 	target := assignment.TemplateRef{Owner: "cs50-fall-2026", Repo: "readability", Branch: "main"}


### PR DESCRIPTION
## Summary

Minimizes GitHub Classroom migration disruption from the #691 budget enforcement (first of a CLI/web pair; web follows):

- **Auto-trim instead of skip**: an over-budget source slug now imports under a slug trimmed to the classroom's budget, suffixed `-2`, `-3`, … past collisions with the rest of the batch (the classroom directory is new, so the batch is the whole assignments.json collision set) — reusing `assignment.NextAvailableSlug`, so the derivation matches reuse and the web. Resolution happens in discovery, before any template repo is generated, so the template, config entry, and future student repos all take the final name. `migrated_from` (source classroom/assignment IDs, starter repo) is untouched, so provenance survives the rename with no schema change.
- **Explicit overrides**: repeatable `--rename <source-slug>=<new-slug>`, validated in preflight — pattern, composed budget, batch uniqueness (verbatim keepers claim their names first, so a rename can never silently duplicate one), unknown source slugs rejected.
- **Visible mapping**: every rewrite is reported (`Note: importing "…" as "…" (…)`), and the plan/dry-run listing annotates rewritten items with `renamed-from=<source-slug>`.
- The `copyOneTemplate` budget skip stays as a backstop but no longer fires for pattern-valid slugs; pattern-invalid slugs still skip as before.

## Test plan

- [x] New `resolveImportSlugs` tests: verbatim keepers, auto-trim, same-prefix suffixing, trim-avoids-keeper, explicit rename precedence, unknown-source / over-budget / collision errors, pattern-invalid passthrough; `parseRenameFlags` parsing/duplicate cases
- [x] `go build ./... && go test ./...`, `golangci-lint run`, `golangci-lint fmt --diff` clean