### PR TITLE
feat(web): add clone-submissions CLI command dialog to gradebook

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2806,6 +2806,16 @@
       "failedTitle": "These submissions couldn't be downloaded:",
       "failedHint": "This is often a transient GitHub error — run the action again to retry."
     },
+    "cloneAll": {
+      "buttonTitle": "Clone all submissions with the CLI",
+      "heading": "Clone all submissions",
+      "subheading": "Run this command in your terminal to clone every student repository for this assignment into a local folder.",
+      "copyCli": "Copy CLI command",
+      "copied": "Copied",
+      "needCli": "Need the teacher CLI?",
+      "installHint": "Install the GitHub CLI, then add the teacher extension:",
+      "copyInstall": "Copy install command"
+    },
     "bulkAccess": {
       "menuLabel": "Update student repo access",
       "menuTitle": "Change every student's role on their own repository",

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
-import { AlertIcon, CalendarIcon } from "@/components/ui/icons"
+import { AlertIcon, CalendarIcon, DownloadIcon } from "@/components/ui/icons"
 import Papa from "papaparse"
 
 import { useQueryClient } from "@tanstack/react-query"
@@ -10,7 +10,14 @@ import Breadcrumb from "@/components/breadcrumb"
 import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import MissingParams from "@/components/MissingParams"
-import { Alert, Badge, HelpTooltip, MetricBar, Spinner } from "@/components/ui"
+import {
+  Alert,
+  Badge,
+  Button,
+  HelpTooltip,
+  MetricBar,
+  Spinner,
+} from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import SubmissionsTable from "@/pages/submissions/SubmissionsTable"
 import SubmissionsControls from "@/pages/submissions/SubmissionsControls"
@@ -19,6 +26,7 @@ import { AcceptLinkModal } from "@/pages/submissions/AcceptLinkModal"
 import { MetricsModal } from "@/pages/submissions/MetricsModal"
 import { OpenAllFeedbackPrsModal } from "@/pages/submissions/OpenAllFeedbackPrsModal"
 import { DownloadAllSubmissionsModal } from "@/pages/submissions/DownloadAllSubmissionsModal"
+import { CloneSubmissionsModal } from "@/pages/submissions/CloneSubmissionsModal"
 import { BulkRepoAccessModal } from "@/components/modals/BulkRepoAccessModal"
 import { CloseSubmissionModal } from "@/components/modals/CloseSubmissionModal"
 import { BulkRepoFeaturesModal } from "@/components/modals/BulkRepoFeaturesModal"
@@ -302,6 +310,9 @@ const SubmissionsPageContent = () => {
   const assignmentSubmitCli =
     `gh student accept ${org} ${classroom} ${assignment}` +
     (secret ? ` --key ${secret}` : "")
+  // Clones every student repo for this assignment — the git-friendly
+  // counterpart of the in-browser zip download (see CloneSubmissionsModal).
+  const cloneSubmissionsCli = `gh teacher download ${org} ${classroom} ${assignment}`
 
   // Toolbar modals: metrics + accept-link are consolidated behind buttons so
   // the roster surfaces near the top instead of below stat cards and the
@@ -310,6 +321,7 @@ const SubmissionsPageContent = () => {
   const [acceptOpen, setAcceptOpen] = useState(false)
   const [openAllPrsOpen, setOpenAllPrsOpen] = useState(false)
   const [downloadAllOpen, setDownloadAllOpen] = useState(false)
+  const [cloneCliOpen, setCloneCliOpen] = useState(false)
   const [bulkAccessOpen, setBulkAccessOpen] = useState(false)
   const [bulkFeaturesOpen, setBulkFeaturesOpen] = useState(false)
   const [bulkTriggerOpen, setBulkTriggerOpen] = useState(false)
@@ -1265,124 +1277,139 @@ const SubmissionsPageContent = () => {
             )
           }
           trailing={
-            <SubmissionsActionsMenu
-              collecting={collecting}
-              regrading={regrading}
-              regradeAllActive={regradeAllActive}
-              canRegradeAll={canRegradeAll}
-              emptyRoster={emptyRoster.show}
-              skipsGrading={skipsGrading}
-              // Metrics summarizes the GRADED snapshot, and computeStats skips
-              // every `pending` row — so hide it whenever an overlay is adding
-              // those rows, live or detection. Keying this on liveCapable alone
-              // left it reachable for a no_autograder assignment, where detection
-              // supplies every row: the modal would report 0 submitted while the
-              // table listed detected submitters right next to it.
-              onMetrics={
-                overlayCapable ? undefined : () => setMetricsOpen(true)
-              }
-              onCollect={() => collectScores.collect()}
-              onRegradeAll={() => setRegradeConfirmOpen(true)}
-              // Bulk-open Feedback PRs: owner-only (needs admin on every repo,
-              // like the live reads), never for empty_repo (no PRs). A
-              // no_autograder repo is templated and PERMITS the Feedback PR, so
-              // it is gated on empty_repo only, not on skipsGrading.
-              onOpenAllPrs={
-                isOwner &&
-                !isEmptyRepoAssignment &&
-                allAssignmentRepos.length > 0
-                  ? () => setOpenAllPrsOpen(true)
-                  : undefined
-              }
-              viewHref={viewRun?.html_url || viewWorkflowUrl}
-              viewLabel={viewLabel}
-              onDownloadCsv={downloadScoresCsv}
-              downloadDisabled={!scoresInfo.length && !nonSubmitters.length}
-              onDownloadAll={() => setDownloadAllOpen(true)}
-              downloadAllDisabled={downloadableOwners.length === 0}
-              // Bulk set student repo access: owner-only (needs admin on every
-              // repo), individual assignments only (a group repo's membership is
-              // founder-managed), never empty_repo, and only when repos exist.
-              onBulkAccess={
-                isOwner &&
-                !isGroupAssignment &&
-                !isEmptyRepoAssignment &&
-                acceptedSet.size > 0
-                  ? () => setBulkAccessOpen(true)
-                  : undefined
-              }
-              // Bulk set repo features: same gate as bulk access. Reconciles
-              // existing repos with the assignment's repo_features (which apply at
-              // accept-time only).
-              onBulkFeatures={
-                isOwner &&
-                !isGroupAssignment &&
-                !isEmptyRepoAssignment &&
-                acceptedSet.size > 0
-                  ? () => setBulkFeaturesOpen(true)
-                  : undefined
-              }
-              // Bulk retrofit autograding triggers: same gate as bulk features
-              // plus default-autograder only — teacher-authored (custom) shims
-              // are never rewritten, and a no_autograder assignment has no shim
-              // to retrofit (skipsGrading). Reconciles existing repos with the
-              // assignment's submission_mode (baked into shims at accept time).
-              // Requires a resolved entry — see assignmentResolved.
-              onBulkTrigger={
-                isOwner &&
-                !isGroupAssignment &&
-                !skipsGrading &&
-                assignmentResolved &&
-                isDefaultAutograder(assignmentInfo.autograder) &&
-                acceptedSet.size > 0
-                  ? () => setBulkTriggerOpen(true)
-                  : undefined
-              }
-              // Pause / Resume autograding across every accepted repo — flips each
-              // autograde workflow's Actions state (no file edit). Same gate as
-              // the trigger retrofit (owner + individual + resolved default
-              // autograder + accepted repos exist).
-              onBulkPause={
-                isOwner &&
-                !isGroupAssignment &&
-                !skipsGrading &&
-                assignmentResolved &&
-                isDefaultAutograder(assignmentInfo.autograder) &&
-                acceptedSet.size > 0
-                  ? () => setBulkPauseOpen(true)
-                  : undefined
-              }
-              onBulkResume={
-                isOwner &&
-                !isGroupAssignment &&
-                !skipsGrading &&
-                assignmentResolved &&
-                isDefaultAutograder(assignmentInfo.autograder) &&
-                acceptedSet.size > 0
-                  ? () => setBulkResumeOpen(true)
-                  : undefined
-              }
-              locked={isLockedAssignment}
-              lockPending={setLock.isPending}
-              // Lock/unlock is an authoring-tier action (teacher|hta), same gate
-              // as Regrade all; a plain TA doesn't see it (GitHub 403s them too).
-              onLockToggle={
-                canRegradeAll ? () => setLockConfirmOpen(true) : undefined
-              }
-              closed={isClosedAssignment}
-              // Close/reopen submission: authoring tier + individual, non-empty
-              // repo shape (a group repo's membership is founder-managed). Unlike
-              // bulk access it does NOT require acceptedSet.size > 0 — closing
-              // still blocks future accepts when no one has accepted yet.
-              onCloseToggle={
-                canRegradeAll &&
-                isOwner &&
-                !isGroupAssignment &&
-                !isEmptyRepoAssignment
-                  ? () => setCloseSubmissionOpen(true)
-                  : undefined
-              }
-            />
+            <>
+              <SubmissionsActionsMenu
+                collecting={collecting}
+                regrading={regrading}
+                regradeAllActive={regradeAllActive}
+                canRegradeAll={canRegradeAll}
+                emptyRoster={emptyRoster.show}
+                skipsGrading={skipsGrading}
+                // Metrics summarizes the GRADED snapshot, and computeStats skips
+                // every `pending` row — so hide it whenever an overlay is adding
+                // those rows, live or detection. Keying this on liveCapable alone
+                // left it reachable for a no_autograder assignment, where detection
+                // supplies every row: the modal would report 0 submitted while the
+                // table listed detected submitters right next to it.
+                onMetrics={
+                  overlayCapable ? undefined : () => setMetricsOpen(true)
+                }
+                onCollect={() => collectScores.collect()}
+                onRegradeAll={() => setRegradeConfirmOpen(true)}
+                // Bulk-open Feedback PRs: owner-only (needs admin on every repo,
+                // like the live reads), never for empty_repo (no PRs). A
+                // no_autograder repo is templated and PERMITS the Feedback PR, so
+                // it is gated on empty_repo only, not on skipsGrading.
+                onOpenAllPrs={
+                  isOwner &&
+                  !isEmptyRepoAssignment &&
+                  allAssignmentRepos.length > 0
+                    ? () => setOpenAllPrsOpen(true)
+                    : undefined
+                }
+                viewHref={viewRun?.html_url || viewWorkflowUrl}
+                viewLabel={viewLabel}
+                onDownloadCsv={downloadScoresCsv}
+                downloadDisabled={!scoresInfo.length && !nonSubmitters.length}
+                onDownloadAll={() => setDownloadAllOpen(true)}
+                downloadAllDisabled={downloadableOwners.length === 0}
+                // Bulk set student repo access: owner-only (needs admin on every
+                // repo), individual assignments only (a group repo's membership is
+                // founder-managed), never empty_repo, and only when repos exist.
+                onBulkAccess={
+                  isOwner &&
+                  !isGroupAssignment &&
+                  !isEmptyRepoAssignment &&
+                  acceptedSet.size > 0
+                    ? () => setBulkAccessOpen(true)
+                    : undefined
+                }
+                // Bulk set repo features: same gate as bulk access. Reconciles
+                // existing repos with the assignment's repo_features (which apply at
+                // accept-time only).
+                onBulkFeatures={
+                  isOwner &&
+                  !isGroupAssignment &&
+                  !isEmptyRepoAssignment &&
+                  acceptedSet.size > 0
+                    ? () => setBulkFeaturesOpen(true)
+                    : undefined
+                }
+                // Bulk retrofit autograding triggers: same gate as bulk features
+                // plus default-autograder only — teacher-authored (custom) shims
+                // are never rewritten, and a no_autograder assignment has no shim
+                // to retrofit (skipsGrading). Reconciles existing repos with the
+                // assignment's submission_mode (baked into shims at accept time).
+                // Requires a resolved entry — see assignmentResolved.
+                onBulkTrigger={
+                  isOwner &&
+                  !isGroupAssignment &&
+                  !skipsGrading &&
+                  assignmentResolved &&
+                  isDefaultAutograder(assignmentInfo.autograder) &&
+                  acceptedSet.size > 0
+                    ? () => setBulkTriggerOpen(true)
+                    : undefined
+                }
+                // Pause / Resume autograding across every accepted repo — flips each
+                // autograde workflow's Actions state (no file edit). Same gate as
+                // the trigger retrofit (owner + individual + resolved default
+                // autograder + accepted repos exist).
+                onBulkPause={
+                  isOwner &&
+                  !isGroupAssignment &&
+                  !skipsGrading &&
+                  assignmentResolved &&
+                  isDefaultAutograder(assignmentInfo.autograder) &&
+                  acceptedSet.size > 0
+                    ? () => setBulkPauseOpen(true)
+                    : undefined
+                }
+                onBulkResume={
+                  isOwner &&
+                  !isGroupAssignment &&
+                  !skipsGrading &&
+                  assignmentResolved &&
+                  isDefaultAutograder(assignmentInfo.autograder) &&
+                  acceptedSet.size > 0
+                    ? () => setBulkResumeOpen(true)
+                    : undefined
+                }
+                locked={isLockedAssignment}
+                lockPending={setLock.isPending}
+                // Lock/unlock is an authoring-tier action (teacher|hta), same gate
+                // as Regrade all; a plain TA doesn't see it (GitHub 403s them too).
+                onLockToggle={
+                  canRegradeAll ? () => setLockConfirmOpen(true) : undefined
+                }
+                closed={isClosedAssignment}
+                // Close/reopen submission: authoring tier + individual, non-empty
+                // repo shape (a group repo's membership is founder-managed). Unlike
+                // bulk access it does NOT require acceptedSet.size > 0 — closing
+                // still blocks future accepts when no one has accepted yet.
+                onCloseToggle={
+                  canRegradeAll &&
+                  isOwner &&
+                  !isGroupAssignment &&
+                  !isEmptyRepoAssignment
+                    ? () => setCloseSubmissionOpen(true)
+                    : undefined
+                }
+              />
+              {/* Clone submissions (CLI) — icon-only so the toolbar stays
+                  compact; opens a modal with the `gh teacher download`
+                  command. See https://github.com/foundation50/classroom50/issues/724. */}
+              <Button
+                variant="outline"
+                size="sm"
+                shape="square"
+                title={t("submissions.cloneAll.buttonTitle")}
+                aria-label={t("submissions.cloneAll.buttonTitle")}
+                onClick={() => setCloneCliOpen(true)}
+              >
+                <DownloadIcon aria-hidden="true" className="size-4" />
+              </Button>
+            </>
           }
         />
         <SubmissionsTable
@@ -1602,6 +1629,11 @@ const SubmissionsPageContent = () => {
         assignment={assignment}
         assignmentName={assignmentInfo?.name ?? assignment}
         owners={downloadableOwners}
+      />
+      <CloneSubmissionsModal
+        open={cloneCliOpen}
+        onClose={() => setCloneCliOpen(false)}
+        cli={cloneSubmissionsCli}
       />
       <BulkRepoAccessModal
         open={bulkAccessOpen}

--- a/web/src/pages/submissions/CloneSubmissionsModal.tsx
+++ b/web/src/pages/submissions/CloneSubmissionsModal.tsx
@@ -1,0 +1,79 @@
+import { ChevronRightIcon, TerminalIcon } from "@/components/ui/icons"
+import { useTranslation } from "react-i18next"
+
+import { CopyableCode, Heading, Modal, rtlFlip } from "@/components/ui"
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
+
+// Published extension repo (see CONTRIBUTING.md "Distribution"), where
+// `gh extension install` resolves the teacher CLI.
+const INSTALL_CLI = "gh extension install foundation50/gh-teacher"
+
+// Shows the `gh teacher download` command that clones every student repo for
+// this assignment — the CLI counterpart of the in-browser zip download, for
+// teachers who grade locally with git. Owns its own clipboard state (two
+// independent copy buttons) so the page stays uninvolved.
+export function CloneSubmissionsModal({
+  open,
+  onClose,
+  cli,
+}: {
+  open: boolean
+  onClose: () => void
+  cli: string
+}) {
+  const { t } = useTranslation()
+  const { copied: copiedCli, copy: copyCli } = useCopyToClipboard(cli, 1500)
+  const { copied: copiedInstall, copy: copyInstall } = useCopyToClipboard(
+    INSTALL_CLI,
+    1500,
+  )
+
+  return (
+    <Modal open={open} onClose={onClose} size="2xl">
+      <div className="flex items-start gap-3">
+        <div className="rounded-box bg-primary/10 p-2.5 text-primary">
+          <TerminalIcon aria-hidden="true" className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <Heading as="h3">{t("submissions.cloneAll.heading")}</Heading>
+          <p className="text-sm text-base-content/70">
+            {t("submissions.cloneAll.subheading")}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-4">
+        <CopyableCode
+          value={cli}
+          copied={copiedCli}
+          onCopy={copyCli}
+          label={t("submissions.cloneAll.copyCli")}
+          copiedLabel={t("submissions.cloneAll.copied")}
+        />
+
+        <details className="group/install">
+          <summary className="flex w-fit cursor-pointer list-none items-center gap-1 text-sm text-base-content/70 hover:text-base-content">
+            <ChevronRightIcon
+              aria-hidden="true"
+              className={`size-4 transition-transform ${rtlFlip} group-open/install:rotate-90`}
+            />
+            {t("submissions.cloneAll.needCli")}
+          </summary>
+          <p className="mt-2 text-sm text-base-content/70">
+            {t("submissions.cloneAll.installHint")}
+          </p>
+          <CopyableCode
+            className="mt-2"
+            value={INSTALL_CLI}
+            copied={copiedInstall}
+            onCopy={copyInstall}
+            label={t("submissions.cloneAll.copyInstall")}
+            copiedLabel={t("submissions.cloneAll.copied")}
+          />
+        </details>
+      </div>
+    </Modal>
+  )
+}
+
+export default CloneSubmissionsModal


### PR DESCRIPTION
## Summary

Teachers can now grab the CLI command that clones every student repository for an assignment straight from the gradebook — the git-friendly counterpart to the in-browser zip download, matching the option the old GitHub Classroom UI offered. An icon-only button to the right of the Actions menu opens a dialog with a copyable `gh teacher download <org> <classroom> <assignment>` command, plus a collapsible install snippet (`gh extension install foundation50/gh-teacher`) for teachers who don't have the extension yet.

No CLI-side changes: `gh teacher download` already exists; this surfaces it in the web app. The dialog follows the existing `AcceptLinkModal` pattern (`Modal` + `CopyableCode` + `useCopyToClipboard`), and all strings go through `t()` with a new `submissions.cloneAll` block in `en.json`.

Closes #724

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - Web: `cd web && npm run check` (tsc, eslint, prettier, depcruise, vitest — 4422 tests passed) plus `audit_i18n.py --strict`
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass. _(n/a — no contract changes)_
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README). _(n/a — no CLI changes)_
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
