### PR TITLE
feat(cli): record one-shot slug renames with renamed_from

### DIFF
--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -182,6 +182,16 @@ type AssignmentEntry struct {
 	RepoFeatures       *RepoFeatures    `json:"repo_features,omitempty"`
 	MigratedFrom       *MigratedFromRef `json:"migrated_from,omitempty"`
 
+	// RenamedFrom is the assignment's PREVIOUS slug, recorded by the one-shot
+	// slug rename (offered only to remediate an over-budget composed repo
+	// name; a renamed assignment can't be renamed again, so this is a single
+	// slug, never a chain). Collection grandfathers historical result.json
+	// payloads carrying it, and the value is RESERVED within the classroom —
+	// a new assignment at an old name would sever GitHub's rename redirects
+	// for every student clone. Mirrored in the assignments-v1 schema and the
+	// web Assignment type.
+	RenamedFrom string `json:"renamed_from,omitempty"`
+
 	// Extra holds unknown top-level entry keys, re-emitted verbatim so a
 	// read-modify-write never drops a field a newer binary/GUI added.
 	// Merged in/out by the custom (Un)MarshalJSON below.
@@ -196,6 +206,7 @@ var knownEntryKeys = map[string]struct{}{
 	"runtime": {}, "tests": {}, "feedback_pr": {}, "empty_repo": {},
 	"locked": {}, "closed": {}, "allowed_files": {}, "release_assets": {}, "pass_threshold": {},
 	"migrated_from": {}, "available_from": {}, "available_from_meta": {},
+	"renamed_from":       {},
 	"student_permission": {}, "submission_mode": {}, "submission_tags": {},
 	"no_autograder":        {},
 	"init_shim":            {},
@@ -789,6 +800,20 @@ func SlugExistsFold(entries []AssignmentEntry, slug string) bool {
 	return false
 }
 
+// SlugReservedFold reports whether `slug` matches any entry's renamed_from
+// (case-insensitively), returning the reserving entry's CURRENT slug. A
+// reserved slug must never be reused: a new assignment there would mint repos
+// at renamed student repos' old names, permanently severing GitHub's automatic
+// redirects for every student clone.
+func SlugReservedFold(entries []AssignmentEntry, slug string) (currentSlug string, reserved bool) {
+	for i := range entries {
+		if entries[i].RenamedFrom != "" && strings.EqualFold(entries[i].RenamedFrom, slug) {
+			return entries[i].Slug, true
+		}
+	}
+	return "", false
+}
+
 // slugMaxLen is the max slug length validate.ShortName accepts (100 chars).
 // Duplicated here (not imported) so the pure data layer stays free of the
 // command seam.
@@ -807,15 +832,23 @@ func trimSlugTo(s string, n int) string {
 	return strings.TrimRight(s, "-")
 }
 
-// NextAvailableSlug returns a slug within maxLen that doesn't collide
-// (case-insensitively): the base is trimmed to maxLen, and a collision
-// auto-suffixes `-2`, `-3`, … with the stem re-trimmed so the candidate stays
-// within maxLen; a base already ending in `-N` increments from N+1. Callers
-// pass the target classroom's composed repo-name budget (#691) — or slugMaxLen
-// when unconstrained; anything larger clamps to the pattern cap. Mirrors the
-// web's nextAvailableSlug so both tools derive the same copy names. Errors
-// only when maxLen can't fit ShortName's 2-char minimum.
+// NextAvailableSlug returns a slug within maxLen that doesn't collide with an
+// existing slug OR a reserved renamed_from (case-insensitively): the base is
+// trimmed to maxLen, and a collision auto-suffixes `-2`, `-3`, … with the stem
+// re-trimmed so the candidate stays within maxLen; a base already ending in
+// `-N` increments from N+1. Callers pass the target classroom's composed
+// repo-name budget (#691) — or slugMaxLen when unconstrained; anything larger
+// clamps to the pattern cap. Mirrors the web's nextAvailableSlug so both tools
+// derive the same copy names. Errors only when maxLen can't fit ShortName's
+// 2-char minimum.
 func NextAvailableSlug(entries []AssignmentEntry, slug string, maxLen int) (string, error) {
+	taken := func(candidate string) bool {
+		if SlugExistsFold(entries, candidate) {
+			return true
+		}
+		_, reserved := SlugReservedFold(entries, candidate)
+		return reserved
+	}
 	if maxLen > slugMaxLen {
 		maxLen = slugMaxLen
 	}
@@ -830,7 +863,7 @@ func NextAvailableSlug(entries []AssignmentEntry, slug string, maxLen int) (stri
 		return "", fmt.Errorf("cannot derive a slug for %q within the %d-character budget (trimming leaves less than the 2-character minimum) — pass an explicit, shorter --slug",
 			slug, maxLen)
 	}
-	if !SlugExistsFold(entries, base) {
+	if !taken(base) {
 		return base, nil
 	}
 	stem := base
@@ -905,6 +938,17 @@ func ValidateAssignmentEntry(entry AssignmentEntry) error {
 	}
 	if err := validateAvailableFromFields(entry); err != nil {
 		return err
+	}
+	// renamed_from is written only by the one-shot slug rename; a set value
+	// must be a valid slug distinct from the current one, or the reservation
+	// and collection-grandfather contracts it feeds become unenforceable.
+	if entry.RenamedFrom != "" {
+		if err := validate.ShortName(entry.RenamedFrom, "renamed_from"); err != nil {
+			return err
+		}
+		if strings.EqualFold(entry.RenamedFrom, entry.Slug) {
+			return fmt.Errorf("renamed_from %q must differ from the slug", entry.RenamedFrom)
+		}
 	}
 	if entry.Autograder == "" {
 		return fmt.Errorf("autograder must not be empty (default is %q)", contract.DefaultAutograderName)

--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -883,7 +883,7 @@ func NextAvailableSlug(entries []AssignmentEntry, slug string, maxLen int) (stri
 			return "", fmt.Errorf("cannot auto-suffix slug %q within the %d-character budget — pass an explicit, shorter --slug", slug, maxLen)
 		}
 		candidate := trimSlugTo(stem, room) + suffix
-		if !SlugExistsFold(entries, candidate) {
+		if !taken(candidate) {
 			return candidate, nil
 		}
 	}

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -1809,7 +1809,8 @@ func TestSlugReservedFold(t *testing.T) {
 }
 
 // TestNextAvailableSlug_SkipsReserved: the auto-derive treats a renamed_from
-// value as taken, so a copy can't silently land on a reserved old name.
+// value as taken — for the base AND for suffixed candidates, so a copy can't
+// silently land on a reserved old name at any step.
 func TestNextAvailableSlug_SkipsReserved(t *testing.T) {
 	entries := []AssignmentEntry{{Slug: "ps3", RenamedFrom: "hello"}}
 	got, err := NextAvailableSlug(entries, "hello", slugMaxLen)
@@ -1818,6 +1819,21 @@ func TestNextAvailableSlug_SkipsReserved(t *testing.T) {
 	}
 	if got != "hello-2" {
 		t.Errorf("NextAvailableSlug = %q, want %q (reserved base suffixed past)", got, "hello-2")
+	}
+
+	// A SUFFIXED candidate matching a reservation must be skipped too:
+	// "hello" is taken (current slug) and "hello-2" is reserved, so the
+	// derive must land on "hello-3".
+	entries = []AssignmentEntry{
+		{Slug: "hello"},
+		{Slug: "ps3", RenamedFrom: "hello-2"},
+	}
+	got, err = NextAvailableSlug(entries, "hello", slugMaxLen)
+	if err != nil {
+		t.Fatalf("NextAvailableSlug: %v", err)
+	}
+	if got != "hello-3" {
+		t.Errorf("NextAvailableSlug = %q, want %q (reserved suffix skipped)", got, "hello-3")
 	}
 }
 

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -1788,6 +1788,92 @@ func TestValidateAssignmentEntry_DueMeta(t *testing.T) {
 	})
 }
 
+// TestSlugReservedFold pins the renamed_from reservation lookup: a pre-rename
+// slug matches case-insensitively and reports the reserving entry's CURRENT
+// slug; current slugs and absent renamed_from never reserve anything.
+func TestSlugReservedFold(t *testing.T) {
+	entries := []AssignmentEntry{
+		{Slug: "hw1"},
+		{Slug: "ps3", RenamedFrom: "problem-set-three-with-a-long-slug"},
+	}
+	current, reserved := SlugReservedFold(entries, "Problem-Set-Three-With-A-Long-Slug")
+	if !reserved || current != "ps3" {
+		t.Errorf("SlugReservedFold = (%q,%t), want (ps3,true)", current, reserved)
+	}
+	if _, reserved := SlugReservedFold(entries, "hw1"); reserved {
+		t.Error("a current slug must not read as reserved")
+	}
+	if _, reserved := SlugReservedFold(entries, "ps3"); reserved {
+		t.Error("the renaming entry's own slug must not read as reserved")
+	}
+}
+
+// TestNextAvailableSlug_SkipsReserved: the auto-derive treats a renamed_from
+// value as taken, so a copy can't silently land on a reserved old name.
+func TestNextAvailableSlug_SkipsReserved(t *testing.T) {
+	entries := []AssignmentEntry{{Slug: "ps3", RenamedFrom: "hello"}}
+	got, err := NextAvailableSlug(entries, "hello", slugMaxLen)
+	if err != nil {
+		t.Fatalf("NextAvailableSlug: %v", err)
+	}
+	if got != "hello-2" {
+		t.Errorf("NextAvailableSlug = %q, want %q (reserved base suffixed past)", got, "hello-2")
+	}
+}
+
+// TestAssignmentEntryRenamedFromRoundTrip: the field survives an
+// encode/decode cycle as a known key (not Extra), and write-path validation
+// rejects a malformed or self-referential value.
+func TestAssignmentEntryRenamedFromRoundTrip(t *testing.T) {
+	file := AssignmentsJSON{
+		Schema: contract.AssignmentsSchemaV1,
+		Assignments: []AssignmentEntry{{
+			Slug:        "ps3",
+			Name:        "PS3",
+			Mode:        ModeIndividual,
+			Autograder:  "default",
+			RenamedFrom: "problem-set-three",
+		}},
+	}
+	data, err := EncodeAssignments(file)
+	if err != nil {
+		t.Fatalf("EncodeAssignments: %v", err)
+	}
+	parsed, err := ParseAssignments(data)
+	if err != nil {
+		t.Fatalf("ParseAssignments: %v", err)
+	}
+	got := parsed.Assignments[0]
+	if got.RenamedFrom != "problem-set-three" {
+		t.Errorf("RenamedFrom = %q, want %q", got.RenamedFrom, "problem-set-three")
+	}
+	if _, inExtra := got.Extra["renamed_from"]; inExtra {
+		t.Error("renamed_from must decode onto the struct, not Extra")
+	}
+}
+
+func TestValidateAssignmentEntry_RenamedFrom(t *testing.T) {
+	base := AssignmentEntry{Slug: "ps3", Name: "PS3", Mode: ModeIndividual, Autograder: "default"}
+
+	ok := base
+	ok.RenamedFrom = "problem-set-three"
+	if err := ValidateAssignmentEntry(ok); err != nil {
+		t.Errorf("a valid renamed_from must pass, got %v", err)
+	}
+
+	bad := base
+	bad.RenamedFrom = "Bad Slug"
+	if err := ValidateAssignmentEntry(bad); err == nil {
+		t.Error("a pattern-invalid renamed_from must fail")
+	}
+
+	self := base
+	self.RenamedFrom = "ps3"
+	if err := ValidateAssignmentEntry(self); err == nil || !strings.Contains(err.Error(), "differ") {
+		t.Errorf("a self-referential renamed_from must fail, got %v", err)
+	}
+}
+
 func entriesWithSlugs(slugs ...string) []AssignmentEntry {
 	out := make([]AssignmentEntry, len(slugs))
 	for i, s := range slugs {

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -773,6 +773,13 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			if err := validate.ComposedRepoNameBudget(classroom, slug); err != nil {
 				return nil, err
 			}
+			// A renamed assignment's old slug is reserved: a new assignment
+			// there would mint repos at renamed student repos' old names,
+			// permanently severing GitHub's redirects for every student clone.
+			if current, reserved := assignment.SlugReservedFold(file.Assignments, slug); reserved {
+				return nil, fmt.Errorf("slug %q is reserved: it is the pre-rename slug of assignment %q, and reusing it would permanently break GitHub's redirects for that assignment's renamed student repos — choose a different slug",
+					slug, current)
+			}
 		}
 		// no_autograder is owned by the gradebook GUI, not `assignment add`
 		// (there is no --no-autograder flag), so `entry`/`attemptEntry` rebuilt
@@ -860,6 +867,13 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			attemptEntry.ReleaseAssets = append([]string(nil), previous.ReleaseAssets...)
 			attemptEntry.Extra = previous.Extra
 			attemptEntry.Locked = previous.Locked
+			// renamed_from and migrated_from are provenance owned by the slug
+			// rename and `classroom migrate` respectively — `add` has no flags
+			// for them, and both are known keys (they decode onto the struct,
+			// not Extra), so a same-slug re-add must carry them or it silently
+			// erases the rename reservation / migration record.
+			attemptEntry.RenamedFrom = previous.RenamedFrom
+			attemptEntry.MigratedFrom = previous.MigratedFrom
 			// Closed is likewise preserved: it's owned out of band by the web
 			// "Close submission" action, not `add`, and `closed` is a known key
 			// (decodes onto the struct, not Extra). Without this carry-forward a

--- a/cli/gh-teacher/internal/assignmentcmd/budget_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/budget_test.go
@@ -119,6 +119,146 @@ func TestRunAssignmentReuse_BlocksOverBudgetSlug(t *testing.T) {
 	}
 }
 
+// renamedAssignmentsBody is a manifest whose only entry was slug-renamed:
+// its renamed_from reserves the old slug and must survive a same-slug re-add.
+func renamedAssignmentsBody() string {
+	return `{
+  "schema": "classroom50/assignments/v1",
+  "assignments": [
+    {
+      "slug": "ps3",
+      "name": "PS3",
+      "mode": "individual",
+      "autograder": "default",
+      "renamed_from": "problem-set-three-with-a-legacy-slug",
+      "migrated_from": {
+        "source": "github_classroom",
+        "classroom_id": 7,
+        "assignment_id": 9,
+        "migrated_at": "2026-01-01T00:00:00Z"
+      }
+    }
+  ]
+}`
+}
+
+// TestRunAssignmentAdd_BlocksReservedSlug: a renamed assignment's old slug is
+// reserved — a new assignment there would mint repos at renamed student repos'
+// old names, severing GitHub's redirects. Nothing is committed.
+func TestRunAssignmentAdd_BlocksReservedSlug(t *testing.T) {
+	server, fix := newLockServer(t, lockServerConfig{
+		assignments: renamedAssignmentsBody(),
+		classroom:   lockClassroomBody(),
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	err := runAssignmentAdd(client, &out, &errOut, addAssignmentParams{
+		Org:        "o",
+		Classroom:  "dst",
+		Slug:       "problem-set-three-with-a-legacy-slug",
+		Name:       "Sneaky",
+		Mode:       assignment.ModeIndividual,
+		Autograder: "default",
+	})
+	if err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("err = %v, want a reserved-slug error", err)
+	}
+	fix.mu.Lock()
+	committed := fix.committed
+	fix.mu.Unlock()
+	if committed != nil {
+		t.Error("a blocked add must not commit anything")
+	}
+}
+
+// TestRunAssignmentAdd_CarriesRenameAndMigrationProvenance: `add` has no flags
+// for renamed_from/migrated_from, and both are known keys (they decode onto
+// the struct, not Extra) — a same-slug re-add must carry them or it silently
+// erases the rename reservation / migration record.
+func TestRunAssignmentAdd_CarriesRenameAndMigrationProvenance(t *testing.T) {
+	server, fix := newLockServer(t, lockServerConfig{
+		assignments: renamedAssignmentsBody(),
+		classroom:   lockClassroomBody(),
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	err := runAssignmentAdd(client, &out, &errOut, addAssignmentParams{
+		Org:        "o",
+		Classroom:  "dst",
+		Slug:       "ps3",
+		Name:       "PS3 (edited)",
+		Mode:       assignment.ModeIndividual,
+		Autograder: "default",
+	})
+	if err != nil {
+		t.Fatalf("runAssignmentAdd(re-add renamed): %v", err)
+	}
+	got := decodeLock(t, fix).Assignments[0]
+	if got.RenamedFrom != "problem-set-three-with-a-legacy-slug" {
+		t.Errorf("RenamedFrom = %q, want the prior value carried", got.RenamedFrom)
+	}
+	if got.MigratedFrom == nil || got.MigratedFrom.ClassroomID != 7 {
+		t.Errorf("MigratedFrom = %+v, want the prior record carried", got.MigratedFrom)
+	}
+}
+
+// TestRunAssignmentReuse_BlocksReservedSlug: an explicit --slug matching a
+// TARGET-classroom renamed_from is refused before anything is committed.
+func TestRunAssignmentReuse_BlocksReservedSlug(t *testing.T) {
+	server, fix := newReuseServer(t, reuseServerConfig{
+		sourceAssignments: sourceAssignmentsBody(),
+		targetAssignments: renamedAssignmentsBody(),
+		targetClassroom:   targetClassroomBody(nil),
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	params := baseReuseParams()
+	params.SlugOverride = "problem-set-three-with-a-legacy-slug"
+	params.SlugWasSet = true
+
+	var out, errOut bytes.Buffer
+	err := runAssignmentReuse(client, &out, &errOut, params)
+	if err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("err = %v, want a reserved-slug error", err)
+	}
+	fix.mu.Lock()
+	committed := fix.committed
+	fix.mu.Unlock()
+	if committed != nil {
+		t.Error("a blocked reuse must not commit anything")
+	}
+}
+
+// TestRunAssignmentReuse_ClearsRenamedFrom: renamed_from is source-classroom
+// provenance (the copy has no renamed repos), so the copy must not carry it —
+// otherwise it wrongly reserves a slug and grandfathers old-slug submissions
+// in the target.
+func TestRunAssignmentReuse_ClearsRenamedFrom(t *testing.T) {
+	sourceBody := `{
+  "schema": "classroom50/assignments/v1",
+  "assignments": [
+    { "slug": "hello", "name": "Hello", "mode": "individual", "autograder": "default", "renamed_from": "hello-with-a-legacy-slug" }
+  ]
+}`
+	server, fix := newReuseServer(t, reuseServerConfig{
+		sourceAssignments: sourceBody,
+		targetAssignments: emptyAssignmentsBody(),
+		targetClassroom:   targetClassroomBody(nil),
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	if err := runAssignmentReuse(client, &out, &errOut, baseReuseParams()); err != nil {
+		t.Fatalf("runAssignmentReuse: %v", err)
+	}
+	got := decodeReuse(t, fix).Assignments[0]
+	if got.RenamedFrom != "" {
+		t.Errorf("RenamedFrom = %q, want cleared on reuse", got.RenamedFrom)
+	}
+}
+
 // TestRunAssignmentReuse_TrimsAutoSlugToBudget: the AUTO-derived slug (no
 // --slug) is trimmed to the target classroom's budget instead of erroring,
 // mirroring the web reuse modals, with a note naming why the copy was renamed.

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -193,6 +193,10 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 		// always starts with an open window. Locked is carried (it gates the
 		// template grant below); Closed is not.
 		copied.Closed = false
+		// renamed_from is likewise source-classroom provenance: the copy has no
+		// renamed student repos, so carrying it would wrongly reserve a slug in
+		// the target and wrongly grandfather old-slug submissions there.
+		copied.RenamedFrom = ""
 
 		dstFile, err := loadAssignments(client, p.Org, p.To, parentSHA)
 		if err != nil {
@@ -209,6 +213,12 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 			if assignment.SlugExistsFold(dstFile.Assignments, p.SlugOverride) {
 				return nil, fmt.Errorf("slug %q already exists in target classroom %q (case-insensitive) — choose a different --slug",
 					p.SlugOverride, p.To)
+			}
+			// A renamed assignment's old slug is reserved (see SlugReservedFold):
+			// reusing it would sever GitHub's redirects for renamed student repos.
+			if current, reserved := assignment.SlugReservedFold(dstFile.Assignments, p.SlugOverride); reserved {
+				return nil, fmt.Errorf("slug %q is reserved in target classroom %q: it is the pre-rename slug of assignment %q — choose a different --slug",
+					p.SlugOverride, p.To, current)
 			}
 			finalSlug = p.SlugOverride
 		} else {

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -1011,6 +1011,15 @@ def collect_classroom(
         assignment_type = "group" if is_group else "individual"
         collected[slug] = assignment_type
 
+        # One-shot pre-rename slug (see validate_result): a non-string or empty
+        # value reads as absent, matching the additive-schema tolerance rule.
+        raw_renamed_from = entry.get("renamed_from")
+        renamed_from = (
+            raw_renamed_from
+            if isinstance(raw_renamed_from, str) and raw_renamed_from
+            else None
+        )
+
         submitted = 0
         # Staff (non-student-team) members who actually submitted this
         # assignment. They count toward the "X of Y" denominator only when they
@@ -1085,7 +1094,14 @@ def collect_classroom(
                 # a mode-flipped or mis-typed result is rejected here — no
                 # separate assignment_type cross-check needed afterward.
                 try:
-                    validate_result(candidate, classroom_short, slug, username, is_group=is_group)
+                    validate_result(
+                        candidate,
+                        classroom_short,
+                        slug,
+                        username,
+                        is_group=is_group,
+                        renamed_from=renamed_from,
+                    )
                 except ValueError as exc:
                     emit_warning(
                         f"{org}/{repo_name}: invalid result.json for "
@@ -1903,6 +1919,7 @@ def validate_result(
     expected_username: str,
     *,
     is_group: bool = False,
+    renamed_from: str | None = None,
 ) -> None:
     """Raise ValueError if the payload fails the v1 contract. The
     classroom/assignment/owner checks defend against a hostile result.json
@@ -1914,6 +1931,11 @@ def validate_result(
     "individual"/"group" and match the mode implied by `is_group`. No
     `usernames` field: who pushed is `submitted_by`; the credited member list
     is resolved by collection after this check.
+
+    `renamed_from` is the manifest entry's pre-rename slug (one-shot, so a
+    single value): a historical release published before the rename carries it
+    in the immutable result.json, and is accepted so old grades survive the
+    rename. Exactly that value — never an arbitrary third slug.
     """
     if not isinstance(payload, dict):
         raise ValueError(f"top-level value must be an object, got {type(payload).__name__}")
@@ -1925,8 +1947,13 @@ def validate_result(
         raise ValueError(f"classroom = {classroom!r}, want {expected_classroom!r}")
 
     assignment = payload.get("assignment")
-    if assignment != expected_assignment:
-        raise ValueError(f"assignment = {assignment!r}, want {expected_assignment!r}")
+    if assignment != expected_assignment and (
+        renamed_from is None or assignment != renamed_from
+    ):
+        want = repr(expected_assignment)
+        if renamed_from is not None:
+            want += f" (or pre-rename {renamed_from!r})"
+        raise ValueError(f"assignment = {assignment!r}, want {want}")
 
     owner = payload.get("owner")
     if not isinstance(owner, str) or not owner:

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -468,6 +468,32 @@ class TestValidateResult:
         with pytest.raises(ValueError, match="assignment"):
             cs.validate_result(payload, "cs-principles", "hello", "alice")
 
+    def test_accepts_pre_rename_assignment_via_renamed_from(self):
+        # A one-shot slug rename leaves historical submit/* releases whose
+        # immutable result.json still carries the OLD slug; the manifest's
+        # renamed_from grandfathers exactly that value.
+        payload = make_result(assignment="hello-with-a-very-long-legacy-slug")
+        cs.validate_result(
+            payload,
+            "cs-principles",
+            "hello",
+            "alice",
+            renamed_from="hello-with-a-very-long-legacy-slug",
+        )
+
+    def test_renamed_from_does_not_accept_other_slugs(self):
+        # The grandfather rule is exact: only the recorded previous slug
+        # passes, never an arbitrary third value.
+        payload = make_result(assignment="goodbye")
+        with pytest.raises(ValueError, match="assignment"):
+            cs.validate_result(
+                payload,
+                "cs-principles",
+                "hello",
+                "alice",
+                renamed_from="hello-with-a-very-long-legacy-slug",
+            )
+
     def test_rejects_mismatched_owner(self):
         # owner must match the roster-derived value — that's the link
         # back to scores by student.

--- a/schemas/assignments-v1.schema.json
+++ b/schemas/assignments-v1.schema.json
@@ -215,6 +215,11 @@
             "migrated_at": { "type": "string" }
           }
         },
+        "renamed_from": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]{1,99}$",
+          "description": "The assignment's PREVIOUS slug, recorded by the one-shot slug rename (offered only to remediate a composed repo-name over GitHub's 100-character limit; a renamed assignment can never be renamed again, so this is always a single slug, never a chain). Two contracts hang off it: (1) score collection accepts a historical result.json whose immutable `assignment` field carries this value (pre-rename submit/* releases keep their grades); (2) the value is RESERVED within the classroom — no new assignment may take it, because creating a repo at a renamed student repo's old name would permanently sever GitHub's automatic redirects for every student clone. Absent on assignments that were never renamed."
+        },
         "student_permission": {
           "enum": ["pull", "triage", "push", "maintain", "admin"],
           "description": "The collaborator role the enrolled student is granted on their OWN assignment repo at accept time (the old GitHub Classroom \"grant students admin access\" checkbox, generalized to GitHub's full ladder). ABSENT means the built-in default: `push` for `individual`, `admin` for `group`. This is accept-time provisioning only — it governs what NEW accepters get; it does not retroactively change repos already accepted (teachers adjust those with the gradebook's per-repo/bulk access controls). Group coherence: a group founder must hold at least `admin` to add teammates via `gh student invite`, so for `mode: group` any configured value below `admin` is clamped up to `admin` by every accept client — prefer omitting it (or writing `admin`) for group assignments. Caution: `admin` lets the student manage the repo's settings and collaborators; changing repo visibility stays blocked by the org-level lockdown setup applies (members_can_change_repo_visibility=false) while that lockdown is intact (verify with the audit)."

--- a/web/src/components/modals/ReuseAssignmentModal.tsx
+++ b/web/src/components/modals/ReuseAssignmentModal.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from "react-i18next"
 import useGetClasses from "@/hooks/useGetClasses"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import type { Assignment } from "@/types/classroom"
+import { renamedFromSlugs } from "@/types/classroom"
 import { useReuseAssignment } from "@/hooks/mutations/useReuseAssignment"
 import {
   ReuseModalShell,
@@ -51,12 +52,17 @@ export const ReuseAssignmentModal = ({
     () => (targetData?.assignments ?? []).map((a) => a.slug),
     [targetData],
   )
+  const reservedSlugs = useMemo(
+    () => renamedFromSlugs(targetData?.assignments ?? []),
+    [targetData],
+  )
 
   const reuse = useReuseAssignment({
     org,
     targetClassroom,
     source: assignment,
     takenSlugs,
+    reservedSlugs,
     takenLoading: targetLoading,
     closeDialog: () => dialogRef.current?.close(),
   })
@@ -132,6 +138,7 @@ export const ReuseAssignmentModal = ({
                   loading: targetLoading,
                   error: targetError,
                   slugTaken: reuse.slugTaken,
+                  slugReserved: reuse.slugReserved,
                   slugOverBudget: reuse.slugOverBudget,
                   slugBudget: reuse.slugBudget,
                   slugTouched: reuse.slugTouched,
@@ -144,7 +151,7 @@ export const ReuseAssignmentModal = ({
               <FormField
                 label={t("components.modals.reuseAssignment.slugLabel")}
                 error={
-                  reuse.slugTaken || reuse.slugOverBudget
+                  reuse.slugTaken || reuse.slugReserved || reuse.slugOverBudget
                     ? slugStatus
                     : undefined
                 }

--- a/web/src/components/modals/ReuseFromClassroomModal.tsx
+++ b/web/src/components/modals/ReuseFromClassroomModal.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from "react-i18next"
 import useGetClasses from "@/hooks/useGetClasses"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import { useReuseAssignment } from "@/hooks/mutations/useReuseAssignment"
+import { renamedFromSlugs } from "@/types/classroom"
 import {
   ReuseModalShell,
   reuseSlugStatus,
@@ -59,6 +60,10 @@ export const ReuseFromClassroomModal = ({
     () => (destData?.assignments ?? []).map((a) => a.slug),
     [destData],
   )
+  const reservedSlugs = useMemo(
+    () => renamedFromSlugs(destData?.assignments ?? []),
+    [destData],
+  )
 
   const selectedAssignment = useMemo(
     () => sourceAssignments.find((a) => a.slug === sourceSlug) ?? null,
@@ -70,6 +75,7 @@ export const ReuseFromClassroomModal = ({
     targetClassroom: classroom,
     source: selectedAssignment,
     takenSlugs,
+    reservedSlugs,
     takenLoading: destLoading,
     closeDialog: () => dialogRef.current?.close(),
   })
@@ -195,6 +201,7 @@ export const ReuseFromClassroomModal = ({
                   loading: destLoading,
                   error: destError,
                   slugTaken: reuse.slugTaken,
+                  slugReserved: reuse.slugReserved,
                   slugOverBudget: reuse.slugOverBudget,
                   slugBudget: reuse.slugBudget,
                   slugTouched: reuse.slugTouched,
@@ -211,7 +218,9 @@ export const ReuseFromClassroomModal = ({
                       classroom,
                     })}
                     error={
-                      reuse.slugTaken || reuse.slugOverBudget
+                      reuse.slugTaken ||
+                      reuse.slugReserved ||
+                      reuse.slugOverBudget
                         ? slugStatus
                         : undefined
                     }

--- a/web/src/components/modals/ReuseModalShell.tsx
+++ b/web/src/components/modals/ReuseModalShell.tsx
@@ -120,6 +120,7 @@ export const reuseSlugStatus = ({
   loading,
   error,
   slugTaken,
+  slugReserved,
   slugOverBudget,
   slugBudget,
   slugTouched,
@@ -132,6 +133,7 @@ export const reuseSlugStatus = ({
   loading: boolean
   error: boolean
   slugTaken: boolean
+  slugReserved: boolean
   slugOverBudget: boolean
   slugBudget: number
   slugTouched: boolean
@@ -156,6 +158,11 @@ export const reuseSlugStatus = ({
         })
   if (slugTaken)
     return t("components.modals.reuseShell.slug.taken", {
+      slug: normalizedSlug,
+      classroom: classroomLabel,
+    })
+  if (slugReserved)
+    return t("components.modals.reuseShell.slug.reserved", {
       slug: normalizedSlug,
       classroom: classroomLabel,
     })

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -467,6 +467,9 @@ describe("editAssignment (preserved-entry integration)", () => {
       original_slug: "hw1-old",
       migrated_at: "2026-01-02T03:04:05Z",
     },
+    // Slug-rename provenance: carries the reservation + collection-grandfather
+    // contracts, so an edit must ride it through untouched like migrated_from.
+    renamed_from: "homework-one-with-a-legacy-slug",
   }
 
   // Route-table GitHubClient covering exactly the endpoints editAssignment hits
@@ -584,6 +587,9 @@ describe("editAssignment (preserved-entry integration)", () => {
 
     // Unmanaged CLI field rides through the read-modify-write.
     expect(edited.migrated_from).toEqual(existingEntry.migrated_from)
+    // Rename provenance likewise: dropping it would erase the slug
+    // reservation and the collection grandfather rule.
+    expect(edited.renamed_from).toBe(existingEntry.renamed_from)
     // Managed edit wins.
     expect(edited.name).toBe("Homework 1 (edited)")
     // Cleared managed key is not resurrected from the stale existing entry.

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -105,6 +105,21 @@ describe("buildReusedEntry", () => {
     expect(entry.name).toBe("Homework 1")
   })
 
+  it("clears renamed_from (source-classroom provenance, mirrors the CLI)", () => {
+    // Carrying it would wrongly reserve a slug in the target and wrongly
+    // grandfather old-slug submissions there.
+    const renamedSource: Assignment = {
+      ...fullSource,
+      renamed_from: "hw1-with-a-legacy-slug",
+    }
+    const entry = buildReusedEntry(renamedSource, {
+      slug: "hw1-fall",
+      name: "Homework 1 (Fall)",
+    })
+    expect(entry.renamed_from).toBeUndefined()
+    expect("renamed_from" in entry).toBe(false)
+  })
+
   it("defaults to the source slug/name when overrides match them", () => {
     const entry = buildReusedEntry(fullSource, {
       slug: fullSource.slug,
@@ -2094,6 +2109,60 @@ describe("copyAssignmentToClassroom (reuse allows cross-org forks)", () => {
       grants: () => grants,
     }
   }
+
+  // A renamed assignment's old slug is reserved at the WRITE path too — the
+  // modal's optimistic check can be stale (e.g. a CLI-side rename landed after
+  // its assignments query), so the commit build re-checks authoritatively.
+  it("rejects a slug reserved by a renamed assignment in the target", async () => {
+    const assignmentsFile = {
+      schema: "classroom50/assignments/v1",
+      assignments: [
+        {
+          slug: "ps3",
+          name: "PS3",
+          mode: "individual",
+          autograder: "default",
+          renamed_from: "hw1",
+        },
+      ],
+    }
+    const request = vi.fn(async (url: string) => {
+      if (/\/repos\/[^/]+\/classroom50$/.test(url))
+        return { default_branch: "main" }
+      if (url.includes("/git/ref/heads/main")) return { object: { sha: "s" } }
+      if (url.includes("/git/commits/s")) return { tree: { sha: "t" } }
+      if (url.includes("/contents/cs51/assignments.json")) {
+        return {
+          type: "file",
+          encoding: "base64",
+          content: btoa(JSON.stringify(assignmentsFile)),
+        }
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    const requestRaw = vi.fn(async () =>
+      JSON.stringify({
+        schema: "classroom50/classroom/v1",
+        short_name: "cs51",
+      }),
+    )
+    const client = { request, requestRaw } as unknown as GitHubClient
+
+    await expect(
+      copyAssignmentToClassroom(client, {
+        org: ORG,
+        source: {
+          slug: "hw1",
+          name: "Homework 1",
+          mode: "individual",
+          autograder: "default",
+          feedback_pr: true,
+        },
+        targetClassroom: "cs51",
+        canGrantTemplateAccess: true,
+      }),
+    ).rejects.toThrow(/reserved/)
+  })
 
   // The real #468 topology: an in-org private fork whose upstream is a private
   // repo in ANOTHER org. Must reuse successfully (generate copies the fork's own

--- a/web/src/domain/assignments/copyReuse.ts
+++ b/web/src/domain/assignments/copyReuse.ts
@@ -82,6 +82,11 @@ export function buildReusedEntry(
       : undefined,
     tests: source.tests ? source.tests.map((t) => ({ ...t })) : undefined,
   }
+  // renamed_from is source-classroom provenance: the copy has no renamed
+  // student repos, so carrying it would wrongly reserve a slug in the target
+  // and wrongly grandfather old-slug submissions there. Mirrors the CLI's
+  // reuse (which clears RenamedFrom).
+  delete entry.renamed_from
   if (!entry.template) delete entry.template
   if (!entry.due_meta) delete entry.due_meta
   if (entry.runtime && !entry.runtime.container) delete entry.runtime.container
@@ -189,6 +194,18 @@ export async function copyAssignmentToClassroom(
   ) {
     throw new Error(
       `Assignment "${entry.slug}" already exists in classroom "${targetClassroom}" — choose a different slug.`,
+    )
+  }
+  // The authoritative reservation counterpart to the modals' optimistic
+  // check: a renamed assignment's old slug must never be reused, even when
+  // the modal's cached assignments predate a CLI-side rename.
+  if (
+    currentAssignments.assignments.some(
+      (a) => a.renamed_from?.toLowerCase() === entrySlugLower,
+    )
+  ) {
+    throw new Error(
+      `Slug "${entry.slug}" is reserved in classroom "${targetClassroom}": it is the previous slug of a renamed assignment, and reusing it would break the redirects its renamed student repositories rely on — choose a different slug.`,
     )
   }
 

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -138,6 +138,9 @@ const ASSIGNMENT_KEY_OWNERSHIP: Record<
   // Written only by the CLI's `migrate`; the form never rebuilds it, so it must
   // ride through a GUI edit untouched.
   migrated_from: "preserved",
+  // Written only by the one-shot slug rename; carries the reservation and
+  // collection-grandfather contracts, so an edit must never drop it.
+  renamed_from: "preserved",
   // Owned by the separate lock/unlock action (useSetAssignmentLock), never the
   // create/edit form, so an edit must preserve it verbatim — otherwise saving
   // an edit would silently unlock a locked assignment.

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -1074,6 +1074,19 @@ export async function createAssignment(
   ) {
     throw new Error(`Assignment already exists: ${assignmentBody.slug}`)
   }
+  // The authoritative reservation counterpart to the form's optimistic check:
+  // a renamed assignment's old slug must never be reused, even when the form's
+  // cached assignments predate a CLI-side rename (see Assignment.renamed_from).
+  const newSlugLower = assignmentBody.slug.toLowerCase()
+  if (
+    currentAssignments.assignments.some(
+      (assignment) => assignment.renamed_from?.toLowerCase() === newSlugLower,
+    )
+  ) {
+    throw new Error(
+      `Slug "${assignmentBody.slug}" is reserved: it is the previous slug of a renamed assignment, and reusing it would break the redirects its renamed student repositories rely on — choose a different slug.`,
+    )
+  }
 
   const nextAssignments: AssignmentsFile = {
     ...currentAssignments,

--- a/web/src/hooks/mutations/useReuseAssignment.ts
+++ b/web/src/hooks/mutations/useReuseAssignment.ts
@@ -23,6 +23,9 @@ type UseReuseAssignmentParams = {
   source: Assignment | null
   // Existing slugs in the target, for the auto-suffix + collision check.
   takenSlugs: string[]
+  // Pre-rename slugs (Assignment.renamed_from) reserved in the target; the
+  // auto-suffix dodges them and a manual match is blocked.
+  reservedSlugs: string[]
   // Blocks submit while the target's assignments load, so a collision can't be
   // missed against an empty taken-set.
   takenLoading: boolean
@@ -40,6 +43,7 @@ export function useReuseAssignment({
   targetClassroom,
   source,
   takenSlugs,
+  reservedSlugs,
   takenLoading,
   closeDialog,
 }: UseReuseAssignmentParams) {
@@ -58,14 +62,18 @@ export function useReuseAssignment({
   const slugBudget = assignmentSlugBudget(targetClassroom)
 
   // Auto-suffixed default ("hw1" -> "hw1-2" if taken), trimmed to the target's
-  // budget. Derived, not state, so it stays correct as the target's
-  // assignments load.
+  // budget and dodging reserved pre-rename slugs. Derived, not state, so it
+  // stays correct as the target's assignments load.
   const autoSlug = useMemo(
     () =>
       source
-        ? nextAvailableSlug(slugify(source.slug), takenSlugs, slugBudget)
+        ? nextAvailableSlug(
+            slugify(source.slug),
+            [...takenSlugs, ...reservedSlugs],
+            slugBudget,
+          )
         : "",
-    [source, takenSlugs, slugBudget],
+    [source, takenSlugs, reservedSlugs, slugBudget],
   )
 
   // Default until the teacher edits; `normalizedSlug` is what gets saved.
@@ -82,6 +90,14 @@ export function useReuseAssignment({
     const lower = normalizedSlug.toLowerCase()
     return takenSlugs.some((s) => s.trim().toLowerCase() === lower)
   }, [normalizedSlug, takenSlugs])
+
+  // A renamed assignment's old slug is reserved: a new assignment there would
+  // sever GitHub's redirects for its renamed student repos.
+  const slugReserved = useMemo(() => {
+    if (!normalizedSlug) return false
+    const lower = normalizedSlug.toLowerCase()
+    return reservedSlugs.some((s) => s.trim().toLowerCase() === lower)
+  }, [normalizedSlug, reservedSlugs])
 
   // Synchronous re-entrancy guard: reuse.isPending updates a tick late, so a
   // rapid double-click could start two overlapping copy commits.
@@ -124,6 +140,7 @@ export function useReuseAssignment({
     Boolean(targetClassroom) &&
     Boolean(normalizedSlug) &&
     !slugTaken &&
+    !slugReserved &&
     !slugOverBudget &&
     !takenLoading &&
     !reuse.isPending
@@ -153,6 +170,7 @@ export function useReuseAssignment({
     normalizedSlug,
     slugTouched,
     slugTaken,
+    slugReserved,
     slugOverBudget,
     slugBudget,
     warning,

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1382,6 +1382,7 @@
         "slugInvalid": "Assignment slug must be {{description}}.",
         "slugOverBudget": "Student repositories are named \"{{classroom}}-<slug>-<username>\", which GitHub caps at {{limit}} characters — this slug can be at most {{budget}} characters (currently {{length}}).",
         "slugNoRoom": "The classroom \"{{classroom}}\" leaves no room for any assignment slug — its short-name plus a username can exceed GitHub's {{limit}}-character repository-name cap. Create a classroom with a shorter slug (at most {{max}} characters) and add the assignment there.",
+        "slugReserved": "\"{{slug}}\" is the previous slug of a renamed assignment and is reserved — reusing it would break the redirects students' renamed repositories rely on. Choose a different slug.",
         "maxGroupSizeInvalid": "Max group size must be a valid number.",
         "setupTimeoutRange": "Setup timeout must be 0 or a whole number of seconds from 1 through {{max}}.",
         "passThresholdRange": "Pass threshold must be a whole number between {{min}} and {{max}}.",
@@ -3272,6 +3273,7 @@
           "checking": "Checking existing assignments…",
           "checkError": "Couldn’t check existing slugs — you can still try; we’ll re-check on save.",
           "taken": "“{{slug}}” is already used in {{classroom}} — pick another.",
+          "reserved": "“{{slug}}” is the previous slug of a renamed assignment in {{classroom}} and is reserved — pick another.",
           "overBudget": "This slug is {{length}} characters; {{classroom}} leaves room for at most {{budget}} so student repository names stay under GitHub's limit.",
           "noRoom": "{{classroom}} leaves no room for any assignment slug — its name is too long for GitHub's repository-name limit. Reuse into a classroom with a shorter name.",
           "willBeSaved": "Will be saved as “{{slug}}”."

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -18,6 +18,7 @@ import { useToast } from "@/context/notifications/NotificationProvider"
 import { useTrackPublishDeploy } from "@/hooks/useTrackPublishDeploy"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
+import { renamedFromSlugs } from "@/types/classroom"
 import { logger } from "@/lib/logger"
 import { logWriteFailure } from "@/lib/logWriteFailure"
 import { useOutageHint } from "@/lib/githubHealth"
@@ -52,6 +53,7 @@ const CreateAssignmentPage = () => {
 
   const { data: assignmentsData } = useGetClassroomAssignments(org, classroom)
   const takenSlugs = (assignmentsData?.assignments ?? []).map((a) => a.slug)
+  const reservedSlugs = renamedFromSlugs(assignmentsData?.assignments ?? [])
 
   const emptyRoster = useEmptyRosterWarning(org, classroom)
 
@@ -113,6 +115,7 @@ const CreateAssignmentPage = () => {
           org={org}
           classroom={classroom}
           takenSlugs={takenSlugs}
+          reservedSlugs={reservedSlugs}
           onSubmit={(values) => {
             // Hide the alert but keep its content frozen for the exit collapse;
             // the next failure (if any) replaces the content when it re-shows.

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -60,6 +60,9 @@ type CreateAssignmentFormProps = {
   slug?: string
   // Existing assignment slugs, for the create-mode uniqueness check.
   takenSlugs?: string[]
+  // Pre-rename slugs (Assignment.renamed_from), reserved against new
+  // assignments in this classroom.
+  reservedSlugs?: string[]
   // Edit mode: whether any student has already accepted this assignment. Gates
   // the provisioning-change caveats (repo source, built-in autograder) so they
   // only show when a change would actually strand existing repos. Absent/false
@@ -78,6 +81,7 @@ const CreateAssignmentForm = ({
   classroom,
   slug,
   takenSlugs,
+  reservedSlugs,
   hasAcceptedStudents = false,
 }: CreateAssignmentFormProps) => {
   const { t } = useTranslation()
@@ -85,6 +89,7 @@ const CreateAssignmentForm = ({
     takenSlugs,
     edit,
     classroom,
+    reservedSlugs,
   })
   // Auto-prefill slug from name until the teacher edits it directly, so a
   // deliberate slug isn't clobbered by later name edits.
@@ -146,6 +151,7 @@ const CreateAssignmentForm = ({
           takenSlugs,
           edit,
           classroom,
+          reservedSlugs,
         })
         // handleSubmit re-throws an onSubmit rejection (an edit-mode mutateAsync
         // failure); the caller's onError banner already surfaces it, so swallow
@@ -191,6 +197,7 @@ const CreateAssignmentForm = ({
                   slugTouched={slugTouched}
                   setSlugTouched={setSlugTouched}
                   takenSlugs={takenSlugs}
+                  reservedSlugs={reservedSlugs}
                   classroom={classroom}
                 />
                 <RepositorySetupSection

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -158,6 +158,23 @@ describe("validateAssignmentForm — required fields", () => {
     const errors = validateAssignmentForm({ ...base, slug: "s".repeat(58) }, t)
     expect(errors.slug).toBeUndefined()
   })
+
+  // A renamed assignment's old slug is reserved: a new assignment there would
+  // sever GitHub's rename redirects for the renamed student repos.
+  it("flags a reserved (pre-rename) slug on create", () => {
+    const errors = validateAssignmentForm({ ...base, slug: "Old-Slug" }, t, {
+      reservedSlugs: ["old-slug"],
+    })
+    expect(errors.slug).toBe("assignments.form.validation.slugReserved")
+  })
+
+  it("does not apply the reservation in edit mode", () => {
+    const errors = validateAssignmentForm({ ...base, slug: "old-slug" }, t, {
+      reservedSlugs: ["old-slug"],
+      edit: true,
+    })
+    expect(errors.slug).toBeUndefined()
+  })
 })
 
 describe("validateAssignmentForm — group size", () => {

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -250,11 +250,14 @@ export function formValuesToRepoFeatures(
 }
 
 // Create-only: slug uniqueness is not validated in edit mode (no rename).
-// `classroom` (the short-name) enables the composed repo-name budget check.
+// `classroom` (the short-name) enables the composed repo-name budget check;
+// `reservedSlugs` are pre-rename slugs (Assignment.renamed_from) no new
+// assignment may take.
 export type SlugContext = {
   takenSlugs?: string[]
   edit?: boolean
   classroom?: string
+  reservedSlugs?: string[]
 }
 
 // The composed repo-name budget error for `slug` in `classroom`, or undefined
@@ -324,6 +327,15 @@ export function validateAssignmentForm(
         // Case-insensitive collision (slugs become repo path segments); write
         // path re-checks authoritatively (nextAvailableSlug).
         errors.slug = t("validation.assignmentSlugTaken", { slug })
+      } else if (
+        (slugContext?.reservedSlugs ?? []).some(
+          (s) => s.trim().toLowerCase() === slug.toLowerCase(),
+        )
+      ) {
+        // A renamed assignment's old slug is reserved: a new assignment there
+        // would mint repos at renamed student repos' old names, severing
+        // GitHub's redirects for every student clone.
+        errors.slug = t("assignments.form.validation.slugReserved", { slug })
       }
     }
   }

--- a/web/src/pages/assignments/sections/DetailsSection.tsx
+++ b/web/src/pages/assignments/sections/DetailsSection.tsx
@@ -19,6 +19,7 @@ export function DetailsSection({
   slugTouched,
   setSlugTouched,
   takenSlugs,
+  reservedSlugs,
   classroom,
 }: {
   form: AssignmentForm
@@ -29,6 +30,9 @@ export function DetailsSection({
   // Existing assignment slugs, so the create-mode auto-fill can pick a slug
   // that's already unique instead of surfacing a conflict only at submit.
   takenSlugs?: string[]
+  // Pre-rename slugs (Assignment.renamed_from) reserved against new
+  // assignments; the auto-fill dodges them like collisions.
+  reservedSlugs?: string[]
   // Classroom short-name; bounds the slug to the composed repo-name budget
   // (#691) so the auto-fill can't mint a name GitHub would reject at accept.
   classroom?: string
@@ -37,6 +41,9 @@ export function DetailsSection({
   // undefined (no classroom in context) leaves nextAvailableSlug at its
   // pattern-cap default.
   const slugBudget = classroom ? assignmentSlugBudget(classroom) : undefined
+  // The auto-fill's collision set: existing slugs plus reserved pre-rename
+  // slugs, mirroring the Go NextAvailableSlug (which folds both).
+  const unavailableSlugs = [...(takenSlugs ?? []), ...(reservedSlugs ?? [])]
 
   return (
     <SectionCard title={t("assignments.form.detailsSection")} onReset={onReset}>
@@ -73,7 +80,7 @@ export function DetailsSection({
                           "slug",
                           nextAvailableSlug(
                             slugify(e.target.value),
-                            takenSlugs ?? [],
+                            unavailableSlugs,
                             slugBudget,
                           ),
                         )
@@ -109,11 +116,21 @@ export function DetailsSection({
               (takenSlugs ?? []).some(
                 (s) => s.trim().toLowerCase() === liveSlug.toLowerCase(),
               )
+            const liveReserved =
+              !edit &&
+              Boolean(liveSlug) &&
+              (reservedSlugs ?? []).some(
+                (s) => s.trim().toLowerCase() === liveSlug.toLowerCase(),
+              )
             const liveError =
               liveBudgetError ??
               (liveTaken
                 ? t("validation.assignmentSlugTaken", { slug: liveSlug })
-                : undefined)
+                : liveReserved
+                  ? t("assignments.form.validation.slugReserved", {
+                      slug: liveSlug,
+                    })
+                  : undefined)
             const slugError = submitError ?? liveError
             return (
               <FormField
@@ -149,7 +166,7 @@ export function DetailsSection({
                         normalized ||
                           nextAvailableSlug(
                             slugify(form.state.values.name),
-                            takenSlugs ?? [],
+                            unavailableSlugs,
                             slugBudget,
                           ),
                       )

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -328,6 +328,20 @@ export type Assignment = {
   tests?: AssignmentTest[]
   // CLI migrate provenance. The GUI doesn't write it but must round-trip it.
   migrated_from?: MigratedFrom
+  // The assignment's PREVIOUS slug, from the one-shot slug rename (a single
+  // slug, never a chain — a renamed assignment can't be renamed again).
+  // Collection grandfathers historical result.json payloads carrying it, and
+  // the value is RESERVED within the classroom: a new assignment at an old
+  // name would sever GitHub's rename redirects for every student clone. In
+  // lockstep with the assignments-v1 schema and the Go AssignmentEntry.
+  renamed_from?: string
+}
+
+// The renamed_from values of a classroom's assignments — slugs RESERVED
+// against new assignments (see Assignment.renamed_from). The single source
+// for every create/reuse validator's reservation set.
+export function renamedFromSlugs(assignments: Assignment[]): string[] {
+  return assignments.flatMap((a) => (a.renamed_from ? [a.renamed_from] : []))
 }
 
 // Trimmed assignment description, or "" when absent. assignments.json is read


### PR DESCRIPTION
## Summary

First of three PRs for the assignment slug rename feature (design in the #691 follow-up plan): the `renamed_from` contract, landed with every mirror in lockstep per the schema rules.

- **Schema** (`assignments-v1`): additive optional `renamed_from` (string, slug pattern) documenting the one-shot semantics — recorded only by the upcoming slug rename (offered solely to remediate an over-budget composed repo name; a renamed assignment can't be renamed again, so it is always a single slug, never a chain).
- **Go**: `AssignmentEntry.RenamedFrom` round-trips as a known key; write-path validation (pattern, must differ from the slug); carried on a same-slug `assignment add` re-add (alongside `migrated_from`, which the CLI re-add was silently dropping — fixed in passing); cleared on `assignment reuse` (source-classroom provenance); `SlugReservedFold` + reservation errors in `add`/`reuse`; `NextAvailableSlug` treats reserved names as taken for the base and every suffixed candidate.
- **Collection** (`collect_scores.py`): `validate_result` grandfathers a historical `result.json` whose immutable `assignment` field carries exactly the pre-rename slug — old submissions keep their grades after a rename; any other mismatch still rejects.
- **Web**: `Assignment.renamed_from` + `renamedFromSlugs` helper; edits preserve it (ownership map "preserved"); reservation enforced optimistically in the create form (live + submit), reuse modals, and auto-derives, and **authoritatively** in the `createAssignment`/`copyAssignmentToClassroom` write paths; web reuse clears it like the CLI.

Why reservation: GitHub redirects a renamed repo's web/API/git traffic indefinitely, but the redirect is permanently severed if a new repo is created at the old name — so a renamed assignment's old slug must never mint repos again.

## Test plan

- [x] New tests: Go round-trip/validation/reservation/carry/clear + suffix-candidate reservation, Python grandfather accept/exact-match-only, web preserve-on-edit, form + modal reservation, write-path reservation, reuse clears provenance
- [x] `go build ./... && go test ./...`, `golangci-lint run`, `golangci-lint fmt --diff` clean
- [x] `pytest skeleton_tests` (869) + `autograders_tests` (388) pass
- [x] `npm run check` (4358 tests) + `audit_i18n.py --strict` pass
- [x] Code review: harness-native fallback (Bugbot review of branch changes; all 3 findings fixed in the follow-up commit — no residuals)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — the field is inert until `gh teacher assignment rename` (next PR) writes it; all enforcement paths are covered by the suites above.