### PR TITLE
feat(web): link the feedback PR directly from submission rows

### DIFF
--- a/web/src/components/submissions/SubmissionDetailsModal.tsx
+++ b/web/src/components/submissions/SubmissionDetailsModal.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useId, useRef } from "react"
 import { useTranslation } from "react-i18next"
-import { GitCommitIcon, MarkGithubIcon, TagIcon } from "@/components/ui/icons"
+import {
+  GitCommitIcon,
+  MarkGithubIcon,
+  RepoIcon,
+  TagIcon,
+} from "@/components/ui/icons"
 
 import { Button, Modal, MonoLtr, Heading } from "@/components/ui"
 
@@ -96,12 +101,12 @@ export function SubmissionDetailsModal({
           rel="noreferrer"
           title={t("submissions.details.viewRepository")}
         >
-          <MarkGithubIcon aria-hidden="true" className="size-4 shrink-0" />
+          <RepoIcon aria-hidden="true" className="size-4 shrink-0" />
           <MonoLtr className="truncate text-sm">{repo}</MonoLtr>
         </a>
       ) : (
         <p className="mt-2 inline-flex w-fit max-w-full items-center gap-1.5 text-base-content/50">
-          <MarkGithubIcon aria-hidden="true" className="size-4 shrink-0" />
+          <RepoIcon aria-hidden="true" className="size-4 shrink-0" />
           <MonoLtr className="truncate text-sm">{repo}</MonoLtr>
         </p>
       )}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2687,6 +2687,8 @@
       "members": "Members",
       "openRepoLabel": "Open repository {{repo}}",
       "viewRepo": "View repo",
+      "openFeedbackPrLabel": "Open feedback pull request for {{repo}}",
+      "viewFeedbackPr": "View feedback PR",
       "manageAccess": "Manage repository access",
       "manageAccessAria": "Manage repository access for {{owner}}",
       "viewCommit": "View latest commit",

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useId, useMemo, useRef } from "react"
 import { useTranslation } from "react-i18next"
-import { MarkGithubIcon, PeopleIcon } from "@/components/ui/icons"
+import { PeopleIcon, RepoIcon } from "@/components/ui/icons"
 
 import { Badge, Modal, MonoLtr, Heading } from "@/components/ui"
 import useGetRepo from "@/hooks/useGetRepo"
@@ -331,12 +331,12 @@ export const ManageSubmissionModal = ({
           rel="noreferrer"
           title={t("submissions.table.viewRepo")}
         >
-          <MarkGithubIcon aria-hidden="true" className="size-4 shrink-0" />
+          <RepoIcon aria-hidden="true" className="size-4 shrink-0" />
           <MonoLtr className="truncate text-sm">{repo}</MonoLtr>
         </a>
       ) : (
         <p className="mt-2 inline-flex w-fit max-w-full items-center gap-1.5 text-base-content/50">
-          <MarkGithubIcon aria-hidden="true" className="size-4 shrink-0" />
+          <RepoIcon aria-hidden="true" className="size-4 shrink-0" />
           <MonoLtr className="truncate text-sm">{repo}</MonoLtr>
         </p>
       )}

--- a/web/src/pages/submissions/ReviewButton.tsx
+++ b/web/src/pages/submissions/ReviewButton.tsx
@@ -1,5 +1,5 @@
-import { CommentIcon } from "@/components/ui/icons"
-import { useId, useRef, useState } from "react"
+import { CodeReviewIcon } from "@/components/ui/icons"
+import { useId, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 
 import { Button, Modal, MonoLtr, Heading } from "@/components/ui"
@@ -9,31 +9,42 @@ import useRepairFeedbackPr from "@/hooks/mutations/useRepairFeedbackPr"
 import { ActionListRow } from "@/pages/submissions/actionLayout"
 import type { AssignmentMode } from "@/types/classroom"
 
-// Review action: links to the open Feedback PR (opened at accept time, or by
-// the autograde runner) when one exists; when none does, offers a teacher-side
-// Repair that re-runs the same idempotent ensure flow with the teacher's token
-// (issue #347 — recovers a PR a student's accept-time attempt failed to open).
-// The PR is the source of truth. The /pulls lookup is deferred until Review is
-// clicked (an eager per-row query would fan out to one request per repo on
-// mount); on click we refetch.
-export const ReviewButton = ({
+// The Feedback-PR action: links to the open Feedback PR (opened at accept
+// time, or by the autograde runner) when one exists; when none does, offers a
+// teacher-side Repair that re-runs the same idempotent ensure flow with the
+// teacher's token (issue #347 — recovers a PR a student's accept-time attempt
+// failed to open). The PR is the source of truth. The /pulls lookup is
+// deferred until the trigger is clicked (an eager per-row query would fan out
+// to one request per repo on mount); on click we refetch.
+//
+// The trigger rendering is a render prop so the hub's Review row and the
+// table's per-row icon (issue #741) share one resolve/repair flow.
+export const FeedbackPrAction = ({
   org,
   repo,
   mode,
   noRepo = false,
+  trigger,
 }: {
   org: string
   repo: string
   mode: AssignmentMode
   // No assignment repo exists yet (never-accepted non-submitter): there can be
-  // no Feedback PR to review or repair, so render the row disabled.
+  // no Feedback PR to review or repair, so the trigger renders disabled.
   noRepo?: boolean
+  trigger: (props: {
+    onClick: () => void
+    resolving: boolean
+  }) => React.ReactNode
 }) => {
   const { t } = useTranslation()
   const { notify } = useToast()
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
   const titleId = useId()
   const [resolving, setResolving] = useState(false)
+  // The empty/error modal is mounted on demand (controlled `open`), not per
+  // trigger: the table renders one action per row, and a hidden <dialog> per
+  // row would be dead DOM weight on large rosters.
+  const [modalOpen, setModalOpen] = useState(false)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   // enabled: false — driven by refetch() on click, never on mount.
   const { refetch } = useGetFeedbackPr(org, repo, false)
@@ -48,12 +59,12 @@ export const ReviewButton = ({
       const { data: pr, error } = await refetch()
       if (error) {
         setErrorMsg(error instanceof Error ? error.message : String(error))
-        dialogRef.current?.showModal()
+        setModalOpen(true)
       } else if (pr) {
         window.open(pr.html_url, "_blank", "noopener,noreferrer")
       } else {
         setErrorMsg(null)
-        dialogRef.current?.showModal()
+        setModalOpen(true)
       }
     } finally {
       setResolving(false)
@@ -95,7 +106,7 @@ export const ReviewButton = ({
                 ? t("submissions.repairPr.created", { repo })
                 : t("submissions.repairPr.alreadyExists", { repo }),
             })
-            dialogRef.current?.close()
+            setModalOpen(false)
             // The PR now exists (created or adopted): resolve and open it.
             const { data: pr } = await refetch()
             if (pr) window.open(pr.html_url, "_blank", "noopener,noreferrer")
@@ -112,78 +123,175 @@ export const ReviewButton = ({
 
   return (
     <>
-      <ActionListRow
-        icon={CommentIcon}
-        title={t("submissions.table.review")}
-        description={t("submissions.manageModal.reviewDescription")}
-        onClick={handleReview}
-        disabled={noRepo}
-        loading={resolving}
-        loadingLabel={t("submissions.table.review")}
-        ariaLabel={t("submissions.table.reviewAria")}
-      />
-      <Modal
-        dialogRef={dialogRef}
-        size="md"
-        hideCloseButton
-        aria-labelledby={titleId}
-      >
-        {errorMsg ? (
-          <>
-            <Heading as="h3" id={titleId}>
-              {t("submissions.reviewModal.errorTitle")}
-            </Heading>
-            <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-base-content/70">
-              {errorMsg}
-            </p>
-          </>
-        ) : (
-          <>
-            <Heading as="h3" id={titleId}>
-              {t("submissions.reviewModal.emptyTitle")}
-            </Heading>
-            <p className="mt-2 text-sm leading-6 text-base-content/70">
-              <Trans
-                i18nKey="submissions.reviewModal.emptyBody"
-                values={{ repo }}
-                components={{ repo: <MonoLtr /> }}
-              />
-            </p>
-            <p className="mt-3 text-sm leading-6 text-base-content/70">
-              {t("submissions.repairPr.hint")}
-            </p>
-          </>
-        )}
-        <div className="modal-action">
-          <a
-            className="btn btn-ghost btn-sm"
-            href={`https://github.com/${org}/${repo}/pulls`}
-            target="_blank"
-            rel="noreferrer"
-          >
-            {t("submissions.reviewModal.openRepoPrs")}
-          </a>
-          {!errorMsg && (
-            <Button
-              size="sm"
-              loading={repair.isPending}
-              loadingLabel={t("submissions.repairPr.repairing")}
-              onClick={handleRepair}
-            >
-              {t("submissions.repairPr.repair")}
-            </Button>
+      {trigger({ onClick: () => void handleReview(), resolving })}
+      {modalOpen && (
+        <Modal
+          open
+          onClose={() => setModalOpen(false)}
+          size="md"
+          hideCloseButton
+          aria-labelledby={titleId}
+        >
+          {errorMsg ? (
+            <>
+              <Heading as="h3" id={titleId}>
+                {t("submissions.reviewModal.errorTitle")}
+              </Heading>
+              <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-base-content/70">
+                {errorMsg}
+              </p>
+            </>
+          ) : (
+            <>
+              <Heading as="h3" id={titleId}>
+                {t("submissions.reviewModal.emptyTitle")}
+              </Heading>
+              <p className="mt-2 text-sm leading-6 text-base-content/70">
+                <Trans
+                  i18nKey="submissions.reviewModal.emptyBody"
+                  values={{ repo }}
+                  components={{ repo: <MonoLtr /> }}
+                />
+              </p>
+              <p className="mt-3 text-sm leading-6 text-base-content/70">
+                {t("submissions.repairPr.hint")}
+              </p>
+            </>
           )}
-          <Button
-            variant={errorMsg ? undefined : "ghost"}
-            size="sm"
-            disabled={repair.isPending}
-            onClick={() => dialogRef.current?.close()}
-          >
-            {t("common.close")}
-          </Button>
-        </div>
-      </Modal>
+          <div className="modal-action">
+            <a
+              className="btn btn-ghost btn-sm"
+              href={`https://github.com/${org}/${repo}/pulls`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t("submissions.reviewModal.openRepoPrs")}
+            </a>
+            {!errorMsg && (
+              <Button
+                size="sm"
+                loading={repair.isPending}
+                loadingLabel={t("submissions.repairPr.repairing")}
+                onClick={handleRepair}
+              >
+                {t("submissions.repairPr.repair")}
+              </Button>
+            )}
+            <Button
+              variant={errorMsg ? undefined : "ghost"}
+              size="sm"
+              disabled={repair.isPending}
+              onClick={() => setModalOpen(false)}
+            >
+              {t("common.close")}
+            </Button>
+          </div>
+        </Modal>
+      )}
     </>
+  )
+}
+
+// The submission hub's Review row: the labeled-list rendering of the shared
+// Feedback-PR action.
+export const ReviewButton = ({
+  org,
+  repo,
+  mode,
+  noRepo = false,
+}: {
+  org: string
+  repo: string
+  mode: AssignmentMode
+  noRepo?: boolean
+}) => {
+  const { t } = useTranslation()
+  return (
+    <FeedbackPrAction
+      org={org}
+      repo={repo}
+      mode={mode}
+      noRepo={noRepo}
+      trigger={({ onClick, resolving }) => (
+        <ActionListRow
+          icon={CodeReviewIcon}
+          title={t("submissions.table.review")}
+          description={t("submissions.manageModal.reviewDescription")}
+          onClick={onClick}
+          disabled={noRepo}
+          loading={resolving}
+          loadingLabel={t("submissions.table.review")}
+          ariaLabel={t("submissions.table.reviewAria")}
+        />
+      )}
+    />
+  )
+}
+
+// Per-row Feedback-PR shortcut (issue #741): one click from the submissions
+// table to the student's Feedback PR, matching the old classroom's direct
+// link. A never-accepted student (`noRepo`) renders an inert dimmed icon and
+// deliberately skips the action's hook/modal machinery, like RegradeButton.
+export const FeedbackPrIconButton = ({
+  org,
+  repo,
+  mode,
+  hasRepo,
+}: {
+  org: string
+  repo: string
+  mode: AssignmentMode
+  hasRepo: boolean
+}) => {
+  const { t } = useTranslation()
+  if (!hasRepo) {
+    // Inert anchor rather than a disabled button, mirroring ActionIconLink's
+    // empty branch: daisyUI suppresses the explanatory tooltip on :disabled
+    // buttons.
+    return (
+      <Button
+        as="a"
+        variant="ghost"
+        size="sm"
+        shape="square"
+        className="cursor-not-allowed text-base-content/30 hover:bg-transparent"
+        disabled
+        aria-label={t("submissions.table.openFeedbackPrLabel", { repo })}
+        title={t("submissions.table.noRepoYetTitle")}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <CodeReviewIcon className="size-4 opacity-50" />
+      </Button>
+    )
+  }
+  return (
+    <FeedbackPrAction
+      org={org}
+      repo={repo}
+      mode={mode}
+      trigger={({ onClick, resolving }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          shape="square"
+          className="text-base-content/70"
+          loading={resolving}
+          loadingLabel={t("submissions.table.viewFeedbackPr")}
+          aria-label={t("submissions.table.openFeedbackPrLabel", { repo })}
+          title={t("submissions.table.viewFeedbackPr")}
+          // The row behind this button opens the manage modal on click; never
+          // let this click double as a row click.
+          onClick={(event) => {
+            event.stopPropagation()
+            onClick()
+          }}
+        >
+          {!resolving && (
+            <CodeReviewIcon aria-hidden="true" className="size-4" />
+          )}
+        </Button>
+      )}
+    />
   )
 }
 

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -3,9 +3,9 @@ import {
   GitBranchIcon,
   GitCommitIcon,
   LogIcon,
-  MarkGithubIcon,
   PauseIcon,
   PlayIcon,
+  RepoIcon,
   ShieldCheckIcon,
   SlidersIcon,
   SyncIcon,
@@ -238,6 +238,7 @@ export const DownloadButton = ({
 export const RepoRowActions = ({
   owner,
   header,
+  feedbackPr,
   release,
   skipsGrading = false,
   onManage,
@@ -246,6 +247,10 @@ export const RepoRowActions = ({
   // The leading affordance for this row family (Open-repo link for individuals,
   // repo link for groups).
   header: React.ReactNode
+  // The direct Feedback-PR shortcut (FeedbackPrIconButton), rendered right
+  // after the repo link (issue #741). Omitted for empty_repo assignments,
+  // which have no Feedback PR — mirrors the hub's Review gate.
+  feedbackPr?: React.ReactNode
   // The submission's latest release page (autograder result). When present, a
   // direct "View autograder details" shortcut links it (skipping the hub). The
   // shortcut is hidden when there's no result to view — before a submission
@@ -262,6 +267,7 @@ export const RepoRowActions = ({
   return (
     <>
       {header}
+      {feedbackPr}
       {releaseHref && (
         <ActionIconLink
           href={releaseHref}
@@ -619,7 +625,7 @@ export const IndividualRowHeader = ({
   return (
     <ActionIconLink
       href={hasRepo ? repoHref : null}
-      icon={MarkGithubIcon}
+      icon={RepoIcon}
       label={t("submissions.table.openRepoLabel", { repo })}
       title={t("submissions.table.viewRepo")}
       emptyLabel={t("submissions.table.openRepoLabel", { repo })}

--- a/web/src/pages/submissions/SubmissionsRows.tsx
+++ b/web/src/pages/submissions/SubmissionsRows.tsx
@@ -1,4 +1,4 @@
-import { MarkGithubIcon } from "@/components/ui/icons"
+import { RepoIcon } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
 
 import { getName, getDisplayName, getInitials } from "@/util/students"
@@ -181,7 +181,7 @@ export const GroupMembers = ({
         rel="noreferrer"
         title={t("submissions.table.openGroupRepo")}
       >
-        <MarkGithubIcon aria-hidden="true" className="size-4 shrink-0" />
+        <RepoIcon aria-hidden="true" className="size-4 shrink-0" />
         <span className="font-mono text-sm">{repoLabel}</span>
       </a>
 
@@ -233,7 +233,7 @@ export const GroupActionControls = ({
   return (
     <ActionIconLink
       href={repoHref}
-      icon={MarkGithubIcon}
+      icon={RepoIcon}
       label={t("submissions.table.openRepoLabel", { repo })}
       title={t("submissions.table.viewRepo")}
       emptyLabel={t("submissions.table.openRepoLabel", { repo })}

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { cleanup, render, screen } from "@testing-library/react"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 vi.mock("react-i18next", async (importOriginal) => {
@@ -26,8 +26,9 @@ vi.mock("@/hooks/useGetRepo", () => ({
 vi.mock("@/hooks/useGetAutogradeState", () => ({
   default: () => ({ data: undefined, isLoading: false, isError: false }),
 }))
+const feedbackRefetch = vi.fn()
 vi.mock("@/hooks/useGetFeedbackPr", () => ({
-  default: () => ({ refetch: vi.fn() }),
+  default: () => ({ refetch: feedbackRefetch }),
 }))
 vi.mock("@/hooks/mutations/useRepairFeedbackPr", () => ({
   default: () => ({ mutate: vi.fn(), isPending: false }),
@@ -94,9 +95,14 @@ beforeEach(() => {
   collaborators.mockReset()
   collaborators.mockReturnValue({ data: undefined })
   downloadSubmission.mockReset()
+  feedbackRefetch.mockReset()
+  vi.stubGlobal("open", vi.fn())
 })
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
 const baseProps = {
   scores: [],
@@ -173,6 +179,111 @@ describe("SubmissionsTable non-submitter repo links", () => {
         enabled: false,
       },
     )
+  })
+})
+
+describe("SubmissionsTable per-row feedback PR shortcut", () => {
+  it("resolves the Feedback PR on click and opens it (no eager per-row fetch)", async () => {
+    const user = userEvent.setup()
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        scores={[scoreRow()]}
+        acceptedUsernames={new Set(["alice"])}
+      />,
+    )
+    // The /pulls lookup is deferred until the shortcut is clicked.
+    expect(feedbackRefetch).not.toHaveBeenCalled()
+    feedbackRefetch.mockResolvedValueOnce({
+      data: { html_url: "https://github.com/acme/cs101-hw1-alice/pull/1" },
+      error: null,
+    })
+    await user.click(
+      screen.getByRole("button", {
+        name: "submissions.table.openFeedbackPrLabel:cs101-hw1-alice",
+      }),
+    )
+    await waitFor(() =>
+      expect(window.open).toHaveBeenCalledWith(
+        "https://github.com/acme/cs101-hw1-alice/pull/1",
+        "_blank",
+        "noopener,noreferrer",
+      ),
+    )
+  })
+
+  it("offers the repair modal when no Feedback PR exists yet", async () => {
+    const user = userEvent.setup()
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        scores={[scoreRow()]}
+        acceptedUsernames={new Set(["alice"])}
+      />,
+    )
+    feedbackRefetch.mockResolvedValueOnce({ data: null, error: null })
+    await user.click(
+      screen.getByRole("button", {
+        name: "submissions.table.openFeedbackPrLabel:cs101-hw1-alice",
+      }),
+    )
+    expect(
+      await screen.findByText("submissions.reviewModal.emptyTitle"),
+    ).toBeTruthy()
+    expect(screen.getByText("submissions.repairPr.repair")).toBeTruthy()
+    expect(window.open).not.toHaveBeenCalled()
+  })
+
+  it("renders an inert shortcut for a never-accepted non-submitter", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        nonSubmitters={[student()]}
+        acceptedUsernames={new Set()}
+      />,
+    )
+    // Present (row alignment + explanatory tooltip) but not clickable.
+    const shortcut = screen.getByLabelText(
+      "submissions.table.openFeedbackPrLabel:cs101-hw1-alice",
+    )
+    expect(shortcut.getAttribute("aria-disabled")).toBe("true")
+    expect(shortcut.getAttribute("href")).toBeNull()
+    expect(feedbackRefetch).not.toHaveBeenCalled()
+  })
+
+  it("omits the shortcut entirely for an empty_repo assignment", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        scores={[scoreRow()]}
+        acceptedUsernames={new Set(["alice"])}
+        skipsGrading
+        emptyRepoAssignment
+      />,
+    )
+    expect(
+      screen.queryByLabelText(
+        "submissions.table.openFeedbackPrLabel:cs101-hw1-alice",
+      ),
+    ).toBeNull()
+  })
+
+  it("offers the shortcut on an unsubmitted group repo row", () => {
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        students={[]}
+        isGroup
+        unsubmittedGroupRepos={[
+          { owner: "team-rocket", repoName: "cs101-hw1-team-rocket" },
+        ]}
+      />,
+    )
+    expect(
+      screen.getByRole("button", {
+        name: "submissions.table.openFeedbackPrLabel:cs101-hw1-team-rocket",
+      }),
+    ).toBeTruthy()
   })
 })
 

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -49,6 +49,7 @@ import {
   IndividualRowHeader,
   RepoRowActions,
 } from "@/pages/submissions/SubmissionsRowActions"
+import { FeedbackPrIconButton } from "@/pages/submissions/ReviewButton"
 import { ManageSubmissionModal } from "@/pages/submissions/ManageSubmissionModal"
 import { ScoreBadge as SharedScoreBadge } from "@/pages/submissions/ScoreBadge"
 import { ScoreCell } from "@/pages/submissions/ScoreCell"
@@ -443,6 +444,19 @@ const SubmissionsTable = ({
   const showPager =
     !initialLoading && !nonSubmittersLoading && displayItems.length > pageSize
 
+  // The per-row Feedback-PR shortcut (issue #741), shared by every row family.
+  // An empty_repo assignment has no Feedback PR, so the shortcut is omitted
+  // entirely — mirrors the hub's Review gate.
+  const feedbackPrShortcut = (repo: string, hasRepo: boolean) =>
+    emptyRepoAssignment ? undefined : (
+      <FeedbackPrIconButton
+        org={org}
+        repo={repo}
+        mode={isGroup ? "group" : "individual"}
+        hasRepo={hasRepo}
+      />
+    )
+
   // One submitted/pending row. Extracted so the paginated sequence can render
   // it inline alongside non-submitter and group-repo rows without duplicating
   // this markup. Keyed by owner by the caller.
@@ -644,6 +658,7 @@ const SubmissionsTable = ({
                 release={rest.release}
                 skipsGrading={skipsGrading}
                 header={<GroupActionControls repo={repo} repoHref={repoHref} />}
+                feedbackPr={feedbackPrShortcut(repo, true)}
                 onManage={openManage}
               />
             ) : (
@@ -658,6 +673,7 @@ const SubmissionsTable = ({
                     hasRepo
                   />
                 }
+                feedbackPr={feedbackPrShortcut(repo, true)}
                 onManage={openManage}
               />
             )}
@@ -857,6 +873,7 @@ const SubmissionsTable = ({
                         hasRepo={accepted}
                       />
                     }
+                    feedbackPr={feedbackPrShortcut(repoName, accepted)}
                     onManage={openManage}
                   />
                 )
@@ -926,6 +943,7 @@ const SubmissionsTable = ({
                         repoHref={groupRepoHref}
                       />
                     }
+                    feedbackPr={feedbackPrShortcut(repoName, true)}
                     onManage={openManage}
                   />
                 }


### PR DESCRIPTION
## Summary

Grading from the submissions table now takes one click to reach a student's Feedback pull request: every row's action cluster gains a code-review icon beside the repo link, restoring the old GitHub Classroom shortcut instead of repo → Pull requests → Feedback.

The shortcut resolves the PR only when clicked (an eager per-row lookup would fan out one `/pulls` request per repo on mount) and shares the hub Review action's flow through one `FeedbackPrAction` component, so a missing PR offers the same Repair path. It renders inert with a "no repo yet" tooltip for never-accepted students and is omitted for `empty_repo` assignments, mirroring the hub's gate; the empty/error modal now mounts on demand rather than as a hidden dialog per row.

Also aligns the icons with GitHub's own: repo links on the submissions surfaces use the `repo` octicon (previously the GitHub mark), and the Review/feedback action uses the `code-review` octicon.

Validated with `npm run check` (tsc, eslint, prettier, arch:validate, 4463 tests), including new table tests for the shortcut's resolve-on-click, repair fallback, inert state, and empty_repo gating.

Closes #741

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [ ] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [ ] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
