### PR TITLE
feat(web): finish Primer alignment follow-ups

### DIFF
--- a/web/src/components/AboutDialog.tsx
+++ b/web/src/components/AboutDialog.tsx
@@ -109,7 +109,7 @@ export const AboutDialog = forwardRef<
               rel="noreferrer"
             >
               v{appVersion.version}
-              <LinkExternalIcon aria-hidden="true" className="size-3" />
+              <LinkExternalIcon aria-hidden="true" className="size-4" />
             </a>
           ) : (
             <>v{appVersion.version}</>
@@ -125,7 +125,7 @@ export const AboutDialog = forwardRef<
             rel="noreferrer"
           >
             {shortCommit()}
-            <LinkExternalIcon aria-hidden="true" className="size-3" />
+            <LinkExternalIcon aria-hidden="true" className="size-4" />
           </a>
           <span className="ms-1 text-base-content/60">
             ({formatBuildDate()})

--- a/web/src/components/GitHubLink.tsx
+++ b/web/src/components/GitHubLink.tsx
@@ -24,7 +24,7 @@ export const GitHubLink = ({
   >
     {showLogo && <MarkGithubIcon className="size-4" aria-hidden="true" />}
     {label}
-    <LinkExternalIcon className="size-3" aria-hidden="true" />
+    <LinkExternalIcon className="size-4" aria-hidden="true" />
   </a>
 )
 

--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -155,6 +155,29 @@ export function SkeletonRegion({
   )
 }
 
+// Placeholder for a settings/detail form while its data loads: label + input
+// bar pairs and an action button, so the loaded form doesn't jump into a
+// layout a centered spinner never hinted at.
+export function FormSkeleton({
+  fields = 4,
+  label,
+}: {
+  fields?: number
+  label?: string
+}) {
+  return (
+    <SkeletonRegion label={label} className="max-w-xl space-y-5">
+      {Array.from({ length: fields }, (_, i) => (
+        <div key={i} className="space-y-1.5">
+          <div className="skeleton skeleton-shimmer h-4 w-28" />
+          <div className="skeleton skeleton-shimmer h-10 w-full rounded-field" />
+        </div>
+      ))}
+      <div className="skeleton skeleton-shimmer h-10 w-28 rounded-field" />
+    </SkeletonRegion>
+  )
+}
+
 // Decorative toolbar placeholder mirroring the list-page Toolbar recipe: a
 // search-box bar on the start side, control pills (selects/toggles/buttons)
 // on the end side. Render inside a SkeletonRegion, which carries the

--- a/web/src/pages/AssignmentSettingsPage.tsx
+++ b/web/src/pages/AssignmentSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { FormSkeleton } from "@/components/list"
 import { Link, useParams, useRouter } from "@tanstack/react-router"
 import { MarkGithubIcon, PeopleIcon } from "@/components/ui/icons"
 import Breadcrumb from "@/components/breadcrumb"
@@ -6,7 +7,6 @@ import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
 import { OrgRepoCreationNotice } from "@/components/OrgRepoCreationNotice"
-import { Spinner } from "@/components/Spinner"
 import { Alert, AnimatedAlert, Button, Card, Heading } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
@@ -56,11 +56,7 @@ const EditAssignmentFormStudent = ({
   const assignmentMode = assignmentData?.mode
 
   if (loadingPublic || loadingRepo) {
-    return (
-      <div className="flex">
-        <Spinner className="m-auto" label={t("assignmentSettings.loading")} />
-      </div>
-    )
+    return <FormSkeleton fields={3} label={t("assignmentSettings.loading")} />
   }
 
   if (!assignmentRepo) {

--- a/web/src/pages/ClassroomSettingsPage.tsx
+++ b/web/src/pages/ClassroomSettingsPage.tsx
@@ -1,9 +1,9 @@
 import Breadcrumb from "@/components/breadcrumb"
+import { FormSkeleton } from "@/components/list"
 import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import MissingParams from "@/components/MissingParams"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
-import { Spinner } from "@/components/Spinner"
 import { useParams } from "@tanstack/react-router"
 import EditClassroomForm from "./classes/EditClassroomForm"
 import ClassroomStaffSection from "./classes/ClassroomStaffSection"
@@ -48,11 +48,7 @@ const EditClassroomContent = ({
   return (
     <LoadingSwap
       loading={loadingClassroom}
-      fallback={
-        <div className="flex">
-          <Spinner className="m-auto" label={t("classes.loadingClassroom")} />
-        </div>
-      }
+      fallback={<FormSkeleton label={t("classes.loadingClassroom")} />}
     >
       {!cl ? (
         <Alert tone="error">{t("classes.couldNotLoad")}</Alert>

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -6,6 +6,7 @@ import { useRevealOnExpand } from "@/hooks/useRevealOnExpand"
 import type { AssignmentForm } from "./assignmentFormModel"
 
 import {
+  FormField,
   Badge,
   Button,
   Collapse,
@@ -43,13 +44,6 @@ const TYPE_OPTIONS = [
 ] as const
 
 type TestErrors = Partial<Record<keyof AssignmentTestDraft, string>>
-
-const FieldError = ({ error, id }: { error?: string; id?: string }) =>
-  error ? (
-    <p id={id} className="text-error text-sm mt-1" role="alert">
-      {error}
-    </p>
-  ) : null
 
 // Editor works on a local copy; nothing reaches the form's `tests` until commit.
 // `mode` routes commit (append vs overwrite at `index`); `baseline` is the
@@ -128,22 +122,22 @@ const AutogradingTestModal = ({
       </div>
 
       <div className="space-y-5">
-        <div>
-          <label htmlFor={field("name")} className="label font-bold">
-            {t("assignments.autograder.testName")}
-          </label>
-          <Input
-            id={field("name")}
-            value={draft.name}
-            onChange={(e) => set("name", e.target.value)}
-            placeholder={t("assignments.autograder.testNamePlaceholder")}
-            invalid={!!errors.name}
-            aria-describedby={
-              errors.name ? `${field("name")}-error` : undefined
-            }
-          />
-          <FieldError error={errors.name} id={`${field("name")}-error`} />
-        </div>
+        <FormField
+          htmlFor={field("name")}
+          label={t("assignments.autograder.testName")}
+          error={errors.name}
+        >
+          {({ id, describedById, invalid }) => (
+            <Input
+              id={id}
+              value={draft.name}
+              onChange={(e) => set("name", e.target.value)}
+              placeholder={t("assignments.autograder.testNamePlaceholder")}
+              invalid={invalid}
+              aria-describedby={describedById}
+            />
+          )}
+        </FormField>
 
         <fieldset>
           <legend className="label font-bold">
@@ -172,133 +166,136 @@ const AutogradingTestModal = ({
           </p>
         </fieldset>
 
-        <div>
-          <label htmlFor={field("setup")} className="label font-bold">
-            {t("assignments.autograder.setupCommand")}
-          </label>
-          <Input
-            id={field("setup")}
-            className="font-mono"
-            value={draft.setup}
-            onChange={(e) => set("setup", e.target.value)}
-            placeholder={t("assignments.autograder.setupCommandPlaceholder")}
-          />
-        </div>
+        <FormField
+          htmlFor={field("setup")}
+          label={t("assignments.autograder.setupCommand")}
+        >
+          {({ id }) => (
+            <Input
+              id={id}
+              className="font-mono"
+              value={draft.setup}
+              onChange={(e) => set("setup", e.target.value)}
+              placeholder={t("assignments.autograder.setupCommandPlaceholder")}
+            />
+          )}
+        </FormField>
 
-        <div>
-          <label htmlFor={field("run")} className="label font-bold">
-            {t("assignments.autograder.runCommand")}
-          </label>
-          <Input
-            id={field("run")}
-            className="font-mono"
-            value={draft.run}
-            onChange={(e) => set("run", e.target.value)}
-            placeholder={t("assignments.autograder.runCommandPlaceholder")}
-            invalid={!!errors.run}
-            aria-describedby={errors.run ? `${field("run")}-error` : undefined}
-          />
-          <FieldError error={errors.run} id={`${field("run")}-error`} />
-        </div>
+        <FormField
+          htmlFor={field("run")}
+          label={t("assignments.autograder.runCommand")}
+          error={errors.run}
+        >
+          {({ id, describedById, invalid }) => (
+            <Input
+              id={id}
+              className="font-mono"
+              value={draft.run}
+              onChange={(e) => set("run", e.target.value)}
+              placeholder={t("assignments.autograder.runCommandPlaceholder")}
+              invalid={invalid}
+              aria-describedby={describedById}
+            />
+          )}
+        </FormField>
 
         {draft.type === "io" && (
           <>
-            <div>
-              <label htmlFor={field("input")} className="label font-bold">
-                {t("assignments.autograder.input")}
-              </label>
-              <Textarea
-                id={field("input")}
-                className="font-mono"
-                value={draft.input}
-                onChange={(e) => set("input", e.target.value)}
-                placeholder={t("assignments.autograder.inputPlaceholder")}
-                rows={3}
-              />
-            </div>
+            <FormField
+              htmlFor={field("input")}
+              label={t("assignments.autograder.input")}
+            >
+              {({ id }) => (
+                <Textarea
+                  id={id}
+                  className="font-mono"
+                  value={draft.input}
+                  onChange={(e) => set("input", e.target.value)}
+                  placeholder={t("assignments.autograder.inputPlaceholder")}
+                  rows={3}
+                />
+              )}
+            </FormField>
 
-            <div>
-              <label htmlFor={field("expected")} className="label font-bold">
-                {t("assignments.autograder.expectedOutput")}
-              </label>
-              <Textarea
-                id={field("expected")}
-                className="font-mono"
-                value={draft.expected}
-                onChange={(e) => set("expected", e.target.value)}
-                placeholder={t(
-                  "assignments.autograder.expectedOutputPlaceholder",
-                )}
-                rows={5}
-                invalid={!!errors.expected}
-                aria-describedby={
-                  errors.expected ? `${field("expected")}-error` : undefined
-                }
-              />
-              <FieldError
-                error={errors.expected}
-                id={`${field("expected")}-error`}
-              />
-            </div>
+            <FormField
+              htmlFor={field("expected")}
+              label={t("assignments.autograder.expectedOutput")}
+              error={errors.expected}
+            >
+              {({ id, describedById, invalid }) => (
+                <Textarea
+                  id={id}
+                  className="font-mono"
+                  value={draft.expected}
+                  onChange={(e) => set("expected", e.target.value)}
+                  placeholder={t(
+                    "assignments.autograder.expectedOutputPlaceholder",
+                  )}
+                  rows={5}
+                  invalid={invalid}
+                  aria-describedby={describedById}
+                />
+              )}
+            </FormField>
 
-            <div>
-              <label htmlFor={field("comparison")} className="label font-bold">
-                {t("assignments.autograder.comparison")}
-              </label>
-              <Select
-                id={field("comparison")}
-                value={draft.comparison}
-                onChange={(e) =>
-                  set("comparison", e.target.value as AssignmentTestComparison)
-                }
-              >
-                <option value="included">
-                  {t("assignments.autograder.comparisonIncluded")}
-                </option>
-                <option value="exact">
-                  {t("assignments.autograder.comparisonExact")}
-                </option>
-                <option value="regex">
-                  {t("assignments.autograder.comparisonRegex")}
-                </option>
-              </Select>
-            </div>
+            <FormField
+              htmlFor={field("comparison")}
+              label={t("assignments.autograder.comparison")}
+            >
+              {({ id }) => (
+                <Select
+                  id={id}
+                  value={draft.comparison}
+                  onChange={(e) =>
+                    set(
+                      "comparison",
+                      e.target.value as AssignmentTestComparison,
+                    )
+                  }
+                >
+                  <option value="included">
+                    {t("assignments.autograder.comparisonIncluded")}
+                  </option>
+                  <option value="exact">
+                    {t("assignments.autograder.comparisonExact")}
+                  </option>
+                  <option value="regex">
+                    {t("assignments.autograder.comparisonRegex")}
+                  </option>
+                </Select>
+              )}
+            </FormField>
           </>
         )}
 
         {draft.type === "run" && (
-          <div className="flex flex-col">
-            <label htmlFor={field("exitCode")} className="label font-bold">
-              {t("assignments.autograder.exitCode")}
-            </label>
-            <Input
-              id={field("exitCode")}
-              className="w-32"
-              type="number"
-              min={0}
-              max={255}
-              step={1}
-              value={draft.exitCode}
-              onChange={(e) =>
-                set(
-                  "exitCode",
-                  e.target.value === "" ? "" : e.target.valueAsNumber,
-                )
-              }
-              placeholder="0"
-              invalid={!!errors.exitCode}
-              aria-describedby={
-                errors.exitCode ? `${field("exitCode")}-error` : undefined
-              }
-            />
-            <p className="text-sm pt-1 text-base-content/70">
-              {t("assignments.autograder.exitCodeHint")}
-            </p>
-            <FieldError
-              error={errors.exitCode}
-              id={`${field("exitCode")}-error`}
-            />
-          </div>
+          <FormField
+            htmlFor={field("exitCode")}
+            label={t("assignments.autograder.exitCode")}
+            error={errors.exitCode}
+            hint={t("assignments.autograder.exitCodeHint")}
+          >
+            {({ id, describedById, invalid }) => (
+              <Input
+                id={id}
+                className="w-32"
+                type="number"
+                min={0}
+                max={255}
+                step={1}
+                value={draft.exitCode}
+                onChange={(e) =>
+                  set(
+                    "exitCode",
+                    e.target.value === "" ? "" : e.target.valueAsNumber,
+                  )
+                }
+                placeholder="0"
+                invalid={invalid}
+                aria-describedby={describedById}
+              />
+            )}
+          </FormField>
         )}
 
         {draft.type === "python" && (
@@ -311,63 +308,58 @@ const AutogradingTestModal = ({
         )}
 
         <div className="flex gap-8">
-          <div className="flex flex-col">
-            <label htmlFor={field("timeout")} className="label font-bold">
-              {t("assignments.autograder.timeout")}
-            </label>
-            <Input
-              id={field("timeout")}
-              className="w-32"
-              type="number"
-              min={0}
-              max={TEST_TIMEOUT_MAX_SECONDS}
-              step={1}
-              value={draft.timeout}
-              onChange={(e) =>
-                set(
-                  "timeout",
-                  e.target.value === "" ? 0 : e.target.valueAsNumber,
-                )
-              }
-              invalid={!!errors.timeout}
-              aria-describedby={
-                errors.timeout ? `${field("timeout")}-error` : undefined
-              }
-            />
-            <p className="text-sm pt-1 text-base-content/70">
-              {t("assignments.autograder.timeoutHint")}
-            </p>
-            <FieldError
-              error={errors.timeout}
-              id={`${field("timeout")}-error`}
-            />
-          </div>
+          <FormField
+            htmlFor={field("timeout")}
+            label={t("assignments.autograder.timeout")}
+            error={errors.timeout}
+            hint={t("assignments.autograder.timeoutHint")}
+          >
+            {({ id, describedById, invalid }) => (
+              <Input
+                id={id}
+                className="w-32"
+                type="number"
+                min={0}
+                max={TEST_TIMEOUT_MAX_SECONDS}
+                step={1}
+                value={draft.timeout}
+                onChange={(e) =>
+                  set(
+                    "timeout",
+                    e.target.value === "" ? 0 : e.target.valueAsNumber,
+                  )
+                }
+                invalid={invalid}
+                aria-describedby={describedById}
+              />
+            )}
+          </FormField>
 
-          <div className="flex flex-col">
-            <label htmlFor={field("points")} className="label font-bold">
-              {t("assignments.autograder.points")}
-            </label>
-            <Input
-              id={field("points")}
-              className="w-32"
-              type="number"
-              min={0}
-              max={1000}
-              step={1}
-              value={draft.points}
-              onChange={(e) =>
-                set(
-                  "points",
-                  e.target.value === "" ? 0 : e.target.valueAsNumber,
-                )
-              }
-              invalid={!!errors.points}
-              aria-describedby={
-                errors.points ? `${field("points")}-error` : undefined
-              }
-            />
-            <FieldError error={errors.points} id={`${field("points")}-error`} />
-          </div>
+          <FormField
+            htmlFor={field("points")}
+            label={t("assignments.autograder.points")}
+            error={errors.points}
+          >
+            {({ id, describedById, invalid }) => (
+              <Input
+                id={id}
+                className="w-32"
+                type="number"
+                min={0}
+                max={1000}
+                step={1}
+                value={draft.points}
+                onChange={(e) =>
+                  set(
+                    "points",
+                    e.target.value === "" ? 0 : e.target.valueAsNumber,
+                  )
+                }
+                invalid={invalid}
+                aria-describedby={describedById}
+              />
+            )}
+          </FormField>
         </div>
       </div>
 

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from "react"
+import { FormSkeleton } from "@/components/list"
 import { useTranslation } from "react-i18next"
 import CreateAssignmentForm, {
   assignmentToFormValues,
@@ -18,7 +19,6 @@ import useGetStudents from "@/hooks/useGetStudents"
 import { assignmentRepoNames } from "@/pages/submissions/dashboard"
 import { ProvisioningChangeConfirmModal } from "@/components/modals/ProvisioningChangeConfirmModal"
 import { LoadingSwap } from "@/lib/LoadingSwap"
-import { Spinner } from "@/components/Spinner"
 import { parseSubmissionTags } from "@/util/submissionTags"
 
 const EditAssignmentForm = ({
@@ -116,9 +116,7 @@ const EditAssignmentForm = ({
     <LoadingSwap
       loading={!defaultData}
       fallback={
-        <div className="flex">
-          <Spinner className="m-auto" label={t("assignmentSettings.loading")} />
-        </div>
+        <FormSkeleton fields={6} label={t("assignmentSettings.loading")} />
       }
     >
       {defaultData ? (

--- a/web/src/pages/orgActivity/TimelineRow.tsx
+++ b/web/src/pages/orgActivity/TimelineRow.tsx
@@ -100,7 +100,7 @@ export function TimelineRow({ item }: { item: TimelineItem }) {
               {item.label}
               <LinkExternalIcon
                 aria-hidden="true"
-                className="size-3 opacity-60"
+                className="size-4 opacity-60"
               />
             </a>
           ) : (

--- a/web/src/pages/orgSettings/OrgActionsSection.tsx
+++ b/web/src/pages/orgSettings/OrgActionsSection.tsx
@@ -107,7 +107,7 @@ const ActionsUsagePanel = ({ org }: { org: string }) => {
             className="inline-flex items-center gap-0.5 text-base-content/60 hover:text-primary"
           >
             {t("orgSettings.actions.budgetManage")}
-            <LinkExternalIcon aria-hidden="true" className="size-3" />
+            <LinkExternalIcon aria-hidden="true" className="size-4" />
           </a>
         </p>
       )}
@@ -188,7 +188,7 @@ const OrgActionsSection = ({
           className="inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
         >
           {t("orgSettings.actions.openSettings")}
-          <LinkExternalIcon aria-hidden="true" className="size-3" />
+          <LinkExternalIcon aria-hidden="true" className="size-4" />
         </a>
       }
     >

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -177,7 +177,7 @@ export function ConcernRow({
             className="mt-1 inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
           >
             {t("orgSettings.audit.viewOnGitHub")}
-            <LinkExternalIcon aria-hidden="true" className="size-3" />
+            <LinkExternalIcon aria-hidden="true" className="size-4" />
           </a>
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -223,7 +223,7 @@ export function ConcernRow({
               className="link inline-flex items-center gap-0.5"
             >
               {t("orgSettings.audit.gitHub")}
-              <LinkExternalIcon aria-hidden="true" className="size-3" />
+              <LinkExternalIcon aria-hidden="true" className="size-4" />
             </a>
             {showFix ? t("orgSettings.audit.orUseFixIt") : ""}:
           </p>
@@ -269,7 +269,7 @@ function RecommendationRow({
           className="mt-1 inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
         >
           {t("orgSettings.audit.viewOnGitHub")}
-          <LinkExternalIcon aria-hidden="true" className="size-3" />
+          <LinkExternalIcon aria-hidden="true" className="size-4" />
         </a>
       </div>
       <div className="flex shrink-0 items-center gap-2">
@@ -401,7 +401,7 @@ function AuditBody({
                     className="mt-1 inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
                   >
                     {t("orgSettings.audit.viewOnGitHub")}
-                    <LinkExternalIcon aria-hidden="true" className="size-3" />
+                    <LinkExternalIcon aria-hidden="true" className="size-4" />
                   </a>
                 </div>
                 <Badge tone="warning" className="shrink-0">

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -560,7 +560,7 @@ const RosterMemberModal = ({
                     className="size-4 opacity-70"
                   />
                   <span className="font-mono">@{row.username}</span>
-                  <LinkExternalIcon aria-hidden="true" className="size-3" />
+                  <LinkExternalIcon aria-hidden="true" className="size-4" />
                 </a>
               ) : row.email ? (
                 <span className="text-sm text-base-content/70">


### PR DESCRIPTION
## Summary

Closes out the parked items from the Primer alignment series (#723, #725, #726, #727, #728, #729, #730):

- **Autograder test-editor modal onto `FormField`**: all 9 label+control fields converted, the modal's private `FieldError` recipe deleted, and the exit-code/timeout hints — previously visible but never programmatically linked — now ride `FormField`'s `hint` slot with `aria-describedby`. The test-type radio group stays a `fieldset`/`legend`.
- **`FormSkeleton`** (in `components/list`): the last three centered-spinner form swaps (`ClassroomSettingsPage`, `EditAssignmentForm` via `LoadingSwap`, `AssignmentSettingsPage` early return) now show label + input-bar pairs with an action placeholder, removing the spinner→form layout jump the loading pattern warns about. The original loading labels are preserved as the region's sr-only announcement.
- **12px icon review concluded** (deviation parked in #723): trailing `link-external` markers next to `text-sm` links (shared `GitHubLink`, About dialog, org settings/audit links, roster modal, activity timeline) move to the designated 16px; icons inside badges, chips, and `text-xs` metas stay at 12px as condensed contexts — a documented deliberate deviation, since Octicons' six designated 12px glyphs don't cover those cases.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 4422 tests incl. the autograder modal suite) passes
- [ ] Visual spot-check: autograder test editor modal, classroom/assignment settings loading states, GitHub deep-links