### PR TITLE
feat(web): align loading states with Primer's loading pattern

### DIFF
--- a/web/src/auth/GitHubAuthCard.tsx
+++ b/web/src/auth/GitHubAuthCard.tsx
@@ -14,15 +14,18 @@ import { GitHubPatPrompt } from "./GitHubPatPrompt"
 import { LoginLanguageMenu } from "./LoginLanguageMenu"
 import { AppVersionBadge } from "@/components/AppVersionBadge"
 import { WIKI_URL } from "@/version"
-import { Alert, Button, Card, Spinner, Heading } from "@/components/ui"
+import { Alert, Button, Card, InlineSpinner, Heading } from "@/components/ui"
 
 function LoadingScreen({ label }: { label: string }) {
   return (
+    // One status region: the visible label is the announcement; the spinner
+    // itself is decorative (InlineSpinner, not Spinner, to avoid a nested
+    // role="status" announcing a second generic "loading").
     <div
       className="flex flex-col items-center gap-4 py-10 text-center text-base-content/70"
       role="status"
     >
-      <Spinner size="lg" />
+      <InlineSpinner size="lg" />
       <p className="text-sm">{label}</p>
     </div>
   )

--- a/web/src/components/PageHeader.tsx
+++ b/web/src/components/PageHeader.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react"
+import { SkeletonRegion } from "@/components/list"
 import { Heading } from "@/components/ui"
 
 // The dashboard page heading: a title, an optional subtitle line, and an
@@ -22,7 +23,9 @@ export default function PageHeader({
     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0">
         {loading ? (
-          <div className="skeleton skeleton-shimmer h-8 w-48" />
+          <SkeletonRegion>
+            <div className="skeleton skeleton-shimmer h-8 w-48" />
+          </SkeletonRegion>
         ) : (
           <Heading as="h1" variant="title-medium">
             {title}

--- a/web/src/components/Spinner.tsx
+++ b/web/src/components/Spinner.tsx
@@ -10,6 +10,10 @@ type SpinnerSize = "xs" | "sm" | "md" | "lg" | "xl"
  * state is already announced (adjacent text, an in-button spinner on a labeled
  * disabled button), keep a bare `aria-hidden` span — the resolution the
  * `no-restricted-syntax` lint nudge expects.
+ *
+ * The visual is anti-flash guarded (`indicator-appear`): it stays invisible
+ * for the first ~250ms so sub-second loads never flash an indicator (Primer
+ * loading guidance). The sr-only label is not delayed.
  */
 export function Spinner({
   size = "md",
@@ -29,7 +33,7 @@ export function Spinner({
       {...props}
     >
       <span
-        className={`loading loading-spinner loading-${size}`}
+        className={`loading loading-spinner loading-${size} indicator-appear`}
         aria-hidden="true"
       />
       <span className="sr-only">{resolvedLabel}</span>
@@ -43,6 +47,7 @@ export default Spinner
  * Decorative in-button/inline spinner: a bare `aria-hidden` span for busy
  * states that are already announced elsewhere (a labeled disabled button,
  * adjacent text). Use `<Spinner>` when the spinner is the only indicator.
+ * Anti-flash guarded like `<Spinner>`.
  */
 export function InlineSpinner({
   size = "xs",
@@ -53,7 +58,7 @@ export function InlineSpinner({
 }) {
   return (
     <span
-      className={`loading loading-spinner loading-${size}${className ? ` ${className}` : ""}`}
+      className={`loading loading-spinner loading-${size} indicator-appear${className ? ` ${className}` : ""}`}
       aria-hidden="true"
     />
   )

--- a/web/src/components/drawer/AssignmentSidebarMenu.tsx
+++ b/web/src/components/drawer/AssignmentSidebarMenu.tsx
@@ -153,7 +153,10 @@ export const AssignmentSidebarMenu = ({
             <>
               {[0, 1].map((i) => (
                 <li key={i} className="flex px-2 py-2">
-                  <span className="skeleton h-4 w-24 bg-neutral-content/10" />
+                  <span
+                    aria-hidden="true"
+                    className="skeleton skeleton-shimmer h-4 w-24 bg-neutral-content/10"
+                  />
                 </li>
               ))}
             </>

--- a/web/src/components/drawer/MyClasses.tsx
+++ b/web/src/components/drawer/MyClasses.tsx
@@ -40,7 +40,10 @@ export const MyClasses = ({ settings = false, selected = "" }) => {
       <ul className="flex flex-col gap-1">
         {!roleResolved ? (
           <li className="flex px-2 py-2">
-            <span className="skeleton inline-block h-4 w-24 align-middle bg-neutral-content/10" />
+            <span
+              aria-hidden="true"
+              className="skeleton skeleton-shimmer inline-block h-4 w-24 align-middle bg-neutral-content/10"
+            />
           </li>
         ) : (
           <SidebarNavItem label={classesLabel}>

--- a/web/src/components/drawer/SidebarFooter.tsx
+++ b/web/src/components/drawer/SidebarFooter.tsx
@@ -498,7 +498,10 @@ const AuthedSidebarFooter = () => {
                 <div className="mt-1 flex items-center gap-1.5">
                   <span className="text-xs text-neutral-content/60">
                     {labelPending ? (
-                      <span className="skeleton inline-block h-3 w-16 align-middle bg-neutral-content/10" />
+                      <span
+                        aria-hidden="true"
+                        className="skeleton skeleton-shimmer inline-block h-3 w-16 align-middle bg-neutral-content/10"
+                      />
                     ) : (
                       roleLabelText
                     )}

--- a/web/src/components/drawer/StaffSidebarMenu.tsx
+++ b/web/src/components/drawer/StaffSidebarMenu.tsx
@@ -35,7 +35,10 @@ export const StaffSidebarMenu = ({
             never flash in then out. */}
         {!roleResolved ? (
           <li className="flex px-2 py-2">
-            <span className="skeleton h-4 w-24 bg-neutral-content/10" />
+            <span
+              aria-hidden="true"
+              className="skeleton skeleton-shimmer h-4 w-24 bg-neutral-content/10"
+            />
           </li>
         ) : (
           showStaffItems && (
@@ -63,7 +66,10 @@ export const StaffSidebarMenu = ({
         </SidebarNavItem>
         {!roleResolved ? (
           <li className="flex px-2 py-2">
-            <span className="skeleton h-4 w-24 bg-neutral-content/10" />
+            <span
+              aria-hidden="true"
+              className="skeleton skeleton-shimmer h-4 w-24 bg-neutral-content/10"
+            />
           </li>
         ) : (
           showStaffItems &&

--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -155,29 +155,45 @@ export function SkeletonRegion({
   )
 }
 
-// Placeholder card grid while a card-collection page loads. One `role="status"`
-// announcement for the whole collection (Primer: don't announce every
-// skeleton); tiles are decorative. Tiles are structured like the loaded cards
-// (title/subtitle/action bars in a bordered card) rather than solid slabs, so
-// the skeleton reads as a vague representation of the content. Card span/height
-// is per page via `cardClassName` (12-col grid spans).
+// Decorative toolbar placeholder mirroring the list-page Toolbar recipe: a
+// search-box bar on the start side, control pills (selects/toggles/buttons)
+// on the end side. Render inside a SkeletonRegion, which carries the
+// announcement.
+export function ToolbarSkeleton({ controls = 2 }: { controls?: number }) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="skeleton skeleton-shimmer h-10 w-full rounded-field sm:max-w-xs" />
+      <div className="flex items-center gap-3">
+        {Array.from({ length: controls }, (_, i) => (
+          <div
+            key={i}
+            className="skeleton skeleton-shimmer h-8 w-24 rounded-field"
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// Decorative placeholder card grid while a card-collection page loads. Tiles
+// are structured like the loaded cards (title/subtitle/action bars in a
+// bordered card) rather than solid slabs, so the skeleton reads as a vague
+// representation of the content. Card span/height is per page via
+// `cardClassName` (12-col grid spans). Render inside a SkeletonRegion — one
+// announcement for the whole page skeleton (Primer: don't announce every
+// piece).
 export function CardGridSkeleton({
   cards = 3,
   cardClassName = "col-span-12 h-40 md:col-span-6 xl:col-span-4",
-  label,
 }: {
   cards?: number
   cardClassName?: string
-  label?: string
 }) {
-  const { t } = useTranslation()
   return (
-    <div role="status" className="grid grid-cols-12 gap-4">
-      <span className="sr-only">{label ?? t("common.loading")}</span>
+    <div className="grid grid-cols-12 gap-4">
       {Array.from({ length: cards }, (_, i) => (
         <div
           key={i}
-          aria-hidden="true"
           className={cx(
             "flex flex-col rounded-box border border-base-300 bg-base-200 p-4",
             cardClassName,

--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -4,6 +4,7 @@
 
 import { AppsIcon, ListUnorderedIcon } from "@/components/ui/icons"
 import type { ComponentType, ReactNode } from "react"
+import { useTranslation } from "react-i18next"
 
 import { Button, Heading, cx } from "@/components/ui"
 
@@ -128,6 +129,57 @@ export function NoSearchResults({
         </Button>
       }
     />
+  )
+}
+
+// Announced wrapper for ad-hoc skeleton blocks: one `role="status"` + sr-only
+// label for the whole region (Primer: a single announcement per collection),
+// visuals hidden from AT. Layout classes go on the inner wrapper.
+export function SkeletonRegion({
+  label,
+  className,
+  children,
+}: {
+  label?: string
+  className?: string
+  children?: ReactNode
+}) {
+  const { t } = useTranslation()
+  return (
+    <div role="status">
+      <span className="sr-only">{label ?? t("common.loading")}</span>
+      <div aria-hidden="true" className={className}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+// Placeholder card grid while a card-collection page loads. One `role="status"`
+// announcement for the whole collection (Primer: don't announce every
+// skeleton); tiles are decorative. Card shape/height is per page via
+// `cardClassName` (12-col grid spans).
+export function CardGridSkeleton({
+  cards = 3,
+  cardClassName = "col-span-12 h-40 md:col-span-6 xl:col-span-4",
+  label,
+}: {
+  cards?: number
+  cardClassName?: string
+  label?: string
+}) {
+  const { t } = useTranslation()
+  return (
+    <div role="status" className="grid grid-cols-12 gap-4">
+      <span className="sr-only">{label ?? t("common.loading")}</span>
+      {Array.from({ length: cards }, (_, i) => (
+        <div
+          key={i}
+          aria-hidden="true"
+          className={cx("skeleton skeleton-shimmer rounded-box", cardClassName)}
+        />
+      ))}
+    </div>
   )
 }
 

--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -157,8 +157,10 @@ export function SkeletonRegion({
 
 // Placeholder card grid while a card-collection page loads. One `role="status"`
 // announcement for the whole collection (Primer: don't announce every
-// skeleton); tiles are decorative. Card shape/height is per page via
-// `cardClassName` (12-col grid spans).
+// skeleton); tiles are decorative. Tiles are structured like the loaded cards
+// (title/subtitle/action bars in a bordered card) rather than solid slabs, so
+// the skeleton reads as a vague representation of the content. Card span/height
+// is per page via `cardClassName` (12-col grid spans).
 export function CardGridSkeleton({
   cards = 3,
   cardClassName = "col-span-12 h-40 md:col-span-6 xl:col-span-4",
@@ -176,8 +178,15 @@ export function CardGridSkeleton({
         <div
           key={i}
           aria-hidden="true"
-          className={cx("skeleton skeleton-shimmer rounded-box", cardClassName)}
-        />
+          className={cx(
+            "flex flex-col rounded-box border border-base-300 bg-base-200 p-4",
+            cardClassName,
+          )}
+        >
+          <div className="skeleton skeleton-shimmer h-5 w-2/5" />
+          <div className="skeleton skeleton-shimmer mt-2 h-3 w-3/5" />
+          <div className="skeleton skeleton-shimmer mt-auto h-8 w-24 rounded-field" />
+        </div>
       ))}
     </div>
   )

--- a/web/src/components/ui/TableShell.tsx
+++ b/web/src/components/ui/TableShell.tsx
@@ -39,7 +39,7 @@ export function TableShell({
         padded && "[&_tbody_td]:py-4",
         className,
       )}
-      aria-busy={ariaBusy}
+      aria-busy={ariaBusy || undefined}
     >
       {children}
     </table>

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -102,7 +102,7 @@ export type {
   ToolbarSelectionProps,
 } from "./Toolbar"
 
-export { Spinner } from "@/components/Spinner"
+export { InlineSpinner, Spinner } from "@/components/Spinner"
 
 export { cx } from "./cx"
 export { hasUtility } from "./cx"

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -285,6 +285,21 @@ body {
   }
 }
 
+/* Loading-indicator anti-flash (Primer loading pattern: don't show an
+   indicator for sub-second waits). The element mounts invisible and a
+   zero-duration, delayed animation reveals it, so a fast load unmounts it
+   before it ever paints — no JS timers, no layout shift. */
+@utility indicator-appear {
+  opacity: 0;
+  animation: indicator-appear 0s 250ms forwards;
+}
+
+@keyframes indicator-appear {
+  to {
+    opacity: 1;
+  }
+}
+
 /* Scroll affordance for capped-height lists. `scroll-fade-y` marks the
    container; a small hook (useScrollFade) sets data-fade-top / data-fade-bottom
    to the edge(s) that have more content, and the mask softens only that edge.

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -925,7 +925,6 @@
   "orgs": {
     "headingCl50": "Classroom 50 organizations",
     "loadingTitle": "Loading your organizations…",
-    "loadingSubtitle": "This may take a moment.",
     "emptyTitle": "No Classroom 50 organizations yet",
     "emptyBody": "Organizations you belong to that use Classroom 50 will appear here. If you expect one, ask your teacher to confirm you've been added, then refresh.",
     "toolbar": {

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -14,7 +14,11 @@ import {
   type AssignmentSort,
 } from "@/pages/assignments/assignmentList"
 import { Badge, Button, EmphasisLtr } from "@/components/ui"
-import { SkeletonRegion, NoSearchResults } from "@/components/list"
+import {
+  NoSearchResults,
+  SkeletonRegion,
+  ToolbarSkeleton,
+} from "@/components/list"
 import Breadcrumb from "@/components/breadcrumb"
 import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
@@ -314,8 +318,7 @@ const AssignmentsPage = () => {
       )}
       {!roleResolved && (
         <SkeletonRegion className="space-y-4">
-          <div className="skeleton skeleton-shimmer h-6 w-48" />
-          <div className="skeleton skeleton-shimmer h-4 w-32" />
+          <ToolbarSkeleton />
           <div className="skeleton skeleton-shimmer h-64 w-full rounded-box" />
         </SkeletonRegion>
       )}

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -14,7 +14,7 @@ import {
   type AssignmentSort,
 } from "@/pages/assignments/assignmentList"
 import { Badge, Button, EmphasisLtr } from "@/components/ui"
-import { NoSearchResults } from "@/components/list"
+import { SkeletonRegion, NoSearchResults } from "@/components/list"
 import Breadcrumb from "@/components/breadcrumb"
 import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
@@ -313,11 +313,11 @@ const AssignmentsPage = () => {
         <ClaimTeacherNotice org={org} classroom={classroom} />
       )}
       {!roleResolved && (
-        <div className="space-y-4">
+        <SkeletonRegion className="space-y-4">
           <div className="skeleton skeleton-shimmer h-6 w-48" />
           <div className="skeleton skeleton-shimmer h-4 w-32" />
           <div className="skeleton skeleton-shimmer h-64 w-full rounded-box" />
-        </div>
+        </SkeletonRegion>
       )}
       {roleResolved && isStaff && org && classroom && (
         <TeacherAssignmentsView org={org} classroom={classroom} />

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -11,7 +11,7 @@ import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
-import { EmptyState } from "@/components/list"
+import { CardGridSkeleton, EmptyState } from "@/components/list"
 import { Alert, Button, Card, EmphasisLtr } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import MissingParams from "@/components/MissingParams"
@@ -195,14 +195,7 @@ const ClassesPage = () => {
           resolve — otherwise a staff view flashes the "no classrooms" empty
           state on the empty-while-loading array before the classes arrive. */}
       {roleLoading || (isStaff && classesLoading) ? (
-        <div className="grid grid-cols-12 gap-4">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div
-              key={i}
-              className="skeleton skeleton-shimmer col-span-6 h-32 rounded-box xl:col-span-4"
-            />
-          ))}
-        </div>
+        <CardGridSkeleton cardClassName="col-span-6 h-32 xl:col-span-4" />
       ) : (
         <>
           {classes.length === 0 && isStaff && <CreateClassroomPane org={org} />}

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -11,7 +11,12 @@ import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
-import { CardGridSkeleton, EmptyState } from "@/components/list"
+import {
+  CardGridSkeleton,
+  EmptyState,
+  SkeletonRegion,
+  ToolbarSkeleton,
+} from "@/components/list"
 import { Alert, Button, Card, EmphasisLtr } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import MissingParams from "@/components/MissingParams"
@@ -195,7 +200,10 @@ const ClassesPage = () => {
           resolve — otherwise a staff view flashes the "no classrooms" empty
           state on the empty-while-loading array before the classes arrive. */}
       {roleLoading || (isStaff && classesLoading) ? (
-        <CardGridSkeleton cardClassName="col-span-6 h-32 xl:col-span-4" />
+        <SkeletonRegion className="space-y-4">
+          <ToolbarSkeleton />
+          <CardGridSkeleton cardClassName="col-span-6 h-32 xl:col-span-4" />
+        </SkeletonRegion>
       ) : (
         <>
           {classes.length === 0 && isStaff && <CreateClassroomPane org={org} />}

--- a/web/src/pages/OrgActivityPage.tsx
+++ b/web/src/pages/OrgActivityPage.tsx
@@ -154,7 +154,7 @@ const OrgActivityPage = () => {
 
         {items.length === 0 ? (
           loading ? (
-            <Card className="mt-4 w-full overflow-hidden" aria-busy>
+            <Card className="mt-4 w-full overflow-hidden" aria-busy="true">
               <ListSkeletonRows rows={6} />
             </Card>
           ) : (

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -456,7 +456,10 @@ const OrgMembersPage = () => {
             </Select>
           </div>
 
-          <Card className="mt-4 w-full overflow-hidden" aria-busy={isLoading}>
+          <Card
+            className="mt-4 w-full overflow-hidden"
+            aria-busy={isLoading || undefined}
+          >
             {isLoading ? (
               <ListSkeletonRows rows={6} />
             ) : isError ? (

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -53,6 +53,8 @@ import {
   CardGridSkeleton,
   EmptyState,
   NoSearchResults,
+  SkeletonRegion,
+  ToolbarSkeleton,
   ViewToggle,
 } from "@/components/list"
 import NewOrgModal from "@/components/modals/NewOrgModal"
@@ -593,11 +595,19 @@ const OrgsPage = () => {
     <>
       <PageShell>
         {isLoading ? (
-          <CardGridSkeleton
-            cards={4}
-            cardClassName="col-span-12 h-36 md:col-span-6"
-            label={t("orgs.loadingTitle")}
-          />
+          <>
+            <PageHeader title={t("orgs.headingCl50")} />
+            <SkeletonRegion
+              label={t("orgs.loadingTitle")}
+              className="space-y-4"
+            >
+              <ToolbarSkeleton controls={3} />
+              <CardGridSkeleton
+                cards={4}
+                cardClassName="col-span-12 h-36 md:col-span-6"
+              />
+            </SkeletonRegion>
+          </>
         ) : (
           <>
             <PageHeader title={t("orgs.headingCl50")} />

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -49,9 +49,13 @@ import {
   cx,
   Heading,
 } from "@/components/ui"
-import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
+import {
+  CardGridSkeleton,
+  EmptyState,
+  NoSearchResults,
+  ViewToggle,
+} from "@/components/list"
 import NewOrgModal from "@/components/modals/NewOrgModal"
-import Spinner from "@/components/Spinner"
 import { EnterDiv, PresenceCardDiv } from "@/lib/motionComponents"
 import { listStagger } from "@/lib/motion"
 import { orgListPrefs, type OrgSortKey } from "@/lib/orgListPrefs"
@@ -589,17 +593,11 @@ const OrgsPage = () => {
     <>
       <PageShell>
         {isLoading ? (
-          <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
-            <Spinner size="lg" className="text-primary" />
-            <div>
-              <p className="text-base font-semibold">
-                {t("orgs.loadingTitle")}
-              </p>
-              <p className="mt-1 text-sm text-base-content/70">
-                {t("orgs.loadingSubtitle")}
-              </p>
-            </div>
-          </div>
+          <CardGridSkeleton
+            cards={4}
+            cardClassName="col-span-12 h-36 md:col-span-6"
+            label={t("orgs.loadingTitle")}
+          />
         ) : (
           <>
             <PageHeader title={t("orgs.headingCl50")} />

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -1,4 +1,5 @@
 import { Link, useParams } from "@tanstack/react-router"
+import { SkeletonRegion } from "@/components/list"
 import { useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { CalendarIcon, PeopleIcon, PersonIcon } from "@/components/ui/icons"
@@ -233,10 +234,10 @@ const SubmissionBody = ({
   // when the list lands a beat later.
   if (releasesLoading || repoLoading || submissionListLoading) {
     return (
-      <div className="space-y-4">
+      <SkeletonRegion className="space-y-4">
         <div className="skeleton skeleton-shimmer h-24 w-full rounded-box" />
         <div className="skeleton skeleton-shimmer h-40 w-full rounded-box" />
-      </div>
+      </SkeletonRegion>
     )
   }
 
@@ -503,10 +504,10 @@ const StudentSubmissionPage = () => {
           // the assignment metadata (mode, tags, locked) resolves — mounting
           // SubmissionBody with a default mode would fetch the wrong list and
           // flash the wrong guidance before flipping.
-          <div className="space-y-4">
+          <SkeletonRegion className="space-y-4">
             <div className="skeleton skeleton-shimmer h-24 w-full rounded-box" />
             <div className="skeleton skeleton-shimmer h-40 w-full rounded-box" />
-          </div>
+          </SkeletonRegion>
         ) : assignmentError ? (
           // A failed Pages metadata read must surface, not silently degrade to
           // the raw slug title + default (push) mode — which would render the

--- a/web/src/pages/accessibility/ContrastSection.tsx
+++ b/web/src/pages/accessibility/ContrastSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react"
+import { SkeletonRegion } from "@/components/list"
 import { useTranslation } from "react-i18next"
 import { InfoIcon } from "@/components/ui/icons"
 
@@ -226,7 +227,9 @@ export function ContrastSection() {
       {error && <Alert tone="error">{t("accessibility.loadError")}</Alert>}
 
       {!error && !audit && (
-        <div className="skeleton skeleton-shimmer h-40 w-full rounded-box" />
+        <SkeletonRegion>
+          <div className="skeleton skeleton-shimmer h-40 w-full rounded-box" />
+        </SkeletonRegion>
       )}
 
       {audit && (

--- a/web/src/pages/accessibility/VpatSection.tsx
+++ b/web/src/pages/accessibility/VpatSection.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react"
+import { SkeletonRegion } from "@/components/list"
 import { useTranslation } from "react-i18next"
 import {
   ArrowSwitchIcon,
@@ -254,7 +255,9 @@ export function VpatSection() {
       {error && <Alert tone="error">{t("accessibility.vpat.loadError")}</Alert>}
 
       {!error && !vpat && (
-        <div className="skeleton skeleton-shimmer h-40 w-full rounded-box" />
+        <SkeletonRegion>
+          <div className="skeleton skeleton-shimmer h-40 w-full rounded-box" />
+        </SkeletonRegion>
       )}
 
       {vpat && (

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -659,7 +659,7 @@ export const RepoFeatureControls = ({
           because it always stacks the label above the control. */}
       <div
         className={cx("flex flex-col gap-3", isRefreshing && "opacity-60")}
-        aria-busy={isRefreshing}
+        aria-busy={isRefreshing || undefined}
       >
         {REPO_FEATURE_KEYS.map(({ field: fieldName, key }) => (
           <form.Field key={fieldName} name={fieldName}>

--- a/web/src/pages/classes/StudentClassroomList.tsx
+++ b/web/src/pages/classes/StudentClassroomList.tsx
@@ -8,7 +8,12 @@ import {
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
+import {
+  CardGridSkeleton,
+  EmptyState,
+  NoSearchResults,
+  ViewToggle,
+} from "@/components/list"
 import {
   Badge,
   Card,
@@ -136,16 +141,7 @@ function StudentClassroomRow({
 }
 
 function ClassroomsSkeleton() {
-  return (
-    <div className="grid grid-cols-12 gap-4">
-      {Array.from({ length: 3 }).map((_, i) => (
-        <div
-          key={i}
-          className="skeleton skeleton-shimmer col-span-12 h-40 rounded-box md:col-span-6 xl:col-span-4"
-        />
-      ))}
-    </div>
-  )
+  return <CardGridSkeleton />
 }
 
 // The student "My Classrooms" list: a search + sort + grid/list toolbar over the

--- a/web/src/pages/classes/StudentClassroomList.tsx
+++ b/web/src/pages/classes/StudentClassroomList.tsx
@@ -12,6 +12,8 @@ import {
   CardGridSkeleton,
   EmptyState,
   NoSearchResults,
+  SkeletonRegion,
+  ToolbarSkeleton,
   ViewToggle,
 } from "@/components/list"
 import {
@@ -141,7 +143,12 @@ function StudentClassroomRow({
 }
 
 function ClassroomsSkeleton() {
-  return <CardGridSkeleton />
+  return (
+    <SkeletonRegion className="space-y-4">
+      <ToolbarSkeleton />
+      <CardGridSkeleton />
+    </SkeletonRegion>
+  )
 }
 
 // The student "My Classrooms" list: a search + sort + grid/list toolbar over the

--- a/web/src/pages/migration/SelectSourceStep.tsx
+++ b/web/src/pages/migration/SelectSourceStep.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/icons"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
-import { EmptyState } from "@/components/list"
+import { SkeletonRegion, EmptyState } from "@/components/list"
 import { Alert, Badge, Button, Card, rtlFlip } from "@/components/ui"
 import { listClassroomsWithOrg } from "@/migration/classroomApi"
 import type { ClassroomWithOrg } from "@/migration/types"
@@ -119,20 +119,22 @@ export const SelectSourceStep = ({
         </label>
 
         {isLoading && (
-          <ul className="mt-4 grid gap-2" aria-hidden="true">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <li
-                key={i}
-                className="flex items-center gap-3 rounded-box border border-base-300 bg-base-100 p-4"
-              >
-                <div className="skeleton skeleton-shimmer size-9 rounded-field" />
-                <div className="flex-1 space-y-2">
-                  <div className="skeleton skeleton-shimmer h-4 w-40 rounded" />
-                  <div className="skeleton skeleton-shimmer h-3 w-56 rounded" />
-                </div>
-              </li>
-            ))}
-          </ul>
+          <SkeletonRegion>
+            <ul className="mt-4 grid gap-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <li
+                  key={i}
+                  className="flex items-center gap-3 rounded-box border border-base-300 bg-base-100 p-4"
+                >
+                  <div className="skeleton skeleton-shimmer size-9 rounded-field" />
+                  <div className="flex-1 space-y-2">
+                    <div className="skeleton skeleton-shimmer h-4 w-40 rounded" />
+                    <div className="skeleton skeleton-shimmer h-3 w-56 rounded" />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </SkeletonRegion>
         )}
 
         {isError && (

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -652,7 +652,10 @@ const EnrolledStudents = ({
       ) : null}
 
       {/* The list card. */}
-      <Card className="w-full overflow-hidden" aria-busy={isLoading}>
+      <Card
+        className="w-full overflow-hidden"
+        aria-busy={isLoading || undefined}
+      >
         {isLoading ? (
           // Skeleton rows shaped like the roster rows, so content fades into
           // place instead of jumping in to replace a centered spinner.

--- a/web/src/pages/students/RosterPreviewTable.test.tsx
+++ b/web/src/pages/students/RosterPreviewTable.test.tsx
@@ -202,8 +202,8 @@ describe("RosterPreviewTable change highlighting", () => {
         onRoleChange={vi.fn()}
       />,
     )
-    expect(container.querySelector("table")?.getAttribute("aria-busy")).toBe(
-      "false",
-    )
+    expect(
+      container.querySelector("table")?.getAttribute("aria-busy"),
+    ).toBeNull()
   })
 })

--- a/web/src/pages/students/RosterPreviewTable.tsx
+++ b/web/src/pages/students/RosterPreviewTable.tsx
@@ -178,7 +178,7 @@ export const RosterPreviewTable = ({
   })
   return (
     <div className="max-h-80 overflow-auto rounded-box border border-base-300">
-      <table className="table table-sm" aria-busy={loading}>
+      <table className="table table-sm" aria-busy={loading || undefined}>
         <thead>
           <tr>
             <th scope="col">#</th>


### PR DESCRIPTION
## Summary

- Sixth PR in the Primer alignment series (#723 icons, #725 typography, #726 size/focus, #727 empty states, #728 notifications), adopting the [loading UI pattern](https://primer.style/product/ui-patterns/loading/).
- **Anti-flash**: `Spinner`/`InlineSpinner` mount invisible and reveal after 250ms via a pure-CSS `indicator-appear` utility (zero-duration delayed animation, no JS timers) — sub-second loads never flash an indicator, per Primer's "less than 1 second: don't show a loading state".
- **Page-shaped skeletons for card-list pages**: new composable primitives in `components/list` — `SkeletonRegion` (one `role="status"` announcement per region), `ToolbarSkeleton` (search bar + control pills), and a structured `CardGridSkeleton` (bordered card tiles with title/subtitle/action bars, not solid slabs). The loading state now mirrors the rendered page — real heading, toolbar placeholders, card grid — on the orgs page (previously a full-height centered spinner with layout jump), teacher + student classrooms, and the assignments role gate.
- **Announced busy regions**: previously silent skeleton blocks (`AssignmentsPage`, `StudentSubmissionPage` ×2, `VpatSection`, `ContrastSection`, `SelectSourceStep`, `PageHeader` title) now carry a single status announcement each; sidebar skeletons gain `aria-hidden` + the shared shimmer recipe.
- **Consistency**: `aria-busy` normalized (attribute present only while busy on non-live containers; `LoadingSwap` keeps its explicit `false`, which matches Primer's live-region guidance verbatim), and `GitHubAuthCard`'s nested double `role="status"` resolved via `InlineSpinner`.

## Notes for review

- Deliberate non-changes: in-button icon-swap spinners stay (they preserve button labels better than `Button loading`'s prepend), and the roster sync button's spinning `SyncIcon` is a refresh affordance, not a loading indicator.
- Also deliberate: form/settings pages that swap a centered spinner (`ClassroomSettingsPage`, `EditAssignmentForm`, `AssignmentSettingsPage`) are out of scope — skeletoning whole forms is a separate design effort.
- `orgs.loadingSubtitle` i18n key removed (the spinner headline it belonged to is gone).

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 4422 tests) passes
- [x] Live verification: `indicator-appear` computes opacity 0 with 250ms delay; composed page skeleton previewed in-session
- [ ] Hard-refresh spot-check of orgs/classrooms loading states on a cold cache