### PR TITLE
feat(web): adopt Primer typography with Mona Sans and title scale

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -33,9 +33,12 @@
     <title>Classroom 50</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- CJK fallback only: the primary face (Mona Sans) is self-hosted and
+         loaded via the bundled stylesheet. Weight 600 included so JP titles
+         render the Primer semibold instead of synthesizing it. -->
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Noto+Sans+JP:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap"
     />
     <script>
       // Anti-flash: apply the persisted (or OS-preferred) theme before the app

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "classroom-alpha",
       "version": "1.33.0",
       "dependencies": {
+        "@fontsource-variable/mona-sans": "^5.3.0",
         "@primer/octicons-react": "^19.33.0",
         "@tailwindcss/vite": "^4.3.3",
         "@tanstack/react-form": "^1.33.3",
@@ -615,6 +616,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fontsource-variable/mona-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/mona-sans/-/mona-sans-5.3.0.tgz",
+      "integrity": "sha512-PkxRB3KI4z9Gjpk7vVqgO3GMSyQuOIIj4TaRDbvbcDj8SzWwI38jvLTQxJM/cTRorhcT7h8qjcllR+qjRtM/Fg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "missing": "tsc -p tsconfig.app.json --pretty false 2>&1 | grep -E \"TS(2304|2305|2307|2503|2552)\""
   },
   "dependencies": {
+    "@fontsource-variable/mona-sans": "^5.3.0",
     "@primer/octicons-react": "^19.33.0",
     "@tailwindcss/vite": "^4.3.3",
     "@tanstack/react-form": "^1.33.3",

--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next"
 import { useGithubAuth } from "./useGithubAuth"
 import { GitHubDevicePrompt } from "./GitHubDevicePrompt"
 import { RevokeAccessLink } from "./RevokeAccessLink"
-import { Alert, Button, Modal } from "@/components/ui"
+import { Alert, Button, Modal, Heading } from "@/components/ui"
 
 // Re-auth for a signed-in teacher who needs to change their delete_repo access.
 // See auth/constants.ts for the base/elevated policy.
@@ -143,7 +143,7 @@ export function ElevatedAccessModal({
               <ShieldCheckIcon aria-hidden="true" className="size-6" />
             </div>
             <div className="min-w-0">
-              <h2 className="text-lg font-semibold">{title}</h2>
+              <Heading as="h2">{title}</Heading>
               <p className="mt-1 text-sm text-base-content/70">{body}</p>
             </div>
           </div>

--- a/web/src/auth/GitHubAuthCard.tsx
+++ b/web/src/auth/GitHubAuthCard.tsx
@@ -15,7 +15,7 @@ import { GitHubPatPrompt } from "./GitHubPatPrompt"
 import { LoginLanguageMenu } from "./LoginLanguageMenu"
 import { AppVersionBadge } from "@/components/AppVersionBadge"
 import { WIKI_URL } from "@/version"
-import { Alert, Button, Card, Spinner } from "@/components/ui"
+import { Alert, Button, Card, Spinner, Heading } from "@/components/ui"
 
 function LoadingScreen({ label }: { label: string }) {
   return (
@@ -62,9 +62,9 @@ export function GitHubAuthCard() {
             <MortarBoardIcon aria-hidden="true" className="size-6" />
           </div>
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">
+            <Heading as="h1" variant="title-medium">
               {t("nav.appName")}
-            </h1>
+            </Heading>
             <p className="mt-1 text-sm text-base-content/70">
               {t("auth.signInSubtitle")}
             </p>

--- a/web/src/components/AboutDialog.tsx
+++ b/web/src/components/AboutDialog.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Link } from "@tanstack/react-router"
 import { LinkExternalIcon } from "@/components/ui/icons"
 
-import { CopyableDetails, Modal } from "@/components/ui"
+import { CopyableDetails, Modal, Heading } from "@/components/ui"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { buildDiagnostics } from "@/lib/diagnostics/snapshot"
 import {
@@ -91,9 +91,9 @@ export const AboutDialog = forwardRef<
       boxClassName="flex max-h-[85vh] flex-col overflow-y-auto text-base-content"
       aria-labelledby={titleId}
     >
-      <h3 id={titleId} className="text-lg font-bold">
+      <Heading as="h3" id={titleId}>
         {t("nav.aboutDialogTitle")}
-      </h3>
+      </Heading>
       <p className="mt-1 mb-4 text-sm text-base-content/70">
         {t("nav.aboutDialogDescription")}
       </p>

--- a/web/src/components/DiagnosticsDialog.tsx
+++ b/web/src/components/DiagnosticsDialog.tsx
@@ -1,7 +1,7 @@
 import { useId } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button, Modal } from "@/components/ui"
+import { Button, Modal, Heading } from "@/components/ui"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { buildDiagnostics } from "@/lib/diagnostics/snapshot"
 import { CheckIcon, CopyIcon } from "@/components/ui/icons"
@@ -33,9 +33,9 @@ export function DiagnosticsDialog({
       boxClassName="flex max-h-[85vh] flex-col overflow-y-auto text-base-content"
       aria-labelledby={titleId}
     >
-      <h3 id={titleId} className="text-lg font-bold">
+      <Heading as="h3" id={titleId}>
         {t("orgActivity.diagnostics.title")}
-      </h3>
+      </Heading>
       <p className="mt-1 mb-4 text-sm text-base-content/70">
         {t("orgActivity.diagnostics.description")}
       </p>

--- a/web/src/components/LanguageDialog.tsx
+++ b/web/src/components/LanguageDialog.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Modal } from "@/components/ui"
+import { Modal, Heading } from "@/components/ui"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
 
 // Language-pack modal shown from the sidebar footer. Extracted alongside
@@ -28,9 +28,9 @@ export const LanguageDialog = forwardRef<
       boxClassName="flex max-h-[85vh] flex-col overflow-y-auto text-base-content"
       aria-labelledby={titleId}
     >
-      <h3 id={titleId} className="text-lg font-bold">
+      <Heading as="h3" id={titleId}>
         {t("nav.languageDialogTitle")}
-      </h3>
+      </Heading>
       <p className="mt-1 mb-4 text-sm text-base-content/70">
         {t("nav.languageDialogDescription")}
       </p>

--- a/web/src/components/MembershipError.tsx
+++ b/web/src/components/MembershipError.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Badge,
   EmphasisLtr,
+  Heading,
 } from "@/components/ui"
 import type { BadgeTone } from "@/components/ui"
 
@@ -174,7 +175,9 @@ export const MembershipError = ({
           <AlertIcon aria-hidden="true" className="size-4" />
           {t("membership.badge")}
         </Badge>
-        <h1 className="mt-6 text-2xl font-bold">{t(titleKey)}</h1>
+        <Heading as="h1" variant="title-medium" className="mt-6">
+          {t(titleKey)}
+        </Heading>
         <p className="mt-2 text-base text-base-content/70">
           {cause === "ssoWithUrl" || cause === "ssoUrlless" ? (
             <Trans

--- a/web/src/components/NotFound.tsx
+++ b/web/src/components/NotFound.tsx
@@ -2,7 +2,7 @@ import { TelescopeIcon } from "@/components/ui/icons"
 import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 
-import { RouterButton } from "@/components/ui"
+import { RouterButton, Heading } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 
 // Rendered by role/visibility-gated pages when the user can't access a resource.
@@ -29,9 +29,9 @@ const NotFound = ({ title, message }: { title?: string; message?: string }) => {
         <TelescopeIcon className="size-8" aria-hidden="true" />
       </div>
       <div>
-        <h1 ref={headingRef} tabIndex={-1} className="text-2xl font-bold">
+        <Heading as="h1" variant="title-medium" ref={headingRef} tabIndex={-1}>
           {resolvedTitle}
-        </h1>
+        </Heading>
         <p className="mt-1 max-w-md text-base-content/70">{resolvedMessage}</p>
       </div>
       <RouterButton to="/" variant="primary" size="sm">

--- a/web/src/components/PageHeader.tsx
+++ b/web/src/components/PageHeader.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react"
+import { Heading } from "@/components/ui"
 
 // The dashboard page heading: a title, an optional subtitle line, and an
 // optional right-aligned action. `loading` swaps the title for the standard
@@ -23,7 +24,9 @@ export default function PageHeader({
         {loading ? (
           <div className="skeleton skeleton-shimmer h-8 w-48" />
         ) : (
-          <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+          <Heading as="h1" variant="title-medium">
+            {title}
+          </Heading>
         )}
         {subtitle && (
           <div className="mt-1 text-sm text-base-content/70">{subtitle}</div>

--- a/web/src/components/PermissionErrorBoundary.tsx
+++ b/web/src/components/PermissionErrorBoundary.tsx
@@ -2,7 +2,7 @@ import { Component, type ErrorInfo, type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 import { ShieldXIcon } from "@/components/ui/icons"
 import { GitHubAPIError } from "@/github-core/errors"
-import { Alert, RouterButton } from "@/components/ui"
+import { Alert, RouterButton, Heading } from "@/components/ui"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("permission-error-boundary")
@@ -28,7 +28,9 @@ function PermissionDeniedMessage() {
         <ShieldXIcon aria-hidden="true" className="size-8" />
       </div>
       <Alert tone="warning" className="max-w-md flex-col text-center">
-        <h1 className="text-lg font-bold">{t("permissionDenied.title")}</h1>
+        <Heading as="h1" variant="title-medium">
+          {t("permissionDenied.title")}
+        </Heading>
         <p className="text-sm">{t("permissionDenied.message")}</p>
       </Alert>
       <RouterButton to="/" variant="primary" size="sm">

--- a/web/src/components/SubmitUpload.tsx
+++ b/web/src/components/SubmitUpload.tsx
@@ -8,6 +8,7 @@ import {
   FileDropzone,
   Modal,
   type PickedFile,
+  Heading,
 } from "@/components/ui"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { useToast } from "@/context/notifications/NotificationProvider"
@@ -144,9 +145,9 @@ export function SubmitUpload({
       >
         <div className="flex items-center gap-2">
           <FileCheckIcon aria-hidden="true" className="size-4 text-primary" />
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {t("submissions.student.upload.title")}
-          </h3>
+          </Heading>
         </div>
         <p className="mt-1 text-sm text-base-content/70">
           {t("submissions.student.upload.intro")}

--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -5,7 +5,7 @@
 import { AppsIcon, ListUnorderedIcon } from "@/components/ui/icons"
 import type { ReactNode } from "react"
 
-import { Button } from "@/components/ui"
+import { Button, Heading } from "@/components/ui"
 
 export type ListViewMode = "grid" | "list"
 
@@ -68,7 +68,7 @@ export function EmptyState({
   return (
     <div className={className}>
       {icon}
-      <h2 className="text-lg font-semibold">{title}</h2>
+      <Heading as="h2">{title}</Heading>
       {body && (
         <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
           {body}

--- a/web/src/components/modals/BulkAutogradeStateModal.tsx
+++ b/web/src/components/modals/BulkAutogradeStateModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { PauseIcon, PlayIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal } from "@/components/ui"
+import { Alert, Button, Modal, Heading } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import {
   BulkResultSection,
@@ -226,13 +226,13 @@ export function BulkAutogradeStateModal({
           )}
         </div>
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {t(
               isPause
                 ? "submissions.bulkAutograde.pauseTitle"
                 : "submissions.bulkAutograde.resumeTitle",
             )}
-          </h3>
+          </Heading>
           <p className="mt-1 text-sm text-base-content/70">
             {t(
               isPause

--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ShieldCheckIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Select } from "@/components/ui"
+import { Alert, Button, Modal, Select, Heading } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import {
   BulkResultSection,
@@ -188,9 +188,9 @@ export function BulkRepoAccessModal({
           <ShieldCheckIcon className="size-4" aria-hidden="true" />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {t("submissions.bulkAccess.title")}
-          </h3>
+          </Heading>
           <p className="mt-1 text-sm text-base-content/70">
             {t("submissions.bulkAccess.subtitle", { count: total })}
           </p>

--- a/web/src/components/modals/BulkRepoFeaturesModal.tsx
+++ b/web/src/components/modals/BulkRepoFeaturesModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { SlidersIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Select } from "@/components/ui"
+import { Alert, Button, Modal, Select, Heading } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import {
   BulkResultSection,
@@ -250,9 +250,9 @@ export function BulkRepoFeaturesModal({
           <SlidersIcon className="size-4" aria-hidden="true" />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {t("submissions.bulkFeatures.title")}
-          </h3>
+          </Heading>
           <p className="mt-1 text-sm text-base-content/70">
             {t("submissions.bulkFeatures.subtitle", { count: total })}
           </p>

--- a/web/src/components/modals/BulkSubmissionTriggerModal.tsx
+++ b/web/src/components/modals/BulkSubmissionTriggerModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { GitBranchIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal } from "@/components/ui"
+import { Alert, Button, Modal, Heading } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import {
   BulkResultSection,
@@ -258,9 +258,9 @@ export function BulkSubmissionTriggerModal({
           <GitBranchIcon className="size-4" aria-hidden="true" />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {t("submissions.bulkTrigger.title")}
-          </h3>
+          </Heading>
           <p className="mt-1 text-sm text-base-content/70">
             {t("submissions.bulkTrigger.subtitle", {
               count: total,

--- a/web/src/components/modals/CloseSubmissionModal.tsx
+++ b/web/src/components/modals/CloseSubmissionModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { CalendarIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal } from "@/components/ui"
+import { Alert, Button, Modal, Heading } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import {
   BulkResultSection,
@@ -226,11 +226,11 @@ export function CloseSubmissionModal({
           <CalendarIcon className="size-4" aria-hidden="true" />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {closing
               ? t("submissions.closeSubmission.title")
               : t("submissions.closeSubmission.reopenTitle")}
-          </h3>
+          </Heading>
           <p className="mt-1 text-sm text-base-content/70">
             {closing
               ? t("submissions.closeSubmission.subtitle", { count: total })

--- a/web/src/components/modals/FreePlanInfoModal.tsx
+++ b/web/src/components/modals/FreePlanInfoModal.tsx
@@ -2,7 +2,7 @@ import { LinkExternalIcon } from "@/components/ui/icons"
 import { useId } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button, Modal } from "@/components/ui"
+import { Button, Modal, Heading } from "@/components/ui"
 
 // Explains why a Free-plan org can't be set up and points the teacher at the
 // GitHub Education benefit that upgrades an org to Team for free. Opened from a
@@ -22,9 +22,9 @@ function FreePlanInfoModal({
 
   return (
     <Modal open={open} onClose={onClose} size="md" aria-labelledby={titleId}>
-      <h3 id={titleId} className="text-lg font-bold">
+      <Heading as="h3" id={titleId}>
         {t("orgs.newOrg.freePlanInfo.title")}
-      </h3>
+      </Heading>
       {orgLogin && (
         <p className="mt-1 font-mono text-sm text-base-content/60">
           {orgLogin}

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -17,6 +17,7 @@ import {
   Input,
   Modal,
   MonoLtr,
+  Heading,
 } from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import useGetRepo from "@/hooks/useGetRepo"
@@ -365,9 +366,9 @@ export function GroupCollaboratorsModal({
         </div>
 
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {assignmentName || t("components.modals.groupCollaborators.title")}
-          </h3>
+          </Heading>
           {repoName && (
             <a
               className="link mt-1 inline-flex items-center gap-1.5 text-sm"

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next"
 import PlanBadge from "@/components/PlanBadge"
 import MissingOrgNotice from "@/components/MissingOrgNotice"
 import FreePlanInfoModal from "@/components/modals/FreePlanInfoModal"
-import { Badge, Button, Modal, Spinner, cx } from "@/components/ui"
+import { Badge, Button, Modal, Spinner, cx, Heading } from "@/components/ui"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
 import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
 import useScrollFade from "@/hooks/useScrollFade"
@@ -185,9 +185,9 @@ function NewOrgModal({
       <Modal open={open} onClose={onClose} size="2xl" aria-labelledby={titleId}>
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
-            <h3 id={titleId} className="text-lg font-bold">
+            <Heading as="h3" id={titleId}>
               {t("orgs.newOrg.title")}
-            </h3>
+            </Heading>
             <p className="mt-1 text-sm text-base-content/70">
               {t("orgs.newOrg.description")}
             </p>

--- a/web/src/components/modals/OrgDetailsModal.tsx
+++ b/web/src/components/modals/OrgDetailsModal.tsx
@@ -3,7 +3,14 @@ import { useId, useState } from "react"
 import { useForm } from "@tanstack/react-form"
 import { useTranslation } from "react-i18next"
 
-import { Button, FormField, Input, Modal, Textarea } from "@/components/ui"
+import {
+  Button,
+  FormField,
+  Input,
+  Modal,
+  Textarea,
+  Heading,
+} from "@/components/ui"
 import { GitHubLink } from "@/components/GitHubLink"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
@@ -154,9 +161,9 @@ function OrgDetailsModal({
         </div>
 
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="truncate text-lg font-bold">
+          <Heading as="h3" className="truncate" id={titleId}>
             {heading}
-          </h3>
+          </Heading>
           <p className="truncate font-mono text-xs text-base-content/50">
             {org.login}
           </p>

--- a/web/src/components/modals/ProvisioningChangeConfirmModal.tsx
+++ b/web/src/components/modals/ProvisioningChangeConfirmModal.tsx
@@ -2,7 +2,7 @@ import { useId } from "react"
 import { useTranslation } from "react-i18next"
 import { AlertIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal } from "@/components/ui"
+import { Alert, Button, Modal, Heading } from "@/components/ui"
 
 type ProvisioningChangeConfirmModalProps = {
   open: boolean
@@ -43,9 +43,9 @@ export function ProvisioningChangeConfirmModal({
           <AlertIcon className="size-4" aria-hidden="true" />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {t("assignmentSettings.provisioningConfirm.title")}
-          </h3>
+          </Heading>
           <Alert tone="warning" className="mt-3 text-sm">
             {t("assignmentSettings.provisioningConfirm.body", {
               count: acceptedCount,

--- a/web/src/components/modals/RenameAssignmentModal.tsx
+++ b/web/src/components/modals/RenameAssignmentModal.tsx
@@ -9,6 +9,7 @@ import {
   FormField,
   Input,
   Modal,
+  Heading,
 } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import { BulkResultSection } from "@/components/bulk/resultView"
@@ -174,11 +175,11 @@ export function RenameAssignmentModal({
           <PencilIcon className="size-4" aria-hidden="true" />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {finish
               ? t("assignments.rename.finishTitle")
               : t("assignments.rename.title")}
-          </h3>
+          </Heading>
           <p className="mt-1 break-all text-sm text-base-content/70">
             {finish ? (
               <Trans

--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -17,6 +17,7 @@ import {
   Input,
   Modal,
   Select,
+  Heading,
 } from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import useGetRepo from "@/hooks/useGetRepo"
@@ -400,9 +401,9 @@ export function RepoAccessModal({
           <ShieldCheckIcon className="size-4" aria-hidden="true" />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {t("components.modals.repoAccess.title")}
-          </h3>
+          </Heading>
           {repoName && (
             <a
               className="link mt-1 inline-flex items-center gap-1.5 text-sm"

--- a/web/src/components/modals/ReuseModalShell.tsx
+++ b/web/src/components/modals/ReuseModalShell.tsx
@@ -3,7 +3,7 @@ import { useEffect, useId, type ReactNode, type RefObject } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 
-import { AnimatedAlert, Button, Modal } from "@/components/ui"
+import { AnimatedAlert, Button, Modal, Heading } from "@/components/ui"
 
 // Shared chrome for the two reuse modals — close button, header, error/warning
 // alerts, Cancel/Reuse footer — so each supplies only its title, description,
@@ -57,9 +57,9 @@ export const ReuseModalShell = ({
           <CopyIcon className="size-4" aria-hidden="true" />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {title}
-          </h3>
+          </Heading>
           <p className="mt-1 text-sm text-base-content/70">{description}</p>
         </div>
       </div>

--- a/web/src/components/modals/StudentProfileModal.tsx
+++ b/web/src/components/modals/StudentProfileModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { LinkExternalIcon, MarkGithubIcon } from "@/components/ui/icons"
 
-import { Badge, Button, Modal } from "@/components/ui"
+import { Badge, Button, Modal, Heading } from "@/components/ui"
 import type { Student } from "@/types/classroom"
 import { getName, getInitials, firstGrapheme } from "@/util/students"
 
@@ -84,9 +84,9 @@ export const StudentProfileModal = ({
           </div>
         </div>
         <div className="min-w-0">
-          <h3 id={titleId} className="truncate text-lg font-bold">
+          <Heading as="h3" className="truncate" id={titleId}>
             {name}
-          </h3>
+          </Heading>
           {student.section?.trim() ? (
             <Badge ghost>{student.section.trim()}</Badge>
           ) : null}

--- a/web/src/components/modals/TemplateAccessModal.tsx
+++ b/web/src/components/modals/TemplateAccessModal.tsx
@@ -7,7 +7,7 @@ import {
   ShieldCheckIcon,
 } from "@/components/ui/icons"
 
-import { Badge, Button, Modal, Spinner } from "@/components/ui"
+import { Badge, Button, Modal, Spinner, Heading } from "@/components/ui"
 import type { Assignment } from "@/types/classroom"
 import type { GitHubRepoTeam } from "@/github-core/types"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
@@ -128,9 +128,9 @@ export const TemplateAccessModal = ({
           <ShieldCheckIcon className="size-4" aria-hidden="true" />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {t("assignments.template.accessModal.title")}
-          </h3>
+          </Heading>
           <p className="mt-1 text-sm text-base-content/70">
             {t("assignments.template.accessModal.description")}
           </p>

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   MonoLtr,
   type ButtonVariant,
+  Heading,
 } from "@/components/ui"
 
 type ConfirmModalProps = {
@@ -155,9 +156,9 @@ export function ConfirmModal({
           </div>
 
           <div className="min-w-0 flex-1">
-            <h3 id={titleId} className="text-lg font-bold">
+            <Heading as="h3" id={titleId}>
               {title}
-            </h3>
+            </Heading>
 
             {description ? (
               <div className="mt-2 text-sm leading-6 text-base-content/70">

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -13,7 +13,7 @@ import {
   RepoLockedIcon,
 } from "@/components/ui/icons"
 
-import { Button, Card, Markdown, Modal } from "@/components/ui"
+import { Button, Card, Markdown, Modal, Heading } from "@/components/ui"
 import type { GitHubRepo } from "@/github-core/types"
 import { assignmentDescription } from "@/types/classroom"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
@@ -74,18 +74,21 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
                 params={{ org, classroom, assignment }}
                 className="group inline-flex max-w-full items-center gap-1.5 transition-colors hover:text-primary"
               >
-                <h3 className="truncate text-base font-semibold leading-tight underline decoration-base-content/30 underline-offset-2 group-hover:decoration-primary">
+                <Heading
+                  as="h3"
+                  className="truncate underline decoration-base-content/30 underline-offset-2 group-hover:decoration-primary"
+                >
                   {title}
-                </h3>
+                </Heading>
                 <LinkIcon
                   aria-hidden="true"
                   className="size-4 shrink-0 text-base-content/40 group-hover:text-primary"
                 />
               </Link>
             ) : (
-              <h3 className="truncate text-base font-semibold leading-tight">
+              <Heading as="h3" className="truncate">
                 {title}
-              </h3>
+              </Heading>
             )}
             <div className="mt-1 flex flex-col gap-0.5 text-xs text-base-content/70">
               {classroom ? (
@@ -176,7 +179,7 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
           <p className="text-xs font-medium uppercase tracking-wide text-base-content/50">
             {t("classes.repo.descriptionModalTitle")}
           </p>
-          <h3 className="text-lg font-bold">{title}</h3>
+          <Heading as="h3">{title}</Heading>
         </div>
         {description ? (
           <Markdown
@@ -225,9 +228,7 @@ export const OrgRepos = ({
           />
         </div>
 
-        <h2 className="text-lg font-semibold">
-          {t("classes.repo.emptyTitle")}
-        </h2>
+        <Heading as="h2">{t("classes.repo.emptyTitle")}</Heading>
 
         <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
           {t("classes.repo.emptyBody")}

--- a/web/src/components/submissions/SubmissionDetailsModal.tsx
+++ b/web/src/components/submissions/SubmissionDetailsModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { GitCommitIcon, MarkGithubIcon, TagIcon } from "@/components/ui/icons"
 
-import { Button, Modal, MonoLtr } from "@/components/ui"
+import { Button, Modal, MonoLtr, Heading } from "@/components/ui"
 
 // One row in the submission-details list. `kind` picks the icon and action
 // label ("View tag" vs "View commit"); `href` is the already-built, safe GitHub
@@ -80,9 +80,9 @@ export function SubmissionDetailsModal({
       size="lg"
       aria-labelledby={titleId}
     >
-      <h3 id={titleId} className="truncate pe-8 text-lg font-bold">
+      <Heading as="h3" className="truncate pe-8" id={titleId}>
         {title}
-      </h3>
+      </Heading>
       {subtitle ? (
         <p className="mt-0.5 truncate text-sm text-base-content/60">
           {subtitle}

--- a/web/src/components/ui/Card.test.tsx
+++ b/web/src/components/ui/Card.test.tsx
@@ -66,7 +66,7 @@ describe("Card", () => {
       </Card>,
     )
     expect(screen.getByRole("heading", { name: "Title" }).className).toContain(
-      "card-title",
+      "font-semibold",
     )
     expect(
       screen.getByRole("button", { name: "Do" }).parentElement?.className,

--- a/web/src/components/ui/Card.tsx
+++ b/web/src/components/ui/Card.tsx
@@ -1,6 +1,7 @@
 import type { ComponentPropsWithoutRef, ElementType, ReactNode } from "react"
 
 import { cx } from "./cx"
+import { headingVariantClass } from "./Heading"
 
 // The canonical surface card. Wraps daisyUI `card` with one border/shadow/
 // radius recipe so the ~6 divergent inline recipes converge. Muted gray on the
@@ -63,7 +64,16 @@ export function CardTitle({
   ...props
 }: ComponentPropsWithoutRef<"h2">) {
   return (
-    <h2 className={cx("card-title", className)} {...props}>
+    // daisyUI `card-title` (18px/600) replaced by the Primer title-small
+    // recipe; keeps card-title's inline-flex layout for leading icons.
+    <h2
+      className={cx(
+        "flex items-center gap-2",
+        headingVariantClass["title-small"],
+        className,
+      )}
+      {...props}
+    >
       {children}
     </h2>
   )

--- a/web/src/components/ui/Heading.tsx
+++ b/web/src/components/ui/Heading.tsx
@@ -1,0 +1,39 @@
+import type { ComponentPropsWithRef, ElementType, ReactNode } from "react"
+
+import { cx } from "./cx"
+
+// Primer's title scale (primer.style/product/primitives/typography), semibold
+// per Primer's title weight: title-medium (20px) for page titles, title-small
+// (16px) for section/modal/card titles, subtitle (20px/400) for lead-ins.
+// The single source for heading recipes — pages must not hand-roll
+// `text-*/font-*` title combos. `as` carries the semantic level (h1-h4),
+// which a11yStructural tests audit independently of the visual variant.
+export type HeadingVariant = "title-medium" | "title-small" | "subtitle"
+
+export const headingVariantClass: Record<HeadingVariant, string> = {
+  "title-medium": "text-xl leading-relaxed font-semibold",
+  "title-small": "text-base leading-normal font-semibold",
+  subtitle: "text-xl leading-relaxed font-normal",
+}
+
+export type HeadingProps = {
+  as?: ElementType
+  variant?: HeadingVariant
+  children?: ReactNode
+} & ComponentPropsWithRef<"h2">
+
+export function Heading({
+  as: Tag = "h2",
+  variant = "title-small",
+  className,
+  children,
+  ...props
+}: HeadingProps) {
+  return (
+    <Tag className={cx(headingVariantClass[variant], className)} {...props}>
+      {children}
+    </Tag>
+  )
+}
+
+export default Heading

--- a/web/src/components/ui/Markdown.tsx
+++ b/web/src/components/ui/Markdown.tsx
@@ -31,20 +31,21 @@ const components: Components = {
     ) : (
       <span>{children}</span>
     ),
-  h1: ({ children }) => <h1 className="text-xl font-bold">{children}</h1>,
-  h2: ({ children }) => <h2 className="text-lg font-bold">{children}</h2>,
-  h3: ({ children }) => <h3 className="text-base font-semibold">{children}</h3>,
+  h1: ({ children }) => <h1 className="text-xl font-semibold">{children}</h1>,
+  h2: ({ children }) => <h2 className="text-base font-semibold">{children}</h2>,
+  h3: ({ children }) => <h3 className="text-sm font-semibold">{children}</h3>,
   ul: ({ children }) => <ul className="list-disc ps-5">{children}</ul>,
   ol: ({ children }) => <ol className="list-decimal ps-5">{children}</ol>,
   code: ({ children }) => (
     // base-300 tint reads as a code chip on both the white canvas and the
-    // muted gray cards this component renders inside.
-    <code className="rounded bg-base-300/50 px-1 py-0.5 text-sm">
+    // muted gray cards this component renders inside. text-code is Primer's
+    // 13px code-block size.
+    <code className="rounded bg-base-300/50 px-1 py-0.5 text-code">
       {children}
     </code>
   ),
   pre: ({ children }) => (
-    <pre className="overflow-x-auto rounded-field border border-base-300 bg-base-100 p-3 text-sm">
+    <pre className="overflow-x-auto rounded-field border border-base-300 bg-base-100 p-3 text-code">
       {children}
     </pre>
   ),

--- a/web/src/components/ui/MetricBar.tsx
+++ b/web/src/components/ui/MetricBar.tsx
@@ -64,7 +64,7 @@ export function MetricBar({
       />
       {showNumbers && (
         <div className="flex items-baseline justify-between gap-2 text-xs tabular-nums">
-          <span className="font-semibold">
+          <span>
             {value} / {max}
           </span>
           <span className="text-base-content/60">{pct}%</span>

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -34,6 +34,8 @@ export type { TextareaProps } from "./Textarea"
 
 export { FormField, HelpTooltip } from "./FormField"
 export type { HelpTooltipPosition } from "./FormField"
+export { Heading, headingVariantClass } from "./Heading"
+export type { HeadingProps, HeadingVariant } from "./Heading"
 
 export { Modal } from "./Modal"
 export type { ModalProps, ModalSize } from "./Modal"

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,9 @@
 @import "tailwindcss";
+/* Self-hosted GitHub Mona Sans (variable, wght 200-900, subsetted per
+   unicode-range). CJK text falls through to Noto Sans JP, still served from
+   Google Fonts (see index.html) since Mona Sans has no CJK coverage. */
+@import "@fontsource-variable/mona-sans";
+@import "@fontsource-variable/mona-sans/wght-italic.css";
 @plugin "daisyui/index.js" {
   themes: sumi --default;
 }
@@ -159,11 +164,24 @@
   }
 }
 
-/* Motion design tokens. One source of truth for animation timing shared by the
-   `.btn` press rule below and the JS variants in src/lib/motion.ts. Durations
-   are deliberately short (a productivity tool should feel responsive, not
-   theatrical); ease-out gives a fast start and gentle settle. */
+/* Design tokens: typography (Primer primitives) and motion. Motion timing is
+   the one source of truth shared by the `.btn` press rule below and the JS
+   variants in src/lib/motion.ts; durations are deliberately short (a
+   productivity tool should feel responsive, not theatrical). */
 @theme {
+  /* Typography primitives mirroring Primer (primer.style/product/primitives/
+     typography): Mona Sans leads the sans stack; the mono stack is Primer's
+     `fontStack-monospace` verbatim. `--text-code` is Primer's 13px code-block
+     size (no Tailwind step exists for it). */
+  --font-sans:
+    "Mona Sans Variable", "Noto Sans JP", "Noto Sans CJK JP", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+  --font-mono:
+    ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+  --text-code: 0.8125rem;
+  --text-code--line-height: 1.5;
+
   --duration-fast: 100ms;
   --duration-base: 150ms;
   --duration-slow: 200ms;
@@ -172,8 +190,7 @@
 
 html,
 body {
-  font-family:
-    "Noto Sans", "Noto Sans JP", "Noto Sans CJK JP", system-ui, sans-serif;
+  font-family: var(--font-sans);
 }
 
 /* Theme cross-fade via the View Transitions API. `useTheme` wraps an explicit
@@ -521,7 +538,7 @@ textarea::placeholder {
   }
 
   .report-print .mono {
-    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-family: var(--font-mono);
   }
 
   .report-print table {

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -11,7 +11,14 @@ import {
 } from "@/components/ui/icons"
 
 import { Spinner } from "@/components/Spinner"
-import { Alert, Button, Card, Markdown, MonoLtr } from "@/components/ui"
+import {
+  Alert,
+  Button,
+  Card,
+  Markdown,
+  MonoLtr,
+  Heading,
+} from "@/components/ui"
 import { assignmentDescription } from "@/types/classroom"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import type { GitHubUser } from "@/github-core/types"
@@ -163,9 +170,9 @@ const AssignmentNotFound = ({
               {t("accept.notFound.badge")}
             </span>
 
-            <h1 className="mt-6 text-2xl font-bold">
+            <Heading as="h1" variant="title-medium" className="mt-6">
               {t("accept.notFound.title")}
-            </h1>
+            </Heading>
 
             <p className="mt-2 text-base text-base-content/70">
               <Trans
@@ -247,9 +254,9 @@ const AssignmentLocked = ({
               {t("accept.locked.badge")}
             </span>
 
-            <h1 className="mt-6 text-2xl font-bold">
+            <Heading as="h1" variant="title-medium" className="mt-6">
               {t("accept.locked.title")}
-            </h1>
+            </Heading>
 
             <p className="mt-2 text-base text-base-content/70">
               <Trans
@@ -301,9 +308,9 @@ const AssignmentClosed = ({
               {t("accept.closed.badge")}
             </span>
 
-            <h1 className="mt-6 text-2xl font-bold">
+            <Heading as="h1" variant="title-medium" className="mt-6">
               {t("accept.closed.title")}
-            </h1>
+            </Heading>
 
             <p className="mt-2 text-base text-base-content/70">
               <Trans
@@ -353,9 +360,9 @@ const NotEnrolled = ({ user }: { user: GitHubUser | null }) => {
               {t("accept.notEnrolled.badge")}
             </span>
 
-            <h1 className="mt-6 text-2xl font-bold">
+            <Heading as="h1" variant="title-medium" className="mt-6">
               {t("accept.notEnrolled.title")}
-            </h1>
+            </Heading>
 
             <p className="mt-2 text-base text-base-content/70">
               {t("accept.notEnrolled.body")}
@@ -922,9 +929,9 @@ const AcceptAssignmentPage = () => {
                 : t("accept.noDueDate")}
             </span>
           </div>
-          <h1 className="text-2xl font-bold tracking-tight pt-2">
+          <Heading as="h1" variant="title-medium" className="pt-2">
             {assignmentData?.name}
-          </h1>
+          </Heading>
           <h2 className="text-lg">
             {repoExistsAlready
               ? t("accept.alreadyAcceptedHeading")

--- a/web/src/pages/AssessmentPage.tsx
+++ b/web/src/pages/AssessmentPage.tsx
@@ -8,6 +8,7 @@ import {
   Select,
   Textarea,
   cx,
+  Heading,
 } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import {
@@ -136,7 +137,9 @@ export default function AssessmentPage() {
   return (
     <main className="mx-auto max-w-3xl space-y-6 p-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-bold">Assessment mode — WCAG 2.2 AA</h1>
+        <Heading as="h1" variant="title-medium">
+          Assessment mode — WCAG 2.2 AA
+        </Heading>
         <p className="text-base-content/70">
           Record a verdict for each manually-assessed success criterion. Saving
           writes <code>vpatVerdicts.json</code>, which feeds the VPAT report.
@@ -158,7 +161,7 @@ export default function AssessmentPage() {
 
       {outstanding.length > 0 && (
         <section className="space-y-4">
-          <h2 className="text-lg font-semibold">Outstanding</h2>
+          <Heading as="h2">Outstanding</Heading>
           <ol className="space-y-4">
             {outstanding.map((c) => (
               <EditableCriterionCard
@@ -175,7 +178,7 @@ export default function AssessmentPage() {
 
       {recorded.length > 0 && (
         <section className="space-y-4">
-          <h2 className="text-lg font-semibold">Recorded verdicts</h2>
+          <Heading as="h2">Recorded verdicts</Heading>
           <ol className="space-y-4">
             {recorded.map((c) => (
               <EditableCriterionCard
@@ -195,9 +198,7 @@ export default function AssessmentPage() {
 
       {readOnly.length > 0 && (
         <section className="space-y-4">
-          <h2 className="text-lg font-semibold">
-            Automated &amp; not-applicable (read-only)
-          </h2>
+          <Heading as="h2">Automated &amp; not-applicable (read-only)</Heading>
           <p className="text-sm text-base-content/70">
             Established by tooling or the client-side-only architecture. Shown
             for the full VPAT picture; not manually editable.
@@ -250,9 +251,9 @@ function EditableCriterionCard({
   return (
     <Card as="li" className={cx("p-4", recorded && "opacity-90")}>
       <div className="flex flex-wrap items-center gap-2">
-        <h3 className="text-base font-semibold">
+        <Heading as="h3">
           {criterion.id} {criterion.name}
-        </h3>
+        </Heading>
         <Badge tone="neutral" soft>
           {criterion.level}
         </Badge>
@@ -334,9 +335,9 @@ function ReadOnlyCriterionCard({ criterion }: { criterion: Criterion }) {
   return (
     <Card as="li" className="p-4">
       <div className="flex flex-wrap items-center gap-2">
-        <h3 className="text-base font-semibold">
+        <Heading as="h3">
           {criterion.id} {criterion.name}
-        </h3>
+        </Heading>
         <Badge tone="neutral" soft>
           {criterion.level}
         </Badge>

--- a/web/src/pages/AssignmentSettingsPage.tsx
+++ b/web/src/pages/AssignmentSettingsPage.tsx
@@ -7,7 +7,7 @@ import PageShell from "@/components/PageShell"
 import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
 import { OrgRepoCreationNotice } from "@/components/OrgRepoCreationNotice"
 import { Spinner } from "@/components/Spinner"
-import { Alert, AnimatedAlert, Button, Card } from "@/components/ui"
+import { Alert, AnimatedAlert, Button, Card, Heading } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 import { can } from "@/authz"
@@ -117,7 +117,9 @@ const EditAssignmentFormStudent = ({
             </div>
 
             <div>
-              <h1 className="card-title text-xl">{assignmentData?.name}</h1>
+              <Heading as="h1" variant="title-medium">
+                {assignmentData?.name}
+              </Heading>
               <p className="text-sm font-medium text-base-content/70">
                 {t("assignmentSettings.groupMembers")}
               </p>

--- a/web/src/pages/OnboardingPage.tsx
+++ b/web/src/pages/OnboardingPage.tsx
@@ -13,6 +13,7 @@ import {
   EmphasisLtr,
   RouterButton,
   rtlFlip,
+  Heading,
 } from "@/components/ui"
 import {
   MembershipError,
@@ -77,9 +78,9 @@ const NotInvited = ({
             <MailIcon aria-hidden="true" className="size-4" />
             {t("getStarted.badge")}
           </Badge>
-          <h1 className="mt-6 text-2xl font-bold">
+          <Heading as="h1" variant="title-medium" className="mt-6">
             {t("getStarted.notInvited.title")}
-          </h1>
+          </Heading>
           <p className="mt-2 text-base text-base-content/70">
             <Trans
               i18nKey="getStarted.notInvited.body"
@@ -139,9 +140,9 @@ const AllSet = ({
             <MailIcon aria-hidden="true" className="size-4" />
             {t("getStarted.badge")}
           </Badge>
-          <h1 className="mt-6 text-2xl font-bold">
+          <Heading as="h1" variant="title-medium" className="mt-6">
             {t("getStarted.active.title")}
-          </h1>
+          </Heading>
           {classroom && (
             <p className="mt-2 text-sm text-base-content/70">{classroom}</p>
           )}
@@ -272,9 +273,9 @@ const OnboardingPage = () => {
         <EnterDiv className="card-body items-center gap-6">
           <Spinner size="xl" label={t("getStarted.checking.title")} />
           <div className="text-center">
-            <h1 className="text-xl font-bold">
+            <Heading as="h1" variant="title-medium">
               {t("getStarted.checking.title")}
-            </h1>
+            </Heading>
             <p className="mt-2 text-sm text-base-content/70">
               {t("getStarted.checking.message", { org })}
             </p>

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from "react"
 import { Trans, useTranslation } from "react-i18next"
-import { Button, HelpTooltip, Input, Modal, cx } from "@/components/ui"
+import { Button, HelpTooltip, Input, Modal, cx, Heading } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -261,9 +261,7 @@ function SetTokenModal({
       closeDisabled={saveMutation.isPending}
     >
       <div className="pe-8">
-        <h3 className="text-lg font-semibold">
-          {t("orgSettings.serviceToken.setModalTitle")}
-        </h3>
+        <Heading as="h3">{t("orgSettings.serviceToken.setModalTitle")}</Heading>
         <p className="mt-1 text-sm text-base-content/70">
           {t("orgSettings.serviceToken.setModalSubtitle")}
         </p>

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -11,7 +11,15 @@ import { useTranslation } from "react-i18next"
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
 import { Spinner } from "@/components/Spinner"
-import { Alert, Button, Card, RouterButton, cx, rtlFlip } from "@/components/ui"
+import {
+  Alert,
+  Button,
+  Card,
+  RouterButton,
+  cx,
+  rtlFlip,
+  Heading,
+} from "@/components/ui"
 import { QueryErrorAlert } from "@/components/QueryErrorAlert"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
@@ -215,7 +223,7 @@ const OrgSteps = ({
               <CheckCircleIcon aria-hidden="true" className="size-9" />
             </div>
             <div>
-              <h2 className="text-xl font-bold">{t("setup.allSetTitle")}</h2>
+              <Heading as="h2">{t("setup.allSetTitle")}</Heading>
               <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
                 {t("setup.allSetBody")}
               </p>

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -41,7 +41,15 @@ import { AnimatePresence, motion } from "motion/react"
 import { useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { GitHubLink } from "@/components/GitHubLink"
-import { Alert, Badge, Button, Card, Toolbar, cx } from "@/components/ui"
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Toolbar,
+  cx,
+  Heading,
+} from "@/components/ui"
 import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
 import NewOrgModal from "@/components/modals/NewOrgModal"
 import Spinner from "@/components/Spinner"
@@ -79,7 +87,9 @@ function PendingInviteCard({ invite }: { invite: GitHubOrgMembership }) {
           />
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
-              <h2 className="truncate text-lg font-bold">{org.login}</h2>
+              <Heading as="h2" className="truncate">
+                {org.login}
+              </Heading>
               <Badge tone="warning" size="sm">
                 {t("orgs.invites.pendingBadge")}
               </Badge>
@@ -354,7 +364,9 @@ function OrgCard({
           />
 
           <div className="min-w-0 flex-1">
-            <h2 className="truncate text-lg font-bold">{heading}</h2>
+            <Heading as="h2" className="truncate">
+              {heading}
+            </Heading>
 
             {org.description && (
               <p className="mt-1 line-clamp-2 text-sm text-base-content/70">

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -17,7 +17,13 @@ import { enterExit, staggerTransition } from "@/lib/motion"
 
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
-import { Badge, Button, MonoLtr, type BadgeTone } from "@/components/ui"
+import {
+  Badge,
+  Button,
+  MonoLtr,
+  type BadgeTone,
+  Heading,
+} from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import RequireRole from "@/components/RequireRole"
 import useGetClasses from "@/hooks/useGetClasses"
@@ -440,7 +446,7 @@ export const PublishedResourcesPane = ({ org }: { org: string }) => {
             aria-hidden="true"
             className="size-4 text-base-content/70"
           />
-          <h2 className="text-lg font-bold">{t("published.orgLevel")}</h2>
+          <Heading as="h2">{t("published.orgLevel")}</Heading>
         </div>
         <p className="mt-1 text-sm text-base-content/70">
           <Trans
@@ -462,7 +468,7 @@ export const PublishedResourcesPane = ({ org }: { org: string }) => {
             aria-hidden="true"
             className="size-4 text-base-content/70"
           />
-          <h2 className="text-lg font-bold">{t("published.perClassroom")}</h2>
+          <Heading as="h2">{t("published.perClassroom")}</Heading>
         </div>
         <p className="mt-1 text-sm text-base-content/70">
           {t("published.perClassroomDescription")}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -8,6 +8,8 @@ import {
   RouterButton,
   SectionAnchorHeading,
   cx,
+  Heading,
+  headingVariantClass,
 } from "@/components/ui"
 import { useTranslation } from "react-i18next"
 import { useMemo, useState } from "react"
@@ -286,7 +288,11 @@ function SettingsSectionCard({
       )}
     >
       <Card.Body>
-        <SectionAnchorHeading anchorId={id} as="h3" className="card-title">
+        <SectionAnchorHeading
+          anchorId={id}
+          as="h3"
+          className={headingVariantClass["title-small"]}
+        >
           {heading}
         </SectionAnchorHeading>
         <p className="text-sm text-base-content/70">{subheading}</p>
@@ -310,7 +316,7 @@ function SettingsGroup({
   return (
     <section className="flex flex-col gap-4">
       <div className="flex flex-col gap-0.5">
-        <h2 className="text-lg font-semibold">{heading}</h2>
+        <Heading as="h2">{heading}</Heading>
         <p className="text-sm text-base-content/60">{description}</p>
       </div>
       {children}

--- a/web/src/pages/accessibility/StatementSection.tsx
+++ b/web/src/pages/accessibility/StatementSection.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next"
 
-import { Card } from "@/components/ui"
+import { Card, Heading } from "@/components/ui"
 import { ACCESSIBILITY_ISSUE_URL } from "@/version"
 
 import { useVpatReport } from "./data"
@@ -17,12 +17,9 @@ export function StatementSection() {
     <section aria-labelledby="statement-heading">
       <Card shadow={false}>
         <Card.Body className="max-w-2xl gap-6 p-6">
-          <h2
-            id="statement-heading"
-            className="text-2xl font-bold tracking-tight"
-          >
+          <Heading as="h2" variant="title-medium" id="statement-heading">
             {t("accessibility.statement.heading")}
-          </h2>
+          </Heading>
           <p className="text-base-content/80">
             {t("accessibility.statement.intro")}
           </p>

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -14,6 +14,7 @@ import {
   Modal,
   Select,
   Textarea,
+  Heading,
 } from "@/components/ui"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import {
@@ -118,9 +119,9 @@ const AutogradingTestModal = ({
       }}
     >
       <div className="mb-6">
-        <h3 id={titleId} className="text-lg font-bold">
+        <Heading as="h3" id={titleId}>
           {t("assignments.autograder.editTest", { number: editor.index + 1 })}
-        </h3>
+        </Heading>
         <p className="text-sm opacity-70">
           {t("assignments.autograder.editTestHint")}
         </p>

--- a/web/src/pages/assignments/ClassroomCollectButton.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.tsx
@@ -3,7 +3,7 @@ import { AlertIcon, SyncIcon } from "@/components/ui/icons"
 import { useEffect, useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button, Modal } from "@/components/ui"
+import { Button, Modal, Heading } from "@/components/ui"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { githubKeys } from "@/github-core/queries"
 import useGetLastCollectScoresRun from "@/hooks/useGetLastCollectScoresRun"
@@ -166,9 +166,9 @@ export function ClassroomCollectButton({
             <AlertIcon className="size-4" aria-hidden="true" />
           </div>
           <div className="min-w-0 flex-1">
-            <h3 id={confirmTitleId} className="text-lg font-bold">
+            <Heading as="h3" id={confirmTitleId}>
               {t("assignments.collect.confirmTitle")}
-            </h3>
+            </Heading>
             <p className="mt-3 text-sm text-base-content/80">
               {t("assignments.collect.confirmBody")}
             </p>

--- a/web/src/pages/assignments/RenameSlugSection.tsx
+++ b/web/src/pages/assignments/RenameSlugSection.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { AlertIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Card, EmphasisLtr } from "@/components/ui"
+import { Alert, Button, Card, EmphasisLtr, Heading } from "@/components/ui"
 import { RenameAssignmentModal } from "@/components/modals/RenameAssignmentModal"
 import { isRenameEligible, needsRenameFinish } from "@/domain/assignments"
 import { GITHUB_REPO_NAME_MAX_LEN } from "@/util/repoNameBudget"
@@ -38,12 +38,12 @@ export function RenameSlugSection({
   return (
     <Card bordered={false} className="mb-6 w-full border border-warning/40">
       <Card.Body className="gap-4">
-        <h2 className="card-title flex items-center gap-2 text-lg">
+        <Heading as="h2" className="flex items-center gap-2">
           <AlertIcon aria-hidden="true" className="size-4 text-warning" />
           {finish
             ? t("assignments.rename.sectionFinishTitle")
             : t("assignments.rename.sectionTitle")}
-        </h2>
+        </Heading>
         <Alert tone="warning" className="text-sm">
           <span className="break-all">
             {finish ? (

--- a/web/src/pages/assignments/sections/SectionCard.tsx
+++ b/web/src/pages/assignments/sections/SectionCard.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react"
 import { UndoIcon } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
-import { Button, Card } from "@/components/ui"
+import { Button, Card, Heading } from "@/components/ui"
 
 // One card wrapper for every top-level section: a bold heading, an optional
 // per-section Reset control, an optional description, and the section body.
@@ -26,7 +26,7 @@ export function SectionCard({
     <Card bordered={false} className="w-full mb-6">
       <Card.Body>
         <div className="flex items-center justify-between gap-3 pb-1">
-          <h3 className="text-lg font-bold">{title}</h3>
+          <Heading as="h3">{title}</Heading>
           {onReset ? (
             <Button
               variant="ghost"

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -1,5 +1,5 @@
 import { ConfirmModal } from "@/components/modals"
-import { Button, Card, EmphasisLtr } from "@/components/ui"
+import { Button, Card, EmphasisLtr, Heading } from "@/components/ui"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { GitHubAPIError } from "@/github-core/errors"
 import { useArchiveClassroom } from "@/hooks/mutations/useArchiveClassroom"
@@ -554,7 +554,9 @@ export function ClassroomCard({
             />
           )}
         </div>
-        <h2 className="truncate text-xl font-semibold">{name}</h2>
+        <Heading as="h2" className="truncate">
+          {name}
+        </Heading>
         <ClassroomStats org={org} slug={summary.path} />
         {/* Side-by-side actions; each stretches (flex-1), so a student's
             single Assignments button still fills the row. Roster is

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -35,7 +35,15 @@ import {
   ROLE_BADGE_TONE,
 } from "@/util/classroomRoleUI"
 import type { GitHubUser, GitHubOrgInvitation } from "@/github-core/types"
-import { Button, Badge, Card, FormField, Input, Select } from "@/components/ui"
+import {
+  Button,
+  Badge,
+  Card,
+  FormField,
+  Input,
+  Select,
+  Heading,
+} from "@/components/ui"
 
 // Manage a classroom's staff (teacher / head TA / TA), backed by the
 // per-classroom GitHub teams `classroom50-<classroom>-<role>`. The route gates
@@ -68,7 +76,7 @@ const ClassroomStaffSection = ({
               aria-hidden="true"
               className="size-4 text-base-content/70"
             />
-            <h3 className="text-lg font-bold">{t("classes.staff.heading")}</h3>
+            <Heading as="h3">{t("classes.staff.heading")}</Heading>
           </div>
           <GitHubLink
             href={`https://github.com/orgs/${org}/teams`}

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -18,7 +18,7 @@ import {
   CLASSROOM_SHORT_NAME_MAX_LEN,
   GITHUB_REPO_NAME_MAX_LEN,
 } from "@/util/repoNameBudget"
-import { Button, Card, FormField, Input } from "@/components/ui"
+import { Button, Card, FormField, Input, Heading } from "@/components/ui"
 
 export type CreateClassroomFormValues = {
   name: string
@@ -134,9 +134,9 @@ const CreateClassroomForm = ({
       }}
     >
       <Card.Body>
-        <h3 className="text-lg font-bold pb-4">
+        <Heading as="h3" className="pb-4">
           {t("classes.form.basicInfo")}
-        </h3>
+        </Heading>
 
         <form.Field name="name">
           {(field) => (

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -12,7 +12,14 @@ import { classroomConfigTreeUrl } from "@/util/orgUrl"
 import { useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { isClassroomArchived, type Classroom } from "@/types/classroom"
-import { Button, Card, EmphasisLtr, FormField, Input } from "@/components/ui"
+import {
+  Button,
+  Card,
+  EmphasisLtr,
+  FormField,
+  Input,
+  Heading,
+} from "@/components/ui"
 
 export type EditClassroomFormValues = {
   name: string
@@ -323,7 +330,7 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
       <Card.Body>
         <div className="flex justify-between">
           <div className="flex items-center gap-3 pb-4">
-            <h3 className="text-lg font-bold">{t("classes.form.basicInfo")}</h3>
+            <Heading as="h3">{t("classes.form.basicInfo")}</Heading>
             <GitHubLink
               href={classroomConfigTreeUrl(org, classroom)}
               label={t("classes.configRepo")}

--- a/web/src/pages/classes/StudentClassroomList.tsx
+++ b/web/src/pages/classes/StudentClassroomList.tsx
@@ -9,7 +9,14 @@ import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
-import { Badge, Card, Input, LabeledControl, Select } from "@/components/ui"
+import {
+  Badge,
+  Card,
+  Input,
+  LabeledControl,
+  Select,
+  Heading,
+} from "@/components/ui"
 import { EnterDiv } from "@/lib/motionComponents"
 import { useListPrefsState } from "@/lib/listPrefs"
 import {
@@ -84,9 +91,9 @@ function StudentClassroomCard({
     >
       <Card.Body className="gap-4">
         <TermBadge term={summary.term} />
-        <h2 className="truncate text-xl font-semibold">
+        <Heading as="h2" className="truncate">
           {classroomTitle(summary)}
-        </h2>
+        </Heading>
         <AcceptedStat count={summary.acceptedCount} />
         <ViewAssignmentsLink
           org={org}

--- a/web/src/pages/migration/ConfirmStep.tsx
+++ b/web/src/pages/migration/ConfirmStep.tsx
@@ -28,6 +28,7 @@ import {
   Modal,
   Spinner,
   Toolbar,
+  Heading,
 } from "@/components/ui"
 import { useDebouncedValue } from "@/hooks/useDebouncedValue"
 import {
@@ -778,10 +779,10 @@ export const ConfirmStep = ({
         size="md"
         aria-label={t("migration.confirm.modalTitle")}
       >
-        <h3 className="flex items-center gap-2 text-lg font-bold">
+        <Heading as="h3" className="flex items-center gap-2">
           <AlertIcon aria-hidden="true" className="size-4 text-warning" />
           {t("migration.confirm.modalTitle")}
-        </h3>
+        </Heading>
         <p className="mt-2 text-sm text-base-content/80">
           {t("migration.confirm.modalSummary", {
             count: selectedCount,

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -2,7 +2,7 @@ import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { PlusIcon, XIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Select, Toolbar } from "@/components/ui"
+import { Alert, Button, Modal, Select, Toolbar, Heading } from "@/components/ui"
 import type { GitHubClient } from "@/github-core/client"
 import type { GitHubUser } from "@/github-core/types"
 import type { StudentCsvRow } from "@/domain/students"
@@ -420,7 +420,7 @@ const BulkActionsBar = ({
         aria-labelledby={titleId}
       >
         <div className="flex items-start justify-between gap-4">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {action === "remove"
               ? t("orgMembers.bulk.removeTitle", {
                   classroom: effectiveClassroom,
@@ -428,7 +428,7 @@ const BulkActionsBar = ({
               : t("orgMembers.bulk.addTitle", {
                   classroom: effectiveClassroom,
                 })}
-          </h3>
+          </Heading>
         </div>
 
         {phase === "working" && (

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -10,7 +10,14 @@ import {
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
-import { Badge, Button, EmphasisLtr, Modal, rtlFlip } from "@/components/ui"
+import {
+  Badge,
+  Button,
+  EmphasisLtr,
+  Modal,
+  rtlFlip,
+  Heading,
+} from "@/components/ui"
 import { removeMemberFromOrg } from "@/domain/orgMembers/removeMemberFromOrg"
 import {
   ClassificationBadge,
@@ -140,9 +147,9 @@ const MemberDetailModal = ({
       aria-labelledby={titleId}
     >
       <div className="flex items-start justify-between gap-4 border-b border-base-300 px-6 py-4">
-        <h2 id={titleId} className="text-lg font-bold">
+        <Heading as="h2" id={titleId}>
           {t("orgMembers.detailTitle")}
-        </h2>
+        </Heading>
         <Button
           variant="ghost"
           size="sm"

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -18,7 +18,14 @@ import { isValidEmail } from "@/util/orgMembership"
 import { STAFF_ROLES, type StaffRole } from "@/types/classroom"
 import { ROLE_LABEL_KEY } from "@/util/classroomRoleUI"
 import type { ClassroomRole } from "@/authz"
-import { AnimatedAlert, Button, Input, Modal, Select } from "@/components/ui"
+import {
+  AnimatedAlert,
+  Button,
+  Input,
+  Modal,
+  Select,
+  Heading,
+} from "@/components/ui"
 
 // Roster "Add member" roles, in display order. Student (default) enrolls via the
 // student team; teacher/TA delegate to the staff-team backend.
@@ -208,9 +215,9 @@ const AddStudent = ({
     >
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {t("students.addTitle")}
-          </h3>
+          </Heading>
           <p className="mt-1 text-sm text-base-content/70">
             {isStaffRole ? t("students.addStaffHint") : t("students.addHint")}
           </p>

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -14,6 +14,7 @@ import {
   Button,
   Card,
   Toolbar,
+  Heading,
 } from "@/components/ui"
 import { ListSkeletonRows } from "@/components/list"
 import type { Student } from "@/types/classroom"
@@ -671,9 +672,7 @@ const EnrolledStudents = ({
           </div>
         ) : isEmpty ? (
           <div className="px-6 py-12 text-center">
-            <h3 className="text-base font-semibold">
-              {t("students.emptyTitle")}
-            </h3>
+            <Heading as="h3">{t("students.emptyTitle")}</Heading>
             <p className="mt-2 text-sm text-base-content/70">
               {t("students.emptyBody")}
             </p>

--- a/web/src/pages/students/InviteLinksModal.tsx
+++ b/web/src/pages/students/InviteLinksModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { CheckIcon, CopyIcon } from "@/components/ui/icons"
 
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
-import { Button, Input, Modal } from "@/components/ui"
+import { Button, Input, Modal, Heading } from "@/components/ui"
 
 // A single copyable link row (read-only input + copy button).
 const CopyLinkField = ({
@@ -84,9 +84,9 @@ const InviteLinksModal = ({
     <Modal open={open} onClose={onClose} size="lg" aria-labelledby={titleId}>
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {t("students.inviteStudents")}
-          </h3>
+          </Heading>
           <p className="mt-1 text-sm text-base-content/70">
             {t("students.inviteLinksHint")}
           </p>

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -9,7 +9,7 @@ import {
 
 import type { GitHubClient } from "@/github-core/client"
 import { ConfirmModal } from "@/components/modals"
-import { Alert, Button, Modal, Toolbar } from "@/components/ui"
+import { Alert, Button, Modal, Toolbar, Heading } from "@/components/ui"
 import { GitHubAPIError } from "@/github-core/errors"
 import { cancelOrgInvitation } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
@@ -585,13 +585,13 @@ const RosterBulkActionsBar = ({
         aria-labelledby={titleId}
       >
         <div className="flex items-start justify-between gap-4">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {action === "invite"
               ? t("students.bulk.inviteTitle")
               : action === "cancel"
                 ? t("students.bulk.cancelTitle")
                 : t("students.bulk.unenrollTitle")}
-          </h3>
+          </Heading>
         </div>
 
         {phase === "working" && (

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -42,7 +42,14 @@ import {
   STATE_BADGE_TONE,
   STATE_LABEL_KEY,
 } from "@/util/classroomRoleUI"
-import { Badge, Button, EmphasisLtr, Modal, Select } from "@/components/ui"
+import {
+  Badge,
+  Button,
+  EmphasisLtr,
+  Modal,
+  Select,
+  Heading,
+} from "@/components/ui"
 
 // Roster-owned detail modal (single native <dialog>), opened by clicking a
 // roster row. Shares the identity header with the Org Members modal; everything
@@ -517,9 +524,9 @@ const RosterMemberModal = ({
       aria-labelledby={titleId}
     >
       <div className="flex items-start justify-between gap-4 border-b border-base-300 px-6 py-4">
-        <h2 id={titleId} className="text-lg font-bold">
+        <Heading as="h2" id={titleId}>
           {t("students.detailTitle")}
-        </h2>
+        </Heading>
         <Button
           variant="ghost"
           size="sm"

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -10,7 +10,7 @@ import type {
   RosterUploadContext,
 } from "@/domain/students"
 import type { GitHubClient } from "@/github-core/client"
-import { Alert, Button, Modal } from "@/components/ui"
+import { Alert, Button, Modal, Heading } from "@/components/ui"
 import {
   classifyRosterUpload,
   hasTeacherPromotion,
@@ -691,9 +691,9 @@ const UploadRoster = ({
       >
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h3 id={titleId} className="text-lg font-bold">
+            <Heading as="h3" id={titleId}>
               {t("students.uploadTitle")}
-            </h3>
+            </Heading>
             {fileName && (
               <p className="text-sm opacity-70 mt-1">
                 {t("students.fileLabel", { fileName })}

--- a/web/src/pages/submissions/AcceptLinkModal.tsx
+++ b/web/src/pages/submissions/AcceptLinkModal.tsx
@@ -14,6 +14,7 @@ import {
   Modal,
   RouterButton,
   rtlFlip,
+  Heading,
 } from "@/components/ui"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { OrgRepoCreationNotice } from "@/components/OrgRepoCreationNotice"
@@ -61,9 +62,7 @@ export function AcceptLinkModal({
           <LinkIcon aria-hidden="true" className="size-4" />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 className="text-lg font-bold">
-            {t("submissions.accept.heading")}
-          </h3>
+          <Heading as="h3">{t("submissions.accept.heading")}</Heading>
           <p className="text-sm text-base-content/70">
             {t("submissions.accept.subheading")}
           </p>

--- a/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
+++ b/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { FileZipIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Spinner } from "@/components/ui"
+import { Alert, Button, Modal, Spinner, Heading } from "@/components/ui"
 import useDownloadAllSubmissions from "@/hooks/mutations/useDownloadAllSubmissions"
 import {
   BULK_DOWNLOAD_WARN_THRESHOLD,
@@ -108,10 +108,10 @@ export function DownloadAllSubmissionsModal({
       size="md"
       aria-labelledby={titleId}
     >
-      <h3 id={titleId} className="flex items-center gap-2 text-lg font-bold">
+      <Heading as="h3" className="flex items-center gap-2" id={titleId}>
         <FileZipIcon aria-hidden="true" className="size-4" />
         {t("submissions.downloadAll.title")}
-      </h3>
+      </Heading>
 
       {error ? (
         <div className="mt-3 space-y-3">

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useMemo, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { MarkGithubIcon, PeopleIcon } from "@/components/ui/icons"
 
-import { Badge, Modal, MonoLtr } from "@/components/ui"
+import { Badge, Modal, MonoLtr, Heading } from "@/components/ui"
 import useGetRepo from "@/hooks/useGetRepo"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
 import useGetAutogradeState from "@/hooks/useGetAutogradeState"
@@ -315,9 +315,9 @@ export const ManageSubmissionModal = ({
       boxClassName={subModalOpen ? "invisible" : undefined}
       aria-labelledby={titleId}
     >
-      <h3 id={titleId} className="truncate pe-8 text-lg font-bold">
+      <Heading as="h3" className="truncate pe-8" id={titleId}>
         {title}
-      </h3>
+      </Heading>
       {subtitle ? (
         <p className="mt-0.5 truncate text-sm text-base-content/60">
           {subtitle}

--- a/web/src/pages/submissions/MetricsModal.tsx
+++ b/web/src/pages/submissions/MetricsModal.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next"
 
-import { Modal, StatCard } from "@/components/ui"
+import { Modal, StatCard, Heading } from "@/components/ui"
 
 // The submission metrics, consolidated behind a single toolbar button so they
 // no longer push the roster down. Pure presentation: the page computes the
@@ -55,7 +55,7 @@ export function MetricsModal({
 
   return (
     <Modal open={open} onClose={onClose} size="2xl">
-      <h3 className="text-lg font-bold">{t("submissions.metrics.title")}</h3>
+      <Heading as="h3">{t("submissions.metrics.title")}</Heading>
       <div className="mt-4 grid grid-cols-2 gap-4">
         <StatCard
           label={

--- a/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
+++ b/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
@@ -2,7 +2,7 @@ import { useId } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { GitPullRequestIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Spinner } from "@/components/ui"
+import { Alert, Button, Modal, Spinner, Heading } from "@/components/ui"
 import useOpenAllFeedbackPrs from "@/hooks/mutations/useOpenAllFeedbackPrs"
 import type { OpenAllRepoResult } from "@/domain/assignments"
 import type { AssignmentMode } from "@/types/classroom"
@@ -92,10 +92,10 @@ export function OpenAllFeedbackPrsModal({
       closeDisabled={running}
       aria-labelledby={titleId}
     >
-      <h3 id={titleId} className="flex items-center gap-2 text-lg font-bold">
+      <Heading as="h3" className="flex items-center gap-2" id={titleId}>
         <GitPullRequestIcon aria-hidden="true" className="size-4" />
         {t("submissions.openAllPrs.title")}
-      </h3>
+      </Heading>
 
       {/* Summary — the run finished. */}
       {summary ? (

--- a/web/src/pages/submissions/ReviewButton.tsx
+++ b/web/src/pages/submissions/ReviewButton.tsx
@@ -2,7 +2,7 @@ import { CommentIcon } from "@/components/ui/icons"
 import { useId, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 
-import { Button, Modal, MonoLtr } from "@/components/ui"
+import { Button, Modal, MonoLtr, Heading } from "@/components/ui"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import useGetFeedbackPr from "@/hooks/useGetFeedbackPr"
 import useRepairFeedbackPr from "@/hooks/mutations/useRepairFeedbackPr"
@@ -130,18 +130,18 @@ export const ReviewButton = ({
       >
         {errorMsg ? (
           <>
-            <h3 id={titleId} className="text-lg font-bold">
+            <Heading as="h3" id={titleId}>
               {t("submissions.reviewModal.errorTitle")}
-            </h3>
+            </Heading>
             <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-base-content/70">
               {errorMsg}
             </p>
           </>
         ) : (
           <>
-            <h3 id={titleId} className="text-lg font-bold">
+            <Heading as="h3" id={titleId}>
               {t("submissions.reviewModal.emptyTitle")}
-            </h3>
+            </Heading>
             <p className="mt-2 text-sm leading-6 text-base-content/70">
               <Trans
                 i18nKey="submissions.reviewModal.emptyBody"

--- a/web/src/pages/submissions/ScoreOverrideModal.tsx
+++ b/web/src/pages/submissions/ScoreOverrideModal.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   Modal,
   Spinner,
+  Heading,
 } from "@/components/ui"
 import { ScoreBadge } from "@/pages/submissions/ScoreBadge"
 import { useSetScoreOverride } from "@/hooks/mutations/useSetScoreOverride"
@@ -210,9 +211,9 @@ export function ScoreOverrideModal({
     >
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
-          <h3 id={titleId} className="text-lg font-bold">
+          <Heading as="h3" id={titleId}>
             {title}
-          </h3>
+          </Heading>
           <p className="text-sm text-base-content/70">{description}</p>
         </div>
 

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -8,7 +8,7 @@ import { AlertIcon } from "@/components/ui/icons"
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { RoleViewProvider } from "@/context/roleView/RoleViewProvider"
-import { Button } from "@/components/ui"
+import { Button, Heading } from "@/components/ui"
 import { logger } from "@/lib/logger"
 import { LOG_SCOPE_ROUTER } from "@/lib/logScopes"
 
@@ -45,7 +45,9 @@ const RootErrorComponent = ({ error }: { error: Error }) => {
         <AlertIcon aria-hidden="true" className="size-8" />
       </div>
       <div>
-        <h1 className="text-2xl font-bold">{t("error.title")}</h1>
+        <Heading as="h1" variant="title-medium">
+          {t("error.title")}
+        </Heading>
         <p className="mt-1 max-w-md text-base-content/70">
           {error?.message || t("error.unexpected")}
         </p>


### PR DESCRIPTION
## Summary

- Adopts [GitHub Primer's typography primitives](https://primer.style/product/primitives/typography/), continuing the Primer alignment started with the Octicons migration (#723).
- **Mona Sans, self-hosted** via `@fontsource-variable/mona-sans` (variable wght 200–900 + italics, subsetted woff2, `font-display: swap`). The Google Fonts link now loads only **Noto Sans JP** as the CJK fallback for translated locales, with weight 600 added so JP titles render true semibold instead of synthesizing it. The anti-flash scripts in `index.html` are untouched.
- **Typography tokens** in `index.css`: `--font-sans` (Mona Sans → Noto Sans JP → Primer's fallback stack), `--font-mono` (Primer's `fontStack-monospace` verbatim, now also shared by the print stylesheet), and `--text-code` (Primer's 13px code-block size, exposed as the `text-code` utility).
- **New `Heading` primitive** in `components/ui` carrying Primer's title scale — `title-medium` (20px/600) for page titles, `title-small` (16px/600) for sections, modals, and cards, plus `subtitle`. 80 hand-rolled heading recipes across 63 files migrated onto it; `CardTitle` drops DaisyUI's `card-title` for the same recipe (single source), and the `card-title text-xl` outlier is fixed.
- **Markdown** headings stepped down proportionally (h1 20/600, h2 16/600, h3 14/600); code chips and blocks now use the 13px `text-code` size.
- Also drops the bold weight from the `MetricBar` ratio text (review feedback).

## Notes for review

- The visible change is global: everything renders in Mona Sans, and titles go from bold (700) at 24/18px to semibold (600) at 20/16px — deliberately denser and GitHub-like. Body text sizes are unchanged (`text-sm`/`text-xs` already matched Primer).
- The contrast audit regenerated byte-identical outputs — no WCAG pair classifications changed.
- Verified computed styles on the running app: body = `Mona Sans Variable`, h1 = 20px/600.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 4416 tests incl. text-spacing/resize/target-size browser tests) passes
- [x] `npm run audit:contrast` — outputs unchanged
- [x] Visual check of the login page (screenshot in review)
- [ ] Visual spot-check of dense pages (submissions), both themes, RTL, and the ja locale