### PR TITLE
fix(web): stop the assignments action column from stretching

### DIFF
--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -474,7 +474,11 @@ const AssignmentsTable = ({
           />
           <th scope="col">{t("assignments.table.colAccepted")}</th>
           <th scope="col">{t("assignments.table.colSubmitted")}</th>
-          <th scope="col">
+          {/* w-0: auto table layout hands surplus width to every column,
+              which stretched this fixed-width button strip. Zero width makes
+              the browser fall back to min-content here and give the slack to
+              the text columns instead. */}
+          <th scope="col" className="w-0">
             <span className="sr-only">{t("assignments.table.colActions")}</span>
           </th>
         </tr>
@@ -737,76 +741,78 @@ const AssignmentsTable = ({
                   )
                 })()}
               </td>
-              <td>
-                <Link
-                  className="btn btn-circle btn-sm btn-ghost"
-                  to="/$org/$classroom/assignments/$assignment/settings"
-                  params={{
-                    org,
-                    classroom,
-                    assignment: assignment.slug,
-                  }}
-                  title={
-                    canMutate
-                      ? t("assignments.table.editAssignment")
-                      : t("assignments.table.viewAssignment")
-                  }
-                  onClick={(event) => {
-                    event.stopPropagation()
-                  }}
-                >
-                  {canMutate ? (
-                    <PencilIcon aria-hidden="true" className="size-4" />
-                  ) : (
-                    <EyeIcon aria-hidden="true" className="size-4" />
-                  )}
-                </Link>
-                {!canMutate ? (
-                  // Read-only rows (archived, or viewer can't author): reviewing
-                  // template access (and reaching the source repo) stays
-                  // available; the modal itself owner-gates the re-grant.
-                  assignment.template && (
-                    <TemplateAccessButton
-                      org={org}
-                      classroom={classroom}
-                      assignment={assignment}
-                    />
-                  )
-                ) : (
-                  <>
-                    <ReuseAssignmentButton
-                      org={org}
-                      classroom={classroom}
-                      assignment={assignment}
-                    />
-                    {assignment.template && (
+              <td className="w-0 py-2! pl-2">
+                <div className="flex items-center justify-end gap-1">
+                  <Link
+                    className="btn btn-circle btn-sm btn-ghost"
+                    to="/$org/$classroom/assignments/$assignment/settings"
+                    params={{
+                      org,
+                      classroom,
+                      assignment: assignment.slug,
+                    }}
+                    title={
+                      canMutate
+                        ? t("assignments.table.editAssignment")
+                        : t("assignments.table.viewAssignment")
+                    }
+                    onClick={(event) => {
+                      event.stopPropagation()
+                    }}
+                  >
+                    {canMutate ? (
+                      <PencilIcon aria-hidden="true" className="size-4" />
+                    ) : (
+                      <EyeIcon aria-hidden="true" className="size-4" />
+                    )}
+                  </Link>
+                  {!canMutate ? (
+                    // Read-only rows (archived, or viewer can't author): reviewing
+                    // template access (and reaching the source repo) stays
+                    // available; the modal itself owner-gates the re-grant.
+                    assignment.template && (
                       <TemplateAccessButton
                         org={org}
                         classroom={classroom}
                         assignment={assignment}
                       />
-                    )}
-                    <LockAssignmentButton
-                      org={org}
-                      classroom={classroom}
-                      assignment={assignment}
-                    />
-                    <DeleteAssignmentButton
-                      org={org}
-                      classroom={classroom}
-                      assignment={assignment}
-                      onDeleteAssignment={() =>
-                        queryClient.invalidateQueries({
-                          queryKey: githubKeys.jsonFile(
-                            org,
-                            CONFIG_REPO,
-                            `${classroom}/assignments.json`,
-                          ),
-                        })
-                      }
-                    />
-                  </>
-                )}
+                    )
+                  ) : (
+                    <>
+                      <ReuseAssignmentButton
+                        org={org}
+                        classroom={classroom}
+                        assignment={assignment}
+                      />
+                      {assignment.template && (
+                        <TemplateAccessButton
+                          org={org}
+                          classroom={classroom}
+                          assignment={assignment}
+                        />
+                      )}
+                      <LockAssignmentButton
+                        org={org}
+                        classroom={classroom}
+                        assignment={assignment}
+                      />
+                      <DeleteAssignmentButton
+                        org={org}
+                        classroom={classroom}
+                        assignment={assignment}
+                        onDeleteAssignment={() =>
+                          queryClient.invalidateQueries({
+                            queryKey: githubKeys.jsonFile(
+                              org,
+                              CONFIG_REPO,
+                              `${classroom}/assignments.json`,
+                            ),
+                          })
+                        }
+                      />
+                    </>
+                  )}
+                </div>
               </td>
             </ClickableTr>
           ))}

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -741,7 +741,7 @@ const AssignmentsTable = ({
                   )
                 })()}
               </td>
-              <td className="w-0 py-2! pl-2">
+              <td className="w-0 py-2! ps-2">
                 <div className="flex items-center justify-end gap-1">
                   <Link
                     className="btn btn-circle btn-sm btn-ghost"


### PR DESCRIPTION
## Summary

The assignments list's action column stretched: `.table` is `width: 100%` with
auto layout, so the browser spread the surplus width across every column —
including the one holding a fixed-width strip of icon buttons. The result was a
wide empty gap to the right of the last action (delete), and text columns
narrower than they needed to be.

`w-0` on that column's `<th>`/`<td>` makes the browser fall back to min-content
there and hand the slack to the text columns instead. While in the cell, the
buttons moved into a `flex items-center justify-end gap-1` wrapper — the recipe
the submissions table's action cell already uses
(`web/src/pages/submissions/SubmissionsRows.tsx`) — and `py-2!` trims the cell's
own vertical padding, which `TableShell`'s `padded` had set to `py-4`; with a
32px button, that cell rather than the text cells was driving the row height.

Visual only. No behaviour, markup semantics, or a11y affordances change: the
buttons keep their 32px hit targets, their labels, and their order.

**Review tip:** most of the diff is re-indentation from the new wrapper
`<div>`. `?w=1` shows the real change — 8 insertions, 2 deletions.

Heads-up: #732 rewrites the same action cell, so whichever of the two lands
second needs a rebase. Happy to take that side.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - Web: `cd web && npm run check` — 352 files, 4422 tests, all green
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass. — n/a, no contract touched
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README). — n/a, no CLI change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`)
