### PR TITLE
feat(web): align empty states with Primer's Blankslate pattern

### DIFF
--- a/web/src/components/list/emptyState.test.tsx
+++ b/web/src/components/list/emptyState.test.tsx
@@ -7,10 +7,10 @@ import { EmptyState, NoSearchResults } from "./index"
 
 afterEach(cleanup)
 
-// EmptyState is the single dashed-card implementation every empty state now
-// renders through, so these lock the slot contract: title is always present,
-// body/action wrappers appear only when passed, and className fully overrides
-// the default shell.
+// EmptyState is the single Blankslate implementation every empty state now
+// renders through, so these lock the slot contract: title/body/action/icon
+// wrappers appear only when passed, className merges onto the variant shell,
+// and the bare variant drops the dashed card.
 describe("EmptyState", () => {
   it("renders the title and omits body/action when not passed", () => {
     render(<EmptyState title="Nothing here" />)
@@ -30,12 +30,34 @@ describe("EmptyState", () => {
     expect(screen.getByRole("button", { name: "Do it" })).toBeDefined()
   })
 
-  it("replaces the default shell class when className is provided", () => {
-    const { container } = render(
-      <EmptyState title="Custom" className="my-shell" />,
-    )
+  it("merges className onto the card shell", () => {
+    const { container } = render(<EmptyState title="Custom" className="mt-4" />)
     const root = container.firstElementChild
-    expect(root?.className).toBe("my-shell")
+    expect(root?.className).toContain("mt-4")
+    expect(root?.className).toContain("border-dashed")
+  })
+
+  it("drops the card shell in the bare variant", () => {
+    const { container } = render(<EmptyState title="Bare" variant="bare" />)
+    expect(container.firstElementChild?.className).not.toContain(
+      "border-dashed",
+    )
+  })
+
+  it("renders the icon in the standard muted circle, hidden from AT", () => {
+    const Probe = (props: { className?: string }) => (
+      <svg data-testid="probe" {...props} />
+    )
+    render(<EmptyState title="With icon" icon={Probe} />)
+    const icon = screen.getByTestId("probe")
+    expect(icon.getAttribute("aria-hidden")).toBe("true")
+    expect(icon.parentElement?.className).toContain("rounded-full")
+  })
+
+  it("supports a body-only empty state without a heading", () => {
+    render(<EmptyState body="Nothing matched" />)
+    expect(screen.queryByRole("heading")).toBeNull()
+    expect(screen.getByText("Nothing matched")).toBeDefined()
   })
 })
 

--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -3,9 +3,15 @@
 // own i18n namespace while sharing the markup and behavior.
 
 import { AppsIcon, ListUnorderedIcon } from "@/components/ui/icons"
-import type { ReactNode } from "react"
+import type { ComponentType, ReactNode } from "react"
 
-import { Button, Heading } from "@/components/ui"
+import { Button, Heading, cx } from "@/components/ui"
+
+// Anything icon-shaped: octicons satisfy this, and tests can pass probes.
+type EmptyStateIcon = ComponentType<{
+  className?: string
+  "aria-hidden"?: boolean | "true" | "false"
+}>
 
 export type ListViewMode = "grid" | "list"
 
@@ -48,29 +54,51 @@ export function ViewToggle({
   )
 }
 
-// The single dashed-border empty-state card. `className` overrides the default
-// shell so the non-uniform call sites keep their own padding (e.g.
-// PublishedResourcesPage's p-6). NoSearchResults and the zero-data
-// states across the list pages all render through this.
+// Primer Blankslate-style empty state (primer.style/product/ui-patterns/
+// empty-states): optional muted icon in a circle, optional title, body,
+// one action slot. `variant="card"` is the dashed-border shell for page-level
+// blankslates; `variant="bare"` is shell-less for table rows and quiet
+// blocks. `className` merges onto the shell (layout-only additions like mt-4).
 export function EmptyState({
-  icon,
+  icon: Icon,
   title,
+  titleAs = "h2",
   body,
   action,
-  className = "rounded-box border border-dashed border-base-300 bg-base-100 p-8 text-center",
+  variant = "card",
+  className,
 }: {
-  icon?: ReactNode
-  title: ReactNode
+  icon?: EmptyStateIcon
+  title?: ReactNode
+  titleAs?: "h1" | "h2" | "h3" | "h4"
   body?: ReactNode
   action?: ReactNode
+  variant?: "card" | "bare"
   className?: string
 }) {
   return (
-    <div className={className}>
-      {icon}
-      <Heading as="h2">{title}</Heading>
+    <div
+      className={cx(
+        "text-center",
+        variant === "card"
+          ? "rounded-box border border-dashed border-base-300 bg-base-100 p-8"
+          : "px-6 py-10",
+        className,
+      )}
+    >
+      {Icon && (
+        <div className="mx-auto mb-3 flex size-12 items-center justify-center rounded-full bg-base-200 text-base-content/70">
+          <Icon aria-hidden="true" className="size-6" />
+        </div>
+      )}
+      {title != null && <Heading as={titleAs}>{title}</Heading>}
       {body && (
-        <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
+        <p
+          className={cx(
+            "mx-auto max-w-md text-sm text-base-content/70",
+            title != null && "mt-1",
+          )}
+        >
           {body}
         </p>
       )}

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -13,6 +13,7 @@ import {
   RepoLockedIcon,
 } from "@/components/ui/icons"
 
+import { EmptyState } from "@/components/list"
 import { Button, Card, Markdown, Modal, Heading } from "@/components/ui"
 import type { GitHubRepo } from "@/github-core/types"
 import { assignmentDescription } from "@/types/classroom"
@@ -220,20 +221,11 @@ export const OrgRepos = ({
 
   if (writableRepos.length === 0) {
     return (
-      <div className="rounded-box border border-dashed border-base-300 bg-base-100 p-8 text-center">
-        <div className="mx-auto mb-3 flex size-12 items-center justify-center rounded-full bg-base-200">
-          <BookIcon
-            aria-hidden="true"
-            className="size-6 text-base-content/70"
-          />
-        </div>
-
-        <Heading as="h2">{t("classes.repo.emptyTitle")}</Heading>
-
-        <p className="mx-auto mt-1 max-w-md text-sm text-base-content/70">
-          {t("classes.repo.emptyBody")}
-        </p>
-      </div>
+      <EmptyState
+        icon={BookIcon}
+        title={t("classes.repo.emptyTitle")}
+        body={t("classes.repo.emptyBody")}
+      />
     )
   }
 

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -11,6 +11,7 @@ import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
+import { EmptyState } from "@/components/list"
 import { Alert, Button, Card, EmphasisLtr } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import MissingParams from "@/components/MissingParams"
@@ -74,23 +75,13 @@ const NewClassroomButton = ({ org }: { org: string }) => {
 const CreateClassroomPane = ({ org }: { org: string }) => {
   const { t } = useTranslation()
   return (
-    <Card dashed>
-      <Card.Body className="items-center py-12 text-center">
-        <div className="mb-2 flex size-14 items-center justify-center rounded-full bg-primary/10 text-primary">
-          <PlusIcon aria-hidden="true" className="size-6" />
-        </div>
-
-        <Card.Title className="text-xl">{t("classes.empty.title")}</Card.Title>
-
-        <p className="max-w-md text-base-content/70">
-          {t("classes.empty.body")}
-        </p>
-
-        <Card.Actions className="mt-4">
-          <NewClassroomButton org={org} />
-        </Card.Actions>
-      </Card.Body>
-    </Card>
+    <EmptyState
+      className="py-12"
+      icon={PlusIcon}
+      title={t("classes.empty.title")}
+      body={t("classes.empty.body")}
+      action={<NewClassroomButton org={org} />}
+    />
   )
 }
 

--- a/web/src/pages/OrgActivityPage.tsx
+++ b/web/src/pages/OrgActivityPage.tsx
@@ -159,13 +159,8 @@ const OrgActivityPage = () => {
             </Card>
           ) : (
             <EmptyState
-              className="mt-4 rounded-box border border-dashed border-base-300 bg-base-100 p-8 text-center"
-              icon={
-                <PulseIcon
-                  aria-hidden="true"
-                  className="mx-auto mb-3 size-8 text-base-content/40"
-                />
-              }
+              className="mt-4"
+              icon={PulseIcon}
               title={
                 hasActiveFilter
                   ? t("orgActivity.noMatch.title")

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react"
+import { EmptyState } from "@/components/list"
 import { Trans, useTranslation } from "react-i18next"
 import { useParams } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
@@ -463,18 +464,21 @@ const OrgMembersPage = () => {
                 {t("orgMembers.loadError")}
               </div>
             ) : filtered.length === 0 ? (
-              <div className="px-6 py-10 text-center text-sm text-base-content/70">
-                {classroomFilter === NO_CLASSROOM_FILTER
-                  ? t("orgMembers.noMembersNoClassroom")
-                  : classroomFilter
-                    ? t("orgMembers.noMembersInClassroom", {
-                        classroom:
-                          classroomOptions.find(
-                            (c) => c.path === classroomFilter,
-                          )?.name ?? classroomFilter,
-                      })
-                    : t("orgMembers.noMatch")}
-              </div>
+              <EmptyState
+                variant="bare"
+                body={
+                  classroomFilter === NO_CLASSROOM_FILTER
+                    ? t("orgMembers.noMembersNoClassroom")
+                    : classroomFilter
+                      ? t("orgMembers.noMembersInClassroom", {
+                          classroom:
+                            classroomOptions.find(
+                              (c) => c.path === classroomFilter,
+                            )?.name ?? classroomFilter,
+                        })
+                      : t("orgMembers.noMatch")
+                }
+              />
             ) : (
               <>
                 {org ? (

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "@tanstack/react-router"
+import { EmptyState } from "@/components/list"
 import { Trans, useTranslation } from "react-i18next"
 import {
   AlertIcon,
@@ -490,8 +491,8 @@ const AssignmentsTable = ({
         {loading && <SkeletonRows bars={SKELETON_BARS} />}
         {!loading && !assignments?.length && (
           <tr>
-            <td colSpan={7} className="text-center">
-              {t("assignments.table.empty")}
+            <td colSpan={7}>
+              <EmptyState variant="bare" body={t("assignments.table.empty")} />
             </td>
           </tr>
         )}

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -10,7 +10,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import { NoSearchResults, ViewToggle } from "@/components/list"
+import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
 import { Button, cx, Input, LabeledControl, Select } from "@/components/ui"
 import useClassroomSummaries, {
   classroomDisplayName,
@@ -296,11 +296,7 @@ const ClassroomList = ({
           onClear={() => setSearch("")}
         />
       ) : emptyFilter ? (
-        <div className="rounded-box border border-dashed border-base-300 bg-base-100 p-8 text-center">
-          <p className="text-sm text-base-content/70">
-            {t(`classes.emptyFilter.${filter}`)}
-          </p>
-        </div>
+        <EmptyState body={t(`classes.emptyFilter.${filter}`)} />
       ) : (
         <div className="grid grid-cols-12 gap-4">
           {displayList.map((summary) =>

--- a/web/src/pages/classes/StudentClassroomList.tsx
+++ b/web/src/pages/classes/StudentClassroomList.tsx
@@ -249,14 +249,7 @@ export function StudentClassroomList({
         />
       ) : empty ? (
         <EmptyState
-          icon={
-            <div className="mx-auto mb-3 flex size-12 items-center justify-center rounded-full bg-base-200">
-              <MortarBoardIcon
-                aria-hidden="true"
-                className="size-6 text-base-content/70"
-              />
-            </div>
-          }
+          icon={MortarBoardIcon}
           title={t("classes.student.emptyTitle")}
           body={t("classes.student.emptyBody")}
         />

--- a/web/src/pages/migration/SelectSourceStep.tsx
+++ b/web/src/pages/migration/SelectSourceStep.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/icons"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { EmptyState } from "@/components/list"
 import { Alert, Badge, Button, Card, rtlFlip } from "@/components/ui"
 import { listClassroomsWithOrg } from "@/migration/classroomApi"
 import type { ClassroomWithOrg } from "@/migration/types"
@@ -144,14 +145,11 @@ export const SelectSourceStep = ({
         )}
 
         {data && data.length === 0 && (
-          <div className="mt-4 rounded-box border border-dashed border-base-300 p-8 text-center">
-            <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-base-200 text-base-content/50">
-              <InboxIcon aria-hidden="true" className="size-6" />
-            </div>
-            <p className="text-sm text-base-content/70">
-              {t("migration.select.empty")}
-            </p>
-          </div>
+          <EmptyState
+            className="mt-4"
+            icon={InboxIcon}
+            body={t("migration.select.empty")}
+          />
         )}
 
         {data && data.length > 0 && (

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react"
+import { EmptyState } from "@/components/list"
 import { useTranslation } from "react-i18next"
 import { InfoIcon } from "@/components/ui/icons"
 
@@ -75,8 +76,11 @@ const CsvRosterView = ({
               <SkeletonRows rows={3} bars={["w-40", "w-16", "w-20"]} />
             ) : rows.length === 0 ? (
               <tr>
-                <td colSpan={3} className="text-center">
-                  {t("students.csvRoster.empty")}
+                <td colSpan={3}>
+                  <EmptyState
+                    variant="bare"
+                    body={t("students.csvRoster.empty")}
+                  />
                 </td>
               </tr>
             ) : (

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -1,6 +1,7 @@
 import {
   AlertIcon,
   PaperAirplaneIcon,
+  PeopleIcon,
   PlusIcon,
   SyncIcon,
   UploadIcon,
@@ -14,9 +15,8 @@ import {
   Button,
   Card,
   Toolbar,
-  Heading,
 } from "@/components/ui"
-import { ListSkeletonRows } from "@/components/list"
+import { EmptyState, ListSkeletonRows } from "@/components/list"
 import type { Student } from "@/types/classroom"
 import { useQueryClient } from "@tanstack/react-query"
 import type { RosterCsvProblem } from "@/domain/students"
@@ -671,32 +671,36 @@ const EnrolledStudents = ({
             </Button>
           </div>
         ) : isEmpty ? (
-          <div className="px-6 py-12 text-center">
-            <Heading as="h3">{t("students.emptyTitle")}</Heading>
-            <p className="mt-2 text-sm text-base-content/70">
-              {t("students.emptyBody")}
-            </p>
-            {addActions ? (
-              <div className="mt-4 flex justify-center gap-2">
-                <Button
-                  variant="primary"
-                  size="sm"
-                  onClick={addActions.onAddStudent}
-                >
-                  <PlusIcon aria-hidden="true" className="size-4" />
-                  {t("students.addTitle")}
-                </Button>
-                <Button size="sm" onClick={addActions.onUploadRoster}>
-                  <UploadIcon aria-hidden="true" className="size-4" />
-                  {t("students.uploadTitle")}
-                </Button>
-                <Button size="sm" onClick={addActions.onInviteLinks}>
-                  <PaperAirplaneIcon aria-hidden="true" className="size-4" />
-                  {t("students.inviteStudents")}
-                </Button>
-              </div>
-            ) : null}
-          </div>
+          <EmptyState
+            variant="bare"
+            className="py-12"
+            icon={PeopleIcon}
+            titleAs="h3"
+            title={t("students.emptyTitle")}
+            body={t("students.emptyBody")}
+            action={
+              addActions ? (
+                <div className="flex justify-center gap-2">
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={addActions.onAddStudent}
+                  >
+                    <PlusIcon aria-hidden="true" className="size-4" />
+                    {t("students.addTitle")}
+                  </Button>
+                  <Button size="sm" onClick={addActions.onUploadRoster}>
+                    <UploadIcon aria-hidden="true" className="size-4" />
+                    {t("students.uploadTitle")}
+                  </Button>
+                  <Button size="sm" onClick={addActions.onInviteLinks}>
+                    <PaperAirplaneIcon aria-hidden="true" className="size-4" />
+                    {t("students.inviteStudents")}
+                  </Button>
+                </div>
+              ) : null
+            }
+          />
         ) : (
           <>
             <RosterBulkActionsBar
@@ -716,22 +720,25 @@ const EnrolledStudents = ({
               canGroupBySection={hasSectionsInFiltered}
             />
             {filtered.length === 0 ? (
-              <div className="px-6 py-10 text-center text-sm text-base-content/70">
-                {query.trim()
-                  ? t("students.noMatch")
-                  : effectiveSection !== "all" && statusFilter === "all"
-                    ? t("students.noneInSection", {
-                        section:
-                          effectiveSection === NO_SECTION
-                            ? t("students.noSection")
-                            : effectiveSection,
-                      })
-                    : t("students.noneWithStatus", {
-                        status:
-                          statusOptions.find((o) => o.value === statusFilter)
-                            ?.label ?? statusFilter,
-                      })}
-              </div>
+              <EmptyState
+                variant="bare"
+                body={
+                  query.trim()
+                    ? t("students.noMatch")
+                    : effectiveSection !== "all" && statusFilter === "all"
+                      ? t("students.noneInSection", {
+                          section:
+                            effectiveSection === NO_SECTION
+                              ? t("students.noSection")
+                              : effectiveSection,
+                        })
+                      : t("students.noneWithStatus", {
+                          status:
+                            statusOptions.find((o) => o.value === statusFilter)
+                              ?.label ?? statusFilter,
+                        })
+                }
+              />
             ) : groupBySection && hasSectionsInFiltered ? (
               <div className="divide-y divide-base-300">
                 {filteredBySection.map(({ section, students: group }) => (

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -1,4 +1,5 @@
 import { FilterRemoveIcon, InboxIcon } from "@/components/ui/icons"
+import { EmptyState } from "@/components/list"
 import { motion } from "motion/react"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -755,50 +756,43 @@ const SubmissionsTable = ({
             !unsubmittedGroupRepos.length &&
             !nonSubmittersLoading && (
               <tr>
-                <td colSpan={5} className="py-10 text-center">
-                  <div className="mx-auto flex max-w-sm flex-col items-center gap-2">
-                    {filtered ? (
-                      <>
-                        <FilterRemoveIcon
-                          aria-hidden="true"
-                          className="size-8 text-base-content/40"
-                        />
-                        <p className="font-medium">
-                          {t("submissions.table.emptyFilteredTitle")}
-                        </p>
-                        <p className="text-sm text-base-content/70">
-                          {t("submissions.table.emptyFilteredBody")}
-                        </p>
-                        {onClearFilters && (
+                <td colSpan={5}>
+                  {filtered ? (
+                    <EmptyState
+                      variant="bare"
+                      icon={FilterRemoveIcon}
+                      titleAs="h3"
+                      title={t("submissions.table.emptyFilteredTitle")}
+                      body={t("submissions.table.emptyFilteredBody")}
+                      action={
+                        onClearFilters && (
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="mt-1"
                             onClick={onClearFilters}
                           >
                             {t("submissions.table.emptyClearFilters")}
                           </Button>
-                        )}
-                      </>
-                    ) : (
-                      <>
-                        <InboxIcon
-                          aria-hidden="true"
-                          className="size-8 text-base-content/40"
-                        />
-                        <p className="font-medium">
-                          {isGroup
-                            ? t("submissions.table.emptyNoGroupsTitle")
-                            : t("submissions.table.emptyNoDataTitle")}
-                        </p>
-                        <p className="text-sm text-base-content/70">
-                          {isGroup
-                            ? t("submissions.table.emptyNoGroupsBody")
-                            : t("submissions.table.emptyNoDataBody")}
-                        </p>
-                      </>
-                    )}
-                  </div>
+                        )
+                      }
+                    />
+                  ) : (
+                    <EmptyState
+                      variant="bare"
+                      icon={InboxIcon}
+                      titleAs="h3"
+                      title={
+                        isGroup
+                          ? t("submissions.table.emptyNoGroupsTitle")
+                          : t("submissions.table.emptyNoDataTitle")
+                      }
+                      body={
+                        isGroup
+                          ? t("submissions.table.emptyNoGroupsBody")
+                          : t("submissions.table.emptyNoDataBody")
+                      }
+                    />
+                  )}
                 </td>
               </tr>
             )}


### PR DESCRIPTION
## Summary

- Fourth PR in the Primer alignment series (#723 Octicons, #725 typography, #726 size/focus), adopting the [empty-states UI pattern](https://primer.style/product/ui-patterns/empty-states) (Blankslate anatomy: muted icon, heading, description, one action).
- **Evolves the shared `EmptyState`** (`components/list`) into a Blankslate-style primitive: standard icon recipe (24px octicon in a muted `size-12` circle, replacing ad-hoc 32px+ hero icons), optional title with a `titleAs` heading-level prop, a `bare` variant for table rows and quiet blocks, and `className` that merges onto the shell instead of replacing it (removes the hand-copied shell in `OrgActivityPage` — the "mirrors X" smell).
- **Migrates 14 hand-rolled empty states** onto the primitive: dashed cards (`OrgRepos`, migration `SelectSourceStep`, the Classes create-first pane, classroom filter-empty), table `colSpan` rows (`SubmissionsTable` filtered + no-data branches, `AssignmentsTable`, `CsvRosterView`), and centered blocks (`EnrolledStudents` roster-empty with its three-action row + filtered-empty, `OrgMembersPage`).
- Extends the `EmptyState` contract tests (+3: icon circle recipe with `aria-hidden`, bare variant, body-only form).

## Notes for review

- Deliberately not migrated, per the pattern's own scope: error/degraded states (`NotFound`, permission boundaries, load errors), the `JoinOrgCard` invite CTA, the Onboarding horizontal waiting card, modal/popover micro-empties, and the autograder inline box.
- All user-facing strings are unchanged (existing i18n keys), so translation packs are unaffected.
- In-table blankslate titles render as real `h3` headings now (were styled `<p>`s) — a small semantics improvement.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 4419 tests) passes
- [x] Live session check: orgs no-match state renders through the new primitive
- [ ] Visual pass over the remaining empty states (empty classroom roster, submissions table with filters, migration picker)