### PR TITLE
feat(web): align notification messaging with Primer's pattern

### DIFF
--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react"
 import { useRouterState } from "@tanstack/react-router"
-import { AlertIcon, ShieldCheckIcon } from "@/components/ui/icons"
+import { ShieldCheckIcon } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
 
 import { useGithubAuth } from "./useGithubAuth"
@@ -150,7 +150,6 @@ export function ElevatedAccessModal({
 
           {error ? (
             <Alert tone="error" className="items-start text-sm">
-              <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
               <span>{error}</span>
             </Alert>
           ) : null}

--- a/web/src/auth/GitHubAuthCard.tsx
+++ b/web/src/auth/GitHubAuthCard.tsx
@@ -1,5 +1,4 @@
 import {
-  AlertIcon,
   InfoIcon,
   MarkGithubIcon,
   MortarBoardIcon,
@@ -123,12 +122,21 @@ export function GitHubAuthCard() {
                       ? auth.error
                       : t("auth.sessionExpired")
                 // "expired" is an informational "please sign in again" prompt,
-                // not a fault; the warning triangle overstates it, so only the
-                // offline/error tones carry the alert icon.
-                const Icon = alert === "expired" ? InfoIcon : AlertIcon
+                // not a fault; the warning triangle overstates it, so it
+                // overrides the tone icon with the info glyph.
                 return (
-                  <Alert tone={tone} className="items-start text-sm">
-                    <Icon aria-hidden="true" className="size-4 shrink-0" />
+                  <Alert
+                    tone={tone}
+                    icon={
+                      alert === "expired" ? (
+                        <InfoIcon
+                          aria-hidden="true"
+                          className="size-4 shrink-0"
+                        />
+                      ) : undefined
+                    }
+                    className="items-start text-sm"
+                  >
                     <span>{message}</span>
                   </Alert>
                 )

--- a/web/src/auth/GitHubAuthedPanel.tsx
+++ b/web/src/auth/GitHubAuthedPanel.tsx
@@ -1,4 +1,3 @@
-import { CheckCircleIcon } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
 
 import type { GitHubUser } from "@/github-core/types"
@@ -20,7 +19,6 @@ export function GitHubAuthedPanel({
           sees a resolved user or a genuine failure. */}
       {user ? (
         <Alert tone="success" className="items-start text-sm">
-          <CheckCircleIcon aria-hidden="true" className="size-4 shrink-0" />
           <span>{t("auth.signedInConfirmed")}</span>
         </Alert>
       ) : null}

--- a/web/src/auth/GitHubPatPrompt.tsx
+++ b/web/src/auth/GitHubPatPrompt.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
-import { AlertIcon, LinkExternalIcon } from "@/components/ui/icons"
+import { LinkExternalIcon } from "@/components/ui/icons"
 
 import { REQUIRED_SCOPES } from "./scopes"
 import {
@@ -75,7 +75,6 @@ export function GitHubPatPrompt({
     >
       {error ? (
         <Alert tone="error" className="items-start text-sm">
-          <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
           <span>{error}</span>
         </Alert>
       ) : null}
@@ -120,7 +119,6 @@ export function GitHubPatPrompt({
               />
             </label>
             <Alert tone="warning" className="items-start text-xs">
-              <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
               <span>{t("auth.patFineGrainedWarning")}</span>
             </Alert>
 

--- a/web/src/components/AppBanner/index.tsx
+++ b/web/src/components/AppBanner/index.tsx
@@ -52,7 +52,7 @@ export const AppBanner = ({
     // dismiss button, neither of which paints outside the bar.
     // eslint-disable-next-line no-restricted-syntax
     <motion.div
-      role="alert"
+      role={tone === "error" ? "alert" : "status"}
       variants={collapseVariants}
       initial="initial"
       animate="animate"

--- a/web/src/components/ArchivedClassroomNotice.tsx
+++ b/web/src/components/ArchivedClassroomNotice.tsx
@@ -1,3 +1,4 @@
+import { Alert } from "@/components/ui"
 import type { PropsWithChildren } from "react"
 
 // The "this classroom is archived" info banner. Owns the daisyUI alert shell +
@@ -8,9 +9,9 @@ export const ArchivedClassroomNotice = ({
   className = "mb-4",
   children,
 }: PropsWithChildren<{ className?: string }>) => (
-  <div role="alert" className={`alert alert-info alert-soft ${className}`}>
+  <Alert tone="info" className={className}>
     <span className="text-sm">{children}</span>
-  </div>
+  </Alert>
 )
 
 export default ArchivedClassroomNotice

--- a/web/src/components/EmptyRosterNotice.tsx
+++ b/web/src/components/EmptyRosterNotice.tsx
@@ -1,7 +1,7 @@
 import { InfoIcon, PersonAddIcon } from "@/components/ui/icons"
 import { Trans, useTranslation } from "react-i18next"
 
-import { EmphasisLtr, RouterButton } from "@/components/ui"
+import { Alert, EmphasisLtr, RouterButton } from "@/components/ui"
 
 // Empty/unenrolled-roster notice. Owns the daisyUI alert shell + ARIA so the
 // assignments list and create pages can't drift in markup; copy adapts to
@@ -21,9 +21,10 @@ export const EmptyRosterNotice = ({
 }) => {
   const { t } = useTranslation()
   return (
-    <div
-      role="alert"
-      className={`alert alert-info alert-soft flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between ${className}`}
+    <Alert
+      tone="info"
+      icon={null}
+      className={`flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between ${className}`}
     >
       <div className="flex items-start gap-2">
         <InfoIcon className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
@@ -51,7 +52,7 @@ export const EmptyRosterNotice = ({
           ? t("components.notices.emptyRoster.manageRoster")
           : t("components.notices.emptyRoster.addStudents")}
       </RouterButton>
-    </div>
+    </Alert>
   )
 }
 

--- a/web/src/components/OrgRepoCreationNotice.test.tsx
+++ b/web/src/components/OrgRepoCreationNotice.test.tsx
@@ -85,7 +85,7 @@ describe("OrgRepoCreationNotice", () => {
     )
     renderInRouter(<OrgRepoCreationNotice org="acme" />)
 
-    const alert = await screen.findByRole("alert")
+    const alert = await screen.findByRole("status")
     expect(alert.textContent).toMatch(MASTER)
     expect(alert.textContent).not.toMatch(PRIVATE)
 
@@ -103,7 +103,7 @@ describe("OrgRepoCreationNotice", () => {
     )
     renderInRouter(<OrgRepoCreationNotice org="acme" />)
 
-    const alert = await screen.findByRole("alert")
+    const alert = await screen.findByRole("status")
     expect(alert.textContent).toMatch(PRIVATE)
     expect(alert.textContent).toContain("private (not public)")
     expect(alert.textContent).toContain("enterprise")

--- a/web/src/components/status/ActionsBanner.tsx
+++ b/web/src/components/status/ActionsBanner.tsx
@@ -425,7 +425,7 @@ export function ActionsBanner() {
               y: -bannerHeight,
               transition: { duration: DURATION.base, ease: EASE_OUT },
             }}
-            role="status"
+            role={anyFailed ? "alert" : "status"}
             aria-live={anyFailed ? "assertive" : "polite"}
             className={`pointer-events-auto w-full border-b shadow-sm ${tone}`}
           >

--- a/web/src/components/ui/Alert.test.tsx
+++ b/web/src/components/ui/Alert.test.tsx
@@ -7,7 +7,7 @@ import { Alert } from "./Alert"
 afterEach(cleanup)
 
 describe("Alert", () => {
-  it("renders the soft tone recipe with role=alert by default", () => {
+  it("renders the soft tone recipe; errors default to role=alert", () => {
     render(<Alert tone="error">boom</Alert>)
     const el = screen.getByRole("alert")
     expect(el.className).toContain("alert")
@@ -16,9 +16,14 @@ describe("Alert", () => {
     expect(el.textContent).toBe("boom")
   })
 
+  it("non-error tones default to role=status", () => {
+    render(<Alert tone="warning">careful</Alert>)
+    expect(screen.getByRole("status")).toBeDefined()
+  })
+
   it("drops alert-soft when soft is false", () => {
     render(<Alert tone="success" soft={false} aria-label="s" />)
-    const el = screen.getByRole("alert")
+    const el = screen.getByRole("status")
     expect(el.className).toContain("alert-success")
     expect(el.className).not.toContain("alert-soft")
   })
@@ -31,5 +36,29 @@ describe("Alert", () => {
     )
     const el = screen.getByRole("status")
     expect(el.className.endsWith("mt-4")).toBe(true)
+  })
+
+  it("renders the designated tone icon, hidden from AT; icon={null} omits it", () => {
+    const { container, rerender } = render(<Alert tone="info">i</Alert>)
+    expect(container.querySelector("svg")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    )
+    rerender(
+      <Alert tone="info" icon={null}>
+        i
+      </Alert>,
+    )
+    expect(container.querySelector("svg")).toBeNull()
+  })
+
+  it("renders title and a labeled dismiss button when onDismiss is given", () => {
+    render(
+      <Alert tone="warning" title="Heads up" onDismiss={() => {}}>
+        body
+      </Alert>,
+    )
+    expect(screen.getByText("Heads up").className).toContain("font-semibold")
+    const dismiss = screen.getByRole("button")
+    expect(dismiss.getAttribute("aria-label")).toBeTruthy()
   })
 })

--- a/web/src/components/ui/Alert.tsx
+++ b/web/src/components/ui/Alert.tsx
@@ -1,13 +1,26 @@
 import type { ComponentPropsWithoutRef, ReactNode } from "react"
+import { useTranslation } from "react-i18next"
 
+import {
+  AlertIcon,
+  CheckCircleIcon,
+  InfoIcon,
+  StopIcon,
+  XIcon,
+} from "@/components/ui/icons"
+
+import { Button } from "./Button"
 import { cx } from "./cx"
 
-// The canonical inline alert. Wraps daisyUI `alert` with the house `alert-soft`
-// style; the tone->class recipe is exported as `alertToneClass` so the toast
+// The canonical inline alert, following Primer's Banner anatomy
+// (primer.style/product/ui-patterns/notification-messaging): a designated
+// tone icon (opt out with `icon={null}`, replace with `icon={...}`), an
+// optional semibold `title`, and an optional dismiss button via `onDismiss`.
+// The tone->class recipe is exported as `alertToneClass` so the toast
 // provider (which needs a motion wrapper, not <Alert>) shares one source and
 // can't drift. `soft` defaults on; pass `soft={false}` for a solid fill.
-// `role` defaults to "alert" (assertive); pass `role="status"` for passive
-// updates.
+// `role` defaults by tone — "alert" (assertive) only for errors, "status"
+// (polite) otherwise — matching the app-wide messaging ARIA convention.
 
 export type AlertTone = "info" | "success" | "warning" | "error"
 
@@ -25,27 +38,74 @@ export function alertToneClass(tone: AlertTone, soft = true): string {
   return cx("alert", TONE_CLASS[tone], soft && "alert-soft")
 }
 
+// Primer Banner's designated state icons (critical -> stop octagon). Shared
+// with the toast provider for the same one-source reason as alertToneClass.
+export const ALERT_TONE_ICON: Record<AlertTone, typeof InfoIcon> = {
+  info: InfoIcon,
+  success: CheckCircleIcon,
+  warning: AlertIcon,
+  error: StopIcon,
+}
+
+export function alertToneRole(tone: AlertTone): "alert" | "status" {
+  return tone === "error" ? "alert" : "status"
+}
+
 export type AlertProps = {
   tone: AlertTone
   soft?: boolean
+  // Default: the designated tone icon. Pass null to omit, or a ReactNode to
+  // replace (contextual icons like a cloud for offline warnings).
+  icon?: ReactNode | null
+  title?: ReactNode
+  onDismiss?: () => void
   children?: ReactNode
 } & ComponentPropsWithoutRef<"div">
 
 export function Alert({
   tone,
   soft = true,
-  role = "alert",
+  icon,
+  title,
+  onDismiss,
+  role,
   className,
   children,
   ...props
 }: AlertProps) {
+  const { t } = useTranslation()
+  const ToneIcon = ALERT_TONE_ICON[tone]
+  const resolvedIcon =
+    icon === null
+      ? null
+      : (icon ?? <ToneIcon aria-hidden="true" className="size-4 shrink-0" />)
   return (
     <div
-      role={role}
+      role={role ?? alertToneRole(tone)}
       className={cx(alertToneClass(tone, soft), className)}
       {...props}
     >
-      {children}
+      {resolvedIcon}
+      {title != null ? (
+        <div className="min-w-0">
+          <p className="font-semibold">{title}</p>
+          {children}
+        </div>
+      ) : (
+        children
+      )}
+      {onDismiss && (
+        <Button
+          variant="ghost"
+          size="xs"
+          shape="circle"
+          className="ms-auto shrink-0"
+          aria-label={t("components.banner.dismiss")}
+          onClick={onDismiss}
+        >
+          <XIcon aria-hidden="true" className="size-4" />
+        </Button>
+      )}
     </div>
   )
 }

--- a/web/src/components/ui/InlineMessage.tsx
+++ b/web/src/components/ui/InlineMessage.tsx
@@ -1,5 +1,11 @@
 import type { ComponentPropsWithoutRef, ReactNode } from "react"
-import { AlertFillIcon, InfoIcon, NoEntryIcon, XCircleFillIcon } from "./icons"
+import {
+  AlertFillIcon,
+  CheckCircleFillIcon,
+  InfoIcon,
+  NoEntryIcon,
+  XCircleFillIcon,
+} from "./icons"
 
 import { cx } from "./cx"
 
@@ -9,12 +15,14 @@ import { cx } from "./cx"
 // body text on base surfaces — NOT the `*-content` on-fill tokens, which are
 // only readable on their own solid fill (on a card they can render invisible).
 
-export type InlineMessageTone = "info" | "warning" | "error" | "neutral"
+export type InlineMessageTone =
+  "info" | "warning" | "error" | "success" | "neutral"
 
 const TONE_TEXT_CLASS: Record<InlineMessageTone, string> = {
   info: "text-info",
   warning: "text-warning",
   error: "text-error",
+  success: "text-success",
   neutral: "text-base-content/70",
 }
 
@@ -22,6 +30,7 @@ const TONE_ICON: Record<InlineMessageTone, typeof InfoIcon> = {
   info: InfoIcon,
   warning: AlertFillIcon,
   error: XCircleFillIcon,
+  success: CheckCircleFillIcon,
   neutral: NoEntryIcon,
 }
 

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -40,7 +40,7 @@ export type { HeadingProps, HeadingVariant } from "./Heading"
 export { Modal } from "./Modal"
 export type { ModalProps, ModalSize } from "./Modal"
 
-export { Alert, alertToneClass } from "./Alert"
+export { Alert, ALERT_TONE_ICON, alertToneClass, alertToneRole } from "./Alert"
 export type { AlertProps, AlertTone } from "./Alert"
 
 export { InlineMessage } from "./InlineMessage"

--- a/web/src/context/notifications/NotificationProvider.tsx
+++ b/web/src/context/notifications/NotificationProvider.tsx
@@ -12,7 +12,12 @@ import { XIcon } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
 import { AnimatePresence, motion } from "motion/react"
 import { toastVariants } from "@/lib/motion"
-import { Button, alertToneClass } from "@/components/ui"
+import {
+  Button,
+  ALERT_TONE_ICON,
+  alertToneClass,
+  alertToneRole,
+} from "@/components/ui"
 import { recordErrorToast } from "@/lib/activity/activityStore"
 import { logger } from "@/lib/logger"
 
@@ -33,7 +38,8 @@ export type Toast = {
   tone: ToastTone
   message: React.ReactNode
   action?: ToastAction
-  // Auto-dismiss after this many ms; 0/undefined means it stays until dismissed.
+  // Auto-dismiss after this many ms. Unset defaults per tone (errors persist,
+  // the rest auto-dismiss after DEFAULT_TOAST_MS); pass 0 to persist explicitly.
   durationMs?: number
 }
 
@@ -62,6 +68,14 @@ const NotificationContext = createContext<NotificationContextValue | null>(null)
 
 let toastSeq = 0
 const nextId = () => `toast-${++toastSeq}`
+
+// Default auto-dismiss for non-error toasts. Errors persist until dismissed
+// (auto-dismissing an error can hide it before assistive tech users act on
+// it); any caller can override either way, with 0 meaning "persist".
+export const DEFAULT_TOAST_MS = 6000
+
+// Newest toasts win; a taller stack buries the page under transient noise.
+const MAX_TOASTS = 5
 
 // App-wide toast surface. Lives above the router so a toast survives the
 // component that fired it unmounting (archiving removes the card, reuse
@@ -118,16 +132,18 @@ export function NotificationProvider({ children }: PropsWithChildren) {
       const id = key ?? nextId()
       clearTimer(id)
 
+      const resolvedDuration =
+        durationMs ?? (tone === "error" ? 0 : DEFAULT_TOAST_MS)
       const toast: Toast = { id, tone, message, action, durationMs }
       setToasts((prev) => {
         const without = prev.filter((t) => t.id !== id)
-        return [...without, toast]
+        return [...without, toast].slice(-MAX_TOASTS)
       })
 
-      if (durationMs && durationMs > 0) {
+      if (resolvedDuration > 0) {
         timers.current.set(
           id,
-          setTimeout(() => dismiss(id), durationMs),
+          setTimeout(() => dismiss(id), resolvedDuration),
         )
       }
       return id
@@ -167,42 +183,50 @@ const ToastViewport = ({
   return (
     <div className="toast toast-end toast-bottom z-50">
       <AnimatePresence>
-        {toasts.map((toast) => (
-          <motion.div
-            key={toast.id}
-            layout
-            variants={toastVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            role="alert"
-            aria-live={toast.tone === "error" ? "assertive" : "polite"}
-            className={`${alertToneClass(toast.tone)} max-w-sm`}
-          >
-            <span className="text-sm">{toast.message}</span>
-            {toast.action && (
+        {toasts.map((toast) => {
+          const ToneIcon = ALERT_TONE_ICON[toast.tone]
+          return (
+            <motion.div
+              key={toast.id}
+              layout
+              variants={toastVariants}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              // App-wide messaging ARIA convention: assertive role="alert"
+              // only for errors, polite role="status" otherwise. The explicit
+              // aria-live restates each role's implicit politeness for
+              // assistive tech that needs it spelled out.
+              role={alertToneRole(toast.tone)}
+              aria-live={toast.tone === "error" ? "assertive" : "polite"}
+              className={`${alertToneClass(toast.tone)} max-w-sm`}
+            >
+              <ToneIcon aria-hidden="true" className="size-4 shrink-0" />
+              <span className="text-sm">{toast.message}</span>
+              {toast.action && (
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  className="font-semibold"
+                  onClick={() => {
+                    toast.action?.onClick()
+                    onDismiss(toast.id)
+                  }}
+                >
+                  {toast.action.label}
+                </Button>
+              )}
               <Button
                 variant="ghost"
                 size="xs"
-                className="font-semibold"
-                onClick={() => {
-                  toast.action?.onClick()
-                  onDismiss(toast.id)
-                }}
+                aria-label={t("common.dismissNotification")}
+                onClick={() => onDismiss(toast.id)}
               >
-                {toast.action.label}
+                <XIcon aria-hidden="true" className="size-4" />
               </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="xs"
-              aria-label={t("common.dismissNotification")}
-              onClick={() => onDismiss(toast.id)}
-            >
-              <XIcon aria-hidden="true" className="size-4" />
-            </Button>
-          </motion.div>
-        ))}
+            </motion.div>
+          )
+        })}
       </AnimatePresence>
     </div>
   )

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -976,7 +976,6 @@ const AcceptAssignmentPage = () => {
 
             {acceptMutation.isError && (
               <Alert tone="error" className="items-start">
-                <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
                 <div>
                   <div className="font-bold">{t("accept.errorTitle")}</div>
                   <div className="mt-1 whitespace-pre-wrap text-sm">

--- a/web/src/pages/AssignmentSettingsPage.tsx
+++ b/web/src/pages/AssignmentSettingsPage.tsx
@@ -65,21 +65,23 @@ const EditAssignmentFormStudent = ({
 
   if (!assignmentRepo) {
     return (
-      <EnterDiv className="alert alert-info alert-soft mt-6">
-        <div>
-          <Trans
-            i18nKey="assignmentSettings.notAccepted"
-            components={{
-              acceptLink: (
-                <Link
-                  className="underline"
-                  to="/$org/$classroom/assignments/$assignment/accept"
-                  params={{ org, classroom, assignment }}
-                />
-              ),
-            }}
-          />
-        </div>
+      <EnterDiv className="mt-6">
+        <Alert tone="info">
+          <div>
+            <Trans
+              i18nKey="assignmentSettings.notAccepted"
+              components={{
+                acceptLink: (
+                  <Link
+                    className="underline"
+                    to="/$org/$classroom/assignments/$assignment/accept"
+                    params={{ org, classroom, assignment }}
+                  />
+                ),
+              }}
+            />
+          </div>
+        </Alert>
       </EnterDiv>
     )
   }

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -203,12 +203,10 @@ const OrgSteps = ({
         {stage === 1 ? (
           <div className="grid gap-4">
             {configReady && (
-              <EnterDiv className="alert alert-success">
-                <CheckCircleIcon
-                  aria-hidden="true"
-                  className="size-4 shrink-0"
-                />
-                <div>{t("setup.setupComplete")}</div>
+              <EnterDiv>
+                <Alert tone="success" soft={false}>
+                  <div>{t("setup.setupComplete")}</div>
+                </Alert>
               </EnterDiv>
             )}
             <InitStepBoard steps={steps} org={org} />

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -24,7 +24,6 @@ import {
 import { useQueryClient } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
 import {
-  AlertIcon,
   ChevronDownIcon,
   EyeClosedIcon,
   InfoIcon,
@@ -654,7 +653,6 @@ const OrgsPage = () => {
 
             {attentionCount > 0 && (
               <Alert tone="warning" role="status" className="text-sm">
-                <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
                 <span>
                   {t("serviceTokenHealth.summary", {
                     count: attentionCount,

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -256,22 +256,24 @@ const SubmissionBody = ({
   // No repo means the student hasn't accepted yet.
   if (!studentRepo) {
     return (
-      <EnterDiv className="alert alert-info alert-soft">
-        <div>
-          <Trans
-            i18nKey="submissions.student.notAccepted"
-            components={{
-              acceptLink: (
-                <Link
-                  className="underline"
-                  to="/$org/$classroom/assignments/$assignment/accept"
-                  params={{ org, classroom, assignment }}
-                  search={secret ? { k: secret } : undefined}
-                />
-              ),
-            }}
-          />
-        </div>
+      <EnterDiv>
+        <Alert tone="info">
+          <div>
+            <Trans
+              i18nKey="submissions.student.notAccepted"
+              components={{
+                acceptLink: (
+                  <Link
+                    className="underline"
+                    to="/$org/$classroom/assignments/$assignment/accept"
+                    params={{ org, classroom, assignment }}
+                    search={secret ? { k: secret } : undefined}
+                  />
+                ),
+              }}
+            />
+          </div>
+        </Alert>
       </EnterDiv>
     )
   }
@@ -513,8 +515,10 @@ const StudentSubmissionPage = () => {
           // here, so guard this read too.
           <Alert tone="error">{t("submissions.student.loadError")}</Alert>
         ) : assignmentData?.locked ? (
-          <EnterDiv className="alert alert-warning alert-soft">
-            <div>{t("submissions.student.locked")}</div>
+          <EnterDiv>
+            <Alert tone="warning">
+              <div>{t("submissions.student.locked")}</div>
+            </Alert>
           </EnterDiv>
         ) : (
           <SubmissionBody

--- a/web/src/pages/migration/ConfirmStep.tsx
+++ b/web/src/pages/migration/ConfirmStep.tsx
@@ -364,7 +364,6 @@ export const ConfirmStep = ({
           </div>
 
           <Alert tone="error" className="mt-3 items-start">
-            <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
             <div>
               <p className="font-medium">
                 {t("migration.access.headline", { org: accessOrg })}

--- a/web/src/pages/orgSettings/OrgPreflightNotice.test.tsx
+++ b/web/src/pages/orgSettings/OrgPreflightNotice.test.tsx
@@ -17,6 +17,8 @@ vi.mock("react-i18next", async (importOriginal) => {
 // a RouterProvider just to assert which notice shows.
 vi.mock("@tanstack/react-router", () => ({
   Link: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  // The ui barrel pulls RouterButton, which calls createLink at module scope.
+  createLink: (component: unknown) => component,
 }))
 
 import type { OrgAuditReport } from "@/orgPolicy/audit"

--- a/web/src/pages/orgSettings/OrgPreflightNotice.tsx
+++ b/web/src/pages/orgSettings/OrgPreflightNotice.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router"
 import { Trans, useTranslation } from "react-i18next"
-import { AlertIcon, XCircleIcon } from "@/components/ui/icons"
+import { ALERT_TONE_ICON, alertToneClass } from "@/components/ui"
 
 import useGetServiceTokenStatus from "@/hooks/useGetServiceTokenStatus"
 import useGetOrgAudit from "@/hooks/useGetOrgAudit"
@@ -41,8 +41,8 @@ const OrgPreflightNotice = ({ org }: { org: string }) => {
   if (failing.length > 0) {
     const categories = failing.join(", ")
     return (
-      <CalloutDiv role="alert" className="alert alert-error alert-soft mb-6">
-        <XCircleIcon aria-hidden="true" className="size-4" />
+      <CalloutDiv role="alert" className={`${alertToneClass("error")} mb-6`}>
+        <ALERT_TONE_ICON.error aria-hidden="true" className="size-4" />
         <div className="text-sm">
           <p className="font-semibold">{t("orgSettings.preflight.title")}</p>
           <p className="mt-0.5 text-base-content/70">
@@ -74,8 +74,8 @@ const OrgPreflightNotice = ({ org }: { org: string }) => {
   )
   if (budgetUnverified) {
     return (
-      <CalloutDiv role="status" className="alert alert-warning alert-soft mb-6">
-        <AlertIcon aria-hidden="true" className="size-4" />
+      <CalloutDiv role="status" className={`${alertToneClass("warning")} mb-6`}>
+        <ALERT_TONE_ICON.warning aria-hidden="true" className="size-4" />
         <div className="text-sm">
           <p className="font-semibold">
             {t("orgSettings.preflight.unverifiedTitle")}

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react"
 import { EmptyState } from "@/components/list"
 import { useTranslation } from "react-i18next"
-import { InfoIcon } from "@/components/ui/icons"
 
 import { Alert, SkeletonRows, Toolbar } from "@/components/ui"
 import { RoleBadges } from "./RoleBadges"
@@ -49,7 +48,6 @@ const CsvRosterView = ({
   return (
     <div className="flex flex-col gap-4">
       <Alert tone="info">
-        <InfoIcon aria-hidden="true" className="size-4" />
         <span>{t("students.csvRoster.notice")}</span>
       </Alert>
 

--- a/web/src/pages/students/RosterWarnings.tsx
+++ b/web/src/pages/students/RosterWarnings.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { AnimatePresence, motion } from "motion/react"
-import { Button } from "@/components/ui"
+import { Alert, Button } from "@/components/ui"
 import { collapseVariants } from "@/lib/motion"
 
 // Per-row action warnings (keyed by row.key so one action's warning can't
@@ -33,12 +33,12 @@ export const RosterWarnings = ({
             exit="exit"
             className="overflow-hidden"
           >
-            <div role="alert" className="alert alert-warning alert-soft">
+            <Alert tone="warning">
               <span className="text-sm">{warning}</span>
               <Button variant="ghost" size="xs" onClick={() => onDismiss(key)}>
                 {t("students.dismiss")}
               </Button>
-            </div>
+            </Alert>
           </motion.div>
         ))}
       </AnimatePresence>

--- a/web/src/test/a11yStructural.test.tsx
+++ b/web/src/test/a11yStructural.test.tsx
@@ -89,10 +89,10 @@ function FireToast({ tone }: { tone: ToastTone }) {
   )
 }
 
-// 4.1.3 Status Messages: the toast viewport is a live region — role="alert" with
-// aria-live tone-mapped (assertive for errors, polite otherwise), so assistive
-// tech announces a status change without moving focus. Structure only (KTD3): no
-// timing or visibility is asserted.
+// 4.1.3 Status Messages: the toast viewport is a live region — errors are
+// assertive role="alert", other tones polite role="status" — so assistive
+// tech announces a status change without moving focus. Structure only (KTD3):
+// no timing or visibility is asserted.
 describe("structural a11y — 4.1.3 status-message live region", () => {
   it("an error toast is an assertive alert", async () => {
     render(
@@ -106,7 +106,7 @@ describe("structural a11y — 4.1.3 status-message live region", () => {
   })
 
   it.each(["info", "success", "warning"] as const)(
-    "a %s toast is a polite alert",
+    "a %s toast is a polite status message",
     async (tone) => {
       render(
         <NotificationProvider>
@@ -114,8 +114,8 @@ describe("structural a11y — 4.1.3 status-message live region", () => {
         </NotificationProvider>,
       )
       await userEvent.click(screen.getByText("fire"))
-      const alert = screen.getByRole("alert")
-      expect(alert.getAttribute("aria-live")).toBe("polite")
+      const status = screen.getByRole("status")
+      expect(status.getAttribute("aria-live")).toBe("polite")
     },
   )
 

--- a/web/src/util/a11y/vpatAutomated.ts
+++ b/web/src/util/a11y/vpatAutomated.ts
@@ -67,12 +67,12 @@ export const AUTOMATED_CRITERIA: Record<string, AutomatedBinding> = {
   },
   "4.1.3": {
     check:
-      "the toast viewport exposes role=alert with tone-mapped aria-live " +
-      "(assertive for errors, polite otherwise) (a11yStructural.test.tsx)",
+      "the toast viewport exposes assertive role=alert for errors and polite " +
+      "role=status otherwise (a11yStructural.test.tsx)",
     remark:
-      "Status changes are announced through a live region: toasts render as " +
-      "role=alert with aria-live tone-mapped (assertive for errors, polite " +
-      "otherwise), so assistive tech announces them without moving focus. " +
+      "Status changes are announced through a live region: error toasts render " +
+      "as assertive role=alert and all other tones as polite role=status, so " +
+      "assistive tech announces them without moving focus. " +
       "Verified automatically on the toast surface (structure only; timing and " +
       "visibility are not machine-checked).",
   },

--- a/web/src/util/a11y/vpatModel.ts
+++ b/web/src/util/a11y/vpatModel.ts
@@ -399,9 +399,9 @@ const BASE_CRITERIA: Criterion[] = [
     status: "supports",
     evidence: "automated",
     remark:
-      "Status changes are announced through a live region: toasts render as " +
-      "role=alert with aria-live tone-mapped (assertive for errors, polite " +
-      "otherwise), so assistive tech announces them without moving focus. " +
+      "Status changes are announced through a live region: error toasts render " +
+      "as assertive role=alert and all other tones as polite role=status, so " +
+      "assistive tech announces them without moving focus. " +
       "Verified automatically on the toast surface (structure only; timing and " +
       "visibility are not machine-checked).",
   },


### PR DESCRIPTION
## Summary

- Fifth PR in the Primer alignment series (#723 Octicons, #725 typography, #726 size/focus, #727 empty states), adopting the [notification messaging pattern](https://primer.style/product/ui-patterns/notification-messaging/).
- **`Alert` gains Primer Banner anatomy**: designated tone icons rendered automatically (`info` / `check-circle` / `alert` / `stop` per Primer's state mapping; `icon={null}` opts out, a ReactNode overrides for contextual icons), plus optional `title` and `onDismiss` slots. The ~8 call sites that hand-placed icons are de-duplicated; the auth card keeps its deliberate "expired → info glyph" override via the new prop.
- **One live-region convention everywhere**: assertive `role="alert"` only for errors, polite `role="status"` otherwise — applied to `Alert` defaults (`alertToneRole`), toasts, `AppBanner`, `ActionsBanner` (was the inverse), `OrgPreflightNotice`, and four previously **silent** `EnterDiv` alerts that assistive tech never announced. VPAT remarks and the structural a11y tests updated to pin the new contract.
- **Toasts**: designated tone icons, a 6s default auto-dismiss with **errors persisting** until dismissed (auto-hiding errors is an a11y anti-pattern; explicit `durationMs` still overrides either way), and a 5-toast stack cap.
- **One recipe, one source**: all 9 hand-written `alert alert-*` class strings across 7 files (`EmptyRosterNotice`, `ArchivedClassroomNotice`, `RosterWarnings`, `OrgPreflightNotice`, and the motion `EnterDiv` sites) now render through `Alert` / `alertToneClass` / the shared `ALERT_TONE_ICON` map; `InlineMessage` gains the missing `success` tone.

## Notes for review

- Most visible change: error alerts now show Primer's designated **stop octagon** instead of a warning triangle, and roughly 100 existing `<Alert>` sites gain a tone icon they previously lacked.
- Non-error alerts that relied on the old blanket `role="alert"` are now polite status regions — a behavior improvement for screen-reader users, reflected in the regenerated `VPAT.md` / `ACCESSIBILITY-REPORT.md`.
- Toast auto-dismiss is new default behavior for call sites that previously persisted; errors keep persisting.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 4422 tests incl. updated a11y structural contracts) passes
- [x] `npm run audit:vpat` regenerated; remarks match the new ARIA contract
- [x] Live session check: dashboard warning alert renders auto icon + polite status role
- [ ] Visual pass over error-heavy flows (failed bulk operations, auth errors) for the stop-octagon change