### PR TITLE
feat(web): flag an out-of-date classroom on the assignments page

### DIFF
--- a/web/src/components/SubmissionFreshnessLine.tsx
+++ b/web/src/components/SubmissionFreshnessLine.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react"
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "@/components/ui"
+
+// The one freshness strip both collect surfaces render: when the submission
+// data was last collected, an "Out of date" badge when it has fallen behind,
+// and the caller's collect action beside them.
+//
+// Shared because the two surfaces are meant to stay in lockstep — the
+// submissions page's per-assignment DataFreshness and the assignments page's
+// classroom-wide ClassroomCollectButton. They differ only in scope and in
+// which action they hang here, so the wording, the tone, and the layout live
+// once. `stale` is decided by the caller: per assignment on one page, across
+// every assignment in the classroom on the other.
+export type SubmissionFreshnessLineProps = {
+  // Relative "x ago" of the last completed collect for this scope, or null
+  // when nothing has been collected yet.
+  lastCollectedLabel: string | null
+  // The snapshot is (probably) behind — a repo was pushed after the collect
+  // that last walked it.
+  stale: boolean
+  // Drop the collected line while its source is still loading, so it doesn't
+  // flash "not collected yet" before the cached snapshot arrives. The badge
+  // and the action still render.
+  showCollectedLine?: boolean
+  // The collect action, rendered after the badge.
+  children?: ReactNode
+}
+
+export function SubmissionFreshnessLine({
+  lastCollectedLabel,
+  stale,
+  showCollectedLine = true,
+  children,
+}: SubmissionFreshnessLineProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/70"
+      role="status"
+    >
+      {showCollectedLine && (
+        <span>
+          {lastCollectedLabel
+            ? t("submissions.freshness.collected", { when: lastCollectedLabel })
+            : t("submissions.freshness.neverCollected")}
+        </span>
+      )}
+
+      {/* Staleness is a chip, never the action's tone: collecting is additive
+          and re-runnable, so a danger-toned button would promise a consequence
+          it doesn't have. */}
+      {stale && (
+        <Badge tone="warning" title={t("submissions.freshness.staleHelp")}>
+          {t("submissions.freshness.stale")}
+        </Badge>
+      )}
+
+      {children}
+    </div>
+  )
+}
+
+export default SubmissionFreshnessLine

--- a/web/src/hooks/useInvalidateAfterCollect.ts
+++ b/web/src/hooks/useInvalidateAfterCollect.ts
@@ -1,0 +1,42 @@
+import { useQueryClient } from "@tanstack/react-query"
+import { useEffect } from "react"
+
+import { githubKeys } from "@/github-core/queries"
+import { CONFIG_REPO } from "@/util/configRepo"
+import type { CollectScoresPhase } from "./useTriggerScoreCollection"
+
+// Drops the reads a finished classroom sweep invalidated, so the page
+// re-derives from fresh data: the gradebook (scores.json), the last-run stamp,
+// and the org repo list. Lives here rather than in the page because
+// `useQueryClient`/`githubKeys` stay out of `pages/` (AGENTS.md).
+//
+// `timeout` is only this client giving up on the poll — the run itself usually
+// lands, so refresh there too rather than leaving the page on stale counts.
+//
+// The org repo list is included because `pushed_at` is frozen at page load:
+// without the re-read, a push that landed before the collect's stamp would be
+// invisible and the staleness badge would clear against a list the sweep
+// already left behind.
+const useInvalidateAfterCollect = (
+  org: string,
+  classroom: string,
+  phase: CollectScoresPhase,
+) => {
+  const queryClient = useQueryClient()
+  useEffect(() => {
+    if (phase !== "completed" && phase !== "timeout") return
+    queryClient.invalidateQueries({
+      queryKey: githubKeys.jsonFile(
+        org,
+        CONFIG_REPO,
+        `${classroom}/scores.json`,
+      ),
+    })
+    queryClient.invalidateQueries({
+      queryKey: githubKeys.lastCollectScoresRun(org),
+    })
+    queryClient.invalidateQueries({ queryKey: githubKeys.orgRepos(org) })
+  }, [phase, classroom, org, queryClient])
+}
+
+export default useInvalidateAfterCollect

--- a/web/src/pages/assignments/ClassroomCollectButton.test.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.test.tsx
@@ -19,15 +19,16 @@ const hookArgs: unknown[][] = []
 let phase = "idle"
 let failure: "dispatch" | "run" | null = null
 let error: unknown = null
+let run: unknown = null
 vi.mock("@/hooks/useTriggerScoreCollection", () => ({
   default: (...args: unknown[]) => {
     hookArgs.push(args)
-    return { collect, phase, failure, run: null, error }
+    return { collect, phase, failure, run, error }
   },
 }))
 
 // Freshness inputs, both already served from the query cache in the app.
-let scoresResult: { data?: unknown; isLoading: boolean } = {
+let scoresResult: { data?: unknown; isLoading: boolean; error?: unknown } = {
   data: undefined,
   isLoading: false,
 }
@@ -40,7 +41,37 @@ vi.mock("@/hooks/useGetLastCollectScoresRun", () => ({
   default: () => lastRunResult,
 }))
 
+// The two staleness inputs. Both are served from the query cache on the real
+// page (the assignments table holds the same two query keys).
+let assignmentsResult: { data?: unknown } = { data: undefined }
+vi.mock("@/hooks/useGetClassAssignments", () => ({
+  default: () => assignmentsResult,
+}))
+
+let orgReposResult: { data?: unknown } = { data: undefined }
+vi.mock("@/hooks/useGetMyOrgRepos", () => ({
+  default: () => orgReposResult,
+}))
+
 import { ClassroomCollectButton } from "./ClassroomCollectButton"
+import { GitHubAPIError } from "@/github-core/errors"
+
+// A settled scores.json read failure, as jsonFileQuery surfaces it.
+const scoresReadError = (status: number) =>
+  new GitHubAPIError({
+    status,
+    url: "https://api.github.com/repos/acme/classroom50/contents/cs50%2Fscores.json",
+    message: status === 404 ? "Not Found" : `boom ${status}`,
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter: null,
+    },
+  })
 
 // One client + spy per test, handed back inferred so the recorded filters keep
 // their types.
@@ -70,8 +101,11 @@ beforeEach(() => {
   phase = "idle"
   failure = null
   error = null
+  run = null
   scoresResult = { data: undefined, isLoading: false }
   lastRunResult = { data: undefined }
+  assignmentsResult = { data: undefined }
+  orgReposResult = { data: undefined }
   // happy-dom's <dialog> lacks showModal/close; stub them so the confirm
   // modal's open-sync effect can run.
   HTMLDialogElement.prototype.showModal = function () {
@@ -142,6 +176,11 @@ describe("ClassroomCollectButton", () => {
     )
     expect(invalidatedKeys()).toContainEqual(
       expect.arrayContaining(["last-collect-scores-run", "acme"]),
+    )
+    // `pushed_at` is frozen at page load; the re-read unfreezes it so the badge
+    // re-derives against the post-sweep repo list.
+    expect(invalidatedKeys()).toContainEqual(
+      expect.arrayContaining(["org-repos", "acme"]),
     )
   })
 
@@ -281,6 +320,204 @@ describe("ClassroomCollectButton", () => {
       expect(
         screen.queryByText("submissions.freshness.neverCollected"),
       ).toBeNull()
+    })
+  })
+
+  // Classroom-wide staleness: one badge, on the same strings the submissions
+  // page uses, driven per assignment rather than by a classroom-wide maximum.
+  describe("out-of-date badge", () => {
+    const withRepos = (pushed: Record<string, string>) => ({
+      data: Object.entries(pushed).map(([name, pushed_at]) => ({
+        name,
+        pushed_at,
+      })),
+    })
+    const withScores = (collectedAt: Record<string, string>) => ({
+      data: { submissions: {}, collectedAt, detected: {} },
+      isLoading: false,
+    })
+
+    beforeEach(() => {
+      assignmentsResult = { data: { assignments: [{ slug: "hw1" }] } }
+    })
+
+    it("flags a bucket pushed after its own collect", () => {
+      orgReposResult = withRepos({ "cs50-hw1-alice": "2026-06-02T00:00:00Z" })
+      scoresResult = withScores({ hw1: "2026-06-01T00:00:00Z" })
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.getByText("submissions.freshness.stale")).toBeTruthy()
+    })
+
+    it("stays quiet when every bucket was collected after its push", () => {
+      orgReposResult = withRepos({ "cs50-hw1-alice": "2026-06-01T00:00:00Z" })
+      scoresResult = withScores({ hw1: "2026-06-02T00:00:00Z" })
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.queryByText("submissions.freshness.stale")).toBeNull()
+    })
+
+    // The repo list is a whole-org pagination, so an unanswerable question is
+    // left unasked — and an unanswered one never claims the data is current.
+    it("shows no badge while the repo list is unavailable", () => {
+      orgReposResult = { data: undefined }
+      scoresResult = withScores({ hw1: "2026-06-01T00:00:00Z" })
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.queryByText("submissions.freshness.stale")).toBeNull()
+    })
+
+    // collect_scores.py skips a bare empty_repo assignment outright, so its
+    // bucket is never written and never stamped — while its student repos
+    // exist and carry an accept-time push. Measured, it would latch the badge
+    // on forever with no collect able to clear it.
+    it("never latches on an empty_repo assignment, which is never collected", () => {
+      assignmentsResult = {
+        data: {
+          assignments: [
+            { slug: "hw1" },
+            { slug: "reflection", empty_repo: true },
+          ],
+        },
+      }
+      orgReposResult = withRepos({
+        "cs50-hw1-alice": "2026-06-01T00:00:00Z",
+        "cs50-reflection-alice": "2026-06-05T00:00:00Z",
+      })
+      scoresResult = withScores({ hw1: "2026-06-03T00:00:00Z" })
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.queryByText("submissions.freshness.stale")).toBeNull()
+    })
+
+    // Before scores.json lands every bucket looks unstamped. The collected
+    // line is suppressed in that window precisely to avoid a false claim; the
+    // badge must not make one either.
+    it("claims nothing while scores.json is still loading", () => {
+      assignmentsResult = { data: { assignments: [{ slug: "hw1" }] } }
+      orgReposResult = withRepos({ "cs50-hw1-alice": "2026-06-02T00:00:00Z" })
+      scoresResult = { data: undefined, isLoading: true }
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.queryByText("submissions.freshness.stale")).toBeNull()
+    })
+
+    // The wiring the app actually uses: scores.json is partially stamped, so a
+    // slug with no stamp of its own must not borrow a sibling's — the caller
+    // hands in the newest stamp as the run fallback, and it has to be ignored
+    // while any bucket is stamped.
+    it("doesn't let a collected assignment mask a never-collected one", () => {
+      assignmentsResult = {
+        data: { assignments: [{ slug: "hw1" }, { slug: "hw2" }] },
+      }
+      orgReposResult = withRepos({
+        "cs50-hw1-alice": "2026-06-01T00:00:00Z",
+        "cs50-hw2-bob": "2026-06-01T00:00:00Z",
+      })
+      // hw1 collected after its push; hw2 has no stamp at all.
+      scoresResult = withScores({ hw1: "2026-06-03T00:00:00Z" })
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.getByText("submissions.freshness.stale")).toBeTruthy()
+    })
+
+    // Pins the sixth-argument wiring: an EXCLUDED empty_repo slug must still
+    // guard its prefix sibling, or "hw1" absorbs "hw1-bonus"'s newer push and
+    // latches a badge no collect can clear. Fails if the component ever hands
+    // classroomSnapshotIsStale an incomplete `allSlugs` list.
+    it("keeps an excluded empty_repo sibling guarding its prefix", () => {
+      assignmentsResult = {
+        data: {
+          assignments: [
+            { slug: "hw1" },
+            { slug: "hw1-bonus", empty_repo: true },
+          ],
+        },
+      }
+      orgReposResult = withRepos({
+        "cs50-hw1-alice": "2026-06-01T00:00:00Z",
+        "cs50-hw1-bonus-bob": "2026-06-05T00:00:00Z",
+      })
+      scoresResult = withScores({ hw1: "2026-06-03T00:00:00Z" })
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.queryByText("submissions.freshness.stale")).toBeNull()
+    })
+
+    // A settled read with no file (404) IS the never-collected state: repos
+    // carry pushes and nothing was ever collected, so the badge may speak.
+    it("shows the badge for a pushed, never-collected classroom", () => {
+      orgReposResult = withRepos({ "cs50-hw1-alice": "2026-06-02T00:00:00Z" })
+      scoresResult = {
+        data: undefined,
+        isLoading: false,
+        error: scoresReadError(404),
+      }
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.getByText("submissions.freshness.stale")).toBeTruthy()
+    })
+
+    // ...but a read that FAILED (rate limit, network) answered nothing, so
+    // claiming "Out of date" from it would be the false claim the loading
+    // gate already avoids.
+    it("claims nothing when the scores read failed", () => {
+      orgReposResult = withRepos({ "cs50-hw1-alice": "2026-06-02T00:00:00Z" })
+      scoresResult = {
+        data: undefined,
+        isLoading: false,
+        error: scoresReadError(403),
+      }
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.queryByText("submissions.freshness.stale")).toBeNull()
+    })
+
+    // A wholly unstamped legacy file leans on the completed-run query, which
+    // lags — it can still report the PRIOR run right after a sweep finishes.
+    // The tracked run this component just watched to completion outranks it,
+    // so the badge clears instead of relighting against yesterday's run.
+    it("trusts a just-completed tracked sweep over the lagging run query", () => {
+      orgReposResult = withRepos({ "cs50-hw1-alice": "2026-06-02T00:00:00Z" })
+      scoresResult = withScores({})
+      lastRunResult = {
+        data: { status: "completed", created_at: "2026-06-01T00:00:00Z" },
+      }
+      phase = "completed"
+      run = { created_at: "2026-06-03T00:00:00Z" }
+      const { wrapper } = setup()
+      render(<ClassroomCollectButton org="acme" classroom="cs50" />, {
+        wrapper,
+      })
+
+      expect(screen.queryByText("submissions.freshness.stale")).toBeNull()
     })
   })
 })

--- a/web/src/pages/assignments/ClassroomCollectButton.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.tsx
@@ -1,23 +1,29 @@
-import { useQueryClient } from "@tanstack/react-query"
 import { AlertIcon, SyncIcon } from "@/components/ui/icons"
-import { useEffect, useId, useState } from "react"
+import { useEffect, useId, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { Button, Modal, Heading } from "@/components/ui"
+import { SubmissionFreshnessLine } from "@/components/SubmissionFreshnessLine"
 import { useToast } from "@/context/notifications/NotificationProvider"
-import { githubKeys } from "@/github-core/queries"
+import { GitHubAPIError } from "@/github-core/errors"
+import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import useGetLastCollectScoresRun from "@/hooks/useGetLastCollectScoresRun"
+import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
 import useGetScores from "@/hooks/useGetScores"
+import useInvalidateAfterCollect from "@/hooks/useInvalidateAfterCollect"
 import useTriggerScoreCollection from "@/hooks/useTriggerScoreCollection"
-import { latestCollectedAt } from "@/pages/submissions/dashboard"
-import { CONFIG_REPO } from "@/util/configRepo"
+import {
+  classroomSnapshotIsStale,
+  latestCollectedAt,
+} from "@/pages/submissions/dashboard"
 import { formatRelativeToNow } from "@/util/formatDate"
 
 // Classroom-wide "Collect all", presented as the assignments toolbar's
-// freshness widget — a passive "Submission data collected x ago" line plus the
-// action, mirroring the submissions page's DataFreshness pairing so the button
-// carries its own context: the table's submission counts come from the
-// scores.json snapshot this button rebuilds. The line reuses the shared
+// freshness widget — a passive "Submission data collected x ago" line, an
+// "Out of date" badge when the snapshot has fallen behind, and the action.
+// Mirrors the submissions page's DataFreshness pairing so the button carries
+// its own context: the table's submission counts come from the scores.json
+// snapshot this button rebuilds. The line and the badge reuse the shared
 // submissions.freshness strings (one wording, no duplicate translation keys).
 //
 // Dispatches collect-scores with only the `classroom` input, so the workflow
@@ -48,7 +54,6 @@ export function ClassroomCollectButton({
 }) {
   const { t } = useTranslation()
   const { notify } = useToast()
-  const queryClient = useQueryClient()
   const collect = useTriggerScoreCollection(org, { classroom })
   const busy = collect.phase === "dispatching" || collect.phase === "running"
   // A sweep is a heavier dispatch than the per-assignment collect (it walks
@@ -65,43 +70,114 @@ export function ClassroomCollectButton({
   // classroom); a wholly unstamped file predates the stamping collector, when
   // every run was org-wide, so the run fallback is sound there — the same
   // precedence the submissions page's effectiveCollectedAt applies per bucket.
-  const { data: scoresData, isLoading: scoresLoading } = useGetScores(
-    org,
-    classroom,
-  )
+  const {
+    data: scoresData,
+    isLoading: scoresLoading,
+    error: scoresError,
+  } = useGetScores(org, classroom)
+  // A missing scores.json 404s — that IS the never-collected state, and the
+  // badge may speak to it. Any other failure (rate limit, network) answered
+  // nothing, so claiming "Out of date" from it would be a false claim.
+  const scoresReadFailed =
+    scoresError != null &&
+    !(scoresError instanceof GitHubAPIError && scoresError.isNotFound)
   const { data: lastRun } = useGetLastCollectScoresRun(org)
   const bucketStamps = Object.values(scoresData?.collectedAt ?? {})
   const newestStamp = bucketStamps.reduce<string | null>(
     latestCollectedAt,
     null,
   )
-  const lastCollectedAt =
+  // A just-finished tracked sweep outranks the lagging completed-run query
+  // (phase "completed" means conclusion success — see useGitHubOperation),
+  // mirroring the submissions page's trackedCompletedAt: without it, a legacy
+  // unstamped file's badge would relight off the PRIOR run the invalidated
+  // refetch can still return right after a successful collect.
+  const trackedCompletedAt =
+    collect.phase === "completed" ? (collect.run?.created_at ?? null) : null
+  const lastCollectedAt = latestCollectedAt(
     newestStamp ??
-    (scoresData && bucketStamps.length === 0 && lastRun?.status === "completed"
-      ? lastRun.created_at
-      : null)
+      (scoresData &&
+      bucketStamps.length === 0 &&
+      lastRun?.status === "completed"
+        ? lastRun.created_at
+        : null),
+    trackedCompletedAt,
+  )
   const lastCollectedLabel = lastCollectedAt
     ? formatRelativeToNow(new Date(lastCollectedAt))
     : null
 
-  // A finished sweep rewrote every bucket in this classroom's scores.json, so
-  // drop the cached gradebook and the last-run stamp; the table's submission
-  // counts re-derive on the refetch. `timeout` is only this client giving up on
-  // the poll — the run itself usually lands, so refresh there too rather than
-  // leaving the page on stale counts.
-  useEffect(() => {
-    if (collect.phase !== "completed" && collect.phase !== "timeout") return
-    queryClient.invalidateQueries({
-      queryKey: githubKeys.jsonFile(
-        org,
-        CONFIG_REPO,
-        `${classroom}/scores.json`,
-      ),
-    })
-    queryClient.invalidateQueries({
-      queryKey: githubKeys.lastCollectScoresRun(org),
-    })
-  }, [collect.phase, classroom, org, queryClient])
+  // Classroom-wide staleness, the same signal the submissions page shows per
+  // assignment: a repo pushed after the collect that last walked ITS bucket.
+  // Both reads are already in the query cache on this page — the table renders
+  // from the same assignment list and holds the same `orgRepos` query key — so
+  // this adds no request; deliberately left ungated for that reason, since one
+  // ungated observer (the table's) decides the fetch for every observer
+  // anyway. While either read is unavailable no badge shows, which is the same
+  // quiet default the submissions page falls back to.
+  const { data: assignmentsData } = useGetClassroomAssignments(org, classroom)
+  const assignments = useMemo(
+    () => assignmentsData?.assignments ?? [],
+    [assignmentsData],
+  )
+  // Every slug in the classroom — the sibling-slug guard needs the COMPLETE
+  // list, or "hw1" starts absorbing "hw1-bonus"'s repos.
+  const assignmentSlugs = useMemo(
+    () => assignments.map((a) => a.slug),
+    [assignments],
+  )
+  // ...but only the collectable ones are asked whether they are behind. A bare
+  // empty_repo assignment is skipped by collect_scores.py outright, so its
+  // bucket is never written and never stamped, while its student repos exist
+  // and carry a push from accept time. Measured against a stamp that can never
+  // arrive it would read as stale forever — a badge no collect could clear.
+  // (no_autograder is NOT excluded: the collector does write its bucket, from
+  // detected submissions rather than grades, so it stamps like any other.
+  // Known edge: a pre-#694 collector never stamps no_autograder buckets, so on
+  // such an org the badge latches for them until the workflows are updated —
+  // accepted, because the skeleton-drift banner is already telling that org's
+  // teachers to update, and updating is the actual fix.)
+  const collectableSlugs = useMemo(
+    () => assignments.filter((a) => a.empty_repo !== true).map((a) => a.slug),
+    [assignments],
+  )
+  const { data: orgRepos } = useGetOrgRepos(org)
+  const stale = useMemo(
+    () =>
+      // Gated on the scores read for the same reason the collected line is:
+      // before scores.json lands every bucket looks unstamped, and claiming
+      // "Out of date" in that window is the false claim the silent line
+      // avoids. A failed (non-404) read gets the same silence — it answered
+      // nothing, so there is nothing truthful to claim.
+      !scoresLoading &&
+      !scoresReadFailed &&
+      classroomSnapshotIsStale({
+        repos: orgRepos,
+        classroom,
+        measuredSlugs: collectableSlugs,
+        collectedAt: scoresData?.collectedAt,
+        runCollectedAt: lastCollectedAt,
+        allSlugs: assignmentSlugs,
+      }),
+    [
+      scoresLoading,
+      scoresReadFailed,
+      orgRepos,
+      classroom,
+      collectableSlugs,
+      assignmentSlugs,
+      scoresData?.collectedAt,
+      lastCollectedAt,
+    ],
+  )
+
+  // A finished sweep rewrote this classroom's scores.json, so drop the reads it
+  // invalidated (gradebook, last-run stamp, org repo list) — the table's counts
+  // and the badge re-derive on the refetch. Note the org-repo re-read unfreezes
+  // `pushed_at` from page load; it cannot see a push the sweep itself missed
+  // (the collector stamps after its walk), so a push landing mid-sweep reads as
+  // collected until the next push or collect.
+  useInvalidateAfterCollect(org, classroom, collect.phase)
 
   useEffect(() => {
     if (collect.phase !== "failed" || collect.failure !== "dispatch") return
@@ -120,41 +196,40 @@ export function ClassroomCollectButton({
   }, [collect.phase, collect.failure, collect.error, classroom, notify, t])
 
   return (
-    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-      {/* Silent while scores.json loads so the line doesn't flash "not
-          collected yet" before the cached snapshot arrives. */}
-      {!scoresLoading && (
-        <span role="status" className="text-sm text-base-content/70">
-          {lastCollectedLabel
-            ? t("submissions.freshness.collected", {
-                when: lastCollectedLabel,
-              })
-            : t("submissions.freshness.neverCollected")}
-        </span>
-      )}
-      <Button
-        variant="ghost"
-        size="sm"
-        loading={busy}
-        loadingLabel={t("submissions.collect.active")}
-        disabled={emptyRoster}
-        title={
-          emptyRoster
-            ? t("submissions.collect.titleEmptyRoster")
-            : t("assignments.collect.title")
-        }
-        onClick={() => setConfirmOpen(true)}
+    <>
+      <SubmissionFreshnessLine
+        lastCollectedLabel={lastCollectedLabel}
+        stale={stale}
+        // Silent while scores.json loads so the line doesn't flash "not
+        // collected yet" before the cached snapshot arrives.
+        showCollectedLine={!scoresLoading}
       >
-        {busy ? (
-          t("submissions.collect.active")
-        ) : (
-          <>
-            <SyncIcon aria-hidden="true" className="size-4" />
-            {t("assignments.collect.label")}
-          </>
-        )}
-      </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          loading={busy}
+          loadingLabel={t("submissions.collect.active")}
+          disabled={emptyRoster}
+          title={
+            emptyRoster
+              ? t("submissions.collect.titleEmptyRoster")
+              : t("assignments.collect.title")
+          }
+          onClick={() => setConfirmOpen(true)}
+        >
+          {busy ? (
+            t("submissions.collect.active")
+          ) : (
+            <>
+              <SyncIcon aria-hidden="true" className="size-4" />
+              {t("assignments.collect.label")}
+            </>
+          )}
+        </Button>
+      </SubmissionFreshnessLine>
 
+      {/* Sibling, not child: the strip is a role="status" live region, and a
+          dialog nested inside it gets re-announced as a status update. */}
       <Modal
         open={confirmOpen}
         onClose={() => setConfirmOpen(false)}
@@ -190,7 +265,7 @@ export function ClassroomCollectButton({
           </Button>
         </div>
       </Modal>
-    </div>
+    </>
   )
 }
 

--- a/web/src/pages/submissions/DataFreshness.test.tsx
+++ b/web/src/pages/submissions/DataFreshness.test.tsx
@@ -60,7 +60,7 @@ describe("DataFreshness", () => {
     expect(btn.className).not.toContain("btn-error")
   })
 
-  it("switches the help tooltip with staleness, on the button and the badge", () => {
+  it("keeps the button tooltip constant; the badge carries the stale help", () => {
     const { rerender } = render(<DataFreshness {...base} stale={false} />)
     const button = () =>
       screen
@@ -68,7 +68,7 @@ describe("DataFreshness", () => {
         .closest("button") as HTMLButtonElement
     expect(button().title).toBe("submissions.freshness.collectHelp")
     rerender(<DataFreshness {...base} stale />)
-    expect(button().title).toBe("submissions.freshness.staleHelp")
+    expect(button().title).toBe("submissions.freshness.collectHelp")
     expect(screen.getByText("submissions.freshness.stale").title).toBe(
       "submissions.freshness.staleHelp",
     )

--- a/web/src/pages/submissions/DataFreshness.tsx
+++ b/web/src/pages/submissions/DataFreshness.tsx
@@ -1,22 +1,21 @@
 import { SyncIcon } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
 
-import { Alert, Badge, Button, cx } from "@/components/ui"
+import { Alert, Button, cx } from "@/components/ui"
+import { SubmissionFreshnessLine } from "@/components/SubmissionFreshnessLine"
 
-// One passive freshness surface for the submissions dashboard. The table always
-// shows the collected scores.json snapshot; this line states when the submission
-// data was last collected and offers a single re-collect button. When an
-// assignment repo has been pushed since the last collect (staleness derived from
-// the org repo list's `pushed_at` — no extra fetch, so it works for every
-// viewer, not just owners), a warning "Out of date" badge joins the line.
-// Following data-freshness UX guidance: never let stale data look
-// authoritative, and give the user a direct way to refresh it.
+// The submissions dashboard's freshness surface: the shared freshness strip
+// (last collected + "Out of date" badge, see SubmissionFreshnessLine) carrying
+// this page's per-assignment collect, plus the degraded-read warning that only
+// this page can raise.
+//
+// The table always shows the collected scores.json snapshot. Staleness comes
+// from the org repo list's `pushed_at` — no extra fetch, so it works for every
+// viewer, not just owners. Following data-freshness UX guidance: never let
+// stale data look authoritative, and give the user a direct way to refresh it.
 //
 // The button reads "Collect now" in every state — the same string the Manage
-// hub's collect action uses, because it is the same dispatch. Staleness is
-// carried by the badge, not by the button's variant: the collect is additive
-// and re-runnable, so a danger-toned button would promise a destructive action
-// it doesn't perform.
+// hub's collect action uses, because it is the same dispatch.
 //
 // A bare empty_repo assignment has no collect at all — the page omits this
 // component and the header's grading badge explains why. A no_autograder
@@ -48,26 +47,12 @@ export function DataFreshness({
 }: DataFreshnessProps) {
   const { t } = useTranslation()
 
-  const collectedLine = lastCollectedLabel
-    ? t("submissions.freshness.collected", { when: lastCollectedLabel })
-    : t("submissions.freshness.neverCollected")
-
   return (
     <div className="flex flex-col items-start gap-1">
-      <div
-        className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/70"
-        role="status"
+      <SubmissionFreshnessLine
+        lastCollectedLabel={lastCollectedLabel}
+        stale={stale}
       >
-        <span>{collectedLine}</span>
-
-        {/* Stale carries its own chip so the out-of-date state is legible
-            without recolouring the action beside it. */}
-        {stale && (
-          <Badge tone="warning" title={t("submissions.freshness.staleHelp")}>
-            {t("submissions.freshness.stale")}
-          </Badge>
-        )}
-
         {onRefresh && (
           // A quiet ghost button in both states, so the freshness line doesn't
           // outshout the search/filter controls beside it in the toolbar.
@@ -78,11 +63,7 @@ export function DataFreshness({
             onClick={onRefresh}
             aria-live="polite"
             className="text-base-content/70"
-            title={
-              stale
-                ? t("submissions.freshness.staleHelp")
-                : t("submissions.freshness.collectHelp")
-            }
+            title={t("submissions.freshness.collectHelp")}
           >
             <SyncIcon
               aria-hidden="true"
@@ -93,7 +74,7 @@ export function DataFreshness({
               : t("submissions.collect.label")}
           </Button>
         )}
-      </div>
+      </SubmissionFreshnessLine>
 
       {/* Degraded live read: some repos couldn't be read, so live status is
           provisional. Say so rather than showing an incomplete view as

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -16,6 +16,7 @@ import {
   buildScoresCsvRows,
   buildSectionLookup,
   classAverage,
+  classroomSnapshotIsStale,
   computeStats,
   displayItemOwner,
   displayPageOwners,
@@ -1329,6 +1330,187 @@ describe("latestAssignmentPush / snapshotIsStale", () => {
   it("is never stale when there is no push", () => {
     expect(snapshotIsStale(null, null)).toBe(false)
     expect(snapshotIsStale(null, "2026-06-20T10:00:00Z")).toBe(false)
+  })
+})
+
+describe("classroomSnapshotIsStale", () => {
+  const repo = (name: string, pushed_at?: string): GitHubRepo =>
+    ({ name, pushed_at }) as GitHubRepo
+
+  const repos = [
+    repo("cs101-hw1-alice", "2026-06-20T10:00:00Z"),
+    repo("cs101-hw2-bob", "2026-06-24T10:00:00Z"),
+  ]
+  const slugs = ["hw1", "hw2"]
+
+  it("is stale when any one assignment was pushed after ITS own collect", () => {
+    // hw1 collected after its push, hw2 collected before its push.
+    expect(
+      classroomSnapshotIsStale({
+        repos,
+        classroom: "cs101",
+        measuredSlugs: slugs,
+        collectedAt: {
+          hw1: "2026-06-21T10:00:00Z",
+          hw2: "2026-06-23T10:00:00Z",
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it("is not stale when every assignment was collected after its push", () => {
+    expect(
+      classroomSnapshotIsStale({
+        repos,
+        classroom: "cs101",
+        measuredSlugs: slugs,
+        collectedAt: {
+          hw1: "2026-06-21T10:00:00Z",
+          hw2: "2026-06-25T10:00:00Z",
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it("doesn't let a freshly collected assignment mask a stale sibling", () => {
+    // The regression a classroom-wide max-vs-max comparison would produce: the
+    // newest stamp (hw1) is newer than the newest push (hw2), yet hw2's own
+    // bucket predates its push.
+    expect(
+      classroomSnapshotIsStale({
+        repos,
+        classroom: "cs101",
+        measuredSlugs: slugs,
+        collectedAt: {
+          hw1: "2026-06-26T10:00:00Z",
+          hw2: "2026-06-23T10:00:00Z",
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it("treats a bucket with no stamp as never collected", () => {
+    expect(
+      classroomSnapshotIsStale({
+        repos,
+        classroom: "cs101",
+        measuredSlugs: slugs,
+        collectedAt: {
+          hw1: "2026-06-21T10:00:00Z",
+        },
+      }),
+    ).toBe(true)
+  })
+
+  // effectiveCollectedAt's rule 2: once ANY bucket is stamped the collector is
+  // stamp-aware, so a missing bucket means never collected and must not borrow
+  // the org-wide run stamp (that run may have swept a different classroom).
+  it("ignores the run fallback once any bucket carries a stamp", () => {
+    expect(
+      classroomSnapshotIsStale({
+        repos,
+        classroom: "cs101",
+        measuredSlugs: slugs,
+        collectedAt: { hw1: "2026-06-26T10:00:00Z" },
+        runCollectedAt: "2026-06-26T10:00:00Z",
+      }),
+    ).toBe(true)
+  })
+
+  it("falls back to the org-wide run stamp for a wholly unstamped file", () => {
+    expect(
+      classroomSnapshotIsStale({
+        repos,
+        classroom: "cs101",
+        measuredSlugs: slugs,
+        collectedAt: {},
+        runCollectedAt: "2026-06-25T10:00:00Z",
+      }),
+    ).toBe(false)
+    expect(
+      classroomSnapshotIsStale({
+        repos,
+        classroom: "cs101",
+        measuredSlugs: slugs,
+        collectedAt: {},
+        runCollectedAt: "2026-06-22T10:00:00Z",
+      }),
+    ).toBe(true)
+  })
+
+  it("applies the sibling-slug guard, so hw1 doesn't absorb hw1-bonus", () => {
+    const withSibling = [
+      repo("cs101-hw1-alice", "2026-06-20T10:00:00Z"),
+      repo("cs101-hw1-bonus-bob", "2026-09-01T10:00:00Z"),
+    ]
+    // hw1's own repos were collected after their push; only hw1-bonus is behind.
+    expect(
+      classroomSnapshotIsStale({
+        repos: withSibling,
+        classroom: "cs101",
+        measuredSlugs: ["hw1", "hw1-bonus"],
+        collectedAt: {
+          hw1: "2026-06-21T10:00:00Z",
+          "hw1-bonus": "2026-09-02T10:00:00Z",
+        },
+      }),
+    ).toBe(false)
+  })
+
+  // An excluded slug (empty_repo) still has to shadow a slug-extending
+  // sibling, so the guard list stays complete while the measured list shrinks.
+  it("keeps the sibling guard complete when a slug is excluded", () => {
+    const withSibling = [
+      repo("cs101-hw1-alice", "2026-06-20T10:00:00Z"),
+      repo("cs101-hw1-bonus-bob", "2026-09-01T10:00:00Z"),
+    ]
+    expect(
+      classroomSnapshotIsStale({
+        repos: withSibling,
+        classroom: "cs101",
+        measuredSlugs: ["hw1"], // hw1-bonus excluded from the question...
+        collectedAt: { hw1: "2026-06-21T10:00:00Z" },
+        allSlugs: ["hw1", "hw1-bonus"], // ...but still guarding hw1's prefix
+      }),
+    ).toBe(false)
+  })
+
+  it("is not stale without a repo list or without assignments", () => {
+    expect(
+      classroomSnapshotIsStale({
+        repos: null,
+        classroom: "cs101",
+        measuredSlugs: slugs,
+        collectedAt: {},
+      }),
+    ).toBe(false)
+    expect(
+      classroomSnapshotIsStale({
+        repos: undefined,
+        classroom: "cs101",
+        measuredSlugs: slugs,
+        collectedAt: {},
+      }),
+    ).toBe(false)
+    expect(
+      classroomSnapshotIsStale({
+        repos,
+        classroom: "cs101",
+        measuredSlugs: [],
+        collectedAt: {},
+      }),
+    ).toBe(false)
+  })
+
+  it("is not stale for an assignment nobody has accepted (no repos)", () => {
+    expect(
+      classroomSnapshotIsStale({
+        repos,
+        classroom: "cs101",
+        measuredSlugs: ["hw3"],
+        collectedAt: {},
+      }),
+    ).toBe(false)
   })
 })
 

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -371,6 +371,61 @@ export function snapshotIsStale(
   return pushMs > collectMs
 }
 
+// Whether ANY assignment in the classroom has a snapshot that is (probably)
+// stale — the classroom-wide counterpart of snapshotIsStale, for the
+// assignments page's freshness line.
+//
+// Compared PER ASSIGNMENT rather than "newest push in the classroom vs newest
+// stamp in the file", which would hide the case this signal exists for: hw1
+// collected a minute ago and hw2 pushed last week but never collected would
+// read as fresh, because hw1's stamp is newer than hw2's push. One assignment
+// out of date makes the classroom's data out of date.
+//
+// `collectedAt` is scores.json's per-bucket stamp map (slug -> ISO), and the
+// per-slug stamp follows the same precedence effectiveCollectedAt documents:
+// once ANY bucket carries a stamp the collector is stamp-aware, so a slug
+// missing from the map was genuinely never collected and must not borrow a
+// sibling's stamp — the org-wide `runCollectedAt` fallback applies only to a
+// wholly unstamped file, written before the collector stamped buckets, where
+// every run was org-wide and the run timestamp is the only signal there is.
+// Borrowing per missing slug instead would resurrect the masking this function
+// exists to prevent. Repo selection runs through latestAssignmentPush, so the
+// sibling-slug guard ("hw1-bonus" under "hw1") applies here too.
+//
+// An options object, like effectiveCollectedAt below: the two slug lists share
+// a type, and positional args let a transposition compile clean while silently
+// re-latching the empty_repo badge this exclusion exists to prevent.
+export function classroomSnapshotIsStale({
+  repos,
+  classroom,
+  measuredSlugs,
+  collectedAt,
+  runCollectedAt = null,
+  allSlugs = measuredSlugs,
+}: {
+  repos: GitHubRepo[] | null | undefined
+  classroom: string
+  // The slugs asked whether they are behind — collectable assignments only.
+  measuredSlugs: string[]
+  collectedAt: Record<string, string> | undefined
+  runCollectedAt?: string | null
+  // Every slug in the classroom, when that differs from the slugs being
+  // measured: the sibling guard needs the complete list even where a slug is
+  // excluded from the question (an empty_repo assignment is never collected,
+  // so it has no stamp to compare against, but its repos still shadow a
+  // slug-extending sibling). Defaults to the measured slugs.
+  allSlugs?: string[]
+}): boolean {
+  if (!repos || measuredSlugs.length === 0) return false
+  const collectorStampsBuckets = Object.keys(collectedAt ?? {}).length > 0
+  return measuredSlugs.some((slug) =>
+    snapshotIsStale(
+      latestAssignmentPush(repos, classroom, slug, allSlugs),
+      collectedAt?.[slug] ?? (collectorStampsBuckets ? null : runCollectedAt),
+    ),
+  )
+}
+
 // Newer of two ISO "last collected" timestamps. Lets the freshness view prefer a
 // just-finished tracked run over the lagging status=completed query, which can
 // still report the prior run while GitHub's Actions list catches up. Null-safe;


### PR DESCRIPTION
## Summary

The assignments page rendered a freshness line but derived no staleness, so it sat permanently in the quiet state however far behind the classroom's snapshot had fallen. It now shows the same **Out of date** badge the submissions page does.

- **Compared per assignment, not classroom-wide.** New `classroomSnapshotIsStale` asks, for each assignment, whether its repos were pushed after the collect that walked *its own* bucket. The aggregate form (newest push vs newest stamp) would report fresh when hw1 was collected a minute ago and hw2 was pushed last week and never collected — there is a regression test named for exactly that.
- **A missing stamp never borrows a sibling's.** Once any bucket is stamped the collector is stamp-aware, so an absent slug means never collected; the org-wide run timestamp stays the fallback only for a wholly unstamped file. This is the precedence `effectiveCollectedAt` already documents (rule 2), applied per bucket instead of re-derived.
- **`empty_repo` assignments are excluded from the question.** `collect_scores.py` skips them outright, so no stamp can ever arrive, while their student repos exist and carry an accept-time push — measured, the badge would latch on with nothing able to clear it. Their slugs still feed the sibling-slug guard, so `hw1` cannot absorb `hw1-bonus`'s repos. `no_autograder` is deliberately *not* excluded: the collector does write its bucket, from detected submissions.
- **Nothing is claimed while the data is loading.** The badge is gated on the scores read, for the same reason the collected line is suppressed there.
- **One shared strip.** The freshness line and badge move to `components/SubmissionFreshnessLine`, used by both collect surfaces, so the markup can't drift the way it had already started to.

Costs nothing on the wire: `AssignmentsTable` already reads the org repo list under the same query key, so this adds no request. A finished collect now also invalidates that key — `pushed_at` is frozen at page load, so the re-read lets the badge re-derive against the post-sweep repo list. (It cannot see a push the sweep itself missed: the collector stamps after its walk, so a push landing mid-sweep reads as collected until the next push or collect — a collector-side limit, noted in the code.)

Closes #737

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - Web: `cd web && npm run check` — passes (4440 unit + 18 browser tests)
  - i18n strict audit — PASS, 0 missing / 0 dead / 0 hardcoded
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror — n/a. `collect_scores.py` is read here, not changed; the `empty_repo` skip it already implements is what the exclusion mirrors.
- [x] If I added or changed a CLI command or flag, I documented it in the wiki — n/a, no CLI surface changed.
- [x] My commits follow Conventional Commits.

## Review notes

A maintainer-side multi-agent review pass produced seven findings, all addressed in this diff: `classroomSnapshotIsStale` now takes an options object (two positional same-typed slug lists invited a silent transposition); the badge is gated on a failed (non-404) scores read, which previously read as "never collected" and claimed staleness from a read that answered nothing; a just-completed tracked sweep now outranks the lagging completed-run query (mirroring the submissions page), so a legacy unstamped file's badge can't relight right after a successful collect; the post-collect invalidation moved into `hooks/useInvalidateAfterCollect` (the `useQueryClient`/`githubKeys` layer rule); the mid-sweep-push comment no longer overclaims what the invalidation covers; the pre-#694-collector `no_autograder` latch is documented as accepted (the skeleton-drift banner already tells that org to update); and four component tests pin the new behaviors plus the sibling-guard wiring.


Originally stacked on #734; now that it has merged, this branch is rebased onto main and the diff is the staleness derivation alone (one commit).

The rebase surfaced one semantic conflict git couldn't flag: after this branch was cut, #734 gained a test asserting the collect button's tooltip switches to `staleHelp` when stale — coverage for the very branch this PR removes. Here the button stays neutral in every state and the **Out of date** badge carries `staleHelp`, so that test now asserts the constant button tooltip and the badge's help text instead (`DataFreshness.test.tsx`).

This branch went through `/simplify` and `/code-review` before opening. Four findings were applied rather than argued with, and two of them were real defects rather than cleanups — the sibling-stamp borrow and the `empty_repo` latch, both of which had passing tests that never exercised the wiring the app actually uses. The tests added for them fail against the previous behaviour; that was verified by reverting the fix, not assumed.

Deliberately left out, noted in #737: `AssignmentsTable` runs an un-memoised per-row `existingGroupRepos` pass on every keystroke in the search box. It is the hotter of the two O(assignments × repos) paths on this page and wants a shared "repos grouped by slug" memo serving both — but it is pre-existing code and not this diff's to widen into.

