### PR TITLE
docs(wiki): update guides for the v1.33.0 release

### DIFF
--- a/wiki/Assignment-Templates.md
+++ b/wiki/Assignment-Templates.md
@@ -36,7 +36,11 @@ Two rules apply across all of them:
 - **A template brings only its default branch** unless the assignment turns
   on **Include all branches** (`include_all_branches: true`), which copies
   every branch into each generated repository. Template-only; it has no
-  effect on the other shapes.
+  effect on the other shapes. A specific source branch can't be chosen:
+  GitHub's create-from-template API has no branch parameter, so a `@branch`
+  suffix on the CLI's `--template` is ignored with a warning. To start
+  students from a different branch, change the template repository's default
+  branch.
 
 For the flag-level details (mutual exclusions and `assignments.json` fields),
 see [`gh teacher assignment add`](gh-teacher#assignment-add).

--- a/wiki/Autograder-Recipes.md
+++ b/wiki/Autograder-Recipes.md
@@ -176,8 +176,8 @@ adopt the built-in autograder:
 
 - **Grade entirely outside Classroom 50.** Create the assignment with **Do
   not use the built-in autograder**; each accept then installs no grading
-  workflow, your template's own CI runs instead, and score collection skips
-  the assignment. See
+  workflow and your template's own CI runs instead. Score collection records
+  who submitted, but no scores. See
   [Turning autograding off or pausing it](Managing-Actions-Cost#turning-autograding-off-or-pausing-it).
 - **Keep a GitHub Classroom `autograding.json`.** A custom runner workflow
   lets your existing grading action keep reading `autograding.json` from

--- a/wiki/Autograding-Basics.md
+++ b/wiki/Autograding-Basics.md
@@ -67,7 +67,7 @@ Two related, optional settings:
   score, and leaving it unset turns the passing concept off.
 - **Built-in autograder off** (`no_autograder`) — accept installs no
   autograding workflow at all; a templated assignment's own CI runs instead,
-  and score collection skips the assignment. See
+  and score collection records who submitted but no scores. See
   [Turning autograding off or pausing it](Managing-Actions-Cost#turning-autograding-off-or-pausing-it).
 
 ### Declarative tests

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -231,10 +231,12 @@ gh teacher classroom add <org> <short-name> --name "<full name>" --term <term>
 gh teacher classroom add cs50-fall-2026 cs-principles --name "CS Principles" --term Fall-2026
 ```
 
-The `<short-name>` must match `^[a-z0-9][a-z0-9-]{1,99}$` (2–100 characters,
-lowercase letters/digits/hyphens, starting with a letter or digit), because it
-becomes part of student repo names like `<short-name>-<assignment>-<username>`.
-`--name` and `--term` are optional but recommended.
+The `<short-name>` must match `^[a-z0-9][a-z0-9-]{1,99}$` (lowercase
+letters/digits/hyphens, starting with a letter or digit) and, for a new
+classroom, is capped at 40 characters. It becomes part of student repository
+names like `<short-name>-<assignment>-<username>`, which GitHub limits to 100
+characters, so the cap leaves room for the assignment slug and any
+username. `--name` and `--term` are optional but recommended.
 
 This commits the four files and creates a **GitHub team** named
 `classroom50-<short-name>` that grants rostered students read access to in-org
@@ -536,13 +538,18 @@ gh teacher assignment add cs50-fall-2026 cs-principles reflection --name "Reflec
 
 **`--name` is required; `--template` is optional.** Omit `--template` for a
 template-less assignment (students get an initialized repository with a README
-and the autograding setup). The slug must match `^[a-z0-9][a-z0-9-]{1,99}$`.
+and the autograding setup). The slug must match `^[a-z0-9][a-z0-9-]{1,99}$`
+and fit the classroom's slug budget: the classroom short-name and the slug
+together can spend at most 59 characters, so
+`<classroom>-<slug>-<username>` stays within GitHub's 100-character
+repository-name limit for any username. The CLI names the exact budget when a
+slug is too long.
 
 **Optional flags:**
 
 | Flag | Purpose |
 | --- | --- |
-| `--template <owner>/<repo>[@branch]` | Starter-code repository (must be flagged as a template). Branch defaults to the template's default. |
+| `--template <owner>/<repo>[@branch]` | Starter-code repository (must be flagged as a template). A `@branch` suffix is ignored with a warning: the assignment always copies the template's default branch. |
 | `--description <text>` | Short description. |
 | `--due <ISO-8601>` | Due date, such as `2026-09-15T23:59:00-04:00`. Stored as UTC; local timezone assumed if you omit the offset. A bare date with no time is rejected. |
 | `--mode individual\|group` | `individual` (default) or `group`. Group requires `--max-group-size`. |
@@ -573,6 +580,23 @@ doesn't trigger grading. Hand-edited workflows are reported and left
 untouched. Tell students to `git pull` afterward. See
 [`assignment submission-mode`](gh-teacher#assignment-submission-mode) for
 `--user`, `--dry-run`, and the custom-autograder rules.
+
+**Rename an over-budget assignment slug:**
+
+```sh
+gh teacher assignment rename <org> <classroom> <old-slug> <new-slug>
+```
+
+Offered only when the current slug can push student repository names past
+GitHub's 100-character limit (for example, a slug imported from GitHub
+Classroom before the budget existed). One command renames the assignment and
+every student repository to match; GitHub redirects the old names, so
+existing clones keep working, and collected scores follow the new slug. A
+rename is one-shot — the old slug stays permanently reserved — and the
+assignment stays locked until every repository is renamed (re-run the same
+command to heal failures). Students run `git pull` once before their next
+`gh student submit`. See
+[`assignment rename`](gh-teacher#assignment-rename) for the full flow.
 
 **Remove an assignment:**
 
@@ -633,7 +657,11 @@ lighter on API rate limits for a large classroom — and is exactly what the web
 app's per-assignment **Sync now** button dispatches. Each collected
 assignment's bucket in `scores.json` gets a `collected_at` UTC timestamp, so
 you (and the web app's freshness strip) can tell when each assignment was last
-walked; a scoped run leaves sibling assignments' buckets untouched.
+walked; a scoped run leaves sibling assignments' buckets untouched. The
+staff-team access grant that rides along with collection is scoped the same
+way: an `assignment=` run grants the staff teams read on only that
+assignment's repositories and template, and staff teams with no members are
+skipped.
 
 Run collection from the Actions tab on `<org>/classroom50`, from your shell, or
 with the web app's per-assignment **Sync now** button. Scores refresh when you

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -174,6 +174,9 @@ gh workflow run collect-scores.yaml --repo <org>/classroom50 -f classroom=<short
 A scoped run walks only the matching assignment's repos (faster and cheaper on
 API rate limits for a large classroom) and stamps that assignment's
 `collected_at` in `scores.json`; sibling assignments' buckets are untouched.
+The staff-team read grant that rides along with collection is scoped the same
+way, so a per-assignment run touches only that assignment's repositories and
+template.
 
 ### 7. Verify the service token
 

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -23,6 +23,13 @@ section).
 A piece of coursework in a classroom. May be individual or
 group, may include starter code, and may have a due date and autograding.
 
+#### Slug
+
+The short lowercase identifier of a classroom or an assignment, used in URLs
+and repository names. The web app derives it from the name (letters with
+diacritics transliterate to their base letters); the CLI calls a classroom's
+slug its **short-name**.
+
 #### Individual assignment
 
 Each student gets their own repository.
@@ -210,6 +217,13 @@ Assignment repositories are named:
 
 For a group assignment, `<username>` is the founder who created the shared
 repository.
+
+GitHub caps a repository name at 100 characters, so the classroom and
+assignment slugs share a budget that leaves room for any username. An
+assignment slug that predates the budget can be renamed once to fit; the old
+slug is recorded as `renamed_from` and stays permanently reserved, so
+GitHub's redirects from the old repository names keep working. See
+[`assignment rename`](gh-teacher#assignment-rename).
 
 ## Coming from GitHub Classroom?
 

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -365,6 +365,16 @@ For a group assignment, `<username>` is the founder who created the shared repo.
 These are normal GitHub repositories — scripts that automate git operations
 against them generally work the same as they did with GitHub Classroom.
 
+GitHub caps a repository name at 100 characters, and a username can be up to
+39, so the classroom slug and the assignment slug together can spend at most
+59 characters. Classroom 50 enforces this budget wherever a slug is minted:
+new classrooms are capped at 40 characters, new assignment slugs must fit the
+classroom's remaining budget, and imported slugs that don't fit are shortened
+automatically. An older assignment that predates the budget can be fixed once
+with a slug rename — see
+[Updating an over-budget assignment slug](Web-Teacher-Guide#updating-an-over-budget-assignment-slug)
+or [`assignment rename`](gh-teacher#assignment-rename).
+
 > [!NOTE]
 > **Adding a template after the fact is a gotcha.** Classroom 50 grants the
 > classroom team read access to a private in-org template when you *create* the

--- a/wiki/Known-Limitations.md
+++ b/wiki/Known-Limitations.md
@@ -73,7 +73,11 @@ exception, re-fetched on every submit. See
 **Renaming a repository breaks tracking.** Classroom 50 finds student work
 by the repository name (`<classroom>-<assignment>-<username>`). A renamed
 repository disappears from the submissions view. Tell students not to rename
-their repositories; if one already did, rename it back.
+their repositories; if one already did, rename it back. The one supported
+rename is the slug update for an assignment whose repository names can exceed
+GitHub's 100-character limit — it renames every student repository
+consistently, and only once per assignment. See
+[Updating an over-budget assignment slug](Web-Teacher-Guide#updating-an-over-budget-assignment-slug).
 
 **Students can re-enable paused workflows.** Students have write access to
 their repositories, which includes the Actions tab, so **Pause autograding**

--- a/wiki/Managing-Actions-Cost.md
+++ b/wiki/Managing-Actions-Cost.md
@@ -49,7 +49,8 @@ you can turn the pipeline off entirely:
 - **Per assignment, at creation** — pick **Do not use the built-in
   autograder** (`no_autograder` in assignments.json). Accept installs no
   autograding workflow at all; a templated assignment's own CI workflows run
-  instead, and score collection skips the assignment. Changeable later, but
+  instead, and score collection records who submitted but no scores.
+  Changeable later, but
   only affects repositories accepted from then on (existing ones keep their
   setup). See [`gh teacher` reference](gh-teacher#assignment-add).
 - **Per assignment, temporarily** — **Pause autograding** in the submissions

--- a/wiki/Migrating-from-GitHub-Classroom.md
+++ b/wiki/Migrating-from-GitHub-Classroom.md
@@ -20,7 +20,10 @@ or [CLI Teacher Guide](CLI-Teacher-Guide#3-set-up-the-organization)).
 `https://classroom50.org/YOUR-ORGANIZATION` and click
 **Import from GitHub Classroom**. Pick the classroom from the list of GitHub
 Classrooms your account administers, review the import summary, and confirm;
-nothing is created until you do.
+nothing is created until you do. Every assignment stays selectable: an item
+the preflight check would skip shows the reason inline with a link to fix it,
+and **Re-check** re-runs the checks once you have. Each import item's
+**Import as** field sets the slug the assignment imports under.
 
 **CLI:**
 
@@ -31,6 +34,21 @@ gh teacher classroom migrate --source cs50-legacy --target cs50-fall-2026
 `--dry-run` previews without changes. See
 [`gh teacher classroom migrate`](gh-teacher#classroom-migrate) for source
 resolution, naming flags, and the failure model.
+
+### Long names are shortened automatically
+
+GitHub Classroom allows longer assignment names than GitHub's repository-name
+limit leaves room for: student repositories are named
+`<classroom>-<assignment>-<username>`, and GitHub caps repository names at
+100 characters. A source slug that doesn't fit the new classroom's budget is
+shortened automatically (suffixed `-2`, `-3`, … past collisions in the same
+batch) instead of being skipped, and each mapping is called out before you
+confirm. To pick the slug yourself, edit the item's **Import as** field in
+the web app, or pass `--rename SOURCE-SLUG=NEW-SLUG` to the CLI (repeatable),
+replacing `SOURCE-SLUG` with the assignment's slug in GitHub Classroom and
+`NEW-SLUG` with the slug to import under. The classroom's own name is
+shortened to 40 characters when derived automatically; a longer explicit
+short-name is rejected before anything is created.
 
 ## What carries over, and what doesn't
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -554,6 +554,7 @@ which misreported freshly pushed repositories.
 | "autograder `<name>` not published yet" / "is malformed YAML" | The autograder's YAML is missing or broken; see [below](#autograder-name-not-published-yet-on-gh-student-accept). |
 | "template `<owner>/<repo>` is not accessible to you" | The template is private and not shared with you; see ["Template not found"](#template-not-found--404-on-gh-student-accept). |
 | "assignment `<X>` has unsupported mode `<mode>`" | The manifest's `mode` is neither `individual` nor `group` (likely hand-edited). Ask your teacher. |
+| "the repository name … is over GitHub's 100-character limit" | The classroom and assignment slugs are too long for your username; see [below](#the-repository-name-is-over-githubs-100-character-limit). |
 | "Assignment already accepted" | Not an error — your repository already exists and your work is untouched. |
 
 ### "Assignment already accepted" on `gh student accept`
@@ -562,6 +563,22 @@ You've already accepted; the repo is at
 `<org>/<classroom>-<assignment>-<username>`. The CLI short-circuits to protect
 your work. Clone it with the URL from `gh repo view <org>/<repo>` if you don't
 have it locally.
+
+### The repository name is over GitHub's 100-character limit
+
+Both `gh student accept` and the web accept page can fail with "the repository
+name `<name>` is … characters, over GitHub's 100-character limit, so it
+couldn't be created."
+
+Student repositories are named `<classroom>-<assignment>-<username>`, and
+GitHub caps repository names at 100 characters. New classrooms and assignments
+can't exceed it, but an assignment created before the limit was enforced (for
+example, one imported from GitHub Classroom with a long name) can, and then
+students with long usernames can't accept. The student can't fix this; the
+teacher renames the assignment slug once — see
+[Updating an over-budget assignment slug](Web-Teacher-Guide#updating-an-over-budget-assignment-slug)
+or [`assignment rename`](gh-teacher#assignment-rename) — and the student
+accepts again.
 
 ### The accept page loads forever, or reports "not published yet"
 
@@ -729,7 +746,19 @@ out-of-scope repos, indistinguishable from "no release yet".)
   Members: Read**.
 - Re-scope and rotate with `gh teacher rotate-service-token <org>`.
 - A `401`/`403` (rather than the `0 submissions` warning) means a bad/expired
-  token or a missing `Members: Read` scope.
+  token or a missing `Members: Read` scope — unless the log names a throttle
+  (see below).
+
+A 403 that is actually GitHub's rate limiter is reported as one, not as a
+token problem, so don't rotate the token for it:
+
+- A throttled staff-team access grant doesn't fail the run. The log says
+  "GitHub is throttling, not refusing" and counts the targets "deferred to
+  the next run"; the next collection picks them up.
+- A throttled collection is fatal (incomplete collected scores must not
+  report success) and the log says "collection was throttled by GitHub
+  (HTTP `<code>`, `<reason>`)". Wait for the window to reset and run
+  collection again.
 
 Also check the assignment itself: with autograding paused or a tag-mode
 assignment no one has submitted to, there are no results to collect.
@@ -743,7 +772,8 @@ failed outright. Open the failing run under the **Actions** tab of
 `<org>/classroom50` (the `collect-scores.yaml` workflow); the log names the
 cause. The most common one is an expired or under-scoped service token; see
 [`collect-scores` warns "collected 0 submissions"](#collect-scores-warns-collected-0-submissions)
-for the token requirements and how to rotate it.
+for the token requirements, how to rotate it, and how to tell a GitHub
+throttle apart (wait and rerun instead of rotating).
 
 ### `gh teacher download` clones nothing
 

--- a/wiki/Web-Student-Guide.md
+++ b/wiki/Web-Student-Guide.md
@@ -101,7 +101,9 @@ Then click **Manage collaborators**:
 
 ## View your submissions
 
-Open the assignment and click **My submission** in the left menu:
+Open the assignment and click **My submission** in the left menu. A callout at
+the top shows whether you've submitted and when; if you haven't, **Show me how
+to submit** walks you through your first submission.
 
 ![Assignment submission](images/web_assignment_submission_student.png)
 

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -107,7 +107,10 @@ On **My classrooms**, click **Create classroom**:
 ![Create classroom form](images/web_create_classroom.png)
 
 - **Name** — the classroom's display name.
-- **Slug** — a unique identifier used in URLs and repository names.
+- **Slug** — a unique identifier used in URLs and repository names, auto-filled
+  from the name (letters with diacritics transliterate, so "Álgebra" becomes
+  "algebra"). At most 40 characters: the slug prefixes every student repository
+  name, and GitHub limits repository names to 100 characters.
 - **Term** (optional) — shown in various places to distinguish course
   offerings.
 
@@ -145,6 +148,13 @@ multi-teacher setups, see
 On the classroom page, click **+ Assignment**. Fill in:
 
 - **Name** — the assignment's name.
+- **Assignment slug** — the identifier used in student repository names,
+  auto-filled from the name (diacritics transliterate, the same as classroom
+  slugs). The classroom slug and the assignment slug together can spend at
+  most 59 characters, so `<CLASSROOM>-<ASSIGNMENT>-<USERNAME>` stays within
+  GitHub's 100-character repository-name limit for any username. If you edit
+  the slug, the form warns as you type when it is over that budget or collides
+  with an existing assignment.
 - **Description** (optional) — details for students.
 - **Due date** (optional) — a date and time in your local timezone. A due date
   marks later submissions **late** in the collected scores; it does not block pushes
@@ -159,9 +169,9 @@ How each student's repository is created:
 
 - **Start with a template** — **No template** or **Template repository**: a
   [template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository)
-  used as each student's starting point. Enter `OWNER/REPOSITORY`, or
-  `REPOSITORY` alone if it's in this organization, replacing each with the
-  template's owner and name. See
+  used as each student's starting point. Search your organization's template
+  repositories by name, or paste `OWNER/REPOSITORY` (or a full GitHub
+  repository URL) for a template the search doesn't list. See
   [Assignment Templates](Assignment-Templates) for requirements.
 - **Add a README** (no-template assignments) — whether the repository starts
   with an initial commit. With it **off**, what students get depends on the
@@ -223,7 +233,9 @@ section — most assignments never need them:
   autograder** (preselected when you switch to Autograded) or **Do not use the
   built-in autograder**. Opting out means accept installs no autograding
   workflow at all: on a templated assignment your template's own CI workflows
-  run instead, and Classroom 50's score collection skips the assignment. Your
+  run instead. The submissions page still shows who submitted (collection
+  records submitters, but no scores), and the repository actions stay
+  available. Your
   choice sticks — leaving Autograded and coming back won't reset it. Can be
   changed after creation (edits only affect repositories accepted from now on;
   turning autograding off later makes already-accepted repositories' autograde
@@ -591,6 +603,30 @@ spreadsheet or external tool. The column-by-column reference is in
   creating one, pre-filled. The page also offers **Clean up invite data**, which
   clears the addresses held for email invitations that were never accepted. See
   [Invitations by email](How-Classroom-50-Works#invitations-by-email).
+
+### Updating an over-budget assignment slug
+
+An assignment whose slug can push student repository names past GitHub's
+100-character limit shows a **Slug too long** badge in the assignments list.
+This affects only assignments created before the limit was enforced, such as
+ones imported from GitHub Classroom with long names.
+
+1. Open the assignment, then **Assignment settings**.
+2. On the **Slug update needed** card above the form, click **Update slug**.
+3. In the **New slug** field, keep the suggested slug or enter your own. A
+   hint shows how many characters the classroom leaves room for.
+4. Click **Update**. One configuration change renames the assignment, then
+   every existing student repository is renamed to match, with per-repository
+   progress.
+
+GitHub redirects the old repository names, so existing clones keep working,
+and collected scores follow the new slug. You can update a slug only once:
+the old slug stays permanently reserved so the redirects survive. The
+assignment stays locked while repositories are renamed; if any repository
+fails, the card switches to **Slug update incomplete** and **Finish update**
+re-runs the renames until everything lands. Students run `git pull` once
+before their next submit. The CLI equivalent is
+[`assignment rename`](gh-teacher#assignment-rename).
 
 ### Changing the submission type later
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -34,6 +34,7 @@ output, or `--verbose` / `-v` for per-step detail.
 | `staff add` / `remove <org> <classroom> <username>` | Manage staff teams (`--role teacher\|hta\|ta`). |
 | `assignment add <org> <classroom> <slug>` | Register/upsert an assignment. |
 | `assignment reuse <org> <slug> --from <src> --to <dst>` | Copy an assignment into another classroom. |
+| `assignment rename <org> <classroom> <old-slug> <new-slug>` | One-shot rename of an over-budget assignment slug and its student repos. |
 | `assignment remove <org> <classroom> <slug>` | Remove an assignment entry. |
 | `assignment list <org> <classroom>` | List assignment slugs. Flags: `--json`, `-q`. |
 | `assignment submission-mode <org> <classroom> <slug> --tag\|--every-push` | Change when the autograder fires and retrofit existing repos' shims. |
@@ -169,9 +170,12 @@ gh teacher classroom add <org> <short-name> [--name "<full name>"] [--term <term
 gh teacher classroom add cs50-fall-2026 cs-principles --name "CS Principles" --term Fall-2026
 ```
 
-**Short-name rules:** `^[a-z0-9][a-z0-9-]{1,99}$` — 2–100 characters, lowercase
-letters/digits/hyphens, starting with a letter or digit. It becomes part of
-student repo names (`<short-name>-<assignment>-<username>`).
+**Short-name rules:** `^[a-z0-9][a-z0-9-]{1,99}$` — lowercase
+letters/digits/hyphens, starting with a letter or digit, and at most 40
+characters for a new classroom. The short-name flows into student repo names
+(`<short-name>-<assignment>-<username>`), which GitHub caps at 100 characters,
+so the 40-character cap leaves room for the assignment slug and any username.
+Existing classrooms with longer short-names stay readable and operable.
 
 `--unlisted` publishes the classroom's resources at an unguessable URL path
 segment (the web app's "Use an unlisted link" option — obscurity, not access
@@ -265,7 +269,19 @@ classrooms into one target organization by running this once per source.
 
 **Flags:** `--source <id-or-org>` (required), `--target <org>` (required),
 `--short-name`, `--term`, `--template-suffix` (escape target name collisions),
-`--include-archived`, `--dry-run`.
+`--rename <source-slug>=<new-slug>` (repeatable), `--include-archived`,
+`--dry-run`.
+
+**Slug handling:** assignment slugs import verbatim when they fit the
+repo-name budget (see `assignment add`). A slug that would push
+`<classroom>-<assignment>-<username>` past GitHub's 100-character limit is
+shortened automatically to the classroom's budget, suffixed `-2`, `-3`, … past
+collisions, and each mapping is reported (`--dry-run` annotates those rows
+with `renamed-from=<source>`). Pass `--rename <source-slug>=<new-slug>` to
+choose the imported slug yourself; explicit renames are validated against the
+slug pattern, the budget, and uniqueness within the batch before anything is
+created. An auto-derived short-name is truncated to 40 characters; an explicit
+`--short-name` past the cap fails before any template repos are created.
 
 **Not migrated:** roster, scores, accepted student repos, and GitHub Classroom's
 autograding config. Re-onboard students with `gh teacher roster add`/`import`
@@ -581,7 +597,13 @@ gh teacher assignment add cs50-fall-2026 cs-principles actions-lab --name "Actio
 
 Registers or upserts one assignment. Re-running with the same slug replaces the
 entry wholesale (dropping tests or a template you don't re-pass — the CLI warns).
-The slug must match `^[a-z0-9][a-z0-9-]{1,99}$`.
+The slug must match `^[a-z0-9][a-z0-9-]{1,99}$`, and a **new** slug must fit
+the repo-name budget: `<classroom>-<slug>` plus a worst-case 39-character
+username must stay within GitHub's 100-character repo-name limit, so the
+classroom short-name and the slug share 59 characters. A slug retired by
+`assignment rename` is permanently reserved. A same-slug replace of an
+existing over-budget entry stays allowed (the entry must remain editable);
+the CLI warns that students with long usernames can't accept it.
 
 **Required:** `--name`.
 
@@ -589,7 +611,7 @@ The slug must match `^[a-z0-9][a-z0-9-]{1,99}$`.
 
 | Flag | Purpose |
 | --- | --- |
-| `--template <owner>/<repo>[@branch]` | Starter-code repo (must be flagged as a template). Omit for a template-less assignment (an initialized repo: README plus the control files). Branch defaults to the template's default. |
+| `--template <owner>/<repo>[@branch]` | Starter-code repo (must be flagged as a template). Omit for a template-less assignment (an initialized repo: README plus the control files). A `@branch` suffix is tolerated but ignored, with a warning — the assignment always copies the template's default branch. To use a different branch, change the template repository's default branch. |
 | `--description <text>` | Short description. |
 | `--due <ISO-8601>` | Due date, such as `2026-09-15T23:59:00-04:00`. Stored as UTC; the machine's local timezone is assumed if you omit the offset. |
 | `--available-from <ISO-8601>` | Release date; stored as UTC (local timezone assumed without an offset). Assignments are hidden from the student list by default (invite-link accept only); set this to list it for everyone once the date passes. Listing-only, not access control: students who already accepted always see it. |
@@ -623,7 +645,8 @@ of every shape is in
   accept commits the `.classroom50.yaml` marker and the template's content but
   no autograde workflow, so the template's own CI runs instead. Requires a
   template (it carries the workflows); keeps the Feedback PR. Score collection
-  and regrade skip it (no `submit/*` releases). Mutually exclusive with
+  records who submitted but no scores (there are no `submit/*` releases);
+  regrade skips it. Mutually exclusive with
   `empty_repo`, a non-default `--autograder`, and the grading-adjacent fields
   (tests/allowed-files/release-assets/pass-threshold/submission-mode/
   submission-tag).
@@ -667,11 +690,55 @@ scriptable version of the web app's "reuse assignment". Every field is copied
 verbatim (including unknown/future ones); only slug and name can change. Student
 repos and scores are not copied.
 
-- A colliding slug auto-suffixes `-2`, `-3`, … unless you pass `--slug`
-  explicitly (which refuses a collision). Read the final slug from `--json`, not
-  the prose.
+- Without `--slug`, the copy keeps the source slug, trimmed to the target
+  classroom's repo-name budget and auto-suffixed `-2`, `-3`, … past collisions
+  (a trim is reported on stderr). An explicit `--slug` refuses a collision, an
+  over-budget value, or a reserved pre-rename slug. Read the final slug from
+  `--json`, not the prose — `auto_suffixed` is true for a collision suffix or
+  a budget trim.
 - Re-grants the target classroom's team read on a private in-org template.
   In-org only (v1). Refuses an archived target.
+
+### `assignment rename`
+
+```sh
+gh teacher assignment rename <org> <classroom> <old-slug> <new-slug> [--dry-run] [--yes]
+gh teacher assignment rename cs50-fall-2026 cs-principles problem-set-three-with-a-long-name ps3
+```
+
+One-shot remediation for an over-budget slug: when
+`<classroom>-<slug>-<username>` can exceed GitHub's 100-character repo-name
+limit, this renames the assignment **and every existing student repo** to
+match. It refuses a slug that already fits the budget, and it refuses a second
+rename: the old slug is recorded as `renamed_from` and permanently reserved,
+because a new repo at a renamed repo's old name would sever the automatic
+redirects student clones rely on.
+
+What happens, in order:
+
+1. One config commit: the slug changes, `renamed_from` records the old slug,
+   the `scores.json` bucket is re-keyed, a per-assignment `autograders/<slug>/`
+   directory moves, and the assignment is locked so nobody accepts mid-rename.
+2. Each student repo, matched by prefix and verified through its
+   `.classroom50.yaml` marker, has the marker's `assignment` field rewritten
+   (`[skip ci]`), then the repo is renamed. GitHub redirects git, web, and API
+   traffic from the old name indefinitely, so student clones keep working.
+3. The lock is restored to its pre-rename state.
+
+Confirmation requires typing the new slug (skip with `--yes` in scripted
+runs); `--dry-run` prints the plan without writing anything. Per-repo failures
+never abort the batch: re-running the same command resumes, skipping
+already-renamed repos and healing stragglers. The assignment stays locked
+while any repo is unrenamed — an accept would occupy the new repo name and
+strand the straggler's rename.
+
+Historical submissions keep their scores (collection accepts the pre-rename
+slug through `renamed_from`). Students run `git pull` once before their next
+`gh student submit`; plain pushes grade correctly immediately. Repos whose
+marker names a different assignment (a sibling slug sharing the prefix), or
+with no readable marker, are skipped untouched.
+
+**Flags:** `--dry-run`, `--yes`, `--quiet`.
 
 ### `assignment remove`
 


### PR DESCRIPTION
## Summary

Documents everything user-facing in the v1.33.0 window (`cli-v1.32.0..HEAD`) across 14 wiki pages, following `docs/github-docs-writing-style.md`.

- **Repo-name budget**: the 100-character repository-name limit, the 59-character shared slug budget, and the 40-character cap on new classroom slugs, documented in How-Classroom-50-Works (canonical model), `gh-teacher` (`classroom add`, `assignment add`, `reuse`, `migrate`), both teacher guides, the Glossary, and a new Troubleshooting entry for the accept-time failure on legacy over-budget names.

- **Assignment slug rename**: new `assignment rename` reference section and at-a-glance row, a task subsection in the CLI Teacher Guide, an "Updating an over-budget assignment slug" procedure in the Web Teacher Guide (**Slug too long** badge, **Update slug** / **Finish update** flow), plus the one-shot/reserved-slug semantics in Known-Limitations and the Glossary.

- **Migration**: over-long source slugs auto-trim instead of skipping, visible skip reasons with **Re-check**, per-item **Import as** overrides, and the CLI's repeatable `--rename` flag.

- **Alignments with shipped behavior**: `no_autograder` collection now records who submitted (5 pages previously said collection skips the assignment); `--template @branch` is ignored with a warning (3 pages); the template field is a search picker; collect-scores troubleshooting distinguishes GitHub throttles from an under-scoped token; the per-assignment **Sync now** staff-grant scoping; the student submission-status callout.

No release bump: `docs` type. The publish-wiki workflow syncs `wiki/` to the GitHub wiki after merge.

## Test plan

- [x] All wiki page links and `Page#anchor` links resolve (checked against GitHub's anchor rules, including the new anchors)
- [x] New copy quotes UI labels and CLI flags verbatim from `en.json` and the cobra command definitions
- [x] Style sweep: no reserved vocabulary ("gradebook", "deadline", "instructor"), sentence-case headers, ALL-CAPS placeholders outside CLI-verbatim contexts