### PR TITLE
feat(web): collect scores for a whole classroom

### DIFF
--- a/web/src/github-core/mutations/workflowDispatch.test.ts
+++ b/web/src/github-core/mutations/workflowDispatch.test.ts
@@ -79,6 +79,24 @@ describe("triggerScoreCollection", () => {
     })
   })
 
+  // The classroom sweep: `assignment` must be absent, not empty — the workflow
+  // treats a present-but-blank input as "collect the whole classroom" too, but
+  // an org whose collect-scores.yaml predates the `assignment` input 422s on the
+  // key itself.
+  it("sends only the classroom input when the scope has no assignment", async () => {
+    const { client, request } = makeClient(() => ({}))
+
+    await triggerScoreCollection(client, "acme", { classroom: "cs50" })
+
+    const dispatchCall = request.mock.calls.find(([url]) =>
+      (url as string).endsWith("/dispatches"),
+    )
+    expect(
+      (dispatchCall?.[1] as { body: { inputs: Record<string, string> } }).body
+        .inputs,
+    ).toEqual({ classroom: "cs50" })
+  })
+
   it("maps a scoped 422 'unexpected inputs' to CollectInputsUnsupportedError", async () => {
     const { client } = makeClient(() => {
       throw unexpectedInputs422()

--- a/web/src/hooks/useGitHubOperation.test.tsx
+++ b/web/src/hooks/useGitHubOperation.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, cleanup, renderHook } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+import { useGitHubOperation } from "./useGitHubOperation"
+import type { GitHubWorkflowRun } from "@/github-core/types"
+
+const MINUTE = 60 * 1000
+const TIMEOUT_MS = 10 * MINUTE
+const QUEUE_TIMEOUT_MS = 30 * MINUTE
+// The tracker never waits longer than the two windows back to back.
+const MAX_WAIT_MS = TIMEOUT_MS + QUEUE_TIMEOUT_MS
+const T0 = new Date("2026-08-24T12:00:00.000Z")
+const STORAGE_KEY = "test:operation"
+
+const at = (offsetMs: number) => new Date(T0.getTime() + offsetMs).toISOString()
+
+const makeRun = (over: Partial<GitHubWorkflowRun> = {}): GitHubWorkflowRun => ({
+  id: 2,
+  status: "queued",
+  conclusion: null,
+  created_at: at(0),
+  html_url: "https://github.com/acme/config/actions/runs/2",
+  event: "workflow_dispatch",
+  ...over,
+})
+
+// The run the poll currently sees, and what the dispatch does. Both are swapped
+// per test; the poll re-reads `currentRun` on every refetch, so a test can move
+// a run from queued to in_progress by reassigning it and advancing the clock.
+let currentRun: GitHubWorkflowRun | null = null
+let dispatchImpl: () => Promise<{ sinceRunId: number | null }> = async () => ({
+  sinceRunId: 1,
+})
+
+const mount = () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return renderHook(
+    () =>
+      useGitHubOperation({
+        storageKey: STORAGE_KEY,
+        queryKey: (sinceRunId) => ["operation", sinceRunId],
+        resetKey: "acme",
+        timeoutMs: TIMEOUT_MS,
+        queueTimeoutMs: QUEUE_TIMEOUT_MS,
+        // Poll on a flat one-minute cadence so the advance amounts below read
+        // as wall-clock, not as a backoff schedule.
+        intervalMs: MINUTE,
+        backoffAfterMs: MINUTE,
+        backoffIntervalMs: MINUTE,
+        dispatch: () => dispatchImpl(),
+        findRun: async () => currentRun,
+      }),
+    { wrapper },
+  )
+}
+
+const advance = async (ms: number) => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+// Dispatch and let the first poll land, so the hook is tracking a run.
+const start = async (view: ReturnType<typeof mount>) => {
+  await act(async () => {
+    view.result.current.trigger()
+  })
+  await advance(MINUTE)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(T0)
+  sessionStorage.clear()
+  currentRun = null
+  dispatchImpl = async () => ({ sinceRunId: 1 })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+// GitHub's own `timeout-minutes` caps execution only. A run held in an Actions
+// concurrency group is healthy, so the client must not expire it — doing so
+// drops the tracked dispatch and re-enables the trigger for a duplicate.
+describe("queue time", () => {
+  it("keeps waiting while the run sits queued past the execution window", async () => {
+    currentRun = makeRun({ status: "queued" })
+    const view = mount()
+    await start(view)
+
+    await advance(TIMEOUT_MS + MINUTE)
+
+    expect(view.result.current.phase).toBe("running")
+  })
+
+  it("starts the execution window when the run leaves the queue", async () => {
+    currentRun = makeRun({ status: "queued" })
+    const view = mount()
+    await start(view)
+
+    // Queued for 20 minutes — twice the execution window — then running, which
+    // puts the deadline at minute 30 (run start + the execution window) rather
+    // than minute 10 (dispatch + the same window).
+    await advance(20 * MINUTE)
+    currentRun = makeRun({
+      status: "in_progress",
+      run_started_at: at(20 * MINUTE),
+    })
+    await advance(2 * MINUTE)
+    expect(view.result.current.phase).toBe("running")
+
+    // Minute 29: past the dispatch-anchored window, inside the run's own.
+    await advance(6 * MINUTE)
+    expect(view.result.current.phase).toBe("running")
+
+    // Minute 31.
+    await advance(2 * MINUTE)
+    expect(view.result.current.phase).toBe("timeout")
+  })
+
+  it("gives up once the queue window elapses with the run still parked", async () => {
+    currentRun = makeRun({ status: "queued" })
+    const view = mount()
+    await start(view)
+
+    await advance(QUEUE_TIMEOUT_MS + MINUTE)
+
+    expect(view.result.current.phase).toBe("timeout")
+  })
+
+  it("caps the wait when the run reports a start stamp skewed ahead", async () => {
+    currentRun = makeRun({
+      status: "in_progress",
+      run_started_at: at(10 * 60 * MINUTE),
+    })
+    const view = mount()
+    await start(view)
+
+    await advance(MAX_WAIT_MS + MINUTE)
+
+    expect(view.result.current.phase).toBe("timeout")
+  })
+})
+
+// "failed" covers both a rejected POST and a run that concluded non-success.
+// Callers that also surface run outcomes need to tell the two apart.
+describe("failure attribution", () => {
+  it("attributes a rejected dispatch to the dispatch", async () => {
+    dispatchImpl = async () => {
+      throw new Error("Resource not accessible by personal access token")
+    }
+    const view = mount()
+    await start(view)
+
+    expect(view.result.current.phase).toBe("failed")
+    expect(view.result.current.failure).toBe("dispatch")
+  })
+
+  it("attributes a non-success conclusion to the run", async () => {
+    currentRun = makeRun({ status: "completed", conclusion: "failure" })
+    const view = mount()
+    await start(view)
+
+    expect(view.result.current.phase).toBe("failed")
+    expect(view.result.current.failure).toBe("run")
+  })
+
+  it("leaves a successful run unattributed", async () => {
+    currentRun = makeRun({ status: "completed", conclusion: "success" })
+    const view = mount()
+    await start(view)
+
+    expect(view.result.current.phase).toBe("completed")
+    expect(view.result.current.failure).toBeNull()
+  })
+})

--- a/web/src/hooks/useGitHubOperation.ts
+++ b/web/src/hooks/useGitHubOperation.ts
@@ -8,6 +8,13 @@ import type { GitHubWorkflowRun } from "@/github-core/types"
 export type OperationPhase =
   "idle" | "dispatching" | "running" | "completed" | "failed" | "timeout"
 
+// Which side failed when `phase` is "failed": the dispatch POST was rejected
+// ("dispatch"), or the run we tracked reached a non-success conclusion ("run").
+// Every dispatch is registered with the Actions banner, so a caller that would
+// otherwise report both needs the split to avoid announcing a run failure the
+// banner already shows.
+export type OperationFailure = "dispatch" | "run"
+
 // The dispatch API returns no run id, so `sinceRunId` records the newest
 // matching run before our POST (null = none); ours is the oldest run past it.
 // `startedAt` anchors the timeout across remounts. Persisted to sessionStorage
@@ -17,6 +24,24 @@ export type DispatchState = { sinceRunId: number | null; startedAt: number }
 // Terminal once GitHub reports a conclusion, even before status flips to completed.
 const isRunFinished = (run: GitHubWorkflowRun | null | undefined) =>
   Boolean(run && (run.status === "completed" || run.conclusion !== null))
+
+// Statuses GitHub reports before any job starts — the run exists on record, but
+// the workflow's own `timeout-minutes` is not counting yet.
+const QUEUED_STATUSES: ReadonlySet<GitHubWorkflowRun["status"]> = new Set([
+  "queued",
+  "waiting",
+  "requested",
+  "pending",
+])
+
+// When our run's job clock started, or null while it is still queued (or not
+// discovered yet). `run_started_at` is the authoritative stamp; a run past the
+// queue that omits it has started regardless, so fall back to its creation time.
+const runStartedMs = (run: GitHubWorkflowRun | null | undefined) => {
+  if (!run || QUEUED_STATUSES.has(run.status)) return null
+  const parsed = Date.parse(run.run_started_at ?? run.created_at)
+  return Number.isNaN(parsed) ? null : parsed
+}
 
 export type GitHubOperationConfig = {
   // Null disables tracking (no persistence/polling, phase stays "idle").
@@ -33,7 +58,10 @@ export type GitHubOperationConfig = {
     signal?: AbortSignal,
   ) => Promise<GitHubWorkflowRun | null>
   // Timing knobs (defaults are the collect-scores values).
+  // `timeoutMs` bounds execution once our run starts; `queueTimeoutMs` bounds
+  // the wait for it to leave the Actions queue and defaults to the same value.
   timeoutMs?: number
+  queueTimeoutMs?: number
   intervalMs?: number
   backoffAfterMs?: number
   backoffIntervalMs?: number
@@ -49,9 +77,11 @@ const DEFAULTS = {
   backoffIntervalMs: 15000,
 }
 
+// `maxWaitMs` is the whole wait (queue + execution), so a remount midway
+// through a long queue wait re-attaches instead of discarding a live dispatch.
 const loadDispatch = (
   storageKey: string | null,
-  timeoutMs: number,
+  maxWaitMs: number,
 ): DispatchState | null => {
   if (!storageKey) return null
   try {
@@ -59,7 +89,7 @@ const loadDispatch = (
     if (!raw) return null
     const parsed = JSON.parse(raw) as DispatchState
     // Drop a stale entry past its timeout window.
-    if (Date.now() - parsed.startedAt > timeoutMs) {
+    if (Date.now() - parsed.startedAt > maxWaitMs) {
       sessionStorage.removeItem(storageKey)
       return null
     }
@@ -92,13 +122,15 @@ const saveDispatch = (
  */
 export function useGitHubOperation(config: GitHubOperationConfig) {
   const timeoutMs = config.timeoutMs ?? DEFAULTS.timeoutMs
+  const queueTimeoutMs = config.queueTimeoutMs ?? timeoutMs
+  const maxWaitMs = queueTimeoutMs + timeoutMs
   const intervalMs = config.intervalMs ?? DEFAULTS.intervalMs
   const backoffAfterMs = config.backoffAfterMs ?? DEFAULTS.backoffAfterMs
   const backoffIntervalMs =
     config.backoffIntervalMs ?? DEFAULTS.backoffIntervalMs
 
   const [dispatch, setDispatch] = useState<DispatchState | null>(() =>
-    loadDispatch(config.storageKey, timeoutMs),
+    loadDispatch(config.storageKey, maxWaitMs),
   )
   const [timedOut, setTimedOut] = useState(false)
 
@@ -107,7 +139,7 @@ export function useGitHubOperation(config: GitHubOperationConfig) {
   const [trackedKey, setTrackedKey] = useState(config.resetKey)
   if (config.resetKey !== trackedKey) {
     setTrackedKey(config.resetKey)
-    setDispatch(loadDispatch(config.storageKey, timeoutMs))
+    setDispatch(loadDispatch(config.storageKey, maxWaitMs))
     setTimedOut(false)
   }
 
@@ -146,6 +178,25 @@ export function useGitHubOperation(config: GitHubOperationConfig) {
   const run = runQuery.data
   const runCompleted = Boolean(dispatch) && isRunFinished(run)
 
+  // Deadline for the wait. GitHub's `timeout-minutes` caps execution only, so a
+  // run parked behind a busy concurrency group can sit queued long before its
+  // job clock starts; anchoring the whole window to the dispatch expired a
+  // healthy run, which dropped the tracked dispatch and re-enabled the trigger
+  // for exactly the duplicate this tracking prevents. Wait the queue out on
+  // `queueTimeoutMs`, then give execution `timeoutMs` from the run's own start.
+  // The two never compound past `maxWaitMs` (which also bounds a `run_started_at`
+  // skewed into the future), so the wait always ends and the banner stays the
+  // long-running surface.
+  const startedMs = runStartedMs(run)
+  const deadline = dispatch
+    ? Math.min(
+        startedMs === null
+          ? dispatch.startedAt + queueTimeoutMs
+          : Math.max(startedMs, dispatch.startedAt) + timeoutMs,
+        dispatch.startedAt + maxWaitMs,
+      )
+    : 0
+
   // Clear persisted state once the run terminates so a remount doesn't re-attach;
   // `phase` stays latched (dispatch resets only on a reset-key change or new
   // dispatch).
@@ -155,31 +206,40 @@ export function useGitHubOperation(config: GitHubOperationConfig) {
   }, [runCompleted, trackedKey])
 
   // Time out the wait: flip a flag that stops the query and latches phase to
-  // "timeout". Deadline anchored to dispatch time, so a remount doesn't grant a
-  // fresh window (a past deadline fires a 0ms timer, not a render-time setState).
+  // "timeout". The deadline is derived from stamps, not from mount time, so a
+  // remount doesn't grant a fresh window (a past deadline fires a 0ms timer,
+  // not a render-time setState) and the timer re-arms when the run starts.
   useEffect(() => {
     if (!dispatch || runCompleted || timedOut) return
-    const remaining = Math.max(0, dispatch.startedAt + timeoutMs - Date.now())
+    const remaining = Math.max(0, deadline - Date.now())
     const id = window.setTimeout(() => {
       setTimedOut(true)
       saveDispatch(config.storageKey, null)
     }, remaining)
     return () => window.clearTimeout(id)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, runCompleted, timedOut, trackedKey])
+  }, [dispatch, runCompleted, timedOut, trackedKey, deadline])
 
   let phase: OperationPhase = "idle"
+  let failure: OperationFailure | null = null
   if (mutation.isPending) phase = "dispatching"
-  else if (mutation.isError) phase = "failed"
-  else if (runCompleted)
-    phase = run?.conclusion === "success" ? "completed" : "failed"
-  else if (timedOut) phase = "timeout"
+  else if (mutation.isError) {
+    phase = "failed"
+    failure = "dispatch"
+  } else if (runCompleted) {
+    if (run?.conclusion === "success") phase = "completed"
+    else {
+      phase = "failed"
+      failure = "run"
+    }
+  } else if (timedOut) phase = "timeout"
   // Transient poll errors self-heal via refetchInterval; stay "running".
   else if (dispatch) phase = "running"
 
   return {
     trigger: () => mutation.mutate(),
     phase,
+    failure,
     run,
     error: mutation.error ?? runQuery.error,
   }

--- a/web/src/hooks/useTriggerScoreCollection.test.tsx
+++ b/web/src/hooks/useTriggerScoreCollection.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from "vitest"
+import { renderHook } from "@testing-library/react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) }
+})
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({}),
+}))
+
+vi.mock("@/context/actions/ActionActivityProvider", () => ({
+  useActionActivityRegistry: () => ({ register: vi.fn() }),
+}))
+
+// Capture the config the tracker primitive is handed: the scope-derived keys
+// and timing are this hook's whole job.
+const configs: {
+  storageKey: string | null
+  resetKey: string
+  timeoutMs?: number
+}[] = []
+vi.mock("@/hooks/useGitHubOperation", () => ({
+  useGitHubOperation: (config: {
+    storageKey: string | null
+    resetKey: string
+    timeoutMs?: number
+  }) => {
+    configs.push(config)
+    return { trigger: vi.fn(), phase: "idle", run: null, error: null }
+  },
+}))
+
+import useTriggerScoreCollection from "./useTriggerScoreCollection"
+
+const configFor = (scope?: { classroom: string; assignment?: string }) => {
+  configs.length = 0
+  renderHook(() => useTriggerScoreCollection("acme", scope))
+  return configs[0]
+}
+
+describe("useTriggerScoreCollection scope keying", () => {
+  it("keeps org-wide, classroom-wide and per-assignment tracking on distinct keys", () => {
+    const orgWide = configFor()
+    const sweep = configFor({ classroom: "cs50" })
+    const one = configFor({ classroom: "cs50", assignment: "hello" })
+
+    expect(orgWide.storageKey).toBe("cl50:collect-scores:acme")
+    expect(sweep.storageKey).toBe("cl50:collect-scores:acme:cs50")
+    expect(one.storageKey).toBe("cl50:collect-scores:acme:cs50:hello")
+
+    // resetKey re-derives tracking on a target change, so it must separate the
+    // same three scopes.
+    expect(new Set([orgWide.resetKey, sweep.resetKey, one.resetKey]).size).toBe(
+      3,
+    )
+  })
+
+  it("tracks a classroom sweep against the workflow's 30-minute job cap", () => {
+    expect(configFor({ classroom: "cs50" }).timeoutMs).toBe(30 * 60 * 1000)
+  })
+
+  it("leaves the default timeout to a per-assignment collect", () => {
+    expect(
+      configFor({ classroom: "cs50", assignment: "hello" }).timeoutMs,
+    ).toBeUndefined()
+    expect(configFor().timeoutMs).toBeUndefined()
+  })
+})

--- a/web/src/hooks/useTriggerScoreCollection.ts
+++ b/web/src/hooks/useTriggerScoreCollection.ts
@@ -8,14 +8,23 @@ import { useGitHubOperation, type OperationPhase } from "./useGitHubOperation"
 
 export type CollectScoresPhase = OperationPhase
 
-// Narrows a dispatched collection to one assignment (the assignment
-// submissions page); omitted collects org-wide.
-export type CollectScoresScope = { classroom: string; assignment: string }
+// A classroom sweep walks every assignment, so it runs far longer than the
+// single-assignment collect the 10-minute default was tuned for. Track it
+// against the workflow's own job cap instead (collect-scores.yaml,
+// `timeout-minutes: 30`) — otherwise a healthy sweep trips the client timeout,
+// which drops the tracked dispatch and re-enables the button while the run is
+// still going, inviting a duplicate queued behind it.
+const SWEEP_TIMEOUT_MS = 30 * 60 * 1000
+
+// Narrows a dispatched collection: `classroom` alone sweeps every assignment in
+// that classroom (the assignments page), `classroom` + `assignment` collects one
+// (the submissions page); omitted collects org-wide.
+export type CollectScoresScope = { classroom: string; assignment?: string }
 
 /**
  * Triggers collect-scores and tracks the run via useGitHubOperation; also
  * registers the dispatch with the activity banner. Pass `scope` to collect a
- * single assignment instead of the whole org.
+ * single classroom, or one assignment within it, instead of the whole org.
  */
 const useTriggerScoreCollection = (
   org: string | undefined,
@@ -26,9 +35,14 @@ const useTriggerScoreCollection = (
   const { t } = useTranslation()
 
   // Scope-suffixed keys so an assignment page's tracked run never bleeds into
-  // another page's (or the org-wide) collect tracker across remounts.
-  const scopeSuffix = scope ? `:${scope.classroom}:${scope.assignment}` : ""
+  // another page's (or the classroom-wide / org-wide) collect tracker across
+  // remounts. A classroom sweep stops one segment short of an assignment scope,
+  // so the two never share a key.
+  const scopeSuffix = scope
+    ? `:${scope.classroom}${scope.assignment ? `:${scope.assignment}` : ""}`
+    : ""
   const { trigger, phase, run, error } = useGitHubOperation({
+    timeoutMs: scope && !scope.assignment ? SWEEP_TIMEOUT_MS : undefined,
     storageKey: org ? `cl50:collect-scores:${org}${scopeSuffix}` : null,
     queryKey: (sinceRunId) =>
       githubKeys.collectScoresRun(org ?? "", sinceRunId),

--- a/web/src/hooks/useTriggerScoreCollection.ts
+++ b/web/src/hooks/useTriggerScoreCollection.ts
@@ -8,12 +8,16 @@ import { useGitHubOperation, type OperationPhase } from "./useGitHubOperation"
 
 export type CollectScoresPhase = OperationPhase
 
-// A classroom sweep walks every assignment, so it runs far longer than the
+// A classroom sweep walks every assignment, so it executes far longer than the
 // single-assignment collect the 10-minute default was tuned for. Track it
 // against the workflow's own job cap instead (collect-scores.yaml,
 // `timeout-minutes: 30`) — otherwise a healthy sweep trips the client timeout,
 // which drops the tracked dispatch and re-enables the button while the run is
-// still going, inviting a duplicate queued behind it.
+// still going, inviting a duplicate queued behind it. That cap measures
+// execution; the sweep shares the `collect-${classroom}` concurrency group with
+// every per-assignment collect in the same classroom (and the group does not
+// cancel in progress), so it can sit queued first — useGitHubOperation waits
+// that out on its own window before this one starts counting.
 const SWEEP_TIMEOUT_MS = 30 * 60 * 1000
 
 // Narrows a dispatched collection: `classroom` alone sweeps every assignment in
@@ -41,7 +45,7 @@ const useTriggerScoreCollection = (
   const scopeSuffix = scope
     ? `:${scope.classroom}${scope.assignment ? `:${scope.assignment}` : ""}`
     : ""
-  const { trigger, phase, run, error } = useGitHubOperation({
+  const { trigger, phase, failure, run, error } = useGitHubOperation({
     timeoutMs: scope && !scope.assignment ? SWEEP_TIMEOUT_MS : undefined,
     storageKey: org ? `cl50:collect-scores:${org}${scopeSuffix}` : null,
     queryKey: (sinceRunId) =>
@@ -64,7 +68,7 @@ const useTriggerScoreCollection = (
     },
   })
 
-  return { collect: trigger, phase, run, error }
+  return { collect: trigger, phase, failure, run, error }
 }
 
 export default useTriggerScoreCollection

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1113,7 +1113,10 @@
     "studentViewAll": "View all assignments for the <classroom>{{classroom}}</classroom> classroom.",
     "collect": {
       "label": "Collect all",
-      "title": "Collect submissions for every assignment in this classroom"
+      "title": "Collect scores for every assignment in this classroom. This rebuilds the submission data behind the table's counts.",
+      "confirmTitle": "Collect scores for all assignments?",
+      "confirmBody": "This starts one workflow run that collects scores for every assignment in this classroom. The run takes longer for a large classroom and uses more GitHub Actions minutes than collecting a single assignment.",
+      "confirmAction": "Collect all"
     },
     "discover": {
       "accept": "Accept assignment",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1111,6 +1111,10 @@
     "archivedNotice": "This classroom is archived — new assignments and student accepts are disabled. Unarchive it from <settingsLink>Classroom settings</settingsLink> to make changes.",
     "studentHeading": "Assignments",
     "studentViewAll": "View all assignments for the <classroom>{{classroom}}</classroom> classroom.",
+    "collect": {
+      "label": "Collect all",
+      "title": "Collect submissions for every assignment in this classroom"
+    },
     "discover": {
       "accept": "Accept assignment",
       "notAccepted": "Not accepted",

--- a/web/src/pages/AssignmentsPage.test.tsx
+++ b/web/src/pages/AssignmentsPage.test.tsx
@@ -67,11 +67,28 @@ vi.mock("@/components/OrgRepoCreationNotice", async () => {
 vi.mock("@/context/classroomRole/ClassroomRoleProvider", () => ({
   useClassroomRoleContext: () => ({ role: "teacher" }),
 }))
-// Stub the heavy children so the test targets only the header subtitle.
+// Stub the heavy children so the test targets only the page's own wiring. The
+// toolbar mock exposes its slots so the collect-action gating is observable;
+// the collect button itself is covered in ClassroomCollectButton.test.tsx.
 vi.mock("@/pages/assignments/AssignmentsTable", () => ({ default: () => null }))
 vi.mock("@/pages/assignments/AssignmentsToolbar", () => ({
-  default: () => null,
+  default: ({
+    leading,
+    trailing,
+  }: {
+    leading?: ReactNode
+    trailing?: ReactNode
+  }) => (
+    <div>
+      <div data-testid="toolbar-leading">{leading}</div>
+      <div data-testid="toolbar-trailing">{trailing}</div>
+    </div>
+  ),
 }))
+vi.mock("@/pages/assignments/ClassroomCollectButton", () => {
+  const stub = () => <div data-testid="collect-all" />
+  return { ClassroomCollectButton: stub, default: stub }
+})
 
 import { TeacherAssignmentsView } from "./AssignmentsPage"
 
@@ -155,5 +172,49 @@ describe("Assignments org repo-creation warning", () => {
     expect(
       screen.queryByText("components.notices.orgRepoCreation.private"),
     ).toBeNull()
+  })
+})
+
+// The classroom-wide collect's page-level gating: the component's own tests
+// exercise it with props already supplied, so the show/hide decisions live
+// here — visible for staff once assignments exist, gone when archived or
+// while the list is empty (nothing to collect for).
+describe("Classroom-wide collect visibility", () => {
+  const assignments = [{ slug: "hw1", type: "individual" }]
+  const renderView = () => {
+    studentCount.mockReturnValue({
+      studentCount: 1,
+      isLoading: false,
+      isError: false,
+    })
+    render(<TeacherAssignmentsView org="acme" classroom="cs101" />)
+  }
+
+  it("leads the toolbar once assignments exist", () => {
+    getAssignments.mockReturnValue({
+      data: { assignments },
+      isLoading: false,
+    })
+    renderView()
+    const leading = screen.getByTestId("toolbar-leading")
+    expect(leading.querySelector('[data-testid="collect-all"]')).not.toBeNull()
+  })
+
+  it("is absent while the classroom has no assignments", () => {
+    renderView()
+    expect(screen.queryByTestId("collect-all")).toBeNull()
+  })
+
+  it("is absent on an archived classroom", () => {
+    getClassroom.mockReturnValue({
+      data: { name: "CS 101", active: false },
+      isLoading: false,
+    })
+    getAssignments.mockReturnValue({
+      data: { assignments },
+      isLoading: false,
+    })
+    renderView()
+    expect(screen.queryByTestId("collect-all")).toBeNull()
   })
 })

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -165,10 +165,12 @@ export const TeacherAssignmentsView = ({
     <NewAssignmentButton org={org} classroom={classroom} />
   ) : null
 
-  // Classroom-wide collect, next to the primary action. Open to any staff
-  // viewer (a TA may collect, as on the submissions page — only authoring is
-  // author-gated). Hidden on an archived classroom and while the list is empty:
-  // there is no assignment to collect for.
+  // Classroom-wide collect, left-aligned in the toolbar (the `leading` slot),
+  // mirroring the submissions toolbar where the DataFreshness/Sync widget
+  // leads and search + filters sit on the right. Open to any staff viewer (a
+  // TA may collect, as on the submissions page — only authoring is
+  // author-gated). Hidden on an archived classroom and while the list is
+  // empty: there is no assignment to collect for.
   const collectAction =
     !archived && hasAssignments ? (
       <ClassroomCollectButton
@@ -176,17 +178,6 @@ export const TeacherAssignmentsView = ({
         classroom={classroom}
         emptyRoster={emptyRoster.show}
       />
-    ) : null
-
-  // Toolbar.Trailing already lays its children out (flex, wrap, gap), so this
-  // is a fragment — but it must collapse to null when both actions are absent,
-  // or the slot renders an empty bar.
-  const toolbarAction =
-    collectAction || primaryAction ? (
-      <>
-        {collectAction}
-        {primaryAction}
-      </>
     ) : null
 
   return (
@@ -247,7 +238,8 @@ export const TeacherAssignmentsView = ({
           sort={sort}
           onSortChange={setSort}
           actionsOnly={!hasAssignments}
-          trailing={toolbarAction}
+          leading={collectAction}
+          trailing={primaryAction}
         />
       )}
       {showNoResults ? (

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from "react-i18next"
 
 import AssignmentsTable from "@/pages/assignments/AssignmentsTable"
 import AssignmentsToolbar from "@/pages/assignments/AssignmentsToolbar"
+import { ClassroomCollectButton } from "@/pages/assignments/ClassroomCollectButton"
 import {
   DEFAULT_FILTERS,
   DEFAULT_SORT,
@@ -156,13 +157,37 @@ export const TeacherAssignmentsView = ({
 
   // Right-aligned toolbar action: the New assignment split button for an author,
   // or the archived badge; null for a read-only viewer (TA).
-  const toolbarAction = archived ? (
+  const primaryAction = archived ? (
     <Badge tone="neutral" size="md">
       {t("assignments.archived")}
     </Badge>
   ) : canAuthor ? (
     <NewAssignmentButton org={org} classroom={classroom} />
   ) : null
+
+  // Classroom-wide collect, next to the primary action. Open to any staff
+  // viewer (a TA may collect, as on the submissions page — only authoring is
+  // author-gated). Hidden on an archived classroom and while the list is empty:
+  // there is no assignment to collect for.
+  const collectAction =
+    !archived && hasAssignments ? (
+      <ClassroomCollectButton
+        org={org}
+        classroom={classroom}
+        emptyRoster={emptyRoster.show}
+      />
+    ) : null
+
+  // Toolbar.Trailing already lays its children out (flex, wrap, gap), so this
+  // is a fragment — but it must collapse to null when both actions are absent,
+  // or the slot renders an empty bar.
+  const toolbarAction =
+    collectAction || primaryAction ? (
+      <>
+        {collectAction}
+        {primaryAction}
+      </>
+    ) : null
 
   return (
     <div className="flex flex-col gap-6">

--- a/web/src/pages/assignments/AssignmentsToolbar.tsx
+++ b/web/src/pages/assignments/AssignmentsToolbar.tsx
@@ -11,11 +11,13 @@ import {
 
 // Search + type/due filters + sort for the teacher assignments table.
 // Controlled by TeacherAssignmentsView; emits query/filter/sort changes.
-// `trailing` hosts right-aligned actions (the New assignment split button or the
-// archived badge), mirroring the submissions toolbar so the primary action sits
-// in the bar, not the page header. When `actionsOnly` is set (no assignments
-// exist yet) only the trailing actions render — the search/filter/sort controls
-// would have nothing to act on.
+// Mirrors the submissions toolbar layout: `leading` hosts the left-aligned
+// classroom-wide action (Collect all), while search + filters + sort + the
+// trailing actions (the New assignment split button or the archived badge)
+// sit on the right — so the primary action lives in the bar, not the page
+// header. When `actionsOnly` is set (no assignments exist yet) only the
+// leading/trailing actions render — the search/filter/sort controls would
+// have nothing to act on.
 const AssignmentsToolbar = ({
   query,
   onQueryChange,
@@ -24,6 +26,7 @@ const AssignmentsToolbar = ({
   sort,
   onSortChange,
   actionsOnly = false,
+  leading,
   trailing,
 }: {
   query: string
@@ -33,6 +36,10 @@ const AssignmentsToolbar = ({
   sort: AssignmentSort
   onSortChange: (sort: AssignmentSort) => void
   actionsOnly?: boolean
+  // Left-aligned lead content (the Collect all button), as on the submissions
+  // toolbar where DataFreshness leads. Search + filters + sort + actions sit
+  // on the right.
+  leading?: ReactNode
   trailing?: ReactNode
 }) => {
   const { t } = useTranslation()
@@ -45,8 +52,9 @@ const AssignmentsToolbar = ({
   }
 
   if (actionsOnly) {
-    return trailing ? (
+    return leading || trailing ? (
       <Toolbar>
+        {leading}
         <Toolbar.Trailing>{trailing}</Toolbar.Trailing>
       </Toolbar>
     ) : null
@@ -54,54 +62,56 @@ const AssignmentsToolbar = ({
 
   return (
     <Toolbar>
-      <Toolbar.Search
-        placeholder={t("assignments.toolbar.searchPlaceholder")}
-        value={query}
-        onChange={onQueryChange}
-        ariaLabel={t("assignments.toolbar.searchAria")}
-        onClear={clearAll}
-        clearActive={hasActiveFilter}
-        hasFilterActive={hasFilterActive}
-      />
-
-      <Toolbar.FilterSelect
-        icon={<ListFilter aria-hidden="true" className="size-4" />}
-        active={filters.type !== "all"}
-        value={filters.type}
-        onChange={(e) =>
-          onFiltersChange({
-            ...filters,
-            type: e.target.value as AssignmentFilters["type"],
-          })
-        }
-        aria-label={t("assignments.toolbar.typeAria")}
-      >
-        <option value="all">{t("assignments.toolbar.typeAll")}</option>
-        <option value="individual">
-          {t("assignments.toolbar.typeIndividual")}
-        </option>
-        <option value="group">{t("assignments.toolbar.typeGroup")}</option>
-      </Toolbar.FilterSelect>
-
-      <Toolbar.FilterSelect
-        icon={<ListFilter aria-hidden="true" className="size-4" />}
-        active={filters.due !== "all"}
-        value={filters.due}
-        onChange={(e) =>
-          onFiltersChange({
-            ...filters,
-            due: e.target.value as AssignmentFilters["due"],
-          })
-        }
-        aria-label={t("assignments.toolbar.dueAria")}
-      >
-        <option value="all">{t("assignments.toolbar.dueAll")}</option>
-        <option value="has-due">{t("assignments.toolbar.dueHas")}</option>
-        <option value="no-due">{t("assignments.toolbar.dueNone")}</option>
-        <option value="overdue">{t("assignments.toolbar.dueOverdue")}</option>
-      </Toolbar.FilterSelect>
+      {leading}
 
       <Toolbar.Trailing>
+        <Toolbar.Search
+          placeholder={t("assignments.toolbar.searchPlaceholder")}
+          value={query}
+          onChange={onQueryChange}
+          ariaLabel={t("assignments.toolbar.searchAria")}
+          onClear={clearAll}
+          clearActive={hasActiveFilter}
+          hasFilterActive={hasFilterActive}
+        />
+
+        <Toolbar.FilterSelect
+          icon={<ListFilter aria-hidden="true" className="size-4" />}
+          active={filters.type !== "all"}
+          value={filters.type}
+          onChange={(e) =>
+            onFiltersChange({
+              ...filters,
+              type: e.target.value as AssignmentFilters["type"],
+            })
+          }
+          aria-label={t("assignments.toolbar.typeAria")}
+        >
+          <option value="all">{t("assignments.toolbar.typeAll")}</option>
+          <option value="individual">
+            {t("assignments.toolbar.typeIndividual")}
+          </option>
+          <option value="group">{t("assignments.toolbar.typeGroup")}</option>
+        </Toolbar.FilterSelect>
+
+        <Toolbar.FilterSelect
+          icon={<ListFilter aria-hidden="true" className="size-4" />}
+          active={filters.due !== "all"}
+          value={filters.due}
+          onChange={(e) =>
+            onFiltersChange({
+              ...filters,
+              due: e.target.value as AssignmentFilters["due"],
+            })
+          }
+          aria-label={t("assignments.toolbar.dueAria")}
+        >
+          <option value="all">{t("assignments.toolbar.dueAll")}</option>
+          <option value="has-due">{t("assignments.toolbar.dueHas")}</option>
+          <option value="no-due">{t("assignments.toolbar.dueNone")}</option>
+          <option value="overdue">{t("assignments.toolbar.dueOverdue")}</option>
+        </Toolbar.FilterSelect>
+
         <Toolbar.FilterSelect
           icon={<ArrowUpDown aria-hidden="true" className="size-4" />}
           value={sort}

--- a/web/src/pages/assignments/ClassroomCollectButton.test.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.test.tsx
@@ -17,11 +17,12 @@ vi.mock("@/context/notifications/NotificationProvider", () => ({
 const collect = vi.fn()
 const hookArgs: unknown[][] = []
 let phase = "idle"
+let failure: "dispatch" | "run" | null = null
 let error: unknown = null
 vi.mock("@/hooks/useTriggerScoreCollection", () => ({
   default: (...args: unknown[]) => {
     hookArgs.push(args)
-    return { collect, phase, run: null, error }
+    return { collect, phase, failure, run: null, error }
   },
 }))
 
@@ -67,6 +68,7 @@ beforeEach(() => {
   notify.mockReset()
   hookArgs.length = 0
   phase = "idle"
+  failure = null
   error = null
   scoresResult = { data: undefined, isLoading: false }
   lastRunResult = { data: undefined }
@@ -172,12 +174,30 @@ describe("ClassroomCollectButton", () => {
     )
 
     phase = "failed"
+    failure = "dispatch"
     error = new Error("Resource not accessible by personal access token")
     rerender(<ClassroomCollectButton org="acme" classroom="cs50" />)
 
     expect(notify).toHaveBeenCalledWith(
       expect.objectContaining({ tone: "error", key: "collect-scores:cs50" }),
     )
+  })
+
+  // A run that concluded non-success is "failed" on the hook too, but it has a
+  // banner row of its own — toasting it would report the one failure twice.
+  it("leaves a failed run to the Actions banner", () => {
+    phase = "running"
+    const { wrapper } = setup()
+    const { rerender } = render(
+      <ClassroomCollectButton org="acme" classroom="cs50" />,
+      { wrapper },
+    )
+
+    phase = "failed"
+    failure = "run"
+    rerender(<ClassroomCollectButton org="acme" classroom="cs50" />)
+
+    expect(notify).not.toHaveBeenCalled()
   })
 
   // The i18n mock returns bare keys, so the assertions match keys, not copy.

--- a/web/src/pages/assignments/ClassroomCollectButton.test.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.test.tsx
@@ -25,6 +25,20 @@ vi.mock("@/hooks/useTriggerScoreCollection", () => ({
   },
 }))
 
+// Freshness inputs, both already served from the query cache in the app.
+let scoresResult: { data?: unknown; isLoading: boolean } = {
+  data: undefined,
+  isLoading: false,
+}
+vi.mock("@/hooks/useGetScores", () => ({
+  default: () => scoresResult,
+}))
+
+let lastRunResult: { data?: unknown } = { data: undefined }
+vi.mock("@/hooks/useGetLastCollectScoresRun", () => ({
+  default: () => lastRunResult,
+}))
+
 import { ClassroomCollectButton } from "./ClassroomCollectButton"
 
 // One client + spy per test, handed back inferred so the recorded filters keep
@@ -45,7 +59,8 @@ const setup = () => {
   }
 }
 
-const button = () => screen.getByRole("button")
+const collectButton = () =>
+  screen.getByRole("button", { name: "assignments.collect.label" })
 
 beforeEach(() => {
   collect.mockReset()
@@ -53,18 +68,45 @@ beforeEach(() => {
   hookArgs.length = 0
   phase = "idle"
   error = null
+  scoresResult = { data: undefined, isLoading: false }
+  lastRunResult = { data: undefined }
+  // happy-dom's <dialog> lacks showModal/close; stub them so the confirm
+  // modal's open-sync effect can run.
+  HTMLDialogElement.prototype.showModal = function () {
+    this.open = true
+  }
+  HTMLDialogElement.prototype.close = function () {
+    this.open = false
+    this.dispatchEvent(new Event("close"))
+  }
 })
 
 afterEach(cleanup)
 
 describe("ClassroomCollectButton", () => {
-  it("dispatches a classroom-wide collect (no assignment in the scope)", () => {
+  it("confirms before dispatching a classroom-wide collect (no assignment in the scope)", () => {
     const { wrapper } = setup()
     render(<ClassroomCollectButton org="acme" classroom="cs50" />, { wrapper })
-    fireEvent.click(button())
+    fireEvent.click(collectButton())
+
+    // The click only opens the confirmation; the sweep is heavier than a
+    // per-assignment collect, so nothing dispatches until it's confirmed.
+    expect(collect).not.toHaveBeenCalled()
+    fireEvent.click(
+      screen.getByRole("button", { name: "assignments.collect.confirmAction" }),
+    )
 
     expect(collect).toHaveBeenCalledTimes(1)
     expect(hookArgs[0]).toEqual(["acme", { classroom: "cs50" }])
+  })
+
+  it("does not dispatch when the confirmation is cancelled", () => {
+    const { wrapper } = setup()
+    render(<ClassroomCollectButton org="acme" classroom="cs50" />, { wrapper })
+    fireEvent.click(collectButton())
+    fireEvent.click(screen.getByRole("button", { name: "common.cancel" }))
+
+    expect(collect).not.toHaveBeenCalled()
   })
 
   it("explains itself and does not dispatch while the roster is empty", () => {
@@ -73,11 +115,11 @@ describe("ClassroomCollectButton", () => {
       wrapper,
     })
 
-    expect((button() as HTMLButtonElement).disabled).toBe(true)
-    expect(button().getAttribute("title")).toBe(
+    expect((collectButton() as HTMLButtonElement).disabled).toBe(true)
+    expect(collectButton().getAttribute("title")).toBe(
       "submissions.collect.titleEmptyRoster",
     )
-    fireEvent.click(button())
+    fireEvent.click(collectButton())
     expect(collect).not.toHaveBeenCalled()
   })
 
@@ -136,5 +178,89 @@ describe("ClassroomCollectButton", () => {
     expect(notify).toHaveBeenCalledWith(
       expect.objectContaining({ tone: "error", key: "collect-scores:cs50" }),
     )
+  })
+
+  // The i18n mock returns bare keys, so the assertions match keys, not copy.
+  describe("freshness line", () => {
+    it("reads never-synced when there is no scores.json", () => {
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(
+        screen.getByText("submissions.freshness.neverCollected"),
+      ).toBeTruthy()
+    })
+
+    it("reads synced from the buckets' collected_at stamps", () => {
+      scoresResult = {
+        data: {
+          submissions: {},
+          collectedAt: {
+            hw1: "2026-06-01T00:00:00Z",
+            hw2: "2026-06-02T00:00:00Z",
+          },
+          detected: {},
+        },
+        isLoading: false,
+      }
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.getByText("submissions.freshness.collected")).toBeTruthy()
+    })
+
+    // A stamped file never borrows the org-wide run timestamp (that run may
+    // have swept another classroom); a wholly unstamped file predates the
+    // stamping collector, when every run was org-wide, so the fallback holds.
+    it("falls back to the org-wide run only for a wholly unstamped file", () => {
+      scoresResult = {
+        data: { submissions: {}, collectedAt: {}, detected: {} },
+        isLoading: false,
+      }
+      lastRunResult = {
+        data: { status: "completed", created_at: "2026-06-01T00:00:00Z" },
+      }
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.getByText("submissions.freshness.collected")).toBeTruthy()
+    })
+
+    it("ignores a run that has not completed", () => {
+      scoresResult = {
+        data: { submissions: {}, collectedAt: {}, detected: {} },
+        isLoading: false,
+      }
+      lastRunResult = {
+        data: { status: "in_progress", created_at: "2026-06-01T00:00:00Z" },
+      }
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(
+        screen.getByText("submissions.freshness.neverCollected"),
+      ).toBeTruthy()
+    })
+
+    it("stays silent while scores.json is still loading", () => {
+      scoresResult = { data: undefined, isLoading: true }
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.queryByText("submissions.freshness.collected")).toBeNull()
+      expect(
+        screen.queryByText("submissions.freshness.neverCollected"),
+      ).toBeNull()
+    })
   })
 })

--- a/web/src/pages/assignments/ClassroomCollectButton.test.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) }
+})
+
+const notify = vi.fn()
+vi.mock("@/context/notifications/NotificationProvider", () => ({
+  useToast: () => ({ notify, dismiss: vi.fn() }),
+}))
+
+const collect = vi.fn()
+const hookArgs: unknown[][] = []
+let phase = "idle"
+let error: unknown = null
+vi.mock("@/hooks/useTriggerScoreCollection", () => ({
+  default: (...args: unknown[]) => {
+    hookArgs.push(args)
+    return { collect, phase, run: null, error }
+  },
+}))
+
+import { ClassroomCollectButton } from "./ClassroomCollectButton"
+
+// One client + spy per test, handed back inferred so the recorded filters keep
+// their types.
+const setup = () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  const invalidate = vi.spyOn(client, "invalidateQueries")
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return {
+    wrapper,
+    invalidate,
+    invalidatedKeys: () =>
+      invalidate.mock.calls.map((call) => call[0]?.queryKey),
+  }
+}
+
+const button = () => screen.getByRole("button")
+
+beforeEach(() => {
+  collect.mockReset()
+  notify.mockReset()
+  hookArgs.length = 0
+  phase = "idle"
+  error = null
+})
+
+afterEach(cleanup)
+
+describe("ClassroomCollectButton", () => {
+  it("dispatches a classroom-wide collect (no assignment in the scope)", () => {
+    const { wrapper } = setup()
+    render(<ClassroomCollectButton org="acme" classroom="cs50" />, { wrapper })
+    fireEvent.click(button())
+
+    expect(collect).toHaveBeenCalledTimes(1)
+    expect(hookArgs[0]).toEqual(["acme", { classroom: "cs50" }])
+  })
+
+  it("explains itself and does not dispatch while the roster is empty", () => {
+    const { wrapper } = setup()
+    render(<ClassroomCollectButton org="acme" classroom="cs50" emptyRoster />, {
+      wrapper,
+    })
+
+    expect((button() as HTMLButtonElement).disabled).toBe(true)
+    expect(button().getAttribute("title")).toBe(
+      "submissions.collect.titleEmptyRoster",
+    )
+    fireEvent.click(button())
+    expect(collect).not.toHaveBeenCalled()
+  })
+
+  it("drops the cached gradebook when the run completes", () => {
+    phase = "running"
+    const { wrapper, invalidate, invalidatedKeys } = setup()
+    const { rerender } = render(
+      <ClassroomCollectButton org="acme" classroom="cs50" />,
+      { wrapper },
+    )
+    expect(invalidate).not.toHaveBeenCalled()
+
+    phase = "completed"
+    rerender(<ClassroomCollectButton org="acme" classroom="cs50" />)
+
+    expect(invalidatedKeys()).toContainEqual(
+      expect.arrayContaining(["json-file", "acme", "cs50/scores.json"]),
+    )
+    expect(invalidatedKeys()).toContainEqual(
+      expect.arrayContaining(["last-collect-scores-run", "acme"]),
+    )
+  })
+
+  // The poll giving up says nothing about the run, which usually lands — so the
+  // stale reads go either way.
+  it("drops the cached gradebook when the poll times out", () => {
+    phase = "running"
+    const { wrapper, invalidatedKeys } = setup()
+    const { rerender } = render(
+      <ClassroomCollectButton org="acme" classroom="cs50" />,
+      { wrapper },
+    )
+
+    phase = "timeout"
+    rerender(<ClassroomCollectButton org="acme" classroom="cs50" />)
+
+    expect(invalidatedKeys()).toContainEqual(
+      expect.arrayContaining(["json-file", "acme", "cs50/scores.json"]),
+    )
+  })
+
+  // A rejected dispatch never registers with the Actions banner (registration
+  // rides the mutation's success), so this toast is its only surface.
+  it("reports a dispatch that never landed", () => {
+    phase = "dispatching"
+    const { wrapper } = setup()
+    const { rerender } = render(
+      <ClassroomCollectButton org="acme" classroom="cs50" />,
+      { wrapper },
+    )
+
+    phase = "failed"
+    error = new Error("Resource not accessible by personal access token")
+    rerender(<ClassroomCollectButton org="acme" classroom="cs50" />)
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: "error", key: "collect-scores:cs50" }),
+    )
+  })
+})

--- a/web/src/pages/assignments/ClassroomCollectButton.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.tsx
@@ -1,19 +1,30 @@
 import { useQueryClient } from "@tanstack/react-query"
-import { RefreshCw } from "lucide-react"
-import { useEffect } from "react"
+import { RefreshCw, TriangleAlert } from "lucide-react"
+import { useEffect, useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button } from "@/components/ui"
+import { Button, Modal } from "@/components/ui"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { githubKeys } from "@/github-core/queries"
+import useGetLastCollectScoresRun from "@/hooks/useGetLastCollectScoresRun"
+import useGetScores from "@/hooks/useGetScores"
 import useTriggerScoreCollection from "@/hooks/useTriggerScoreCollection"
+import { latestCollectedAt } from "@/pages/submissions/dashboard"
 import { CONFIG_REPO } from "@/util/configRepo"
+import { formatRelativeToNow } from "@/util/formatDate"
 
-// Classroom-wide "Collect all": dispatches collect-scores with only the
-// `classroom` input, so the workflow walks every assignment in this classroom
-// instead of the single-assignment scope the submissions page dispatches.
-// Unlike that scope, `classroom` is the workflow's long-standing input, so
-// there is no CollectInputsUnsupportedError branch to handle here.
+// Classroom-wide "Collect all", presented as the assignments toolbar's
+// freshness widget — a passive "Submission data synced x ago" line plus the
+// action, mirroring the submissions page's DataFreshness pairing so the button
+// carries its own context: the table's submission counts come from the
+// scores.json snapshot this button rebuilds. The line reuses the shared
+// submissions.freshness strings (one wording, no duplicate translation keys).
+//
+// Dispatches collect-scores with only the `classroom` input, so the workflow
+// walks every assignment in this classroom instead of the single-assignment
+// scope the submissions page dispatches. Unlike that scope, `classroom` is the
+// workflow's long-standing input, so there is no CollectInputsUnsupportedError
+// branch to handle here.
 //
 // Once dispatched, the run's outcome is reported by the app-wide Actions banner
 // (the hook registers it), which also survives navigating away mid-sweep — so
@@ -39,6 +50,38 @@ export function ClassroomCollectButton({
   const queryClient = useQueryClient()
   const collect = useTriggerScoreCollection(org, { classroom })
   const busy = collect.phase === "dispatching" || collect.phase === "running"
+  // A sweep is a heavier dispatch than the per-assignment collect (it walks
+  // every assignment, and Actions minutes scale with the classroom), so the
+  // click confirms before dispatching instead of firing straight away.
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const confirmTitleId = useId()
+
+  // Classroom-level freshness: the newest per-bucket collected_at stamp — any
+  // collect that walked this classroom moved at least one. scores.json is
+  // already in the query cache (the assignments table reads it for submission
+  // counts), so this line costs no extra fetch. A stamped file never borrows
+  // the org-wide run timestamp (that run may have swept a different
+  // classroom); a wholly unstamped file predates the stamping collector, when
+  // every run was org-wide, so the run fallback is sound there — the same
+  // precedence the submissions page's effectiveCollectedAt applies per bucket.
+  const { data: scoresData, isLoading: scoresLoading } = useGetScores(
+    org,
+    classroom,
+  )
+  const { data: lastRun } = useGetLastCollectScoresRun(org)
+  const bucketStamps = Object.values(scoresData?.collectedAt ?? {})
+  const newestStamp = bucketStamps.reduce<string | null>(
+    latestCollectedAt,
+    null,
+  )
+  const lastCollectedAt =
+    newestStamp ??
+    (scoresData && bucketStamps.length === 0 && lastRun?.status === "completed"
+      ? lastRun.created_at
+      : null)
+  const lastCollectedLabel = lastCollectedAt
+    ? formatRelativeToNow(new Date(lastCollectedAt))
+    : null
 
   // A finished sweep rewrote every bucket in this classroom's scores.json, so
   // drop the cached gradebook and the last-run stamp; the table's submission
@@ -76,28 +119,77 @@ export function ClassroomCollectButton({
   }, [collect.phase, collect.error, classroom, notify, t])
 
   return (
-    <Button
-      variant="ghost"
-      size="sm"
-      loading={busy}
-      loadingLabel={t("submissions.collect.active")}
-      disabled={emptyRoster}
-      title={
-        emptyRoster
-          ? t("submissions.collect.titleEmptyRoster")
-          : t("assignments.collect.title")
-      }
-      onClick={() => collect.collect()}
-    >
-      {busy ? (
-        t("submissions.collect.active")
-      ) : (
-        <>
-          <RefreshCw aria-hidden="true" className="size-4" />
-          {t("assignments.collect.label")}
-        </>
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+      {/* Silent while scores.json loads so the line doesn't flash "not synced
+          yet" before the cached snapshot arrives. */}
+      {!scoresLoading && (
+        <span role="status" className="text-sm text-base-content/70">
+          {lastCollectedLabel
+            ? t("submissions.freshness.collected", {
+                when: lastCollectedLabel,
+              })
+            : t("submissions.freshness.neverCollected")}
+        </span>
       )}
-    </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        loading={busy}
+        loadingLabel={t("submissions.collect.active")}
+        disabled={emptyRoster}
+        title={
+          emptyRoster
+            ? t("submissions.collect.titleEmptyRoster")
+            : t("assignments.collect.title")
+        }
+        onClick={() => setConfirmOpen(true)}
+      >
+        {busy ? (
+          t("submissions.collect.active")
+        ) : (
+          <>
+            <RefreshCw aria-hidden="true" className="size-4" />
+            {t("assignments.collect.label")}
+          </>
+        )}
+      </Button>
+
+      <Modal
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        size="lg"
+        aria-labelledby={confirmTitleId}
+      >
+        <div className="flex items-start gap-4">
+          <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-warning/10 text-warning">
+            <TriangleAlert className="size-5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 id={confirmTitleId} className="text-lg font-bold">
+              {t("assignments.collect.confirmTitle")}
+            </h3>
+            <p className="mt-3 text-sm text-base-content/80">
+              {t("assignments.collect.confirmBody")}
+            </p>
+          </div>
+        </div>
+
+        <div className="modal-action">
+          <Button variant="ghost" onClick={() => setConfirmOpen(false)}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => {
+              setConfirmOpen(false)
+              collect.collect()
+            }}
+          >
+            {t("assignments.collect.confirmAction")}
+          </Button>
+        </div>
+      </Modal>
+    </div>
   )
 }
 

--- a/web/src/pages/assignments/ClassroomCollectButton.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.tsx
@@ -33,7 +33,8 @@ import { formatRelativeToNow } from "@/util/formatDate"
 // happens on the mutation's success, so a rejected POST (no config-repo write,
 // no classroom50 repo) has no banner row and would otherwise just un-spin the
 // button silently. That one case gets a toast, reusing the submissions page's
-// wording for the same failure.
+// wording for the same failure — keyed off `failure`, since the hook reports a
+// run that concluded non-success as "failed" too and the banner already has it.
 export function ClassroomCollectButton({
   org,
   classroom,
@@ -103,7 +104,7 @@ export function ClassroomCollectButton({
   }, [collect.phase, classroom, org, queryClient])
 
   useEffect(() => {
-    if (collect.phase !== "failed") return
+    if (collect.phase !== "failed" || collect.failure !== "dispatch") return
     notify({
       tone: "error",
       key: `collect-scores:${classroom}`,
@@ -116,7 +117,7 @@ export function ClassroomCollectButton({
               "submissions.collect.statusFailedHint",
             )}`,
     })
-  }, [collect.phase, collect.error, classroom, notify, t])
+  }, [collect.phase, collect.failure, collect.error, classroom, notify, t])
 
   return (
     <div className="flex flex-wrap items-center gap-x-2 gap-y-1">

--- a/web/src/pages/assignments/ClassroomCollectButton.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.tsx
@@ -1,0 +1,104 @@
+import { useQueryClient } from "@tanstack/react-query"
+import { RefreshCw } from "lucide-react"
+import { useEffect } from "react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@/components/ui"
+import { useToast } from "@/context/notifications/NotificationProvider"
+import { githubKeys } from "@/github-core/queries"
+import useTriggerScoreCollection from "@/hooks/useTriggerScoreCollection"
+import { CONFIG_REPO } from "@/util/configRepo"
+
+// Classroom-wide "Collect all": dispatches collect-scores with only the
+// `classroom` input, so the workflow walks every assignment in this classroom
+// instead of the single-assignment scope the submissions page dispatches.
+// Unlike that scope, `classroom` is the workflow's long-standing input, so
+// there is no CollectInputsUnsupportedError branch to handle here.
+//
+// Once dispatched, the run's outcome is reported by the app-wide Actions banner
+// (the hook registers it), which also survives navigating away mid-sweep — so
+// this component only carries the in-flight state and drops the reads the sweep
+// invalidated. A dispatch that never lands is the exception: registration
+// happens on the mutation's success, so a rejected POST (no config-repo write,
+// no classroom50 repo) has no banner row and would otherwise just un-spin the
+// button silently. That one case gets a toast, reusing the submissions page's
+// wording for the same failure.
+export function ClassroomCollectButton({
+  org,
+  classroom,
+  emptyRoster = false,
+}: {
+  org: string
+  classroom: string
+  // Nothing to collect until someone is enrolled. The dispatch would still
+  // succeed, so this is a UX gate, not a correctness one.
+  emptyRoster?: boolean
+}) {
+  const { t } = useTranslation()
+  const { notify } = useToast()
+  const queryClient = useQueryClient()
+  const collect = useTriggerScoreCollection(org, { classroom })
+  const busy = collect.phase === "dispatching" || collect.phase === "running"
+
+  // A finished sweep rewrote every bucket in this classroom's scores.json, so
+  // drop the cached gradebook and the last-run stamp; the table's submission
+  // counts re-derive on the refetch. `timeout` is only this client giving up on
+  // the poll — the run itself usually lands, so refresh there too rather than
+  // leaving the page on stale counts.
+  useEffect(() => {
+    if (collect.phase !== "completed" && collect.phase !== "timeout") return
+    queryClient.invalidateQueries({
+      queryKey: githubKeys.jsonFile(
+        org,
+        CONFIG_REPO,
+        `${classroom}/scores.json`,
+      ),
+    })
+    queryClient.invalidateQueries({
+      queryKey: githubKeys.lastCollectScoresRun(org),
+    })
+  }, [collect.phase, classroom, org, queryClient])
+
+  useEffect(() => {
+    if (collect.phase !== "failed") return
+    notify({
+      tone: "error",
+      key: `collect-scores:${classroom}`,
+      message:
+        collect.error instanceof Error
+          ? `${t("submissions.collect.statusFailedWithReason", {
+              reason: collect.error.message,
+            })} ${t("submissions.collect.statusFailedHint")}`
+          : `${t("submissions.collect.statusFailed")} ${t(
+              "submissions.collect.statusFailedHint",
+            )}`,
+    })
+  }, [collect.phase, collect.error, classroom, notify, t])
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      loading={busy}
+      loadingLabel={t("submissions.collect.active")}
+      disabled={emptyRoster}
+      title={
+        emptyRoster
+          ? t("submissions.collect.titleEmptyRoster")
+          : t("assignments.collect.title")
+      }
+      onClick={() => collect.collect()}
+    >
+      {busy ? (
+        t("submissions.collect.active")
+      ) : (
+        <>
+          <RefreshCw aria-hidden="true" className="size-4" />
+          {t("assignments.collect.label")}
+        </>
+      )}
+    </Button>
+  )
+}
+
+export default ClassroomCollectButton

--- a/wiki/Autograding-Basics.md
+++ b/wiki/Autograding-Basics.md
@@ -26,7 +26,9 @@ see [Managing Actions cost](Managing-Actions-Cost).
    **View grade** link opens the Release.
 5. The **score-collection** workflow gathers the **collected scores**
    (`scores.json` in your `classroom50` repository) — on demand with
-   **Sync now** on the submissions page. That's what the web app's submissions
+   **Sync now** on the submissions page, or **Collect all** on the classroom's
+   assignments list to refresh every assignment in one run. That's what the
+   web app's submissions
    page and both CSV exports read. See [Reading results](#reading-results).
 
 Steps 3–5 run with no per-repository maintenance: everything substantive (the runner
@@ -349,7 +351,9 @@ Every graded submission produces the same three records:
 
 Releases and statuses appear the moment grading finishes. The collected scores
 lag until **collection** runs — on demand with **Sync now** on the
-submissions page (`gh workflow run collect-scores.yaml` from the shell). If a
+submissions page, **Collect all** on the classroom's assignments list
+(every assignment in one run), or `gh workflow run collect-scores.yaml` from
+the shell. If a
 student says "I submitted" and you see no score, sync first.
 
 On the submissions page, each row shows the student's (or group's) current

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -162,8 +162,9 @@ gh api -X PUT /repos/<org>/classroom50/actions/permissions/access \
 ### 6. Score collection
 
 Trigger the `collect-scores.yaml` workflow from the Actions tab, optionally
-scoped to one classroom or a single assignment (the same scoped run the web
-app's per-assignment **Sync now** button dispatches):
+scoped to one classroom or a single assignment (the same scoped runs the web
+app dispatches: **Collect all** on a classroom's assignments list sends the
+classroom-only scope, and the per-assignment **Sync now** sends both inputs):
 
 ```sh
 gh workflow run collect-scores.yaml --repo <org>/classroom50
@@ -171,9 +172,10 @@ gh workflow run collect-scores.yaml --repo <org>/classroom50 -f classroom=<short
 gh workflow run collect-scores.yaml --repo <org>/classroom50 -f classroom=<short-name> -f assignment=<slug>
 ```
 
-A scoped run walks only the matching assignment's repos (faster and cheaper on
-API rate limits for a large classroom) and stamps that assignment's
-`collected_at` in `scores.json`; sibling assignments' buckets are untouched.
+A scoped run walks only the matching repos — one classroom's, or a single
+assignment's (faster and cheaper on API rate limits for a large classroom) —
+and stamps each walked assignment's
+`collected_at` in `scores.json`; buckets outside the scope are untouched.
 The staff-team read grant that rides along with collection is scoped the same
 way, so a per-assignment run touches only that assignment's repositories and
 template.

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -72,13 +72,15 @@ read it:
   `classroom50` repository and GitHub teams immediately, but only for the thing they
   change — they don't run the web app's broader sync.
 - **Scores** refresh only when collection runs: on demand with
-  **Sync now** / `collect-scores.yaml`.
+  **Sync now** (one assignment), **Collect all** (a whole classroom), or
+  `collect-scores.yaml`.
 
 `gh teacher roster sync <org> <classroom> --write` is the one CLI command that
 syncs rather than reading or writing a single thing: it catches the roster up with
 the classroom's GitHub state, chiefly the email invitations students have accepted.
 Opening the classroom in the web app as an owner does the same on its own. Without
-`--write`, `roster sync` reports and changes nothing. **Sync now** covers scores.
+`--write`, `roster sync` reports and changes nothing. **Sync now** and
+**Collect all** cover scores.
 See [What triggers a sync](#what-triggers-a-sync).
 
 ## Interactive and background work

--- a/wiki/Managing-Actions-Cost.md
+++ b/wiki/Managing-Actions-Cost.md
@@ -19,6 +19,11 @@ when minutes run out.
   `every-push` mode grades each push to the default branch: five pushes in
   ten minutes are five graded runs. Multiply by roster size to estimate an
   assignment's cost.
+- **Score collection bills too, by scope.** A collection run is one job in
+  your `classroom50` repository that walks every repository in its scope. A
+  per-assignment **Sync now** stays cheap; **Collect all** on a classroom's
+  assignments list walks every assignment in the classroom in one run
+  (capped at 30 minutes), which is why it asks you to confirm first.
 
 ## The levers, by impact
 

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -505,7 +505,8 @@ are **scoped to the current assignment** — they walk only this assignment's
 repositories, so a sync is fast even in a large classroom and doesn't rebuild
 other assignments' scores. The strip shows when this assignment's data was
 last synced (a per-assignment `collected_at` stamp in `scores.json`). Click
-**View workflow** to see the Actions run.
+**View workflow** to see the Actions run. To refresh every assignment in one
+run instead, see [Collect the whole classroom](#collect-the-whole-classroom).
 
 The top of the page shows:
 
@@ -525,6 +526,27 @@ and links to the repository, the commit, the feedback pull request
 result lives — per-test breakdowns, past attempts, grading a specific commit,
 and who submitted — see
 [Reading results](Autograding-Basics#reading-results) in Autograding Basics.
+
+### Collect the whole classroom
+
+The classroom's assignments list refreshes all scores in one run. Above the
+table, a freshness line shows when the classroom's submission data was last
+synced, next to a **Collect all** button. Clicking it dispatches a single
+`collect-scores.yaml` run scoped to the classroom, so one run walks every
+assignment and rebuilds all of the classroom's collected scores; the table's
+per-assignment submission counts refresh when the run finishes.
+
+Because the run walks every assignment's repositories, it takes longer than a
+single-assignment sync and uses more GitHub Actions minutes, so **Collect all**
+asks you to confirm before dispatching. To refresh one assignment while
+grading, prefer **Sync now** on that assignment's submissions page.
+
+Any staff member can collect, the same as the per-assignment sync. The button
+is hidden on an archived classroom and while the classroom has no assignments,
+and disabled while the roster is empty. Once dispatched, the run appears in
+the banner at the top of the app as **Collecting scores**, which keeps
+tracking the run if you navigate away and links to the Actions run
+(**View run**).
 
 ### Scores and overrides
 


### PR DESCRIPTION
## Summary

The web app could only collect scores one assignment at a time — a teacher refreshing a classroom's gradebook had to walk every submissions page and press "Collect now" on each, or run `collect-scores.yaml` by hand from the Actions tab.

This adds a **Collect all** action to the classroom's assignments toolbar. It dispatches the same workflow with only the `classroom` input, so one run walks every assignment in the classroom.

The dispatch layer already supported it (`triggerScoreCollection`'s `scope.assignment` was already optional, and the workflow documents a blank `assignment` as "collect the whole classroom") — only `useTriggerScoreCollection` narrowed `assignment` back to required, and no page but the submissions page called it.

Behavior:

- The action leads the toolbar, mirroring the submissions page's layout: the collect affordance sits left (where DataFreshness leads there), and search + filters + sort + the New assignment button sit right, so the two toolbars read the same way.
- The button is paired with a passive freshness line ("Submission data synced x ago", reusing the shared `submissions.freshness.*` strings), so the context is implicit: the table's submission counts come from the `scores.json` snapshot this button rebuilds. The timestamp is the newest per-bucket `collected_at` stamp — free, since the table already has `scores.json` in the query cache — and a stamped file never borrows the org-wide run timestamp (that run may have swept a different classroom); only a wholly unstamped pre-stamp-collector file falls back to it, the same precedence `effectiveCollectedAt` applies per bucket.
- Clicking confirms before dispatching: a sweep takes longer for a large classroom and uses more GitHub Actions minutes than a single-assignment collect, so the modal says so and the dispatch only fires from its confirm action.
- Visible to any staff viewer — a TA can already collect per assignment; only authoring is author-gated. Hidden on an archived classroom and while the classroom has no assignments; disabled with an explanatory title while the roster is empty.
- A sweep's execution is tracked against the workflow's own 30-minute job cap (`collect-scores.yaml`, `timeout-minutes: 30`) instead of the 10-minute default tuned for a single assignment. That cap measures execution only, and the sweep shares the `collect-${classroom}` concurrency group with every per-assignment collect in the classroom, so `useGitHubOperation` now waits out the Actions queue on its own window before the execution window starts counting (anchored on `run_started_at`) — previously a healthy queued run could trip the client timeout, which drops the tracked dispatch and re-enables the button mid-run, inviting a duplicate queued behind it.
- The outcome is reported by the existing app-wide Actions banner, which the hook already registers every dispatch with and which survives navigating away mid-sweep. The one case it cannot cover is a dispatch that never lands — registration rides the mutation's success — so a rejected POST (no config-repo write, no `classroom50` repo) gets an error toast, reusing the submissions page's wording for the same failure. The hook now attributes a failure to the dispatch or the run (`failure: "dispatch" | "run"`), and the toast fires only for the dispatch side — a run that concluded non-success is already the banner's to report.
- A finished run invalidates this classroom's `scores.json` and the last-collect-run stamp, so the table's submission counts and the freshness line re-derive. A client-side `timeout` invalidates too: the poll giving up says nothing about the run, and leaving the page on stale counts is the worse default.
- No workflow-version guard: `classroom` has been a dispatch input since #58, while `assignment` arrived in #593 — so the `CollectInputsUnsupportedError` (422 "unexpected inputs") case is specific to the per-assignment scope and cannot fire here.

The wiki pages that describe score collection now cover the classroom-wide collect: a new "Collect the whole classroom" section in the Web Teacher Guide, and updated mentions in GitHub Integration (the dispatch-scope examples), Autograding Basics, How Classroom 50 Works, and Managing Actions Cost (what a sweep bills). They publish with the merge, since the wiki syncs from `wiki/` on `main`.

Closes #719

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - Web: `cd web && npm run check` — passes (tsc, eslint, prettier, arch:validate, 352 test files / 4416 tests).
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass. — n/a, no contract change: the workflow inputs and the `scores.json` shape are untouched.
- [x] If I added or changed a CLI command or flag, I documented it in the wiki. — no CLI change, but the wiki pages describing score collection are updated for the classroom-wide collect (Web Teacher Guide, GitHub Integration, Autograding Basics, How Classroom 50 Works, Managing Actions Cost).
- [x] My commits follow Conventional Commits.

## Files

| File | Change |
| --- | --- |
| `web/src/hooks/useGitHubOperation.ts` | queue-aware deadline (`queueTimeoutMs`, anchored on `run_started_at` once the run leaves the queue) and failure attribution (`failure: "dispatch" \| "run"`) |
| `web/src/hooks/useGitHubOperation.test.tsx` | new — queue-wait windows, skewed start stamps, and failure attribution, on fake timers |
| `web/src/hooks/useTriggerScoreCollection.ts` | `CollectScoresScope.assignment` optional; scope suffix keeps a sweep and an assignment collect on distinct storage/query keys; 30-minute execution window for a sweep; forwards `failure` |
| `web/src/hooks/useTriggerScoreCollection.test.tsx` | new — scope keying and the timing window, without mocking the hook under test |
| `web/src/pages/assignments/ClassroomCollectButton.tsx` | new — freshness line + button + confirm modal, cache invalidation, dispatch-failure toast |
| `web/src/pages/assignments/ClassroomCollectButton.test.tsx` | new — confirm-then-dispatch flow, cancel, empty-roster gate, freshness-line derivation, invalidation on completed/timeout, dispatch-vs-run failure toast |
| `web/src/pages/assignments/AssignmentsToolbar.tsx` | `leading` slot for the collect action; search + filters move into the trailing group, mirroring `SubmissionsControls` |
| `web/src/pages/AssignmentsPage.tsx` | passes the collect action as `leading` and the primary action as `trailing` |
| `web/src/pages/AssignmentsPage.test.tsx` | page-level gating of the collect action: leads the toolbar for staff with assignments, absent when archived or the list is empty |
| `web/src/locales/en.json` | `assignments.collect.label`, `.title`, and the confirm-modal strings; the freshness and status strings are reused from `submissions.freshness.*` / `submissions.collect.*` rather than duplicated across 18 language packs |
| `web/src/github-core/mutations/workflowDispatch.test.ts` | a classroom-only dispatch must omit the `assignment` key entirely, not send it blank |
| `wiki/` (5 pages) | Web Teacher Guide gains a "Collect the whole classroom" section; GitHub Integration, Autograding Basics, How Classroom 50 Works, and Managing Actions Cost mention the classroom-wide collect where they describe collection |

## Not in this PR

- **Org-wide collect.** The dispatch supports omitting both inputs, but it crosses classroom boundaries and wants its own permission discussion.
- **Dispatch-to-run binding.** Run discovery identifies our run as the oldest one past the pre-dispatch baseline, and the sweep and per-assignment trackers share that lookup. Two dispatches snapshotting the same baseline within the seconds before the first run appears can bind to the same run — a pre-existing property of every dispatch surface (the dispatch API returns no run id to correlate on), with mild consequences (the concurrency group serializes the runs, and completion invalidates the same caches). Correlating via a dispatch marker input is its own change.
- **Classroom-wide staleness.** The submissions page's red "Sync now" (push after last collect) needs every assignment's repos' `pushed_at` correlated against per-bucket stamps; the freshness line here stays passive.
- **One presenter for `OperationPhase`.** The submissions status strip, the activity banner, and this button are three hand-written mappings of the same five states; unifying them is worth doing once a third collect surface lands, not here.
- **The second poller.** `useGitHubOperation` polls the run while the activity banner polls the same workflow's runs anyway — pre-existing for every dispatch site, not introduced here.
- **`OP_TTL_MS`.** The activity banner drops a tracker after 15 minutes, so the banner row for a very long sweep can disappear before the run ends. Changing that TTL affects every tracked operation, so it is left alone.
