### PR TITLE
feat(web): consolidate assignment row actions into a manage modal

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1487,6 +1487,7 @@
       "copyLinkAria": "Copy the accept link for {{name}}",
       "copyLinkPending": "Checking whether this classroom needs an access key…",
       "linkCopied": "Accept link copied",
+      "cloneAria": "Clone all submissions for {{name}}",
       "openSubmissionsAria": "Open {{name}} submissions",
       "deleteAria": "Delete {{name}}",
       "deleteTitle": "Delete assignment?",
@@ -1512,6 +1513,20 @@
       "lockCancel": "Cancel",
       "lockSuccess": "Locked {{name}}.",
       "unlockSuccess": "Unlocked {{name}}."
+    },
+    "manageModal": {
+      "open": "Manage assignment",
+      "openAria": "Manage {{name}}",
+      "editDescription": "Edit the assignment's settings and autograder",
+      "viewDescription": "View the assignment's settings and autograder",
+      "acceptLinkDescription": "Copy the invitation link students use to accept",
+      "cloneDescription": "Clone every student repository with the CLI",
+      "templateAccessDescription": "Review which teams can read the template repository",
+      "reuseDescription": "Duplicate this assignment into another classroom",
+      "lockDescription": "Close the assignment to every student",
+      "unlockDescription": "Reopen the assignment to students",
+      "delete": "Delete assignment",
+      "deleteDescription": "Remove the assignment; student repositories are kept"
     },
     "toolbar": {
       "searchPlaceholder": "Search assignments…",

--- a/web/src/pages/assignments/AssignmentRowActions.tsx
+++ b/web/src/pages/assignments/AssignmentRowActions.tsx
@@ -1,0 +1,449 @@
+import { useState } from "react"
+import { Trans, useTranslation } from "react-i18next"
+import {
+  CheckIcon,
+  DownloadIcon,
+  DuplicateIcon,
+  LinkIcon,
+  LockIcon,
+  ShieldCheckIcon,
+  TrashIcon,
+  UnlockIcon,
+} from "@/components/ui/icons"
+
+import { Button, EmphasisLtr } from "@/components/ui"
+import { ConfirmModal } from "@/components/modals"
+import { ReuseAssignmentModal } from "@/components/modals/ReuseAssignmentModal"
+import { TemplateAccessModal } from "@/components/modals/TemplateAccessModal"
+import { CloneSubmissionsModal } from "@/pages/submissions/CloneSubmissionsModal"
+import { ActionListRow } from "@/pages/submissions/actionLayout"
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
+import { acceptLinkUrl } from "@/util/acceptLink"
+import { useDeleteAssignment } from "@/hooks/mutations/useDeleteAssignment"
+import { useSetAssignmentLock } from "@/hooks/mutations/useSetAssignmentLock"
+import { useToast } from "@/context/notifications/NotificationProvider"
+import type { Assignment } from "@/types/classroom"
+
+// Assignment display name with a slug fallback, shared by the action labels.
+export const assignmentName = (assignment: Assignment): string =>
+  assignment.name || assignment.slug
+
+// Each action renders in one of two shapes: the table row's compact icon
+// button (`variant="icon"`), or the manage-assignment hub's labeled list row
+// (`variant="row"`). One component per action so the labels, gating, and the
+// owned confirm/sub-modal exist in exactly one place.
+type ActionVariant = "icon" | "row"
+
+// Actions that present their own stacked modal notify the hub through
+// `onSubModalToggle` so it can hide its box while the sub-modal is up (the
+// same no-visible-layering convention as ManageSubmissionModal). The icon
+// variant runs outside the hub and just omits the callback.
+type SubModalProps = {
+  onSubModalToggle?: (open: boolean) => void
+}
+
+// Per-row "Copy accept link" — reaching the same link through the submissions
+// page's share modal costs four clicks per assignment (issue #731). Copying
+// mutates nothing, so it stays on archived and TA rows too.
+//
+// Disabled while the classroom read is unresolved — still loading, or failed:
+// either way `secret` is undefined, indistinguishable from "unprotected", and
+// copying a protected classroom's link without its `?k=` would hand students a
+// silent 404.
+export const CopyAcceptLinkAction = ({
+  org,
+  classroom,
+  assignment,
+  secret,
+  secretPending = false,
+  variant = "icon",
+}: {
+  org: string
+  classroom: string
+  assignment: Assignment
+  secret?: string
+  secretPending?: boolean
+  variant?: ActionVariant
+}) => {
+  const { t } = useTranslation()
+  const { copied, copy } = useCopyToClipboard(
+    acceptLinkUrl(org, classroom, assignment.slug, secret),
+    1500,
+  )
+
+  const state = secretPending
+    ? t("assignments.table.copyLinkPending")
+    : copied
+      ? t("assignments.table.linkCopied")
+      : undefined
+
+  if (variant === "row") {
+    return (
+      <ActionListRow
+        icon={copied ? CheckIcon : LinkIcon}
+        title={t("assignments.table.copyLinkTitle")}
+        description={
+          state ?? t("assignments.manageModal.acceptLinkDescription")
+        }
+        onClick={() => void copy()}
+        disabled={secretPending}
+        ariaLabel={t("assignments.table.copyLinkAria", {
+          name: assignmentName(assignment),
+        })}
+      />
+    )
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      shape="circle"
+      disabled={secretPending}
+      title={state ?? t("assignments.table.copyLinkTitle")}
+      aria-label={t("assignments.table.copyLinkAria", {
+        name: assignmentName(assignment),
+      })}
+      onClick={(e) => {
+        e.stopPropagation()
+        void copy()
+      }}
+    >
+      {copied ? (
+        <CheckIcon aria-hidden="true" className="size-4 text-success" />
+      ) : (
+        <LinkIcon aria-hidden="true" className="size-4" />
+      )}
+    </Button>
+  )
+}
+
+// Per-row "Clone all submissions": opens the modal with the `gh teacher
+// download` command for this assignment — the same CLI hand-off the
+// submissions page offers, one page earlier. A Download icon (as in GitHub
+// Classroom): the icon names the user's goal — getting the submissions onto
+// their machine — not the CLI mechanism. Read-only, so it survives the
+// archived/can't-author gate.
+export const CloneSubmissionsAction = ({
+  org,
+  classroom,
+  assignment,
+  variant = "icon",
+  onSubModalToggle,
+}: {
+  org: string
+  classroom: string
+  assignment: Assignment
+  variant?: ActionVariant
+} & SubModalProps) => {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const setOpenAndNotify = (next: boolean) => {
+    setOpen(next)
+    onSubModalToggle?.(next)
+  }
+  const cli = `gh teacher download ${org} ${classroom} ${assignment.slug}`
+
+  return (
+    <>
+      {variant === "row" ? (
+        <ActionListRow
+          icon={DownloadIcon}
+          title={t("submissions.cloneAll.heading")}
+          description={t("assignments.manageModal.cloneDescription")}
+          onClick={() => setOpenAndNotify(true)}
+          ariaLabel={t("assignments.table.cloneAria", {
+            name: assignmentName(assignment),
+          })}
+        />
+      ) : (
+        <Button
+          variant="ghost"
+          size="sm"
+          shape="circle"
+          title={t("submissions.cloneAll.buttonTitle")}
+          aria-label={t("assignments.table.cloneAria", {
+            name: assignmentName(assignment),
+          })}
+          onClick={(e) => {
+            e.stopPropagation()
+            setOpenAndNotify(true)
+          }}
+        >
+          <DownloadIcon aria-hidden="true" className="size-4" />
+        </Button>
+      )}
+      <CloneSubmissionsModal
+        open={open}
+        onClose={() => setOpenAndNotify(false)}
+        cli={cli}
+      />
+    </>
+  )
+}
+
+// "Template access" (hub only): review which template repo the assignment
+// uses and which GitHub teams can read it, and (org owners only) re-grant the
+// classroom student/TA teams read — the acceptance-blocking fix from issue
+// #305. Renders nothing without a template.
+export const TemplateAccessAction = ({
+  org,
+  classroom,
+  assignment,
+  onSubModalToggle,
+}: {
+  org: string
+  classroom: string
+  assignment: Assignment
+} & SubModalProps) => {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const setOpenAndNotify = (next: boolean) => {
+    setOpen(next)
+    onSubModalToggle?.(next)
+  }
+  if (!assignment.template) return null
+
+  return (
+    <>
+      <ActionListRow
+        icon={ShieldCheckIcon}
+        title={t("assignments.template.accessModal.triggerTitle")}
+        description={t("assignments.manageModal.templateAccessDescription")}
+        onClick={() => setOpenAndNotify(true)}
+        ariaLabel={t("assignments.template.accessModal.triggerAria", {
+          name: assignmentName(assignment),
+        })}
+      />
+      {open ? (
+        <TemplateAccessModal
+          org={org}
+          classroom={classroom}
+          assignment={assignment}
+          onClose={() => setOpenAndNotify(false)}
+        />
+      ) : null}
+    </>
+  )
+}
+
+// "Reuse in another classroom" (hub only) — a Duplicate icon, not Copy:
+// Octicons reserves `copy` for copy-to-clipboard, and this duplicates the
+// assignment into another classroom.
+export const ReuseAssignmentAction = ({
+  org,
+  classroom,
+  assignment,
+  onSubModalToggle,
+}: {
+  org: string
+  classroom: string
+  assignment: Assignment
+} & SubModalProps) => {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const setOpenAndNotify = (next: boolean) => {
+    setOpen(next)
+    onSubModalToggle?.(next)
+  }
+
+  return (
+    <>
+      <ActionListRow
+        icon={DuplicateIcon}
+        title={t("assignments.table.reuseTitle")}
+        description={t("assignments.manageModal.reuseDescription")}
+        onClick={() => setOpenAndNotify(true)}
+        ariaLabel={t("assignments.table.reuseAria")}
+      />
+      {open ? (
+        <ReuseAssignmentModal
+          org={org}
+          classroom={classroom}
+          assignment={assignment}
+          onClose={() => setOpenAndNotify(false)}
+        />
+      ) : null}
+    </>
+  )
+}
+
+// Lock/Unlock. Locking closes the assignment to every student (accept +
+// submission surfaces refuse it) and, for a private in-org template, removes
+// the student team's read on it; unlocking reverses both. The template side
+// effect can partly fail without failing the flag flip, so a non-fatal
+// templateAccessWarning surfaces as a warning toast. The confirm stacks on
+// the hub like the submission hub's regrade confirm — small enough that the
+// hub box stays visible underneath.
+export const LockAssignmentAction = ({
+  org,
+  classroom,
+  assignment,
+  variant = "icon",
+}: {
+  org: string
+  classroom: string
+  assignment: Assignment
+  variant?: ActionVariant
+}) => {
+  const { t } = useTranslation()
+  const { notify } = useToast()
+  const [open, setOpen] = useState(false)
+  const locked = Boolean(assignment.locked)
+  const label = assignmentName(assignment)
+  // The lock-vs-unlock label set, chosen once so the JSX below reads one field
+  // each instead of repeating the `locked ? … : …` branch at every attribute.
+  const copy = locked
+    ? {
+        title: t("assignments.table.unlockTitle"),
+        aria: t("assignments.table.unlockAria", { name: label }),
+        description: t("assignments.manageModal.unlockDescription"),
+        modalTitle: t("assignments.table.unlockTitleModal"),
+        descriptionKey: "assignments.table.unlockDescription",
+        confirm: t("assignments.table.unlockConfirm"),
+      }
+    : {
+        title: t("assignments.table.lockTitle"),
+        aria: t("assignments.table.lockAria", { name: label }),
+        description: t("assignments.manageModal.lockDescription"),
+        modalTitle: t("assignments.table.lockTitleModal"),
+        descriptionKey: "assignments.table.lockDescription",
+        confirm: t("assignments.table.lockConfirm"),
+      }
+  const setLock = useSetAssignmentLock(org, classroom, (result) => {
+    if (result.templateAccessWarning) {
+      notify({ tone: "warning", message: result.templateAccessWarning })
+      return
+    }
+    notify({
+      tone: "success",
+      message: result.locked
+        ? t("assignments.table.lockSuccess", { name: label })
+        : t("assignments.table.unlockSuccess", { name: label }),
+    })
+  })
+
+  return (
+    <>
+      {variant === "row" ? (
+        <ActionListRow
+          icon={locked ? UnlockIcon : LockIcon}
+          title={copy.title}
+          description={copy.description}
+          onClick={() => setOpen(true)}
+          ariaLabel={copy.aria}
+        />
+      ) : (
+        <Button
+          variant="ghost"
+          size="sm"
+          shape="circle"
+          className={locked ? "text-warning" : undefined}
+          title={copy.title}
+          aria-label={copy.aria}
+          onClick={(e) => {
+            e.stopPropagation()
+            setOpen(true)
+          }}
+        >
+          {locked ? (
+            <UnlockIcon aria-hidden="true" className="size-4" />
+          ) : (
+            <LockIcon aria-hidden="true" className="size-4" />
+          )}
+        </Button>
+      )}
+
+      <ConfirmModal
+        open={open}
+        title={copy.modalTitle}
+        description={
+          <Trans
+            i18nKey={copy.descriptionKey}
+            values={{ assignment: label }}
+            components={{
+              assignment: <EmphasisLtr className="text-base-content" />,
+            }}
+          />
+        }
+        confirmLabel={copy.confirm}
+        cancelLabel={t("assignments.table.lockCancel")}
+        dangerous={!locked}
+        needsConfirm={false}
+        onConfirm={async () => {
+          await setLock.mutateAsync({
+            org,
+            classroom,
+            slug: assignment.slug,
+            locked: !locked,
+          })
+        }}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  )
+}
+
+// Delete (hub only): typed-slug confirm, then invalidation via the caller's
+// `onDeleteAssignment` (cache keys stay at the table, per the mutation-hook
+// convention).
+export const DeleteAssignmentAction = ({
+  org,
+  classroom,
+  assignment,
+  onDeleteAssignment,
+}: {
+  org: string
+  classroom: string
+  assignment: Assignment
+  onDeleteAssignment: () => void
+}) => {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const deleteAssignmentMutation = useDeleteAssignment()
+
+  return (
+    <>
+      <ActionListRow
+        icon={TrashIcon}
+        title={t("assignments.manageModal.delete")}
+        description={t("assignments.manageModal.deleteDescription")}
+        onClick={() => setOpen(true)}
+        ariaLabel={t("assignments.table.deleteAria", {
+          name: assignmentName(assignment),
+        })}
+      />
+
+      <ConfirmModal
+        open={open}
+        title={t("assignments.table.deleteTitle")}
+        description={
+          <Trans
+            i18nKey="assignments.table.deleteDescription"
+            values={{
+              assignment: assignmentName(assignment),
+              classroom: `${org}/${classroom}`,
+            }}
+            components={{
+              assignment: <EmphasisLtr className="text-base-content" />,
+              classroom: <EmphasisLtr className="text-base-content" />,
+            }}
+          />
+        }
+        confirmText={assignment.slug}
+        confirmLabel={t("assignments.table.deleteConfirm")}
+        cancelLabel={t("assignments.table.deleteCancel")}
+        dangerous
+        onConfirm={async () => {
+          await deleteAssignmentMutation.mutateAsync({
+            org,
+            classroom,
+            assignment: assignment.slug,
+          })
+          onDeleteAssignment()
+        }}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  )
+}

--- a/web/src/pages/assignments/AssignmentsTable.test.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.test.tsx
@@ -65,6 +65,10 @@ const assignment = (over: Partial<Assignment> = {}): Assignment =>
 
 const inOrgTemplate = { owner: "acme", repo: "tmpl", branch: "main" }
 const ACCESS_ARIA = "assignments.template.accessModal.triggerAria"
+const MANAGE_ARIA = "assignments.manageModal.openAria"
+
+// Opens the assignment hub for the first (only) rendered row.
+const openHub = () => fireEvent.click(screen.getByLabelText(MANAGE_ARIA))
 
 // Table-wide text (the bars' "value / max" ratios, percentages, fallback
 // strings).
@@ -235,8 +239,8 @@ describe("AssignmentsTable submission denominator", () => {
   })
 })
 
-describe("AssignmentsTable — Template access button", () => {
-  it("renders the trigger for an in-org templated assignment", () => {
+describe("AssignmentsTable — Template access action (in the hub)", () => {
+  it("shows the action in the hub for an in-org templated assignment", () => {
     wrap(
       <AssignmentsTable
         org="acme"
@@ -245,10 +249,13 @@ describe("AssignmentsTable — Template access button", () => {
         studentCount={0}
       />,
     )
+    // Not a quick action anymore — it lives behind the Manage trigger.
+    expect(screen.queryByLabelText(ACCESS_ARIA)).toBeNull()
+    openHub()
     expect(screen.queryByLabelText(ACCESS_ARIA)).toBeTruthy()
   })
 
-  it("renders the trigger for an out-of-org template too (review + link)", () => {
+  it("shows it for an out-of-org template too (review + link)", () => {
     wrap(
       <AssignmentsTable
         org="acme"
@@ -259,10 +266,11 @@ describe("AssignmentsTable — Template access button", () => {
         studentCount={0}
       />,
     )
+    openHub()
     expect(screen.queryByLabelText(ACCESS_ARIA)).toBeTruthy()
   })
 
-  it("does not render it for a template-less assignment", () => {
+  it("does not show it for a template-less assignment", () => {
     wrap(
       <AssignmentsTable
         org="acme"
@@ -271,10 +279,11 @@ describe("AssignmentsTable — Template access button", () => {
         studentCount={0}
       />,
     )
+    openHub()
     expect(screen.queryByLabelText(ACCESS_ARIA)).toBeNull()
   })
 
-  it("still renders it when archived (viewing stays available)", () => {
+  it("still shows it when archived (viewing stays available)", () => {
     wrap(
       <AssignmentsTable
         org="acme"
@@ -284,10 +293,11 @@ describe("AssignmentsTable — Template access button", () => {
         archived
       />,
     )
+    openHub()
     expect(screen.queryByLabelText(ACCESS_ARIA)).toBeTruthy()
   })
 
-  it("opens the template-access modal on click", () => {
+  it("opens the template-access modal from the hub", () => {
     wrap(
       <AssignmentsTable
         org="acme"
@@ -296,9 +306,77 @@ describe("AssignmentsTable — Template access button", () => {
         studentCount={0}
       />,
     )
+    openHub()
     expect(screen.queryByTestId("template-access-modal")).toBeNull()
     fireEvent.click(screen.getByLabelText(ACCESS_ARIA))
     expect(screen.getByTestId("template-access-modal").textContent).toBe("hw1")
+  })
+})
+
+describe("AssignmentsTable — assignment hub", () => {
+  it("keeps only the quick actions on the row; the rest live in the hub", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment({ template: inOrgTemplate })]}
+        studentCount={0}
+        canAuthor
+      />,
+    )
+    // Quick actions: accept link, clone CLI, edit (a router link whose title
+    // the Link mock drops — covered by the hub assertions below), lock, plus
+    // the trigger.
+    expect(screen.getByLabelText("assignments.table.copyLinkAria")).toBeTruthy()
+    expect(screen.getByLabelText("assignments.table.cloneAria")).toBeTruthy()
+    expect(screen.getByLabelText("assignments.table.lockAria")).toBeTruthy()
+    // Consolidated actions are not on the row.
+    expect(screen.queryByLabelText(ACCESS_ARIA)).toBeNull()
+    expect(screen.queryByLabelText("assignments.table.reuseAria")).toBeNull()
+    expect(screen.queryByLabelText("assignments.table.deleteAria")).toBeNull()
+  })
+
+  it("consolidates every action (quick ones included) for an author", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment({ template: inOrgTemplate })]}
+        studentCount={0}
+        canAuthor
+      />,
+    )
+    openHub()
+    expect(screen.getByText("assignments.table.editAssignment")).toBeTruthy()
+    // Quick actions repeat inside the hub (row + hub = 2 matches each).
+    expect(
+      screen.getAllByLabelText("assignments.table.copyLinkAria").length,
+    ).toBe(2)
+    expect(screen.getAllByLabelText("assignments.table.cloneAria").length).toBe(
+      2,
+    )
+    expect(screen.getAllByLabelText("assignments.table.lockAria").length).toBe(
+      2,
+    )
+    expect(screen.getByLabelText(ACCESS_ARIA)).toBeTruthy()
+    expect(screen.getByLabelText("assignments.table.reuseAria")).toBeTruthy()
+    expect(screen.getByLabelText("assignments.table.deleteAria")).toBeTruthy()
+  })
+
+  it("hides the mutating rows for a read-only viewer", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[assignment()]}
+        studentCount={0}
+      />,
+    )
+    openHub()
+    expect(screen.getByText("assignments.table.viewAssignment")).toBeTruthy()
+    expect(screen.queryByLabelText("assignments.table.reuseAria")).toBeNull()
+    expect(screen.queryByLabelText("assignments.table.lockAria")).toBeNull()
+    expect(screen.queryByLabelText("assignments.table.deleteAria")).toBeNull()
   })
 })
 

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -1,22 +1,15 @@
 import { useNavigate } from "@tanstack/react-router"
 import { EmptyState } from "@/components/list"
-import { Trans, useTranslation } from "react-i18next"
+import { useTranslation } from "react-i18next"
 import {
   AlertIcon,
-  CheckIcon,
-  CopyIcon,
   EyeIcon,
-  LinkIcon,
   LockIcon,
   PencilIcon,
-  ShieldCheckIcon,
-  TrashIcon,
-  UnlockIcon,
+  SlidersIcon,
 } from "@/components/ui/icons"
 
 import useGetScores from "@/hooks/useGetScores"
-import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
-import { acceptLinkUrl } from "@/util/acceptLink"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
 import { existingGroupRepos } from "@/pages/submissions/dashboard"
 import { isNoAutograderAssignment } from "@/domain/assignments/autogradingState"
@@ -24,15 +17,16 @@ import { formatDueDate, formatDueDateTime, isPastDue } from "@/util/formatDate"
 import { composedRepoNameFits } from "@/util/repoNameBudget"
 import { Link } from "@tanstack/react-router"
 import { useState } from "react"
-import { ConfirmModal } from "@/components/modals"
-import { ReuseAssignmentModal } from "@/components/modals/ReuseAssignmentModal"
-import { TemplateAccessModal } from "@/components/modals/TemplateAccessModal"
 import { githubKeys } from "@/github-core/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { useQueryClient } from "@tanstack/react-query"
-import { useDeleteAssignment } from "@/hooks/mutations/useDeleteAssignment"
-import { useSetAssignmentLock } from "@/hooks/mutations/useSetAssignmentLock"
-import { useToast } from "@/context/notifications/NotificationProvider"
+import {
+  assignmentName as name,
+  CloneSubmissionsAction,
+  CopyAcceptLinkAction,
+  LockAssignmentAction,
+} from "@/pages/assignments/AssignmentRowActions"
+import { ManageAssignmentModal } from "@/pages/assignments/ManageAssignmentModal"
 import type { Assignment } from "@/types/classroom"
 import { ClickableTr } from "@/lib/motionComponents"
 import { blockEnter } from "@/lib/motion"
@@ -45,327 +39,12 @@ import {
 import {
   Badge,
   Button,
-  EmphasisLtr,
   MetricCount,
   MetricBar,
   SkeletonRows,
   SortableTh,
   TableShell,
 } from "@/components/ui"
-
-const DeleteAssignmentButton = ({
-  org,
-  classroom,
-  assignment,
-  onDeleteAssignment,
-}: {
-  org: string
-  classroom: string
-  assignment: Assignment
-  onDeleteAssignment: () => void
-}) => {
-  const { t } = useTranslation()
-  const [open, setOpen] = useState(false)
-  const deleteAssignmentMutation = useDeleteAssignment()
-
-  return (
-    <>
-      <Button
-        variant="ghost"
-        size="sm"
-        shape="circle"
-        onClick={(e) => {
-          e.stopPropagation()
-          setOpen(true)
-        }}
-        className="text-base-content/60 hover:text-error focus-visible:text-error"
-        aria-label={t("assignments.table.deleteAria", {
-          name: assignment.name || assignment.slug,
-        })}
-      >
-        <TrashIcon className="size-4" aria-hidden="true" />
-      </Button>
-
-      <ConfirmModal
-        open={open}
-        title={t("assignments.table.deleteTitle")}
-        description={
-          <Trans
-            i18nKey="assignments.table.deleteDescription"
-            values={{
-              assignment: assignment.name || assignment.slug,
-              classroom: `${org}/${classroom}`,
-            }}
-            components={{
-              assignment: <EmphasisLtr className="text-base-content" />,
-              classroom: <EmphasisLtr className="text-base-content" />,
-            }}
-          />
-        }
-        confirmText={assignment.slug}
-        confirmLabel={t("assignments.table.deleteConfirm")}
-        cancelLabel={t("assignments.table.deleteCancel")}
-        dangerous
-        onConfirm={async () => {
-          await deleteAssignmentMutation.mutateAsync({
-            org,
-            classroom,
-            assignment: assignment.slug,
-          })
-          onDeleteAssignment()
-        }}
-        onClose={() => setOpen(false)}
-      />
-    </>
-  )
-}
-
-// Per-row "Copy accept link" — reaching the same link through the submissions
-// page's share modal costs four clicks per assignment (issue #731). Copying
-// mutates nothing, so it stays on archived and TA rows too.
-//
-// Disabled while the classroom read is unresolved — still loading, or failed:
-// either way `secret` is undefined, indistinguishable from "unprotected", and
-// copying a protected classroom's link without its `?k=` would hand students a
-// silent 404.
-const CopyAcceptLinkButton = ({
-  org,
-  classroom,
-  assignment,
-  secret,
-  secretPending = false,
-}: {
-  org: string
-  classroom: string
-  assignment: Assignment
-  secret?: string
-  secretPending?: boolean
-}) => {
-  const { t } = useTranslation()
-  const { copied, copy } = useCopyToClipboard(
-    acceptLinkUrl(org, classroom, assignment.slug, secret),
-    1500,
-  )
-
-  return (
-    <Button
-      variant="ghost"
-      size="sm"
-      shape="circle"
-      disabled={secretPending}
-      title={
-        secretPending
-          ? t("assignments.table.copyLinkPending")
-          : copied
-            ? t("assignments.table.linkCopied")
-            : t("assignments.table.copyLinkTitle")
-      }
-      aria-label={t("assignments.table.copyLinkAria", {
-        name: name(assignment),
-      })}
-      onClick={(e) => {
-        e.stopPropagation()
-        void copy()
-      }}
-    >
-      {copied ? (
-        <CheckIcon aria-hidden="true" className="size-4 text-success" />
-      ) : (
-        <LinkIcon aria-hidden="true" className="size-4" />
-      )}
-    </Button>
-  )
-}
-
-const ReuseAssignmentButton = ({
-  org,
-  classroom,
-  assignment,
-}: {
-  org: string
-  classroom: string
-  assignment: Assignment
-}) => {
-  const { t } = useTranslation()
-  const [open, setOpen] = useState(false)
-
-  return (
-    <>
-      <Button
-        variant="ghost"
-        size="sm"
-        shape="circle"
-        onClick={(e) => {
-          e.stopPropagation()
-          setOpen(true)
-        }}
-        title={t("assignments.table.reuseTitle")}
-        aria-label={t("assignments.table.reuseAria")}
-      >
-        <CopyIcon aria-hidden="true" className="size-4" />
-      </Button>
-
-      {open ? (
-        <ReuseAssignmentModal
-          org={org}
-          classroom={classroom}
-          assignment={assignment}
-          onClose={() => setOpen(false)}
-        />
-      ) : null}
-    </>
-  )
-}
-
-// Per-row "Template access": opens a modal to review which template repo the
-// assignment uses and which GitHub teams can read it, and (org owners only)
-// re-grant the classroom student/TA teams read — the acceptance-blocking fix
-// from issue #305. Merges the former source-repo link and fix-access button.
-const TemplateAccessButton = ({
-  org,
-  classroom,
-  assignment,
-}: {
-  org: string
-  classroom: string
-  assignment: Assignment
-}) => {
-  const { t } = useTranslation()
-  const [open, setOpen] = useState(false)
-  if (!assignment.template) return null
-
-  return (
-    <>
-      <Button
-        variant="ghost"
-        size="sm"
-        shape="circle"
-        title={t("assignments.template.accessModal.triggerTitle")}
-        aria-label={t("assignments.template.accessModal.triggerAria", {
-          name: assignment.name || assignment.slug,
-        })}
-        onClick={(e) => {
-          e.stopPropagation()
-          setOpen(true)
-        }}
-      >
-        <ShieldCheckIcon aria-hidden="true" className="size-4" />
-      </Button>
-      {open ? (
-        <TemplateAccessModal
-          org={org}
-          classroom={classroom}
-          assignment={assignment}
-          onClose={() => setOpen(false)}
-        />
-      ) : null}
-    </>
-  )
-}
-
-// Per-row Lock/Unlock action. Locking closes the assignment to every student
-// (accept + submission surfaces refuse it) and, for a private in-org template,
-// removes the student team's read on it; unlocking reverses both. The template
-// side effect can partly fail without failing the flag flip, so a non-fatal
-// templateAccessWarning surfaces as a warning toast.
-const LockAssignmentButton = ({
-  org,
-  classroom,
-  assignment,
-}: {
-  org: string
-  classroom: string
-  assignment: Assignment
-}) => {
-  const { t } = useTranslation()
-  const { notify } = useToast()
-  const [open, setOpen] = useState(false)
-  const locked = Boolean(assignment.locked)
-  const label = name(assignment)
-  // The lock-vs-unlock label set, chosen once so the JSX below reads one field
-  // each instead of repeating the `locked ? … : …` branch at every attribute.
-  const copy = locked
-    ? {
-        title: t("assignments.table.unlockTitle"),
-        aria: t("assignments.table.unlockAria", { name: label }),
-        modalTitle: t("assignments.table.unlockTitleModal"),
-        descriptionKey: "assignments.table.unlockDescription",
-        confirm: t("assignments.table.unlockConfirm"),
-      }
-    : {
-        title: t("assignments.table.lockTitle"),
-        aria: t("assignments.table.lockAria", { name: label }),
-        modalTitle: t("assignments.table.lockTitleModal"),
-        descriptionKey: "assignments.table.lockDescription",
-        confirm: t("assignments.table.lockConfirm"),
-      }
-  const setLock = useSetAssignmentLock(org, classroom, (result) => {
-    if (result.templateAccessWarning) {
-      notify({ tone: "warning", message: result.templateAccessWarning })
-      return
-    }
-    notify({
-      tone: "success",
-      message: result.locked
-        ? t("assignments.table.lockSuccess", { name: label })
-        : t("assignments.table.unlockSuccess", { name: label }),
-    })
-  })
-
-  return (
-    <>
-      <Button
-        variant="ghost"
-        size="sm"
-        shape="circle"
-        className={locked ? "text-warning" : undefined}
-        title={copy.title}
-        aria-label={copy.aria}
-        onClick={(e) => {
-          e.stopPropagation()
-          setOpen(true)
-        }}
-      >
-        {locked ? (
-          <UnlockIcon aria-hidden="true" className="size-4" />
-        ) : (
-          <LockIcon aria-hidden="true" className="size-4" />
-        )}
-      </Button>
-
-      <ConfirmModal
-        open={open}
-        title={copy.modalTitle}
-        description={
-          <Trans
-            i18nKey={copy.descriptionKey}
-            values={{ assignment: label }}
-            components={{
-              assignment: <EmphasisLtr className="text-base-content" />,
-            }}
-          />
-        }
-        confirmLabel={copy.confirm}
-        cancelLabel={t("assignments.table.lockCancel")}
-        dangerous={!locked}
-        needsConfirm={false}
-        onConfirm={async () => {
-          await setLock.mutateAsync({
-            org,
-            classroom,
-            slug: assignment.slug,
-            locked: !locked,
-          })
-        }}
-        onClose={() => setOpen(false)}
-      />
-    </>
-  )
-}
-
-// Assignment display name with a slug fallback, shared by the row action labels.
-const name = (assignment: Assignment): string =>
-  assignment.name || assignment.slug
 
 // The Release Date cell. Dates are data, not status, so a passed (released)
 // date renders as plain text like the Due date column; only the scheduled
@@ -517,378 +196,411 @@ const AssignmentsTable = ({
   const navigate = useNavigate()
   // Mutating row actions require both an unarchived classroom and author rights.
   const canMutate = !archived && canAuthor
+  // The row whose assignment hub (ManageAssignmentModal) is open. Stored as a
+  // slug and re-resolved against the live list on every render, so the hub
+  // reflects a lock flip after assignments.json refetches and unmounts itself
+  // when the assignment is deleted.
+  const [manageSlug, setManageSlug] = useState<string | null>(null)
+  const manageAssignment = manageSlug
+    ? (assignments?.find((a) => a.slug === manageSlug) ?? null)
+    : null
+  const invalidateAssignments = () =>
+    queryClient.invalidateQueries({
+      queryKey: githubKeys.jsonFile(
+        org,
+        CONFIG_REPO,
+        `${classroom}/assignments.json`,
+      ),
+    })
 
   return (
-    // The shell's own entrance is off: the page-level PageTransition already
-    // animates navigation, and the tbody blockEnter below is the data-arrival
-    // cue — a third nested entrance reads as a double pop.
-    <TableShell animate={false} padded ariaBusy={loading}>
-      <caption className="sr-only">{t("assignments.table.caption")}</caption>
-      <thead>
-        <tr>
-          <SortableTh
-            label={t("assignments.table.colAssignment")}
-            sort={sort}
-            asc="name-asc"
-            desc="name-desc"
-            onSortChange={onSortChange}
-            title={t("assignments.table.sortByName")}
-          />
-          <th scope="col">{t("assignments.table.colType")}</th>
-          <th scope="col">{t("assignments.table.colReleaseDate")}</th>
-          <SortableTh
-            label={t("assignments.table.colDueDate")}
-            sort={sort}
-            asc="due-asc"
-            desc="due-desc"
-            onSortChange={onSortChange}
-            title={t("assignments.table.sortByDue")}
-          />
-          <th scope="col">{t("assignments.table.colAccepted")}</th>
-          <th scope="col">{t("assignments.table.colSubmitted")}</th>
-          {/* w-0: auto table layout hands surplus width to every column,
+    <>
+      {/* The shell's own entrance is off: the page-level PageTransition already
+        animates navigation, and the tbody blockEnter below is the data-arrival
+        cue — a third nested entrance reads as a double pop. */}
+      <TableShell animate={false} padded ariaBusy={loading}>
+        <caption className="sr-only">{t("assignments.table.caption")}</caption>
+        <thead>
+          <tr>
+            <SortableTh
+              label={t("assignments.table.colAssignment")}
+              sort={sort}
+              asc="name-asc"
+              desc="name-desc"
+              onSortChange={onSortChange}
+              title={t("assignments.table.sortByName")}
+            />
+            <th scope="col">{t("assignments.table.colType")}</th>
+            <th scope="col">{t("assignments.table.colReleaseDate")}</th>
+            <SortableTh
+              label={t("assignments.table.colDueDate")}
+              sort={sort}
+              asc="due-asc"
+              desc="due-desc"
+              onSortChange={onSortChange}
+              title={t("assignments.table.sortByDue")}
+            />
+            <th scope="col">{t("assignments.table.colAccepted")}</th>
+            <th scope="col">{t("assignments.table.colSubmitted")}</th>
+            {/* w-0: auto table layout hands surplus width to every column,
               which stretched this fixed-width button strip. Zero width makes
               the browser fall back to min-content here and give the slack to
               the text columns instead. */}
-          <th scope="col" className="w-0">
-            <span className="sr-only">{t("assignments.table.colActions")}</span>
-          </th>
-        </tr>
-      </thead>
-      {/* Same recipe as the submissions table: the body enters as one block
+            <th scope="col" className="w-0">
+              <span className="sr-only">
+                {t("assignments.table.colActions")}
+              </span>
+            </th>
+          </tr>
+        </thead>
+        {/* Same recipe as the submissions table: the body enters as one block
             (blockEnter) and replays when the view changes (data arrival, filter,
             sort — not per search keystroke, which the signature excludes). */}
-      <motion.tbody
-        key={`${loading}:${viewSignature}`}
-        variants={blockEnter}
-        initial="initial"
-        animate="animate"
-      >
-        {loading && <SkeletonRows bars={SKELETON_BARS} />}
-        {!loading && !assignments?.length && (
-          <tr>
-            <td colSpan={7}>
-              <EmptyState variant="bare" body={t("assignments.table.empty")} />
-            </td>
-          </tr>
-        )}
-        {!loading &&
-          assignments?.map((assignment) => (
-            <ClickableTr key={assignment.slug} className="hover:bg-base-200">
-              <td
-                onClick={() =>
-                  navigate({
-                    to: "/$org/$classroom/assignments/$assignment/submissions",
-                    params: { org, classroom, assignment: assignment.slug },
-                  })
-                }
-                className="truncate"
-              >
-                {/* Real link (not a click-only div) so the row's primary
+        <motion.tbody
+          key={`${loading}:${viewSignature}`}
+          variants={blockEnter}
+          initial="initial"
+          animate="animate"
+        >
+          {loading && <SkeletonRows bars={SKELETON_BARS} />}
+          {!loading && !assignments?.length && (
+            <tr>
+              <td colSpan={7}>
+                <EmptyState
+                  variant="bare"
+                  body={t("assignments.table.empty")}
+                />
+              </td>
+            </tr>
+          )}
+          {!loading &&
+            assignments?.map((assignment) => (
+              <ClickableTr key={assignment.slug} className="hover:bg-base-200">
+                <td
+                  onClick={() =>
+                    navigate({
+                      to: "/$org/$classroom/assignments/$assignment/submissions",
+                      params: { org, classroom, assignment: assignment.slug },
+                    })
+                  }
+                  className="truncate"
+                >
+                  {/* Real link (not a click-only div) so the row's primary
                       action is keyboard-reachable and exposes a link role; the
                       td onClick stays as a mouse convenience. */}
-                <Link
-                  to="/$org/$classroom/assignments/$assignment/submissions"
-                  params={{ org, classroom, assignment: assignment.slug }}
-                  aria-label={t("assignments.table.openSubmissionsAria", {
-                    name: name(assignment),
-                  })}
-                  className="font-bold link link-info no-underline"
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  {assignment.name}
-                </Link>
-                <div className="font-mono text-xs text-base-content/70">
-                  {assignment.slug}
-                </div>
-                {assignment.locked && (
-                  <Badge
-                    tone="warning"
-                    size="sm"
-                    className="mt-1 gap-1 whitespace-nowrap"
-                    title={t("assignments.table.lockedBadgeTitle")}
-                  >
-                    <LockIcon aria-hidden="true" className="size-3" />
-                    {t("assignments.table.lockedBadge")}
-                  </Badge>
-                )}
-                {!composedRepoNameFits(classroom, assignment.slug).fits && (
-                  // Over the composed repo-name budget (#691): some usernames
-                  // can't accept. Links to the settings page, where the
-                  // eligibility-gated rename remediation lives.
                   <Link
-                    to="/$org/$classroom/assignments/$assignment/settings"
+                    to="/$org/$classroom/assignments/$assignment/submissions"
                     params={{ org, classroom, assignment: assignment.slug }}
+                    aria-label={t("assignments.table.openSubmissionsAria", {
+                      name: name(assignment),
+                    })}
+                    className="font-bold link link-info no-underline"
                     onClick={(event) => event.stopPropagation()}
-                    className="mt-1 block w-fit"
-                    title={t("assignments.table.overBudgetBadgeTitle")}
                   >
-                    <Badge
-                      tone="error"
-                      size="sm"
-                      className="gap-1 whitespace-nowrap"
-                    >
-                      <AlertIcon aria-hidden="true" className="size-3" />
-                      {t("assignments.table.overBudgetBadge")}
-                    </Badge>
+                    {assignment.name}
                   </Link>
-                )}
-              </td>
-              <td
-                onClick={() =>
-                  navigate({
-                    to: "/$org/$classroom/assignments/$assignment/submissions",
-                    params: { org, classroom, assignment: assignment.slug },
-                  })
-                }
-                className="max-xl:text-xs"
-              >
-                <ModeBadge mode={assignment.mode} />
-              </td>
-              <td
-                onClick={() =>
-                  navigate({
-                    to: "/$org/$classroom/assignments/$assignment/submissions",
-                    params: { org, classroom, assignment: assignment.slug },
-                  })
-                }
-              >
-                <ReleaseDateCell assignment={assignment} />
-              </td>
-              <td
-                onClick={() =>
-                  navigate({
-                    to: "/$org/$classroom/assignments/$assignment/submissions",
-                    params: { org, classroom, assignment: assignment.slug },
-                  })
-                }
-              >
-                <DueDateCell due={assignment.due} />
-              </td>
-              {/* The funnel cells deep-link to the actionable cohort: who
+                  <div className="font-mono text-xs text-base-content/70">
+                    {assignment.slug}
+                  </div>
+                  {assignment.locked && (
+                    <Badge
+                      tone="warning"
+                      size="sm"
+                      className="mt-1 gap-1 whitespace-nowrap"
+                      title={t("assignments.table.lockedBadgeTitle")}
+                    >
+                      <LockIcon aria-hidden="true" className="size-3" />
+                      {t("assignments.table.lockedBadge")}
+                    </Badge>
+                  )}
+                  {!composedRepoNameFits(classroom, assignment.slug).fits && (
+                    // Over the composed repo-name budget (#691): some usernames
+                    // can't accept. Links to the settings page, where the
+                    // eligibility-gated rename remediation lives.
+                    <Link
+                      to="/$org/$classroom/assignments/$assignment/settings"
+                      params={{ org, classroom, assignment: assignment.slug }}
+                      onClick={(event) => event.stopPropagation()}
+                      className="mt-1 block w-fit"
+                      title={t("assignments.table.overBudgetBadgeTitle")}
+                    >
+                      <Badge
+                        tone="error"
+                        size="sm"
+                        className="gap-1 whitespace-nowrap"
+                      >
+                        <AlertIcon aria-hidden="true" className="size-3" />
+                        {t("assignments.table.overBudgetBadge")}
+                      </Badge>
+                    </Link>
+                  )}
+                </td>
+                <td
+                  onClick={() =>
+                    navigate({
+                      to: "/$org/$classroom/assignments/$assignment/submissions",
+                      params: { org, classroom, assignment: assignment.slug },
+                    })
+                  }
+                  className="max-xl:text-xs"
+                >
+                  <ModeBadge mode={assignment.mode} />
+                </td>
+                <td
+                  onClick={() =>
+                    navigate({
+                      to: "/$org/$classroom/assignments/$assignment/submissions",
+                      params: { org, classroom, assignment: assignment.slug },
+                    })
+                  }
+                >
+                  <ReleaseDateCell assignment={assignment} />
+                </td>
+                <td
+                  onClick={() =>
+                    navigate({
+                      to: "/$org/$classroom/assignments/$assignment/submissions",
+                      params: { org, classroom, assignment: assignment.slug },
+                    })
+                  }
+                >
+                  <DueDateCell due={assignment.due} />
+                </td>
+                {/* The funnel cells deep-link to the actionable cohort: who
                     hasn't accepted / hasn't submitted. Groups have no
                     acceptance filter (no roster denominator), so their
                     Accepted cell opens the dashboard unfiltered. */}
-              <td
-                onClick={() =>
-                  navigate({
-                    to: "/$org/$classroom/assignments/$assignment/submissions",
-                    params: { org, classroom, assignment: assignment.slug },
-                    search:
-                      assignment.mode === "group"
-                        ? undefined
-                        : { status: "not-accepted" },
-                  })
-                }
-              >
-                {(() => {
-                  const { submitted, accepted } = funnelCounts(assignment)
-                  if (accepted === undefined) {
-                    // Org repo list still loading — no acceptance signal yet.
-                    return <span className="text-base-content/60">—</span>
+                <td
+                  onClick={() =>
+                    navigate({
+                      to: "/$org/$classroom/assignments/$assignment/submissions",
+                      params: { org, classroom, assignment: assignment.slug },
+                      search:
+                        assignment.mode === "group"
+                          ? undefined
+                          : { status: "not-accepted" },
+                    })
                   }
-                  if (assignment.mode === "group") {
-                    // A group assignment nobody has started has no repos and
-                    // therefore no denominator to measure — a bare "0" would
-                    // imply one. Muted empty state + tooltip instead.
-                    if (accepted === 0) {
-                      return (
-                        <span
-                          className="inline-block w-28 whitespace-nowrap text-center text-base-content/60"
-                          title={t("assignments.table.noGroupsYetTitle")}
-                        >
-                          {t("assignments.table.noGroupsYet")}
-                        </span>
-                      )
-                    }
-                    // Groups have no roster denominator (any student can
-                    // found one), so acceptance is a bare count — no bar;
-                    // the "groups" context lives in the tooltip.
-                    return (
-                      <MetricCount
-                        value={accepted}
-                        tone="info"
-                        title={t("assignments.table.groupsAcceptedTitle")}
-                      />
-                    )
-                  }
-                  const total = studentCount ?? 0
-                  // Clamp (KTD4-style): a staff/extra repo could push the
-                  // count past the student-role total, and a recorded
-                  // submission implies its repo existed.
-                  const shown = Math.min(
-                    Math.max(accepted, Math.min(submitted, total)),
-                    total,
-                  )
-                  return (
-                    <MetricBar
-                      value={shown}
-                      max={total}
-                      tone="info"
-                      title={t("assignments.table.acceptedTitle", {
-                        accepted: shown,
-                        total,
-                      })}
-                    />
-                  )
-                })()}
-              </td>
-              <td
-                onClick={() =>
-                  navigate({
-                    to: "/$org/$classroom/assignments/$assignment/submissions",
-                    params: { org, classroom, assignment: assignment.slug },
-                    search: { status: "not-submitted" },
-                  })
-                }
-              >
-                {(() => {
-                  const { submitted, accepted, notCollected } =
-                    funnelCounts(assignment)
-                  if (notCollected) {
-                    return (
-                      <span className="whitespace-nowrap text-base-content/60">
-                        {t("assignments.table.notCollectedYet")}
-                      </span>
-                    )
-                  }
-                  if (assignment.mode === "group") {
-                    // Groups submit per-repo, so the only meaningful
-                    // denominator is the number of groups that accepted.
-                    // Until the repo list loads, fall back to the bare count
-                    // rather than a false "N / 0".
+                >
+                  {(() => {
+                    const { submitted, accepted } = funnelCounts(assignment)
                     if (accepted === undefined) {
+                      // Org repo list still loading — no acceptance signal yet.
+                      return <span className="text-base-content/60">—</span>
+                    }
+                    if (assignment.mode === "group") {
+                      // A group assignment nobody has started has no repos and
+                      // therefore no denominator to measure — a bare "0" would
+                      // imply one. Muted empty state + tooltip instead.
+                      if (accepted === 0) {
+                        return (
+                          <span
+                            className="inline-block w-28 whitespace-nowrap text-center text-base-content/60"
+                            title={t("assignments.table.noGroupsYetTitle")}
+                          >
+                            {t("assignments.table.noGroupsYet")}
+                          </span>
+                        )
+                      }
+                      // Groups have no roster denominator (any student can
+                      // found one), so acceptance is a bare count — no bar;
+                      // the "groups" context lives in the tooltip.
                       return (
-                        <span className="whitespace-nowrap">
-                          {t("assignments.table.groupsSubmitted", {
-                            count: submitted,
-                          })}
-                        </span>
+                        <MetricCount
+                          value={accepted}
+                          tone="info"
+                          title={t("assignments.table.groupsAcceptedTitle")}
+                        />
                       )
                     }
-                    // No groups yet: nothing to measure against — mirror the
-                    // Accepted cell's empty state instead of a false "0 / 0".
-                    if (accepted === 0) {
-                      return (
-                        <span
-                          className="inline-block w-28 text-center text-base-content/60"
-                          title={t("assignments.table.noGroupsYetTitle")}
-                        >
-                          —
-                        </span>
-                      )
-                    }
-                    const shown = Math.min(submitted, accepted)
+                    const total = studentCount ?? 0
+                    // Clamp (KTD4-style): a staff/extra repo could push the
+                    // count past the student-role total, and a recorded
+                    // submission implies its repo existed.
+                    const shown = Math.min(
+                      Math.max(accepted, Math.min(submitted, total)),
+                      total,
+                    )
                     return (
                       <MetricBar
                         value={shown}
-                        max={accepted}
-                        tone="success"
-                        title={t("assignments.table.submittedTitleGroup", {
-                          submitted: shown,
-                          accepted,
+                        max={total}
+                        tone="info"
+                        title={t("assignments.table.acceptedTitle", {
+                          accepted: shown,
+                          total,
                         })}
                       />
                     )
+                  })()}
+                </td>
+                <td
+                  onClick={() =>
+                    navigate({
+                      to: "/$org/$classroom/assignments/$assignment/submissions",
+                      params: { org, classroom, assignment: assignment.slug },
+                      search: { status: "not-submitted" },
+                    })
                   }
-                  // Denominator is the authoritative student-role count, not
-                  // the roster row count (which includes staff). The
-                  // numerator is a repo-count from scores.json with no role
-                  // join, so a submission from a non-student repo could push
-                  // it past the denominator — clamp the displayed fraction
-                  // and the bar to 100% (KTD4). undefined count reads as 0
-                  // until it resolves.
-                  const total = studentCount ?? 0
-                  const shown = Math.min(submitted, total)
-                  return (
-                    <MetricBar
-                      value={shown}
-                      max={total}
-                      tone="success"
-                      title={t("assignments.table.submittedTitle", {
-                        submitted: shown,
-                        total,
-                      })}
-                    />
-                  )
-                })()}
-              </td>
-              <td className="w-0 py-2! ps-2">
-                <div className="flex items-center justify-end gap-1">
-                  <Link
-                    className="btn btn-circle btn-sm btn-ghost"
-                    to="/$org/$classroom/assignments/$assignment/settings"
-                    params={{
-                      org,
-                      classroom,
-                      assignment: assignment.slug,
-                    }}
-                    title={
-                      canMutate
-                        ? t("assignments.table.editAssignment")
-                        : t("assignments.table.viewAssignment")
+                >
+                  {(() => {
+                    const { submitted, accepted, notCollected } =
+                      funnelCounts(assignment)
+                    if (notCollected) {
+                      return (
+                        <span className="whitespace-nowrap text-base-content/60">
+                          {t("assignments.table.notCollectedYet")}
+                        </span>
+                      )
                     }
-                    onClick={(event) => {
-                      event.stopPropagation()
-                    }}
-                  >
-                    {canMutate ? (
-                      <PencilIcon aria-hidden="true" className="size-4" />
-                    ) : (
-                      <EyeIcon aria-hidden="true" className="size-4" />
+                    if (assignment.mode === "group") {
+                      // Groups submit per-repo, so the only meaningful
+                      // denominator is the number of groups that accepted.
+                      // Until the repo list loads, fall back to the bare count
+                      // rather than a false "N / 0".
+                      if (accepted === undefined) {
+                        return (
+                          <span className="whitespace-nowrap">
+                            {t("assignments.table.groupsSubmitted", {
+                              count: submitted,
+                            })}
+                          </span>
+                        )
+                      }
+                      // No groups yet: nothing to measure against — mirror the
+                      // Accepted cell's empty state instead of a false "0 / 0".
+                      if (accepted === 0) {
+                        return (
+                          <span
+                            className="inline-block w-28 text-center text-base-content/60"
+                            title={t("assignments.table.noGroupsYetTitle")}
+                          >
+                            —
+                          </span>
+                        )
+                      }
+                      const shown = Math.min(submitted, accepted)
+                      return (
+                        <MetricBar
+                          value={shown}
+                          max={accepted}
+                          tone="success"
+                          title={t("assignments.table.submittedTitleGroup", {
+                            submitted: shown,
+                            accepted,
+                          })}
+                        />
+                      )
+                    }
+                    // Denominator is the authoritative student-role count, not
+                    // the roster row count (which includes staff). The
+                    // numerator is a repo-count from scores.json with no role
+                    // join, so a submission from a non-student repo could push
+                    // it past the denominator — clamp the displayed fraction
+                    // and the bar to 100% (KTD4). undefined count reads as 0
+                    // until it resolves.
+                    const total = studentCount ?? 0
+                    const shown = Math.min(submitted, total)
+                    return (
+                      <MetricBar
+                        value={shown}
+                        max={total}
+                        tone="success"
+                        title={t("assignments.table.submittedTitle", {
+                          submitted: shown,
+                          total,
+                        })}
+                      />
+                    )
+                  })()}
+                </td>
+                <td className="w-0 py-2! ps-2">
+                  <div className="flex items-center justify-end gap-1">
+                    {/* Quick-access shortcuts (accept link, clone CLI, edit,
+                      lock); everything else lives in the assignment hub
+                      behind the Manage trigger. The read-only shortcuts
+                      survive the archived / can't-author gate: copying a link
+                      or a clone command mutates nothing. */}
+                    <CopyAcceptLinkAction
+                      org={org}
+                      classroom={classroom}
+                      assignment={assignment}
+                      secret={secret}
+                      secretPending={secretPending}
+                    />
+                    <CloneSubmissionsAction
+                      org={org}
+                      classroom={classroom}
+                      assignment={assignment}
+                    />
+                    <Link
+                      className="btn btn-circle btn-sm btn-ghost"
+                      to="/$org/$classroom/assignments/$assignment/settings"
+                      params={{
+                        org,
+                        classroom,
+                        assignment: assignment.slug,
+                      }}
+                      title={
+                        canMutate
+                          ? t("assignments.table.editAssignment")
+                          : t("assignments.table.viewAssignment")
+                      }
+                      onClick={(event) => {
+                        event.stopPropagation()
+                      }}
+                    >
+                      {canMutate ? (
+                        <PencilIcon aria-hidden="true" className="size-4" />
+                      ) : (
+                        <EyeIcon aria-hidden="true" className="size-4" />
+                      )}
+                    </Link>
+                    {canMutate && (
+                      <LockAssignmentAction
+                        org={org}
+                        classroom={classroom}
+                        assignment={assignment}
+                      />
                     )}
-                  </Link>
-                  {/* Read-only actions, so they survive the archived /
-                      can't-author gate below: copying a link mutates nothing, and
-                      reviewing template access (or reaching the source repo)
-                      stays available because the modal owner-gates its re-grant.
-                      TemplateAccessButton renders nothing without a template. */}
-                  <CopyAcceptLinkButton
-                    org={org}
-                    classroom={classroom}
-                    assignment={assignment}
-                    secret={secret}
-                    secretPending={secretPending}
-                  />
-                  <TemplateAccessButton
-                    org={org}
-                    classroom={classroom}
-                    assignment={assignment}
-                  />
-                  {canMutate && (
-                    <>
-                      <ReuseAssignmentButton
-                        org={org}
-                        classroom={classroom}
-                        assignment={assignment}
-                      />
-                      <LockAssignmentButton
-                        org={org}
-                        classroom={classroom}
-                        assignment={assignment}
-                      />
-                      <DeleteAssignmentButton
-                        org={org}
-                        classroom={classroom}
-                        assignment={assignment}
-                        onDeleteAssignment={() =>
-                          queryClient.invalidateQueries({
-                            queryKey: githubKeys.jsonFile(
-                              org,
-                              CONFIG_REPO,
-                              `${classroom}/assignments.json`,
-                            ),
-                          })
-                        }
-                      />
-                    </>
-                  )}
-                </div>
-              </td>
-            </ClickableTr>
-          ))}
-      </motion.tbody>
-    </TableShell>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      shape="square"
+                      className="text-base-content/70"
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        setManageSlug(assignment.slug)
+                      }}
+                      aria-label={t("assignments.manageModal.openAria", {
+                        name: name(assignment),
+                      })}
+                      title={t("assignments.manageModal.open")}
+                    >
+                      <SlidersIcon aria-hidden="true" className="size-4" />
+                    </Button>
+                  </div>
+                </td>
+              </ClickableTr>
+            ))}
+        </motion.tbody>
+      </TableShell>
+      {/* Mounted only while a row's Manage trigger is active, keyed by slug so
+          it opens once on mount (same convention as the submission hub). */}
+      {manageAssignment && (
+        <ManageAssignmentModal
+          key={`manage-${manageAssignment.slug}`}
+          onClose={() => setManageSlug(null)}
+          org={org}
+          classroom={classroom}
+          assignment={manageAssignment}
+          secret={secret}
+          secretPending={secretPending}
+          canMutate={canMutate}
+          onDeleteAssignment={invalidateAssignments}
+        />
+      )}
+    </>
   )
 }
 

--- a/web/src/pages/assignments/ManageAssignmentModal.tsx
+++ b/web/src/pages/assignments/ManageAssignmentModal.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useId, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { useNavigate } from "@tanstack/react-router"
+import { EyeIcon, LockIcon, PencilIcon } from "@/components/ui/icons"
+
+import { Badge, Heading, Modal, MonoLtr } from "@/components/ui"
+import { ActionListRow } from "@/pages/submissions/actionLayout"
+import {
+  assignmentName,
+  CloneSubmissionsAction,
+  CopyAcceptLinkAction,
+  DeleteAssignmentAction,
+  LockAssignmentAction,
+  ReuseAssignmentAction,
+  TemplateAccessAction,
+} from "@/pages/assignments/AssignmentRowActions"
+import type { Assignment } from "@/types/classroom"
+
+// The assignment hub: the assignments table's counterpart of the submission
+// hub (ManageSubmissionModal) — one Manage entry point per row gathering every
+// per-assignment action as a labeled list row, so the table keeps only a few
+// quick-access shortcuts. Rich sub-modals (clone CLI, template access, reuse)
+// stack on the hub via native <dialog> nesting and hide its box while up
+// (`subModalOpen`); the small lock/delete confirms stack visibly, like the
+// submission hub's regrade confirm.
+//
+// Mounted only while a row is selected (the caller gates + remounts via `key`),
+// so it opens once on mount; Esc/backdrop/X fire onClose to clear the selection.
+export const ManageAssignmentModal = ({
+  onClose,
+  org,
+  classroom,
+  assignment,
+  secret,
+  secretPending,
+  canMutate,
+  onDeleteAssignment,
+}: {
+  onClose: () => void
+  org: string
+  classroom: string
+  assignment: Assignment
+  secret?: string
+  secretPending?: boolean
+  // Author on an unarchived classroom: gates the mutating rows (edit label,
+  // reuse, lock, delete), same tier as the table's quick actions.
+  canMutate: boolean
+  onDeleteAssignment: () => void
+}) => {
+  const dialogRef = useRef<HTMLDialogElement | null>(null)
+  const titleId = useId()
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [subModalOpen, setSubModalOpen] = useState(false)
+
+  useEffect(() => {
+    dialogRef.current?.showModal()
+  }, [])
+
+  return (
+    <Modal
+      dialogRef={dialogRef}
+      onClose={onClose}
+      size="lg"
+      // Keep the dialog open but hide its box while a stacked sub-modal is up,
+      // so the two modal boxes don't visibly layer. The sub-modal renders its
+      // own backdrop on top; dismissing it un-hides this box.
+      boxClassName={subModalOpen ? "invisible" : undefined}
+      aria-labelledby={titleId}
+    >
+      <Heading as="h3" className="truncate pe-8" id={titleId}>
+        {assignmentName(assignment)}
+      </Heading>
+      <p className="mt-0.5 flex items-center gap-2 text-sm text-base-content/60">
+        <MonoLtr className="truncate">{assignment.slug}</MonoLtr>
+        {assignment.locked && (
+          <Badge
+            tone="warning"
+            size="sm"
+            className="gap-1 whitespace-nowrap"
+            title={t("assignments.table.lockedBadgeTitle")}
+          >
+            <LockIcon aria-hidden="true" className="size-3" />
+            {t("assignments.table.lockedBadge")}
+          </Badge>
+        )}
+      </p>
+
+      <div className="mt-4 flex flex-col">
+        <ActionListRow
+          icon={canMutate ? PencilIcon : EyeIcon}
+          title={
+            canMutate
+              ? t("assignments.table.editAssignment")
+              : t("assignments.table.viewAssignment")
+          }
+          description={
+            canMutate
+              ? t("assignments.manageModal.editDescription")
+              : t("assignments.manageModal.viewDescription")
+          }
+          onClick={() =>
+            void navigate({
+              to: "/$org/$classroom/assignments/$assignment/settings",
+              params: { org, classroom, assignment: assignment.slug },
+            })
+          }
+        />
+        <CopyAcceptLinkAction
+          variant="row"
+          org={org}
+          classroom={classroom}
+          assignment={assignment}
+          secret={secret}
+          secretPending={secretPending}
+        />
+        <CloneSubmissionsAction
+          variant="row"
+          org={org}
+          classroom={classroom}
+          assignment={assignment}
+          onSubModalToggle={setSubModalOpen}
+        />
+        <TemplateAccessAction
+          org={org}
+          classroom={classroom}
+          assignment={assignment}
+          onSubModalToggle={setSubModalOpen}
+        />
+        {canMutate && (
+          <>
+            <ReuseAssignmentAction
+              org={org}
+              classroom={classroom}
+              assignment={assignment}
+              onSubModalToggle={setSubModalOpen}
+            />
+            <LockAssignmentAction
+              variant="row"
+              org={org}
+              classroom={classroom}
+              assignment={assignment}
+            />
+            <DeleteAssignmentAction
+              org={org}
+              classroom={classroom}
+              assignment={assignment}
+              onDeleteAssignment={onDeleteAssignment}
+            />
+          </>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+export default ManageAssignmentModal


### PR DESCRIPTION
## Summary

Assignment rows had grown a six-icon action cluster that could not absorb another action. Each row now keeps four quick actions — copy accept link, clone all submissions, edit, and lock — plus a single Manage trigger that opens an assignment hub (`ManageAssignmentModal`), the assignments-table twin of the submission hub: every action, quick ones included, is a labeled row with a one-line description. Template access, reuse, and delete now live only in the hub, and cloning all submissions via `gh teacher download` is now reachable from the assignments list instead of only from a gradebook page.

Two icon corrections ride along, per [Octicons](https://primer.style/octicons/) guidance: reuse-in-another-classroom drops the `copy` octicon (reserved for copy-to-clipboard) for `duplicate`, and the clone quick action uses the download icon, matching GitHub Classroom's precedent for the same action.

Design decisions worth a look:

- Each action exists once in `AssignmentRowActions.tsx` with an `icon`/`row` variant, so the table shortcut and the hub row share labels, gating, and the owned confirm/sub-modal — they cannot drift.
- The hub stores only the selected slug and re-resolves the assignment from the live list each render, so a lock flip is reflected after `assignments.json` refetches and a deleted assignment unmounts the hub instead of showing stale data.
- Stacking follows the submission hub's conventions: rich sub-modals (clone CLI, template access, reuse) hide the hub box while up; the small lock/delete confirms layer visibly on top.

Validation: `npm run check` is green (tsc, eslint, prettier, dependency-cruiser, 4466 tests across 354 files); the table tests now open the hub to reach the consolidated actions, and new cases cover the quick-action split, the hub's full action set for authors, and the read-only gating.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - Web: `cd web && npm run check`
- [ ] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass. (N/A)
- [ ] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README). (N/A)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
