### PR TITLE
feat(web): align the color palette with GitHub Primer

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -4,50 +4,54 @@
 }
 
 /* ── Light theme: "sumi" ─────────────────────────────────────────────────────
-   GitHub-flavored palette on Primer's NEUTRAL foundations (primer.style color
-   usage): pure neutral grays for surfaces, borders, and ink — no hue tint — so
-   color is reserved for semantic roles. Roles follow Primer: green for
-   primary/success (the GitHub hero hue), blue for info/links (accent role),
-   purple for accent (done role), gold for warning (attention), red for error
-   (danger), slate for secondary. Where a token doubles as BODY TEXT the raw
-   Primer values are too light for the AAA floor (7:1 on the base-200 card
-   ground), so those use hue-preserved deeper shades. Flat surfaces
-   (--depth/--noise 0) with softly rounded shapes; the radius scale is
-   box > field > selector so nesting reads naturally. */
+   GitHub Primer's light primitives, used verbatim (primer.style/product/
+   primitives/color): neutral grays for surfaces, borders, and ink — no hue
+   tint — so color is reserved for semantic roles. Each token below names the
+   Primer primitive it mirrors, so a Primer upgrade is a value-for-value swap
+   rather than a re-derivation.
+
+   Primer splits each role in two — `bgColor-<role>-emphasis` for a fill,
+   `fgColor-<role>` a shade deeper for text — but a daisyUI role token is a
+   single value that serves both (`btn-primary` fills with it, `text-primary`
+   inks with it). Each token therefore takes the `fgColor` value: it is the
+   text-legible one of the pair, and a solid fill built from it still clears the
+   large-text floor with a white label.
+
+   Flat surfaces (--depth/--noise 0) with softly rounded shapes; the radius
+   scale is box > field > selector so nesting reads naturally. */
 @plugin "daisyui/theme" {
   name: "sumi";
   default: true;
   color-scheme: light;
 
-  --color-base-100: #ffffff;
-  --color-base-200: #f6f8fa;
-  --color-base-300: #d1d9e0;
-  --color-base-content: #24292f;
+  --color-base-100: #ffffff; /* bgColor-default */
+  --color-base-200: #f6f8fa; /* bgColor-muted / bgColor-inset */
+  --color-base-300: #d1d9e0; /* borderColor-default */
+  --color-base-content: #1f2328; /* fgColor-default */
 
-  --color-primary: #065c25;
-  --color-primary-content: #ffffff;
-  --color-secondary: #424a53;
+  --color-primary: #1a7f37; /* fgColor-success */
+  --color-primary-content: #ffffff; /* fgColor-onEmphasis */
+  --color-secondary: #59636e; /* fgColor-neutral */
   --color-secondary-content: #ffffff;
-  --color-accent: #5c1fb8;
+  --color-accent: #8250df; /* fgColor-done */
   --color-accent-content: #ffffff;
 
-  /* Sidebar rail follows `neutral`: a deep neutral gray, so the rail reads as
-     a quiet dark panel against the light canvas. */
-  --color-neutral: #24292f;
-  --color-neutral-content: #f6f8fa;
+  /* Sidebar rail follows `neutral`: Primer's inverse surface, so the rail reads
+     as a quiet dark panel against the light canvas. */
+  --color-neutral: #25292e; /* bgColor-inverse */
+  --color-neutral-content: #ffffff; /* fgColor-onInverse */
 
-  --color-info: #0d43ab;
+  --color-info: #0969da; /* fgColor-accent */
   --color-info-content: #ffffff;
-  --color-success: #065c25;
+  --color-success: #1a7f37; /* fgColor-success */
   --color-success-content: #ffffff;
-  --color-warning: #db9d00;
+  --color-warning: #9a6700; /* fgColor-attention */
   /* Light content so a SOLID warning fill (btn-warning / non-soft badge) reads
      as white-on-gold like every other semantic fill here — a dark content
      would give dark-on-gold, failing contrast. Soft badges are unaffected
-     (they use --color-warning as foreground, not the content token). The fill
-     itself is darkened for text use in the AA-override block below. */
+     (they use --color-warning as foreground, not the content token). */
   --color-warning-content: #ffffff;
-  --color-error: #9a1b25;
+  --color-error: #d1242f; /* fgColor-danger */
   --color-error-content: #ffffff;
 
   --radius-selector: 0.375rem;
@@ -61,42 +65,40 @@
 }
 
 /* ── Dark theme: "sumi-dark" ──────────────────────────────────────────────────
-   The night side on Primer's dark neutral scale: #0d1117 canvas with lighter
-   muted panels (#151b23) and visible neutral borders, pure gray with no hue
-   tint. The semantic roles lift to the light ends of the same hues — green
-   primary/success, blue info/links, purple accent, gold warning, red error —
-   so they pop against the dark ground while keeping the same role identity as
-   light mode. */
+   Primer's dark primitives, used verbatim: #0d1117 canvas with lighter muted
+   panels (#151b23) and Primer's dark border gray. Same fill-vs-text reasoning
+   as the light theme above — each role token takes Primer's `fgColor` value,
+   which on a dark ground is the lighter of the pair. */
 @plugin "daisyui/theme" {
   name: "sumi-dark";
   default: false;
   prefersdark: true;
   color-scheme: dark;
 
-  --color-base-100: #0d1117;
-  --color-base-200: #151b23;
-  --color-base-300: #30363d;
-  --color-base-content: #f0f6fc;
+  --color-base-100: #0d1117; /* bgColor-default */
+  --color-base-200: #151b23; /* bgColor-muted / bgColor-inset */
+  --color-base-300: #3d444d; /* borderColor-default */
+  --color-base-content: #f0f6fc; /* fgColor-default */
 
-  --color-primary: #57cb70;
+  --color-primary: #3fb950; /* fgColor-success */
   --color-primary-content: #0d1117;
-  --color-secondary: #aab6c2;
+  --color-secondary: #9198a1; /* fgColor-muted / fgColor-neutral */
   --color-secondary-content: #0d1117;
-  --color-accent: #c9a2ff;
+  --color-accent: #ab7df8; /* fgColor-done */
   --color-accent-content: #0d1117;
 
   /* Sidebar surface: a slightly lighter panel than base so the rail reads
      as a distinct surface in dark mode. */
-  --color-neutral: #212830;
+  --color-neutral: #212830; /* bgColor-emphasis */
   --color-neutral-content: #f0f6fc;
 
-  --color-info: #82c2ff;
+  --color-info: #4493f8; /* fgColor-accent */
   --color-info-content: #0d1117;
-  --color-success: #57cb70;
+  --color-success: #3fb950; /* fgColor-success */
   --color-success-content: #0d1117;
-  --color-warning: #d3a637;
+  --color-warning: #d29922; /* fgColor-attention */
   --color-warning-content: #0d1117;
-  --color-error: #ffa198;
+  --color-error: #f85149; /* fgColor-danger */
   --color-error-content: #0d1117;
 
   --radius-selector: 0.375rem;
@@ -121,7 +123,7 @@
     var(--color-neutral-content) 88%,
     transparent
   );
-  --sidebar-surface: #39424e;
+  --sidebar-surface: #3d444d;
 }
 [data-theme="sumi-dark"] {
   --sidebar-accent: color-mix(
@@ -139,7 +141,7 @@
 /* Drawer rest-dim. The rail sits a notch darker than `neutral` while the
    pointer is elsewhere, so the chrome recedes and page content is the focus;
    hovering (or keyboard focus landing inside) lifts it back to full. Dimming
-   the SURFACE darker — never the text — is the AAA-safe rendition: light rail
+   the SURFACE darker — never the text — is the AA-safe rendition: light rail
    text on a darker ground gains contrast, so the guarded resting pairs only
    improve (contrastModel.ts audits the dimmed rail too). Scoped to
    hover-capable pointers so touch devices always get the full-brightness rail. */
@@ -299,44 +301,36 @@ body {
   scroll-behavior: auto !important;
 }
 
-/* ── WCAG 2.2 AAA contrast overrides ───────────────────────────────────────
-   Targets 1.4.6 (7:1 body / 4.5:1 large text) and 1.4.11 (3:1 non-text; no AAA
-   tier). src/util/a11y/contrastGuard.test.ts recomputes every pair, so a value
-   changed here that drops below the floor fails CI. Hues are preserved
-   (lightness moved) to keep the sumi identity. */
-[data-theme="sumi"] {
-  /* Deeper ink lifts every base-content tier toward AAA (was #24292f). */
-  --color-base-content: #1f2328;
-  --color-warning: #6f4300; /* warning-as-text: >=7:1 body on base-200 (AAA) */
-  --color-warning-fill: #6f4300; /* solid warning button: white label >=4.5 large */
-}
-
-/* daisyUI derives .btn-warning / non-soft .badge-warning from --color-warning;
-   darkening it for text AAA darkens the fill too — intentional, still reads gold. */
+/* ── WCAG 2.2 AA contrast overrides ────────────────────────────────────────
+   Targets 1.4.3 (4.5:1 body / 3:1 large text) and 1.4.11 (3:1 non-text).
+   src/util/a11y/contrastGuard.test.ts recomputes every pair, so a value changed
+   here that drops below the floor fails CI. The palette itself is now Primer
+   verbatim — Primer's primitives are tuned to AA, not AAA — so no semantic token
+   is re-derived here; only composed values the theme invents (muted opacity
+   tiers, soft-badge nudges) need a floor. */
 
 /* Muted opacity tiers (`text-base-content/NN`). At their shipped opacities the
-   low tiers can't reach 7:1 on the darkest realistic surface (base-300 — the
+   low tiers can't reach 4.5:1 on the darkest realistic surface (base-300 — the
    Primer border gray also serves neutral chips). Remap each tier's rendered
-   opacity to an AAA floor while keeping a perceptible ladder, so the
-   muted/primary hierarchy survives. Light needs >=~84% on base-300; dark needs
-   >=~68% on base-100. Utilities are overridden by their generated class so
-   every call site is covered at once. */
+   opacity to an AA floor while keeping a perceptible ladder, so the
+   muted/primary hierarchy survives. Utilities are overridden by their generated
+   class so every call site is covered at once. */
 [data-theme="sumi"] {
-  --muted-30: 84%;
-  --muted-40: 84%;
-  --muted-50: 84%;
-  --muted-60: 86%;
-  --muted-70: 88%;
-  --muted-80: 91%;
+  --muted-30: 68%;
+  --muted-40: 68%;
+  --muted-50: 70%;
+  --muted-60: 74%;
+  --muted-70: 78%;
+  --muted-80: 86%;
   --muted-90: 93%;
 }
 [data-theme="sumi-dark"] {
-  --muted-30: 68%;
-  --muted-40: 68%;
-  --muted-50: 68%;
-  --muted-60: 74%;
-  --muted-70: 80%;
-  --muted-80: 86%;
+  --muted-30: 52%;
+  --muted-40: 52%;
+  --muted-50: 58%;
+  --muted-60: 66%;
+  --muted-70: 74%;
+  --muted-80: 84%;
   --muted-90: 92%;
 }
 .text-base-content\/30 {
@@ -389,7 +383,7 @@ body {
   );
 }
 
-/* Input placeholders: raise to the AAA muted floor (was ~0.65). */
+/* Input placeholders: raise to the AA muted floor (was ~0.65). */
 .input::placeholder,
 .textarea::placeholder,
 input::placeholder,
@@ -402,7 +396,7 @@ textarea::placeholder {
   opacity: 1;
 }
 
-/* DaisyUI `.label`: raise to the AAA muted floor (was ~0.70). */
+/* DaisyUI `.label`: raise to the AA muted floor (was ~0.70). */
 .label {
   color: color-mix(
     in oklab,
@@ -412,49 +406,51 @@ textarea::placeholder {
 }
 
 /* Links: daisyUI `.link` (and `hover:text-primary`) render the primary token as
-   text, which lands ~6:1 on base-100 in both themes. Use a per-theme link color
-   (darker in light, lighter in dark) that clears 7:1 without touching the brand
+   text, which is green here. Use Primer's dedicated link role (fgColor-link)
+   instead, so a link reads blue as it does on GitHub without touching the brand
    primary used for fills and marks. */
 [data-theme="sumi"] {
-  --color-link: #0d43ab;
+  --color-link: #0969da; /* fgColor-link */
 }
 [data-theme="sumi-dark"] {
-  --color-link: #82c2ff;
+  --color-link: #4493f8; /* fgColor-link */
 }
 .link {
   color: var(--color-link);
 }
 
 /* Soft badges render the semantic token as text on an 8% tint of that token.
-   Nudge the foreground per theme (darker in light, lighter in dark) hard enough
-   to clear 7:1 body at badge-sm/xs, without touching the button-fill tokens. */
+   Primer draws this pair from its FOREGROUND role (fgColor-danger #d1242f) not
+   the emphasis fill (#cf222e) — a shade deeper in light, a shade lighter in
+   dark. Nudge the foreground per theme by that much, which also buys the AA
+   body floor at badge-sm/xs without touching the button-fill tokens. */
 [data-theme="sumi"] .badge-soft {
   color: color-mix(
     in oklab,
-    var(--badge-color, var(--color-base-content)) 65%,
+    var(--badge-color, var(--color-base-content)) 82%,
     black
   );
 }
 [data-theme="sumi-dark"] .badge-soft {
   color: color-mix(
     in oklab,
-    var(--badge-color, var(--color-base-content)) 60%,
+    var(--badge-color, var(--color-base-content)) 88%,
     white
   );
 }
 
 /* Sidebar muted rows: `text-neutral-content/{50,60,70}` on the rail surface land
-   under 7:1. Raise the rendered opacity so resting (non-hover) row/footer text is
-   AAA; the hover state already lifts to full neutral-content. 85% clears 7:1 on
-   both the light opaque rail (#39424e -> 7.44:1) and the dark translucent sheet
-   (10.24:1). */
+   under the AA floor. Raise the rendered opacity so resting (non-hover)
+   row/footer text is AA; the hover state already lifts to full neutral-content.
+   72% clears 4.5:1 on both the light opaque rail and the dark translucent
+   sheet. */
 [data-theme="sumi"] .text-neutral-content\/50,
 [data-theme="sumi-dark"] .text-neutral-content\/50,
 [data-theme="sumi"] .text-neutral-content\/60,
 [data-theme="sumi-dark"] .text-neutral-content\/60,
 [data-theme="sumi"] .text-neutral-content\/70,
 [data-theme="sumi-dark"] .text-neutral-content\/70 {
-  color: color-mix(in oklab, var(--color-neutral-content) 85%, transparent);
+  color: color-mix(in oklab, var(--color-neutral-content) 72%, transparent);
 }
 
 /* Print / Save-as-PDF of the full accessibility report. The report content is

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -48,13 +48,15 @@
     "summaryFail": "{{failures}} color pair(s) are below the WCAG contrast floor.",
     "criteria": {
       "aboutHeading": "About this audit",
-      "standardText": "WCAG 2.2 — 1.4.6 Contrast (Enhanced, AAA) for text, 1.4.11 Non-text Contrast for UI components.",
+      "standardText": "WCAG 2.2 — 1.4.3 Contrast (Minimum, AA) for text, 1.4.11 Non-text Contrast for UI components. The palette follows GitHub's Primer primitives, which target Level AA.",
       "thresholdsHeading": "Required minimums (WCAG floor):",
       "bodyText": "Body text ≥ {{body}}:1",
       "largeText": "Large text ≥ {{large}}:1",
       "nonText": "Non-text (UI components) ≥ {{nonText}}:1",
       "marginHeading": "Recommended safety margin",
       "marginWhy": "We hold each pair a little above the WCAG minimum — headroom that absorbs anti-aliasing, sub-pixel rendering, and future palette tweaks. It's a recommendation, not required for conformance.",
+      "enhancedHeading": "Enhanced (AAA)",
+      "enhancedWhy": "Each pair is also scored against the stricter 1.4.6 Enhanced floors (body ≥ {{body}}:1, large ≥ {{large}}:1). This is reported for transparency, not required — AA is the conformance target.",
       "generated": "Generated {{generated}}"
     },
     "col": {

--- a/web/src/pages/accessibility/ContrastSection.tsx
+++ b/web/src/pages/accessibility/ContrastSection.tsx
@@ -303,6 +303,17 @@ export function ContrastSection() {
               </div>
               <div>
                 <p className="font-medium text-base-content">
+                  {t("accessibility.criteria.enhancedHeading")}
+                </p>
+                <p className="mt-1">
+                  {t("accessibility.criteria.enhancedWhy", {
+                    body: audit.enhancedThresholds.body,
+                    large: audit.enhancedThresholds.large,
+                  })}
+                </p>
+              </div>
+              <div>
+                <p className="font-medium text-base-content">
                   {t("accessibility.legend.heading")}
                 </p>
                 <div className="mt-1 flex flex-col gap-1">

--- a/web/src/util/a11y/contrastGuard.test.ts
+++ b/web/src/util/a11y/contrastGuard.test.ts
@@ -5,13 +5,16 @@ import { evaluateAll, type Evaluated } from "./contrastModel"
 // The WCAG 2.2 contrast regression guard. Runs in `npm run check`.
 //
 // Enforcement strictness (a deliberate decision): the guard HARD-FAILS at the
-// WCAG spec floor — 7:1 body text and 4.5:1 large text (1.4.6 AAA), 3:1
-// non-text (1.4.11) — so any future palette edit that drops a real pair below
-// the standard breaks CI. The extra design-safety margin (7.5 / 5 / 3.5) is
-// REPORTED but NON-BLOCKING, so a spec-compliant brand tweak that dips into the
-// margin band doesn't fail the build. Exempt pairs (logotypes, disabled/inactive
-// controls, structural dividers outside 1.4.11's "required to identify" scope)
-// are skipped.
+// WCAG spec floor — 4.5:1 body text and 3:1 large text (1.4.3 AA), 3:1 non-text
+// (1.4.11) — so any future palette edit that drops a real pair below the standard
+// breaks CI. AA is the enforced target because the palette is GitHub Primer
+// verbatim and Primer's primitives are tuned to AA; the stricter 1.4.6 (AAA)
+// floors are still scored per pair and reported (the VPAT's 1.4.6 row derives
+// from that tally), just never enforced. The extra design-safety margin (5 / 3.5)
+// is likewise REPORTED but NON-BLOCKING, so a spec-compliant brand tweak that
+// dips into the margin band doesn't fail the build. Exempt pairs (logotypes,
+// disabled/inactive controls, structural dividers outside 1.4.11's "required to
+// identify" scope) are skipped.
 //
 // This is a hermetic computation (no browser); its color-space + alpha math is
 // pinned against known/browser-computed values in contrast.test.ts.

--- a/web/src/util/a11y/contrastModel.ts
+++ b/web/src/util/a11y/contrastModel.ts
@@ -20,10 +20,18 @@ import {
 export type SizeClass = "body" | "large"
 export type Theme = "sumi" | "sumi-dark"
 
-/** WCAG 1.4.6 (AAA text) / 1.4.11 (non-text) spec floors. */
-export const SPEC_FLOOR = { body: 7, large: 4.5, nonText: 3 } as const
+/** WCAG 1.4.3 (AA text) / 1.4.11 (non-text) spec floors — what the guard enforces. */
+export const SPEC_FLOOR = { body: 4.5, large: 3, nonText: 3 } as const
 /** Design-target margins (reported, non-blocking per the guard-strictness decision). */
-export const MARGIN_TARGET = { body: 7.5, large: 5, nonText: 3.5 } as const
+export const MARGIN_TARGET = { body: 5, large: 3.5, nonText: 3.5 } as const
+/**
+ * WCAG 1.4.6 (Enhanced, AAA) text floors. Measured but NOT enforced: the palette
+ * is GitHub Primer verbatim, and Primer's primitives are tuned to AA. Scoring it
+ * anyway keeps the VPAT's 1.4.6 row derived from the live audit (KTD4) instead of
+ * hand-set, so the claim can't drift from the palette. Non-text has no AAA tier,
+ * so those pairs reuse the AA floor.
+ */
+export const ENHANCED_FLOOR = { body: 7, large: 4.5, nonText: 3 } as const
 
 export type Kind = "text" | "nonText"
 
@@ -73,77 +81,77 @@ export type Pair = {
 // Raw theme token values. These duplicate the index.css tokens (node has no CSS
 // engine to read them); the drift guard in contrastSource.test.ts asserts they
 // stay in sync, so the copy can't silently diverge.
-// Light theme "sumi" (base-content and warning darkened per the AAA overrides).
-// Neutral grays follow Primer's light scale; text-role tokens are
-// hue-preserved deeper shades of the Primer role hues to clear the AAA floors.
+// Light theme "sumi" — GitHub Primer's light primitives, verbatim. Each role
+// token is Primer's `fgColor-<role>` (not the `bgColor-*-emphasis` fill), since
+// one daisyUI token serves both text and fill; see the index.css rationale.
 export const SUMI = {
   base100: "#ffffff",
   base200: "#f6f8fa",
   base300: "#d1d9e0",
   baseContent: "#1f2328",
-  primary: "#065c25",
+  primary: "#1a7f37",
   primaryContent: "#ffffff",
-  secondary: "#424a53",
+  secondary: "#59636e",
   secondaryContent: "#ffffff",
-  accent: "#5c1fb8",
+  accent: "#8250df",
   accentContent: "#ffffff",
-  neutral: "#24292f",
-  neutralContent: "#f6f8fa",
-  info: "#0d43ab",
+  neutral: "#25292e",
+  neutralContent: "#ffffff",
+  info: "#0969da",
   infoContent: "#ffffff",
-  success: "#065c25",
+  success: "#1a7f37",
   successContent: "#ffffff",
-  // AAA override: warning darkened for text use AND fill (white label >=4.5).
-  warningText: "#6f4300",
-  warningFill: "#6f4300",
+  warning: "#9a6700",
   warningContent: "#ffffff",
-  error: "#9a1b25",
+  error: "#d1242f",
   errorContent: "#ffffff",
-  // Sidebar: opaque slate panel over the light canvas.
-  sidebarSurface: "#39424e",
+  // Sidebar: opaque Primer neutral panel over the light canvas.
+  sidebarSurface: "#3d444d",
   // Per-theme link color and muted-tier opacity floors (index.css overrides).
-  link: "#0d43ab",
-  muted: { 30: 84, 40: 84, 50: 84, 60: 86, 70: 88, 80: 91, 90: 93 } as Record<
+  link: "#0969da",
+  muted: { 30: 68, 40: 68, 50: 70, 60: 74, 70: 78, 80: 86, 90: 93 } as Record<
     number,
     number
   >,
-  badgeNudge: 65,
-  sidebarMuted: 85,
+  badgeNudge: 82,
+  sidebarMuted: 72,
 } as const
 
-// Dark theme "sumi-dark". Exported for the drift guard (see SUMI).
+// Dark theme "sumi-dark" — Primer's dark primitives. Exported for the drift
+// guard (see SUMI).
 export const DARK = {
   base100: "#0d1117",
   base200: "#151b23",
-  base300: "#30363d",
+  base300: "#3d444d",
   baseContent: "#f0f6fc",
-  primary: "#57cb70",
+  primary: "#3fb950",
   primaryContent: "#0d1117",
-  secondary: "#aab6c2",
+  secondary: "#9198a1",
   secondaryContent: "#0d1117",
-  accent: "#c9a2ff",
+  accent: "#ab7df8",
   accentContent: "#0d1117",
   neutral: "#212830",
   neutralContent: "#f0f6fc",
-  info: "#82c2ff",
+  info: "#4493f8",
   infoContent: "#0d1117",
-  success: "#57cb70",
+  success: "#3fb950",
   successContent: "#0d1117",
-  warning: "#d3a637",
+  warning: "#d29922",
   warningContent: "#0d1117",
-  error: "#ffa198",
+  error: "#f85149",
   errorContent: "#0d1117",
   // Per-theme link color and muted-tier opacity floors (index.css overrides).
-  link: "#82c2ff",
-  muted: { 30: 68, 40: 68, 50: 68, 60: 74, 70: 80, 80: 86, 90: 92 } as Record<
+  link: "#4493f8",
+  muted: { 30: 52, 40: 52, 50: 58, 60: 66, 70: 74, 80: 84, 90: 92 } as Record<
     number,
     number
   >,
-  badgeNudge: 60,
-  sidebarMuted: 85,
+  badgeNudge: 88,
+  sidebarMuted: 72,
 } as const
 
-// The dark sidebar surface is a translucent sheet over base-100, NOT #39424e.
+// The dark sidebar surface is a translucent sheet over base-100, NOT the light
+// theme's opaque panel.
 // --sidebar-surface: color-mix(in oklch, neutral-content 10%, transparent)
 function darkSidebarSurface(): LinearRgb {
   const sheet = mixColor("oklch", DARK.neutralContent, 10, "transparent")
@@ -214,7 +222,7 @@ function buildTheme(theme: Theme): Pair[] {
     "body",
   )
 
-  // Muted tiers at their AAA-remapped opacities (index.css), audited against the
+  // Muted tiers at their AA-remapped opacities (index.css), audited against the
   // worst-case surface for the ink polarity: darkest surface (base-300) in light,
   // lightest (base-100) in dark.
   const tierWorstBg = theme === "sumi" ? opaque(T.base300) : opaque(T.base100)
@@ -236,11 +244,7 @@ function buildTheme(theme: Theme): Pair[] {
     ["info", T.info, T.infoContent],
     ["success", T.success, T.successContent],
     ["error", T.error, T.errorContent],
-    [
-      "warning",
-      theme === "sumi" ? SUMI.warningFill : DARK.warning,
-      theme === "sumi" ? SUMI.warningContent : DARK.warningContent,
-    ],
+    ["warning", T.warning, T.warningContent],
   ]
   for (const [name, fill, content] of fills) {
     add(
@@ -258,8 +262,7 @@ function buildTheme(theme: Theme): Pair[] {
     ["secondary", T.secondary],
     ["info", T.info],
     ["success", T.success],
-    // warning soft text uses the darkened warningText (light) / warning (dark).
-    ["warning", theme === "sumi" ? SUMI.warningText : DARK.warning],
+    ["warning", T.warning],
     ["error", T.error],
   ]
   for (const [name, token] of semantics) {
@@ -294,8 +297,7 @@ function buildTheme(theme: Theme): Pair[] {
     info: T.info,
     success: T.success,
     error: T.error,
-    // warning text uses the AAA-darkened warningText (light) / warning (dark).
-    warning: theme === "sumi" ? SUMI.warningText : DARK.warning,
+    warning: T.warning,
   }
   for (const name of MODELED_TEXT_SEMANTICS) {
     add(
@@ -319,7 +321,7 @@ function buildTheme(theme: Theme): Pair[] {
   )
 
   // Sidebar (dark rail in both themes). The index.css override remaps every
-  // resting muted tier used on the rail (/50, /60, /70) to the same 85% floor,
+  // resting muted tier used on the rail (/50, /60, /70) to the same 72% floor,
   // so one pair represents them all; hover lifts to full neutral-content.
   const sidebarSurface =
     theme === "sumi" ? opaque(SUMI.sidebarSurface) : darkSidebarSurface()
@@ -340,7 +342,7 @@ function buildTheme(theme: Theme): Pair[] {
 
   // Rest-dimmed rail (index.css .sidebar-rail): on hover-capable pointers the
   // rail background darkens to SIDEBAR_REST_DIM% of `neutral` toward black
-  // until hovered or focused. Text stays at the resting 85% tier, so audit
+  // until hovered or focused. Text stays at the resting 72% tier, so audit
   // that text over the dimmed surface — the darkest ground rail text ever
   // sits on.
   add(
@@ -394,18 +396,23 @@ export type Evaluated = Pair & {
   margin: number
   passesFloor: boolean
   passesMargin: boolean
+  /** The AAA (1.4.6) floor for this pair; reported, never enforced. */
+  enhancedFloor: number
+  passesEnhanced: boolean
   /** The bg as an opaque sRGB hex (the surface behind the text). */
   bgHex: string
   /** The fg as actually displayed: flattened over the opaque bg, as sRGB hex. */
   fgHex: string
 }
 
-/** Evaluate one pair against its spec floor and design margin. */
+/** Evaluate one pair against its spec floor, design margin, and the AAA floor. */
 export function evaluate(p: Pair): Evaluated {
   const ratio = ratioOver(p.fg, p.bg)
   const floor = p.kind === "nonText" ? SPEC_FLOOR.nonText : SPEC_FLOOR[p.size]
   const margin =
     p.kind === "nonText" ? MARGIN_TARGET.nonText : MARGIN_TARGET[p.size]
+  const enhancedFloor =
+    p.kind === "nonText" ? ENHANCED_FLOOR.nonText : ENHANCED_FLOOR[p.size]
   // Resolve the displayed colors: the bg is flattened to opaque (over white if
   // itself translucent), and the fg is composited over that bg — matching what
   // ratioOver scores and what a viewer actually sees.
@@ -417,6 +424,8 @@ export function evaluate(p: Pair): Evaluated {
     margin,
     passesFloor: p.exempt || ratio >= floor,
     passesMargin: p.exempt || ratio >= margin,
+    enhancedFloor,
+    passesEnhanced: p.exempt || ratio >= enhancedFloor,
     bgHex: toHex(opaqueBg),
     fgHex: toHex(flattenOver(p.fg, opaqueBg)),
   }

--- a/web/src/util/a11y/contrastReport.test.ts
+++ b/web/src/util/a11y/contrastReport.test.ts
@@ -11,8 +11,8 @@ describe("renderContrastReport", () => {
 
   it("states the WCAG 2.2 standard and thresholds", () => {
     expect(md).toContain("WCAG 2.2")
-    expect(md).toContain("body text ≥ 7:1")
-    expect(md).toContain("large text ≥ 4.5:1")
+    expect(md).toContain("body text ≥ 4.5:1")
+    expect(md).toContain("large text ≥ 3:1")
     expect(md).toContain("non-text ≥ 3:1")
   })
 

--- a/web/src/util/a11y/contrastReport.ts
+++ b/web/src/util/a11y/contrastReport.ts
@@ -8,6 +8,7 @@
 // enforce the same facts, every rendering reflects guaranteed-green state.
 
 import {
+  ENHANCED_FLOOR,
   evaluateAll,
   MARGIN_TARGET,
   SPEC_FLOOR,
@@ -28,6 +29,8 @@ export type ContrastAuditRow = {
   status: ContrastStatus
   /** Clears the WCAG floor (a Pass) but sits below the recommended margin. */
   withinMargin: boolean
+  /** Also clears the AAA 1.4.6 floor (reported only; never enforced). */
+  meetsEnhanced: boolean
   /** Displayed foreground (fg composited over the opaque surface), sRGB hex. */
   fgHex: string
   /** Opaque surface behind the text, sRGB hex. */
@@ -47,11 +50,17 @@ export type ContrastAuditJson = {
   generated: string
   thresholds: typeof SPEC_FLOOR
   margins: typeof MARGIN_TARGET
+  /** The AAA 1.4.6 text floors the audit also scores against (never enforced). */
+  enhancedThresholds: typeof ENHANCED_FLOOR
   summary: {
     total: number
     failures: number
     marginMisses: number
     allPass: boolean
+    /** Pairs that clear their AA floor but not the AAA 1.4.6 one. */
+    enhancedMisses: number
+    /** True when every enforced pair also clears AAA — what 1.4.6 derives from. */
+    allPassEnhanced: boolean
   }
   themes: ContrastAuditTheme[]
 }
@@ -76,6 +85,9 @@ export function buildContrastAudit(now = new Date()): ContrastAuditJson {
   const marginMisses = rows.filter(
     (r) => !r.exempt && r.passesFloor && !r.passesMargin,
   ).length
+  const enhancedMisses = rows.filter(
+    (r) => !r.exempt && r.passesFloor && !r.passesEnhanced,
+  ).length
 
   const themes: ContrastAuditTheme[] = (["sumi", "sumi-dark"] as const).map(
     (theme) => ({
@@ -93,6 +105,7 @@ export function buildContrastAudit(now = new Date()): ContrastAuditJson {
           margin: r.margin,
           status: statusOf(r.exempt, r.passesFloor),
           withinMargin: !r.exempt && r.passesFloor && !r.passesMargin,
+          meetsEnhanced: r.passesEnhanced,
           fgHex: r.fgHex,
           bgHex: r.bgHex,
         })),
@@ -105,11 +118,14 @@ export function buildContrastAudit(now = new Date()): ContrastAuditJson {
     generated: now.toISOString().slice(0, 10),
     thresholds: SPEC_FLOOR,
     margins: MARGIN_TARGET,
+    enhancedThresholds: ENHANCED_FLOOR,
     summary: {
       total: rows.length,
       failures,
       marginMisses,
       allPass: failures === 0,
+      enhancedMisses,
+      allPassEnhanced: failures === 0 && enhancedMisses === 0,
     },
     themes,
   }
@@ -133,7 +149,7 @@ function statusCell(row: ContrastAuditRow): string {
 /** Render the Markdown report — derived from the same structured audit. */
 export function renderContrastReport(now = new Date()): string {
   const audit = buildContrastAudit(now)
-  const { thresholds: t, margins: m, summary } = audit
+  const { thresholds: t, margins: m, enhancedThresholds: e, summary } = audit
 
   const out: string[] = []
   out.push("# WCAG 2.2 Contrast Audit — Classroom50 web app")
@@ -147,14 +163,20 @@ export function renderContrastReport(now = new Date()): string {
   out.push("")
   out.push(`- **Generated:** ${audit.generated}`)
   out.push(
-    "- **Standard:** WCAG 2.2 — 1.4.6 Contrast (Enhanced, AAA) for text, " +
-      "1.4.11 Non-text Contrast (AA; no AAA tier exists) for UI components.",
+    "- **Standard:** WCAG 2.2 — 1.4.3 Contrast (Minimum, AA) for text, " +
+      "1.4.11 Non-text Contrast (AA) for UI components. The palette is GitHub " +
+      "Primer verbatim, and Primer's primitives are tuned to AA, so AA is the " +
+      "enforced target; 1.4.6 (Enhanced, AAA) is scored below but not required.",
   )
   out.push(
     `- **Thresholds:** body text ≥ ${t.body}:1, large text ≥ ${t.large}:1, non-text ≥ ${t.nonText}:1.`,
   )
   out.push(
     `- **Recommended safety margin (above the WCAG minimum):** body ≥ ${m.body}:1, large ≥ ${m.large}:1, non-text ≥ ${m.nonText}:1. Extra headroom for anti-aliasing, sub-pixel rendering, and future palette tweaks; not required for conformance.`,
+  )
+  out.push(
+    `- **Enhanced (1.4.6 AAA, reported only):** body ≥ ${e.body}:1, large ≥ ${e.large}:1.` +
+      ` ${summary.enhancedMisses === 0 ? "**Every audited pair also clears AAA.**" : `${summary.enhancedMisses} pair(s) meet AA but not AAA.`}`,
   )
   out.push(
     `- **Result:** ${summary.allPass ? "**All audited pairs meet their WCAG floor.**" : `**${summary.failures} pair(s) below the WCAG floor.**`}` +
@@ -174,13 +196,15 @@ export function renderContrastReport(now = new Date()): string {
     out.push(`## ${theme.label}`)
     out.push("")
     out.push(
-      "| Pair | Foreground / surface | Colors | Size | Ratio | Floor | Status |",
+      "| Pair | Foreground / surface | Colors | Size | Ratio | Floor | Status | AAA |",
     )
-    out.push("| --- | --- | --- | --- | ---: | ---: | --- |")
+    out.push("| --- | --- | --- | --- | ---: | ---: | --- | --- |")
     for (const r of theme.rows) {
       const colors = `text \`${r.fgHex}\` on \`${r.bgHex}\``
+      const enhanced =
+        r.status === "exempt" ? "—" : r.meetsEnhanced ? "✅" : "—"
       out.push(
-        `| \`${r.id}\` | ${r.label} | ${colors} | ${r.size} | ${r.ratio.toFixed(2)}:1 | ${r.floor}:1 | ${statusCell(r)} |`,
+        `| \`${r.id}\` | ${r.label} | ${colors} | ${r.size} | ${r.ratio.toFixed(2)}:1 | ${r.floor}:1 | ${statusCell(r)} | ${enhanced} |`,
       )
     }
     out.push("")
@@ -194,6 +218,10 @@ export function renderContrastReport(now = new Date()): string {
       "(see the safety-margin bullet above) — still a pass, just less headroom.",
   )
   out.push("- ❌ FAIL — below the WCAG floor.")
+  out.push(
+    "- AAA — the pair also clears the stricter 1.4.6 Enhanced floor. Informational: " +
+      "the palette targets AA, so a blank cell here is not a finding.",
+  )
   out.push(
     "- — exempt — outside WCAG scope (logotypes, disabled/inactive controls, " +
       "structural dividers that are not the sole means of identifying a component).",

--- a/web/src/util/a11y/contrastSource.test.ts
+++ b/web/src/util/a11y/contrastSource.test.ts
@@ -26,7 +26,7 @@ const repoWeb = path.resolve(here, "..", "..", "..")
 const cssText = readFileSync(path.join(repoWeb, "src/index.css"), "utf8")
 
 // Read a CSS custom property for a theme. A token can appear twice (daisyUI
-// `@plugin "daisyui/theme"` base value + a `[data-theme=...]` AAA override), so
+// `@plugin "daisyui/theme"` base value + a `[data-theme=...]` AA override), so
 // return the LAST match — the effective, override-wins value.
 function cssVar(theme: "sumi" | "sumi-dark", token: string): string | null {
   // Match either `name: "<theme>"` plugin blocks or `[data-theme="<theme>"]`
@@ -68,8 +68,7 @@ describe("model tokens stay in sync with index.css (drift guard)", () => {
     ["sumi", "color-info", SUMI.info],
     ["sumi", "color-success", SUMI.success],
     ["sumi", "color-error", SUMI.error],
-    ["sumi", "color-warning", SUMI.warningText],
-    ["sumi", "color-warning-fill", SUMI.warningFill],
+    ["sumi", "color-warning", SUMI.warning],
     ["sumi", "color-link", SUMI.link],
     ["sumi", "sidebar-surface", SUMI.sidebarSurface],
     ["sumi-dark", "color-base-100", DARK.base100],

--- a/web/src/util/a11y/vpatGuard.test.ts
+++ b/web/src/util/a11y/vpatGuard.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { buildContrastAudit } from "./contrastReport"
-import { CONTRAST_CRITERION_IDS } from "./vpatModel"
+import { CONTRAST_CRITERION_IDS, ENHANCED_CRITERION_ID } from "./vpatModel"
 import { buildVpatReport } from "./vpatReport"
 
 // The VPAT integrity guard. Runs in `npm run check`.
@@ -35,16 +35,18 @@ describe("VPAT integrity guard", () => {
   )
 
   it("derives the contrast criteria from the live contrast audit (not hand-set)", () => {
-    const allPass = buildContrastAudit().summary.allPass
-    const expected = allPass ? "supports" : "partially"
+    const summary = buildContrastAudit().summary
     for (const id of CONTRAST_CRITERION_IDS) {
+      // 1.4.6 is the AAA tier: same audit, stricter floors, own verdict.
+      const allPass =
+        id === ENHANCED_CRITERION_ID ? summary.allPassEnhanced : summary.allPass
       const c = report.criteria.find((x) => x.id === id)
       expect(c, `contrast criterion ${id} present`).toBeDefined()
       expect(c?.evidence).toBe("contrast")
       expect(
         c?.status,
         `${id} must reflect the contrast audit (allPass=${allPass})`,
-      ).toBe(expected)
+      ).toBe(allPass ? "supports" : "partially")
     }
   })
 

--- a/web/src/util/a11y/vpatModel.ts
+++ b/web/src/util/a11y/vpatModel.ts
@@ -91,16 +91,21 @@ export function hasGenericRemark(c: Pick<Criterion, "status" | "evidence">) {
 // reader sees they are intentionally derived, not hand-set.
 export const CONTRAST_CRITERION_IDS = ["1.4.3", "1.4.6", "1.4.11"] as const
 
+// Of those, the AAA tier. vpatReport.ts derives it from the audit's stricter
+// (7:1 / 4.5:1) tally rather than the AA one, so the two rows can differ.
+export const ENHANCED_CRITERION_ID = "1.4.6" as const
+
 const NOT_EVALUATED_REMARK =
   "Not yet formally assessed. Automated checks establish a floor; a manual " +
   "keyboard and screen-reader pass on the primary flows will set the final " +
   "conformance level."
 
-// The applicable WCAG 2.2 Level A/AA criteria for the app (plus the three
-// AAA contrast criteria already achieved). Grouped by principle. Contrast rows
-// carry a placeholder status/evidence that vpatReport.ts replaces from the live
-// audit; client-side-only rows are notApplicable with an architectural remark;
-// the rest start notEvaluated until the manual assessment sets them.
+// The applicable WCAG 2.2 Level A/AA criteria for the app, plus 1.4.6 (AAA
+// contrast) reported for transparency beyond the AA target. Grouped by
+// principle. Contrast rows carry a placeholder status/evidence that
+// vpatReport.ts replaces from the live audit; client-side-only rows are
+// notApplicable with an architectural remark; the rest start notEvaluated until
+// the manual assessment sets them.
 const BASE_CRITERIA: Criterion[] = [
   // ── Perceivable ────────────────────────────────────────────────────────────
   {
@@ -150,7 +155,9 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Contrast (Enhanced)",
     level: "AAA",
     principle: "Perceivable",
-    status: "supports",
+    // Placeholder — resolved from the audit's AAA tally in vpatReport.ts. Beyond
+    // the AA target: reported so the gap to AAA is visible, not claimed.
+    status: "partially",
     evidence: "contrast",
     remark: "Resolved from the automated contrast audit.",
   },

--- a/web/src/util/a11y/vpatReport.test.ts
+++ b/web/src/util/a11y/vpatReport.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { CONTRAST_CRITERION_IDS } from "./vpatModel"
+import { CONTRAST_CRITERION_IDS, ENHANCED_CRITERION_ID } from "./vpatModel"
 import {
   buildVpatReport,
   renderCombinedReport,
@@ -35,7 +35,12 @@ describe("buildVpatReport (JSON source of truth)", () => {
   })
 
   it("derives the contrast criteria from the audit — passing → Supports", () => {
-    const passing = buildVpatReport(FIXED, { allPass: true, failures: 0 })
+    const passing = buildVpatReport(FIXED, {
+      allPass: true,
+      failures: 0,
+      allPassEnhanced: true,
+      enhancedMisses: 0,
+    })
     for (const id of CONTRAST_CRITERION_IDS) {
       const c = passing.criteria.find((x) => x.id === id)
       expect(c?.status, `${id} on passing audit`).toBe("supports")
@@ -43,18 +48,47 @@ describe("buildVpatReport (JSON source of truth)", () => {
     }
   })
 
+  it("derives 1.4.6 from the AAA tally, independently of the AA verdict", () => {
+    // The shipped case: AA clean, AAA short — the AA rows Support while the
+    // Enhanced row Partially Supports and names the AAA-miss count.
+    const aaOnly = buildVpatReport(FIXED, {
+      allPass: true,
+      failures: 0,
+      allPassEnhanced: false,
+      enhancedMisses: 3,
+    })
+    const enhanced = aaOnly.criteria.find((x) => x.id === ENHANCED_CRITERION_ID)
+    expect(enhanced?.status).toBe("partially")
+    expect(enhanced?.remark).toContain("3 audited pairs")
+    for (const id of CONTRAST_CRITERION_IDS) {
+      if (id === ENHANCED_CRITERION_ID) continue
+      expect(aaOnly.criteria.find((x) => x.id === id)?.status).toBe("supports")
+    }
+  })
+
   it("flips the contrast criteria when the audit fails (proves KTD4 wiring)", () => {
-    const failing = buildVpatReport(FIXED, { allPass: false, failures: 2 })
+    const failing = buildVpatReport(FIXED, {
+      allPass: false,
+      failures: 2,
+      allPassEnhanced: false,
+      enhancedMisses: 2,
+    })
     for (const id of CONTRAST_CRITERION_IDS) {
       const c = failing.criteria.find((x) => x.id === id)
       expect(c?.status, `${id} on failing audit`).toBe("partially")
+      if (id === ENHANCED_CRITERION_ID) continue
       expect(c?.remark, `${id} names the failing count`).toContain("2 pairs")
     }
     // A non-contrast criterion is unaffected by the audit result: its status is
     // identical whether the contrast audit passes or fails (only the contrast
     // rows are audit-derived). Asserted as an invariant so it survives the
     // manual assessment filling in non-contrast verdicts over time.
-    const passing = buildVpatReport(FIXED, { allPass: true, failures: 0 })
+    const passing = buildVpatReport(FIXED, {
+      allPass: true,
+      failures: 0,
+      allPassEnhanced: true,
+      enhancedMisses: 0,
+    })
     const nonContrastId = "2.4.6" // not a contrast criterion; audit-independent
     expect(CONTRAST_CRITERION_IDS).not.toContain(nonContrastId)
     const failingStatus = failing.criteria.find(

--- a/web/src/util/a11y/vpatReport.ts
+++ b/web/src/util/a11y/vpatReport.ts
@@ -14,6 +14,7 @@ import {
   CONFORMANCE_LABEL,
   CONTRAST_CRITERION_IDS,
   CRITERIA,
+  ENHANCED_CRITERION_ID,
   PRINCIPLE_ORDER,
   type ConformanceLevel,
   type Criterion,
@@ -56,7 +57,7 @@ function contrastStatus(
       status: "supports",
       remark:
         "Verified by the automated contrast audit: every audited text and " +
-        "UI-component pair meets its WCAG floor (text at the AAA 7:1 / 4.5:1 " +
+        "UI-component pair meets its WCAG floor (text at the AA 4.5:1 / 3:1 " +
         "level). See the live report at /accessibility. Guarded in CI.",
     }
   }
@@ -69,27 +70,70 @@ function contrastStatus(
   }
 }
 
+/**
+ * Derive 1.4.6 (Enhanced, AAA) from the same audit's AAA tally. The palette is
+ * GitHub Primer verbatim and Primer's primitives are tuned to AA, so this row is
+ * expected to be Partially Supports — but it stays DERIVED rather than hand-set,
+ * so the claim always matches the measured palette.
+ */
+function enhancedStatus(
+  allPassEnhanced: boolean,
+  enhancedMisses: number,
+): {
+  status: ConformanceLevel
+  remark: string
+} {
+  if (allPassEnhanced) {
+    return {
+      status: "supports",
+      remark:
+        "Verified by the automated contrast audit: every audited pair also " +
+        "clears the Enhanced 7:1 / 4.5:1 floors. See /accessibility.",
+    }
+  }
+  const pairs = enhancedMisses === 1 ? "pair" : "pairs"
+  return {
+    status: "partially",
+    remark:
+      "The palette follows GitHub's Primer primitives, which target Level AA; " +
+      `${enhancedMisses} audited ${pairs} therefore meet 1.4.3 (AA) but not the ` +
+      "Enhanced 7:1 / 4.5:1 floors. The per-pair AAA column at /accessibility " +
+      "shows which. AA is the product's stated conformance target.",
+  }
+}
+
 /** The canonical structured VPAT. Deterministic for a given model + date. */
 export function buildVpatReport(
   now = new Date(),
-  contrast: { allPass: boolean; failures: number } = (() => {
+  contrast: {
+    allPass: boolean
+    failures: number
+    allPassEnhanced: boolean
+    enhancedMisses: number
+  } = (() => {
     const s = buildContrastAudit(now).summary
-    return { allPass: s.allPass, failures: s.failures }
+    return {
+      allPass: s.allPass,
+      failures: s.failures,
+      allPassEnhanced: s.allPassEnhanced,
+      enhancedMisses: s.enhancedMisses,
+    }
   })(),
 ): VpatReportJson {
   const derived = contrastStatus(contrast.allPass, contrast.failures)
+  // 1.4.6 is the AAA tier: same audit, stricter floors, so it gets its own
+  // derivation rather than inheriting the AA verdict.
+  const derivedEnhanced = enhancedStatus(
+    contrast.allPassEnhanced,
+    contrast.enhancedMisses,
+  )
   const contrastIds = new Set<string>(CONTRAST_CRITERION_IDS)
 
-  const criteria: Criterion[] = CRITERIA.map((c) =>
-    contrastIds.has(c.id)
-      ? {
-          ...c,
-          status: derived.status,
-          evidence: "contrast",
-          remark: derived.remark,
-        }
-      : { ...c },
-  )
+  const criteria: Criterion[] = CRITERIA.map((c) => {
+    if (!contrastIds.has(c.id)) return { ...c }
+    const d = c.id === ENHANCED_CRITERION_ID ? derivedEnhanced : derived
+    return { ...c, status: d.status, evidence: "contrast", remark: d.remark }
+  })
 
   const byStatus = criteria.reduce(
     (acc, c) => {


### PR DESCRIPTION
## Summary

Replaces the hand-derived "sumi" palette with GitHub's [Primer primitives](https://primer.style/product/primitives/color/) verbatim, in both themes. Every token now carries a comment naming the Primer primitive it mirrors, so a future Primer upgrade is a value-for-value swap rather than a re-derivation.

Primer splits each role into a fill (`bgColor-*-emphasis`) and a deeper text value (`fgColor-*`), but a daisyUI role token is a single value serving both `btn-primary` and `text-primary`. Each token therefore takes the `fgColor` value — it is the text-legible one of the pair, and a solid fill built from it still clears the large-text floor with a white label. The emphasis fills measure 4.24:1 as body text, which would fail even AA.

| Role | Before | After | Primer token |
| --- | --- | --- | --- |
| primary / success | `#065c25` | `#1a7f37` | `fgColor-success` |
| info | `#0d43ab` | `#0969da` | `fgColor-accent` |
| accent | `#5c1fb8` | `#8250df` | `fgColor-done` |
| error | `#9a1b25` | `#d1242f` | `fgColor-danger` |
| warning | `#6f4300` | `#9a6700` | `fgColor-attention` |
| secondary | `#424a53` | `#59636e` | `fgColor-neutral` |
| link | `#0d43ab` | `#0969da` | `fgColor-link` |

Dark mode moves to Primer's dark set (`#3fb950`, `#4493f8`, `#ab7df8`, `#f85149`, `#d29922`), plus `borderColor-default` `#3d444d` and `bgColor-inverse` `#25292e` for the sidebar rail.

## The AAA → AA trade

Primer's primitives are tuned to Level AA, so adopting them verbatim is incompatible with the previously enforced AAA (7:1) body-text floor. The enforced floor is now 1.4.3 AA (4.5:1 body / 3:1 large); 1.4.11 non-text is unchanged at 3:1.

Rather than drop the AAA information, `ENHANCED_FLOOR` still scores every pair at 7:1 / 4.5:1 and the result is reported per pair. The VPAT's 1.4.6 row now derives from *that* tally instead of inheriting the AA verdict, so the two rows can differ and the claim can never drift from the measured palette:

- 1.4.3 (AA) → **Supports** — 74 pairs, 0 failures
- 1.4.6 (AAA) → **Partially Supports** — names the 30 pairs that meet AA but not AAA
- 1.4.11 (AA) → **Supports**

Two consequences worth review attention:

- **The public `/accessibility` page now advertises AA, not AAA.** The audit gains an "Enhanced (AAA)" explainer and a per-pair AAA column, so the gap is disclosed rather than hidden. If an AAA claim has been published anywhere outside this repo, it needs the same correction.
- **The muted tiers are visibly better.** The old AAA floor had squashed `text-base-content/30`…`/90` into an 84–93% band — almost no perceptible hierarchy. They now span 68–93% in light mode, so the muted/primary text distinction reads as designed.

## Test plan

- [x] `npm run check` — exit 0; `tsc -b`, `eslint`, `prettier`, `arch:validate` (no dependency violations), and 4390 tests across 349 files all pass
- [x] Contrast regression guard green at the AA floor in both themes; the drift guard confirms every model token still matches `index.css`
- [x] Coverage guards green — every muted tier and semantic `text-*` utility used in `src/**` is audited
- [x] `audit_i18n.py --strict` → PASS (0 missing, 0 dead keys)
- [x] Browser-based test files (5 files / 18 tests) run and pass — these silently error out without a local Playwright browser
- [ ] Visual pass over light and dark mode in a browser, especially solid `btn-warning`/`btn-primary` fills and soft badges