### PR TITLE
docs(wiki): document the web features shipping in 1.34

### DIFF
--- a/web/src/components/ui/FormField.test.tsx
+++ b/web/src/components/ui/FormField.test.tsx
@@ -58,7 +58,7 @@ describe("FormField", () => {
     const input = screen.getByLabelText("Name")
     expect(input.getAttribute("aria-describedby")).toBe(alert.id)
     expect(input.getAttribute("aria-invalid")).toBe("true")
-    // The invalid field renders a decorative error marker (lucide svg) in the
+    // The invalid field renders a decorative error marker icon in the
     // label row; the alert text carries the accessible announcement.
     expect(
       document.querySelector("svg.text-error[aria-hidden='true']"),

--- a/wiki/Autograding-Basics.md
+++ b/wiki/Autograding-Basics.md
@@ -359,7 +359,8 @@ student says "I submitted" and you see no score, collect first.
 On the submissions page, each row shows the student's (or group's) current
 score with links to the repository, the graded **commit**, the Release
 (**View autograder details**), the full **review** diff (starter code → graded
-commit), and the Feedback PR (**Review**).
+commit), and the Feedback PR (**View feedback PR** on the row, or **Review**
+in its manage dialog).
 
 ### Latest score versus history
 

--- a/wiki/Course-Lifecycle-and-End-of-Term.md
+++ b/wiki/Course-Lifecycle-and-End-of-Term.md
@@ -132,8 +132,9 @@ gh teacher assignment reuse cs50-fall-2026 hello --from cs-principles --to cs-pr
 Every field is copied (template, tests, runtime, due date included; update
 the due date after copying). Student repositories and scores are not copied,
 and the target classroom's team is re-granted read access to a private
-template inside the organization. The web app offers the same action on an
-assignment. See
+template inside the organization. The web app offers the same action as
+**Reuse in another classroom**, in the assignment row's **Manage assignment**
+dialog. See
 [`gh teacher assignment reuse`](gh-teacher#assignment-reuse).
 
 ## Resetting an organization (destructive)

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -287,7 +287,9 @@ Download scores as a CSV from the submissions page
 in the same **Actions** menu bundles every repository's latest submission into
 a single zip (built in your browser). For real clones, to run your own
 tooling locally, `gh teacher download` clones every submission repository and also
-writes a `scores.csv` summary at the destination root. The raw score data also
+writes a `scores.csv` summary at the destination root (the submissions page's
+**Clone all submissions** button hands you that command ready to copy). The
+raw score data also
 lives in `scores.json` in your `classroom50` repository, so you can build your own
 automations against it. The column-by-column reference for both CSVs is in
 [Score exports](Autograding-Basics#score-exports) in Autograding Basics.

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -376,7 +376,10 @@ is imported.
 Each row needs at least one column that identifies a student: `github_id`,
 `username`, or `email`. Every other column is optional. Headers are matched
 case-insensitively, and any unrecognized column is ignored, so a CSV exported
-from your SIS or gradebook usually works unchanged.
+from your SIS or gradebook usually works unchanged. Save the file as UTF-8
+when you can (Excel's **CSV UTF-8** export); a file that isn't is read as
+Windows-1252 — Excel's plain "CSV" export — and the upload shows a notice so
+you can check that accented names survived.
 
 When a row has more than one, they're used in that order — `github_id` first,
 then `username`, then `email`:
@@ -507,7 +510,9 @@ strip at the top of the submissions page (the **Actions** menu carries the same
 only this assignment's repositories, so a collection is fast even in a large
 classroom and doesn't rebuild other assignments' scores. The strip shows when
 this assignment's data was last collected (a per-assignment `collected_at`
-stamp in `scores.json`). Click
+stamp in `scores.json`), and an **Out of date** badge appears beside it when
+students have pushed since that collection — collect to grade and score the
+newest work. Click
 **View workflow** to see the Actions run. To refresh every assignment in one
 run instead, see [Collect the whole classroom](#collect-the-whole-classroom).
 
@@ -525,7 +530,8 @@ The top of the page shows:
 Each row shows a student's (or group's) latest submission plus its full history
 (newest first). For each submission you can view the score, the submission date,
 and links to the repository, the commit, the feedback pull request
-(**Review**), and the Release (**View autograder details**). For where every
+(**View feedback PR** on the row; its manage dialog carries the same link as
+**Review**), and the Release (**View autograder details**). For where every
 result lives — per-test breakdowns, past attempts, grading a specific commit,
 and who submitted — see
 [Reading results](Autograding-Basics#reading-results) in Autograding Basics.
@@ -534,7 +540,11 @@ and who submitted — see
 
 The classroom's assignments list refreshes all scores in one run. Above the
 table, a freshness line shows when the classroom's submission data was last
-collected, next to a **Collect all** button. Clicking it dispatches a single
+collected, next to a **Collect all** button. The same **Out of date** badge
+appears there when any assignment's repositories have pushes newer than that
+assignment's last collection — each assignment is judged against its own
+stamp, so one freshly collected assignment can't mask a sibling that was
+never collected. Clicking **Collect all** dispatches a single
 `collect-scores.yaml` run scoped to the classroom, so one run walks every
 assignment and rebuilds all of the classroom's collected scores; the table's
 per-assignment submission counts refresh when the run finishes.
@@ -610,7 +620,10 @@ assignment:
   bundled into a single zip (built in the browser, one repository at a time;
   for very large classrooms prefer `gh teacher download`, which clones every repository
   and writes a `scores.csv` — see the
-  [CLI Teacher Guide](CLI-Teacher-Guide#10-download-submissions)).
+  [CLI Teacher Guide](CLI-Teacher-Guide#10-download-submissions)). The **Clone
+  all submissions** button next to the **Actions** menu — and the download
+  icon in an assignment's row on the **Assignments** page — opens a dialog
+  with that CLI command filled in for the assignment, ready to copy.
 
 ### Download scores
 
@@ -620,6 +633,13 @@ spreadsheet or external tool. The column-by-column reference is in
 
 ## Edit assignments and classrooms
 
+- **Manage an assignment from the list** — each row on the **Assignments**
+  page keeps four quick actions (copy accept link, clone submissions, edit,
+  lock) plus **Manage assignment**, a dialog gathering every per-assignment
+  action in one place: the quick four, **Template access** (review which
+  teams can read the template, and re-grant the classroom teams' read),
+  **Reuse in another classroom**, and **Delete assignment** (which asks you
+  to type the slug to confirm; student repositories are kept).
 - **Edit an assignment** — open the assignment, then **Assignment settings**.
   Same form as creating one, pre-filled. Provisioning settings (repository
   source, built-in autograder, grading mode) are editable; a change only affects

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -506,7 +506,9 @@ Bulk upsert. Accepts three header shapes: the stored roster shape
 (`username,first_name,last_name,email,section,github_id,role`), the same without
 `role`, and the first five columns alone, so a `roster.csv` exported from a
 web-managed classroom imports verbatim. The field reference is in
-[Roster CSV fields](Web-Teacher-Guide#roster-csv-fields).
+[Roster CSV fields](Web-Teacher-Guide#roster-csv-fields). A file that isn't
+UTF-8 is read as Windows-1252 (Excel's plain "CSV" export), with a notice to
+double-check non-ASCII names.
 
 Each row is routed by what identifies it:
 


### PR DESCRIPTION
## Summary

1.34 ships five user-visible web changes that had no wiki coverage: the **Out of date** freshness badge on both collect surfaces (#738), the assignment row's **Manage assignment** hub that now holds template access, reuse, and delete (#745), the direct **View feedback PR** row link (#743), the **Clone all submissions** dialog that hands out the `gh teacher download` command (#740), and the Windows-1252 fallback for uploaded roster CSVs (#746). This documents each one where teachers would look — Web Teacher Guide, FAQ, Autograding Basics, Course Lifecycle, and the `gh teacher` reference.

It also drops a stale lucide reference from a `FormField` test comment left behind by the Octicons migration (#723).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
