### PR TITLE
fix: stop corrupting non-ASCII names in uploaded roster CSVs

### DIFF
--- a/cli/gh-teacher/go.mod
+++ b/cli/gh-teacher/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/thlib/go-timezone-local v0.0.8 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
+	golang.org/x/text v0.40.0
 )
 
 replace github.com/foundation50/classroom50-cli-shared => ../shared

--- a/cli/gh-teacher/internal/configrepo/students_csv.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv.go
@@ -10,6 +10,9 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/charmap"
 )
 
 // RosterColumns: canonical required column order. github_id is tool-managed —
@@ -59,6 +62,25 @@ var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 // in an editor but makes the first line of the file unparseable.
 func TrimUTF8BOM(data []byte) []byte {
 	return bytes.TrimPrefix(data, utf8BOM)
+}
+
+// NormalizeTeacherText converts a teacher-supplied local file to UTF-8. Bytes
+// that already validate as UTF-8 (after BOM strip) pass through; anything else
+// is decoded as Windows-1252 — Excel's plain "CSV" export on a Western-locale
+// Windows box — which accepts every byte sequence, matching the web app's
+// fallback. transcoded reports the fallback ran, so a caller can tell the
+// teacher to double-check non-ASCII names.
+func NormalizeTeacherText(data []byte) (out []byte, transcoded bool) {
+	data = TrimUTF8BOM(data)
+	if utf8.Valid(data) {
+		return data, false
+	}
+	decoded, err := charmap.Windows1252.NewDecoder().Bytes(data)
+	if err != nil {
+		// Windows-1252 decodes every byte sequence; unreachable in practice.
+		return data, false
+	}
+	return decoded, true
 }
 
 // RosterRow is one student in the roster. GitHubID == 0 means unresolved — a

--- a/cli/gh-teacher/internal/configrepo/students_csv_test.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv_test.go
@@ -892,6 +892,56 @@ func TestParseImportCSV_StripsUTF8BOM(t *testing.T) {
 	}
 }
 
+func TestNormalizeTeacherText(t *testing.T) {
+	// "ÆØÅæøå" in Windows-1252 single bytes — Excel's plain "CSV" export on a
+	// Western-locale Windows box (issue #742).
+	win1252Name := []byte{0xC6, 0xD8, 0xC5, 0xE6, 0xF8, 0xE5}
+
+	cases := []struct {
+		name           string
+		in             []byte
+		want           string
+		wantTranscoded bool
+	}{
+		{"ascii passthrough", []byte("username\nalice\n"), "username\nalice\n", false},
+		{"utf-8 passthrough", []byte("first_name\nÆØÅæøå\n"), "first_name\nÆØÅæøå\n", false},
+		{"utf-8 BOM stripped", append([]byte{0xEF, 0xBB, 0xBF}, "username\nalice\n"...), "username\nalice\n", false},
+		{"windows-1252 transcoded", append([]byte("first_name\n"), append(win1252Name, '\n')...), "first_name\nÆØÅæøå\n", true},
+		{"empty", nil, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, transcoded := NormalizeTeacherText(tc.in)
+			if string(out) != tc.want {
+				t.Fatalf("NormalizeTeacherText = %q, want %q", out, tc.want)
+			}
+			if transcoded != tc.wantTranscoded {
+				t.Fatalf("transcoded = %v, want %v", transcoded, tc.wantTranscoded)
+			}
+		})
+	}
+}
+
+func TestParseImportCSV_Windows1252ViaNormalize(t *testing.T) {
+	// The readTeacherFile path: a Windows-1252 import normalizes to UTF-8
+	// before parsing, so the name survives instead of landing invalid bytes
+	// in roster.csv (which the web then renders as U+FFFD).
+	in := append([]byte("username,first_name,last_name,email,section\nalice,"),
+		0xC6, 0xD8, 0xC5, 0xE6, 0xF8, 0xE5)
+	in = append(in, []byte(",A,,s\n")...)
+	normalized, transcoded := NormalizeTeacherText(in)
+	if !transcoded {
+		t.Fatal("expected the Windows-1252 fallback to run")
+	}
+	rows, err := ParseImportCSV(normalized)
+	if err != nil {
+		t.Fatalf("ParseImportCSV after normalize: %v", err)
+	}
+	if len(rows) != 1 || rows[0].FirstName != "ÆØÅæøå" {
+		t.Fatalf("expected first_name ÆØÅæøå, got %#v", rows)
+	}
+}
+
 func TestParseImportCSV_RejectsWidenedExportWithGuidance(t *testing.T) {
 	// A roster CSV widened past the canonical role column (legacy web exports
 	// carried enrollment bookkeeping columns) is still rejected: import

--- a/cli/gh-teacher/internal/configrepo/students_csv_test.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv_test.go
@@ -893,9 +893,9 @@ func TestParseImportCSV_StripsUTF8BOM(t *testing.T) {
 }
 
 func TestNormalizeTeacherText(t *testing.T) {
-	// "ÆØÅæøå" in Windows-1252 single bytes — Excel's plain "CSV" export on a
-	// Western-locale Windows box (issue #742).
-	win1252Name := []byte{0xC6, 0xD8, 0xC5, 0xE6, 0xF8, 0xE5}
+	// "Bjørn Ægir" in Windows-1252 single bytes (ø=0xF8, Æ=0xC6) — what Excel's
+	// plain "CSV" export produces on a Western-locale Windows box (issue #742).
+	win1252Name := []byte{0x42, 0x6A, 0xF8, 0x72, 0x6E, 0x20, 0xC6, 0x67, 0x69, 0x72}
 
 	cases := []struct {
 		name           string
@@ -904,9 +904,9 @@ func TestNormalizeTeacherText(t *testing.T) {
 		wantTranscoded bool
 	}{
 		{"ascii passthrough", []byte("username\nalice\n"), "username\nalice\n", false},
-		{"utf-8 passthrough", []byte("first_name\nÆØÅæøå\n"), "first_name\nÆØÅæøå\n", false},
+		{"utf-8 passthrough", []byte("first_name\nBjørn Ægir\n"), "first_name\nBjørn Ægir\n", false},
 		{"utf-8 BOM stripped", append([]byte{0xEF, 0xBB, 0xBF}, "username\nalice\n"...), "username\nalice\n", false},
-		{"windows-1252 transcoded", append([]byte("first_name\n"), append(win1252Name, '\n')...), "first_name\nÆØÅæøå\n", true},
+		{"windows-1252 transcoded", append([]byte("first_name\n"), append(win1252Name, '\n')...), "first_name\nBjørn Ægir\n", true},
 		{"empty", nil, "", false},
 	}
 	for _, tc := range cases {
@@ -927,7 +927,7 @@ func TestParseImportCSV_Windows1252ViaNormalize(t *testing.T) {
 	// before parsing, so the name survives instead of landing invalid bytes
 	// in roster.csv (which the web then renders as U+FFFD).
 	in := append([]byte("username,first_name,last_name,email,section\nalice,"),
-		0xC6, 0xD8, 0xC5, 0xE6, 0xF8, 0xE5)
+		0x42, 0x6A, 0xF8, 0x72, 0x6E) // "Bjørn" in Windows-1252
 	in = append(in, []byte(",A,,s\n")...)
 	normalized, transcoded := NormalizeTeacherText(in)
 	if !transcoded {
@@ -937,8 +937,8 @@ func TestParseImportCSV_Windows1252ViaNormalize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseImportCSV after normalize: %v", err)
 	}
-	if len(rows) != 1 || rows[0].FirstName != "ÆØÅæøå" {
-		t.Fatalf("expected first_name ÆØÅæøå, got %#v", rows)
+	if len(rows) != 1 || rows[0].FirstName != "Bjørn" {
+		t.Fatalf("expected first_name Bjørn, got %#v", rows)
 	}
 }
 

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -122,7 +122,7 @@ func rosterInviteCmd() *cobra.Command {
 			var data []byte
 			if path != "" {
 				var err error
-				if _, data, err = readTeacherFile(path, "--file path"); err != nil {
+				if _, data, err = readTeacherFile(cmd.ErrOrStderr(), path, "--file path"); err != nil {
 					return err
 				}
 			}
@@ -147,9 +147,11 @@ func rosterInviteCmd() *cobra.Command {
 
 // readTeacherFile reads a local file a teacher passed on the command line,
 // returning the resolved absolute path alongside the bytes so callers name the
-// file they actually opened. `what` labels the argument in a resolve error
-// (e.g. "--file path", "import path").
-func readTeacherFile(path, what string) (string, []byte, error) {
+// file they actually opened. Content is normalized to UTF-8 (see
+// NormalizeTeacherText), with a stderr notice when the Windows-1252 fallback
+// ran. `what` labels the argument in a resolve error (e.g. "--file path",
+// "import path").
+func readTeacherFile(errOut io.Writer, path, what string) (string, []byte, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return "", nil, fmt.Errorf("resolve %s: %w", what, err)
@@ -158,7 +160,11 @@ func readTeacherFile(path, what string) (string, []byte, error) {
 	if err != nil {
 		return "", nil, fmt.Errorf("read %s: %w", abs, err)
 	}
-	return abs, data, nil
+	normalized, transcoded := configrepo.NormalizeTeacherText(data)
+	if transcoded {
+		_, _ = fmt.Fprintf(errOut, "Notice: %s is not UTF-8 encoded and was read as Windows-1252 — double-check any non-ASCII names\n", abs)
+	}
+	return abs, normalized, nil
 }
 
 // errClassroomTeamUnusable refuses a send when classroom.json records no usable

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -654,7 +654,7 @@ func runRosterImport(client githubapi.Client, out, errOut io.Writer, org, classr
 		return err
 	}
 
-	abs, data, err := readTeacherFile(csvPath, "import path")
+	abs, data, err := readTeacherFile(errOut, csvPath, "import path")
 	if err != nil {
 		return err
 	}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -801,6 +801,7 @@
     "uploadInviteNotice_one": "This will send {{count}} GitHub organization invitation to students who aren't members yet.",
     "uploadInviteNotice_other": "This will send {{count}} GitHub organization invitations to students who aren't members yet.",
     "uploadTeacherOwnerNotice": "Rows marked Teacher will be invited as organization OWNERS, granting full control of the organization. Only assign the teacher role to people you trust with owner access.",
+    "uploadEncodingFallbackNotice": "This file isn't UTF-8 encoded, so it was read as Windows-1252. Check that names and accents look right below — for best results, export from Excel as \"CSV UTF-8\".",
     "roleWritebackMalformed": "Invitations were sent, but the assigned roles couldn't be written because roster.csv is malformed. Fix the flagged lines on the roster, then re-check — roles will converge on the next sync.",
     "roleWritebackFailed": "Invitations were sent, but writing the assigned roles to roster.csv failed. The roles will converge on the next sync, or re-run the import to retry.",
     "metadataWritebackMalformed": "The import completed, but student details couldn't be updated because roster.csv is malformed. Fix the flagged lines on the roster, then re-check.",

--- a/web/src/pages/students/UploadRoster.test.tsx
+++ b/web/src/pages/students/UploadRoster.test.tsx
@@ -1050,3 +1050,62 @@ describe("UploadRoster identity mismatch gate", () => {
     expect(importButton()?.disabled).toBe(false)
   })
 })
+
+// Issue #742: a Windows-1252 roster (Excel's plain "CSV" export on Windows)
+// must decode to the real characters, not U+FFFD, and the preview must say the
+// fallback ran so the teacher checks the names.
+describe("UploadRoster legacy-encoding fallback", () => {
+  it("decodes a Windows-1252 file and shows the encoding notice", async () => {
+    const user = userEvent.setup()
+    renderModal(
+      <UploadRoster org="acme" classroom="cs50" client={client} open={true} />,
+    )
+
+    // "email,first_name\nada@x.no,ÆØÅæøå\n" with the name in Windows-1252
+    // single bytes — File.text() would have read six U+FFFDs here.
+    const ascii = (s: string) => Array.from(s, (c) => c.charCodeAt(0))
+    const bytes = new Uint8Array([
+      ...ascii("email,first_name\nada@x.no,"),
+      0xc6,
+      0xd8,
+      0xc5,
+      0xe6,
+      0xf8,
+      0xe5,
+      ...ascii("\n"),
+    ])
+    await uploadFile(user, new File([bytes], "roster.csv"))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("students.uploadEncodingFallbackNotice"),
+      ).toBeTruthy(),
+    )
+    // The row table is collapsed behind the summary's details toggle.
+    await user.click(
+      await waitFor(() => screen.getByText("students.summaryViewDetails")),
+    )
+    await waitFor(() => expect(screen.getByText(/ÆØÅæøå/)).toBeTruthy())
+    expect(screen.queryByText(/\uFFFD/)).toBeNull()
+  })
+
+  it("shows no notice for a UTF-8 file", async () => {
+    const user = userEvent.setup()
+    renderModal(
+      <UploadRoster org="acme" classroom="cs50" client={client} open={true} />,
+    )
+
+    await uploadFile(
+      user,
+      file("roster.csv", "email,first_name\nada@x.no,ÆØÅæøå\n"),
+    )
+
+    await user.click(
+      await waitFor(() => screen.getByText("students.summaryViewDetails")),
+    )
+    await waitFor(() => expect(screen.getByText(/ÆØÅæøå/)).toBeTruthy())
+    expect(
+      screen.queryByText("students.uploadEncodingFallbackNotice"),
+    ).toBeNull()
+  })
+})

--- a/web/src/pages/students/UploadRoster.test.tsx
+++ b/web/src/pages/students/UploadRoster.test.tsx
@@ -1061,17 +1061,16 @@ describe("UploadRoster legacy-encoding fallback", () => {
       <UploadRoster org="acme" classroom="cs50" client={client} open={true} />,
     )
 
-    // "email,first_name\nada@x.no,ÆØÅæøå\n" with the name in Windows-1252
-    // single bytes — File.text() would have read six U+FFFDs here.
+    // "email,first_name\nada@x.no,Bjørn\n" with the name in Windows-1252
+    // single bytes (ø=0xF8) — File.text() would have read U+FFFD here.
     const ascii = (s: string) => Array.from(s, (c) => c.charCodeAt(0))
     const bytes = new Uint8Array([
       ...ascii("email,first_name\nada@x.no,"),
-      0xc6,
-      0xd8,
-      0xc5,
-      0xe6,
+      0x42,
+      0x6a,
       0xf8,
-      0xe5,
+      0x72,
+      0x6e,
       ...ascii("\n"),
     ])
     await uploadFile(user, new File([bytes], "roster.csv"))
@@ -1085,7 +1084,7 @@ describe("UploadRoster legacy-encoding fallback", () => {
     await user.click(
       await waitFor(() => screen.getByText("students.summaryViewDetails")),
     )
-    await waitFor(() => expect(screen.getByText(/ÆØÅæøå/)).toBeTruthy())
+    await waitFor(() => expect(screen.getByText(/Bjørn/)).toBeTruthy())
     expect(screen.queryByText(/\uFFFD/)).toBeNull()
   })
 
@@ -1097,13 +1096,13 @@ describe("UploadRoster legacy-encoding fallback", () => {
 
     await uploadFile(
       user,
-      file("roster.csv", "email,first_name\nada@x.no,ÆØÅæøå\n"),
+      file("roster.csv", "email,first_name\nada@x.no,Bjørn\n"),
     )
 
     await user.click(
       await waitFor(() => screen.getByText("students.summaryViewDetails")),
     )
-    await waitFor(() => expect(screen.getByText(/ÆØÅæøå/)).toBeTruthy())
+    await waitFor(() => expect(screen.getByText(/Bjørn/)).toBeTruthy())
     expect(
       screen.queryByText("students.uploadEncodingFallbackNotice"),
     ).toBeNull()

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -17,6 +17,7 @@ import {
   type PreflightResult,
 } from "@/util/rosterUploadPreflight"
 import { logger } from "@/lib/logger"
+import { decodeTextFile } from "@/util/fileBytes"
 import { isTeacherRole } from "@/authz"
 import type { ClassroomRole } from "@/util/teamRoster"
 import {
@@ -106,6 +107,9 @@ const UploadRoster = ({
   // always the initial one — its parser handles all three shapes — so the other
   // two exist only as the teacher's explicit override.
   const [fileText, setFileText] = useState("")
+  // True when the file wasn't UTF-8 and was decoded as Windows-1252 — worth a
+  // notice so the teacher checks the preview for garbled names (issue #742).
+  const [encodingFallback, setEncodingFallback] = useState(false)
   const [uploadKind, setUploadKind] = useState<UploadKind>(DEFAULT_UPLOAD_KIND)
   // Rows as parsed, before identity resolution, plus the lines the parse could
   // not address to anyone. `parseId` increments on every parse so the resolution
@@ -173,6 +177,7 @@ const UploadRoster = ({
     setPhase("idle")
     setFileName("")
     setFileText("")
+    setEncodingFallback(false)
     setUploadKind(DEFAULT_UPLOAD_KIND)
     setParsedRows([])
     setDroppedRows([])
@@ -552,10 +557,11 @@ const UploadRoster = ({
   const ingestFile = async (file: File) => {
     const token = ++ingestToken.current
     try {
-      const text = await file.text()
+      const { text, fallbackUsed } = await decodeTextFile(file)
       if (ingestToken.current !== token) return
       setFileName(file.name)
       setFileText(text)
+      setEncodingFallback(fallbackUsed)
       applyKind(text, DEFAULT_UPLOAD_KIND)
       setResult(null)
       setEmailResult(null)
@@ -746,6 +752,15 @@ const UploadRoster = ({
 
         {phase === "preview" && (
           <div className="mt-6">
+            {/* Legacy-encoding fallback: the bytes weren't UTF-8, so they were
+                read as Windows-1252. Right for Excel's Western "ANSI" CSV
+                export; a rarer code page shows garbled names the teacher can
+                catch here before importing. */}
+            {encodingFallback ? (
+              <Alert tone="info" className="mb-4">
+                <span>{t("students.uploadEncodingFallbackNotice")}</span>
+              </Alert>
+            ) : null}
             {/* How the file is being read, with an override. Roster CSV is always
                 the initial choice; the other two are assertions about every line
                 that the same parser honours. */}

--- a/web/src/util/fileBytes.test.ts
+++ b/web/src/util/fileBytes.test.ts
@@ -42,9 +42,11 @@ describe("decodeTextFile", () => {
     new File([new Uint8Array(bytes)], "roster.csv")
 
   it("decodes valid UTF-8 without the fallback", async () => {
-    const file = fileOf(new TextEncoder().encode("Name,Email\nÆØÅæøå,a@x.no\n"))
+    const file = fileOf(
+      new TextEncoder().encode("Name,Email\nBjørn Ægir,b@x.no\n"),
+    )
     expect(await decodeTextFile(file)).toEqual({
-      text: "Name,Email\nÆØÅæøå,a@x.no\n",
+      text: "Name,Email\nBjørn Ægir,b@x.no\n",
       fallbackUsed: false,
     })
   })
@@ -58,25 +60,28 @@ describe("decodeTextFile", () => {
     })
   })
 
-  // The issue #742 repro: Excel's plain "CSV" export on Windows is
-  // Windows-1252, which File.text() would decode to a run of U+FFFD.
-  it("decodes a Windows-1252 file (æøå) via the fallback", async () => {
-    // "ÆØÅæøå" in Windows-1252 single bytes.
-    const name = [0xc6, 0xd8, 0xc5, 0xe6, 0xf8, 0xe5]
+  // Issue #742: Excel's plain "CSV" export on Windows is Windows-1252, which
+  // File.text() would decode to a run of U+FFFD.
+  it("decodes a Windows-1252 file via the fallback", async () => {
+    // "Bjørn Håkonsen" in Windows-1252 single bytes (ø=0xF8, å=0xE5).
+    const name = [
+      0x42, 0x6a, 0xf8, 0x72, 0x6e, 0x20, 0x48, 0xe5, 0x6b, 0x6f, 0x6e, 0x73,
+      0x65, 0x6e,
+    ]
     const ascii = (s: string) => Array.from(s, (c) => c.charCodeAt(0))
     const file = fileOf([
       ...ascii("Name,Email\n"),
       ...name,
-      ...ascii(",mail@example.org\n"),
+      ...ascii(",b@x.no\n"),
     ])
     expect(await decodeTextFile(file)).toEqual({
-      text: "Name,Email\nÆØÅæøå,mail@example.org\n",
+      text: "Name,Email\nBjørn Håkonsen,b@x.no\n",
       fallbackUsed: true,
     })
   })
 
   it("decodes UTF-16LE with a BOM", async () => {
-    const text = "username\nÆØÅ\n"
+    const text = "username\nBjørn\n"
     const bytes = new Uint8Array(2 + text.length * 2)
     bytes[0] = 0xff
     bytes[1] = 0xfe

--- a/web/src/util/fileBytes.test.ts
+++ b/web/src/util/fileBytes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { bytesToBase64, fileToBase64 } from "./fileBytes"
+import { bytesToBase64, decodeTextFile, fileToBase64 } from "./fileBytes"
 
 describe("bytesToBase64", () => {
   it("encodes bytes to standard base64 (matches btoa for ASCII)", () => {
@@ -34,5 +34,67 @@ describe("fileToBase64", () => {
     expect(
       Array.from(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0))),
     ).toEqual([1, 2, 3, 4])
+  })
+})
+
+describe("decodeTextFile", () => {
+  const fileOf = (bytes: number[] | Uint8Array) =>
+    new File([new Uint8Array(bytes)], "roster.csv")
+
+  it("decodes valid UTF-8 without the fallback", async () => {
+    const file = fileOf(new TextEncoder().encode("Name,Email\nÆØÅæøå,a@x.no\n"))
+    expect(await decodeTextFile(file)).toEqual({
+      text: "Name,Email\nÆØÅæøå,a@x.no\n",
+      fallbackUsed: false,
+    })
+  })
+
+  it("strips a UTF-8 BOM", async () => {
+    const body = new TextEncoder().encode("username\nada\n")
+    const file = fileOf(new Uint8Array([0xef, 0xbb, 0xbf, ...body]))
+    expect(await decodeTextFile(file)).toEqual({
+      text: "username\nada\n",
+      fallbackUsed: false,
+    })
+  })
+
+  // The issue #742 repro: Excel's plain "CSV" export on Windows is
+  // Windows-1252, which File.text() would decode to a run of U+FFFD.
+  it("decodes a Windows-1252 file (æøå) via the fallback", async () => {
+    // "ÆØÅæøå" in Windows-1252 single bytes.
+    const name = [0xc6, 0xd8, 0xc5, 0xe6, 0xf8, 0xe5]
+    const ascii = (s: string) => Array.from(s, (c) => c.charCodeAt(0))
+    const file = fileOf([
+      ...ascii("Name,Email\n"),
+      ...name,
+      ...ascii(",mail@example.org\n"),
+    ])
+    expect(await decodeTextFile(file)).toEqual({
+      text: "Name,Email\nÆØÅæøå,mail@example.org\n",
+      fallbackUsed: true,
+    })
+  })
+
+  it("decodes UTF-16LE with a BOM", async () => {
+    const text = "username\nÆØÅ\n"
+    const bytes = new Uint8Array(2 + text.length * 2)
+    bytes[0] = 0xff
+    bytes[1] = 0xfe
+    for (let i = 0; i < text.length; i++) {
+      const code = text.charCodeAt(i)
+      bytes[2 + i * 2] = code & 0xff
+      bytes[3 + i * 2] = code >> 8
+    }
+    expect(await decodeTextFile(fileOf(bytes))).toEqual({
+      text,
+      fallbackUsed: false,
+    })
+  })
+
+  it("handles an empty file", async () => {
+    expect(await decodeTextFile(fileOf([]))).toEqual({
+      text: "",
+      fallbackUsed: false,
+    })
   })
 })

--- a/web/src/util/fileBytes.ts
+++ b/web/src/util/fileBytes.ts
@@ -15,3 +15,48 @@ export function bytesToBase64(bytes: Uint8Array): string {
   }
   return btoa(binary)
 }
+
+export interface DecodedTextFile {
+  text: string
+  /** True when the file wasn't valid UTF-8 and was decoded as Windows-1252. */
+  fallbackUsed: boolean
+}
+
+// Decode a teacher-supplied text file without assuming UTF-8. File.text()
+// decodes as UTF-8 in non-fatal mode, so a Windows-1252 file (Excel's plain
+// "CSV" export on Windows) turns every non-ASCII byte into U+FFFD (issue
+// #742). Order: BOM sniff (UTF-8/UTF-16 — TextDecoder strips the BOM itself),
+// then strict UTF-8, then Windows-1252 — which decodes any byte sequence, so
+// this never throws. A non-1252 legacy code page decodes as visible mojibake
+// the preview step lets the teacher catch.
+export async function decodeTextFile(file: File): Promise<DecodedTextFile> {
+  const bytes = new Uint8Array(await file.arrayBuffer())
+  const bomEncoding = detectBomEncoding(bytes)
+  if (bomEncoding) {
+    return {
+      text: new TextDecoder(bomEncoding).decode(bytes),
+      fallbackUsed: false,
+    }
+  }
+  try {
+    return {
+      text: new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+      fallbackUsed: false,
+    }
+  } catch {
+    return {
+      text: new TextDecoder("windows-1252").decode(bytes),
+      fallbackUsed: true,
+    }
+  }
+}
+
+function detectBomEncoding(
+  bytes: Uint8Array,
+): "utf-8" | "utf-16le" | "utf-16be" | null {
+  if (bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf)
+    return "utf-8"
+  if (bytes[0] === 0xff && bytes[1] === 0xfe) return "utf-16le"
+  if (bytes[0] === 0xfe && bytes[1] === 0xff) return "utf-16be"
+  return null
+}


### PR DESCRIPTION
## Summary

Uploading a roster CSV saved as Windows-1252 (Excel's default "CSV" export on Windows) turned every non-ASCII character into `�` — permanently, since the corrupted string was committed to `roster.csv` as valid UTF-8. Both ingest paths now try strict UTF-8 first and fall back to Windows-1252: the web upload (which previously hard-assumed UTF-8 via `file.text()`) and the CLI's `roster import` / `roster invite --file` (which previously passed invalid-UTF-8 bytes through verbatim). UTF-8 and UTF-16 BOMs are also handled on the web side.

Because a non-Western locale's ANSI export would decode as visible mojibake rather than `�`, the fallback is never silent: the web preview shows an info notice (and suggests Excel's "CSV UTF-8" export), and the CLI prints a stderr notice, so the teacher can check the names before anything is written.

Validated with new unit tests on both sides, including rosters round-tripped from raw Windows-1252 bytes (`web/src/util/fileBytes.test.ts`, `UploadRoster.test.tsx`, `students_csv_test.go`).

Closes #742

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
