### PR TITLE
feat(web): align radii and focus ring with Primer size primitives

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -23,7 +23,9 @@
    large-text floor with a white label.
 
    Flat surfaces (--depth/--noise 0) with softly rounded shapes; the radius
-   scale is box > field > selector so nesting reads naturally. */
+   scale is box > field > selector so nesting reads naturally, with field and
+   selector on Primer's borderRadius-medium (6px) and -small (3px) and box on
+   borderRadius-large (12px). */
 @plugin "daisyui/theme" {
   name: "sumi";
   default: true;
@@ -59,8 +61,8 @@
   --color-error: #d1242f; /* fgColor-danger */
   --color-error-content: #ffffff;
 
-  --radius-selector: 0.375rem;
-  --radius-field: 0.5rem;
+  --radius-selector: 0.1875rem;
+  --radius-field: 0.375rem;
   --radius-box: 0.75rem;
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
@@ -106,8 +108,8 @@
   --color-error: #f85149; /* fgColor-danger */
   --color-error-content: #0d1117;
 
-  --radius-selector: 0.375rem;
-  --radius-field: 0.5rem;
+  --radius-selector: 0.1875rem;
+  --radius-field: 0.375rem;
   --radius-box: 0.75rem;
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
@@ -191,6 +193,40 @@
 html,
 body {
   font-family: var(--font-sans);
+}
+
+/* Primer focus ring (primer.style/product/primitives/size): one uniform
+   2px accent outline, inset (-2px), on keyboard focus. --color-info is the
+   sumi token mirroring Primer's focus-outlineColor (fgColor-accent). The
+   control-class selectors match daisyUI's own focus rules' specificity so
+   this later rule wins without !important. */
+:focus-visible,
+.btn:focus-visible,
+.input:focus-visible,
+.select:focus-visible,
+.textarea:focus-visible,
+.checkbox:focus-visible,
+.radio:focus-visible,
+.toggle:focus-visible,
+.range:focus-visible,
+.tab:focus-visible,
+.link:focus-visible {
+  outline: 2px solid var(--color-info);
+  outline-offset: -2px;
+}
+
+/* Text-field wrappers (label.input > input.grow) indicate focus at the
+   wrapper, like daisyUI; the borderless inner control must not double the
+   ring inside it. */
+.input:focus-within,
+.select:focus-within,
+.textarea:focus-within {
+  outline: 2px solid var(--color-info);
+  outline-offset: -2px;
+}
+.input :focus-visible,
+.textarea :focus-visible {
+  outline: none;
 }
 
 /* Theme cross-fade via the View Transitions API. `useTheme` wraps an explicit

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -255,7 +255,7 @@ const StaffRoleList = ({
             target="_blank"
             rel="noreferrer"
             title={t("classes.staff.viewTeamTitle", { role: rolePlural })}
-            className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+            className="shrink-0 rounded-full"
           >
             <Badge
               size="sm"


### PR DESCRIPTION
## Summary

- Third PR in the Primer alignment series (after Octicons #723 and typography #725), adopting [Primer's size primitives](https://primer.style/product/primitives/size/).
- **Border radii** snap to Primer's scale in both sumi themes: `--radius-field` 8px → 6px (`borderRadius-medium`, buttons/inputs/selects) and `--radius-selector` 6px → 3px (`borderRadius-small`, badges/checkboxes); `--radius-box` stays 12px (`borderRadius-large`, cards/modals). Usage was already token-driven (`rounded-box` ×134, `rounded-field` ×34, zero hand-rolled radii), so the token edit carries the whole change.
- **Focus ring**: replaces daisyUI's per-component, component-colored +2px outlines with Primer's uniform focus style — `2px solid` accent (`--color-info`, the sumi token mirroring Primer's `focus-outlineColor`) at `-2px` inset, on `:focus-visible`. Text-field wrappers ring via `:focus-within` with the inner grower suppressed, so there is no double ring. The one hand-rolled `focus-visible:outline-none` + custom ring override is removed in favor of the global rule; remaining `ring-*` uses are selected/hover-state indicators, not focus.

## Notes for review

- Verified by trusted-keyboard Tab passes in a signed-in session, both themes: every stop (primary/ghost/small buttons, selects, dropdown menus, links, text fields) shows the uniform accent inset ring; nothing is ringless. This is a WCAG 2.4.7 improvement worth reflecting in the next VPAT pass (currently "not evaluated").
- Control sizes untouched — `btn-xs` stays at the 24px target-size floor the browser test asserts.
- Out of scope, deliberately: breakpoints (Tailwind's diverge from Primer's; high-risk/low-value) and spacing (already on the 4px grid).

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 4416 tests incl. target-size/reflow browser tests) passes
- [x] Keyboard-tab focus audit in live session, light + dark
- [ ] Quick visual pass over dense pages for the tighter 6px/3px radii