### PR TITLE
fix(web): carry the accept link through first-time sign-in

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { useGitHubHealth } from "@/lib/githubHealth"
 import { GitHubStatusNote } from "@/components/GitHubStatusNote"
-import { BASE_PATH, isAuthedPath } from "@/auth/authedPath"
+import { BASE_PATH, isAuthedPath, loginRedirectSearch } from "@/auth/authedPath"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("app")
@@ -22,6 +22,7 @@ export function App() {
     isValidatingStuck,
     retryUserValidation,
     signOut,
+    signedOutDeliberately,
   } = useGithubAuth()
   const { t } = useTranslation()
   const {
@@ -41,22 +42,37 @@ export function App() {
     router,
     select: (s) => s.location.pathname,
   })
+  const searchStr = useRouterState({
+    router,
+    select: (s) => s.location.searchStr,
+  })
   // Redirect eagerly rather than waiting for invalidate(): unmounts the authed
-  // subtree synchronously, closing the null-client crash window. No ?redirect=
-  // — sign-out is deliberate.
+  // subtree synchronously, closing the null-client crash window. On a cold load
+  // this fires before the _authed guard can, so it carries the ?redirect= deep
+  // link itself (#748).
   const sessionEndedOnAuthedRoute =
     status === "unauthenticated" && isAuthedPath(pathname)
 
   useEffect(() => {
     if (!sessionEndedOnAuthedRoute) return
-    log.info("session ended on authed route, redirecting to /login")
-    // Hard-redirect fallback: a rejected navigate() would leave the spinner up
-    // forever (the effect won't re-run — its only dep is unchanged).
-    router.navigate({ to: "/login" }).catch(() => {
-      log.warn("navigate to /login failed, hard-redirecting", { record: true })
-      window.location.assign(`${BASE_PATH}/login`)
+    const search = loginRedirectSearch({
+      pathname,
+      searchStr,
+      signedOutDeliberately,
     })
-  }, [sessionEndedOnAuthedRoute])
+    log.info("session ended on authed route, redirecting to /login", {
+      carriesRedirect: Boolean(search),
+    })
+    // Hard-redirect fallback: a rejected navigate() would leave the spinner up
+    // forever while the guard condition holds.
+    router.navigate({ to: "/login", search }).catch(() => {
+      log.warn("navigate to /login failed, hard-redirecting", { record: true })
+      const query = search
+        ? `?redirect=${encodeURIComponent(search.redirect)}`
+        : ""
+      window.location.assign(`${BASE_PATH}/login${query}`)
+    })
+  }, [sessionEndedOnAuthedRoute, pathname, searchStr, signedOutDeliberately])
 
   if (status === "loading" || sessionEndedOnAuthedRoute) {
     // A settled, persistent validation failure would otherwise spin forever

--- a/web/src/auth/authedPath.test.ts
+++ b/web/src/auth/authedPath.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { isAuthedPath } from "./authedPath"
+import { isAuthedPath, loginRedirectSearch } from "./authedPath"
 
 // App gates the session-end /login redirect on isAuthedPath: the public auth
 // screens ("/login", "/auth", "/auth/") and the public accessibility report
@@ -46,5 +46,50 @@ describe("isAuthedPath", () => {
     expect(scoped("/classroom50/login")).toBe(false)
     expect(scoped("/classroom50/")).toBe(true)
     expect(scoped("/classroom50/acme")).toBe(true)
+  })
+})
+
+// #748: App's eager /login redirect fires before the _authed guard can on a
+// cold unauthenticated load, so it must carry the deep link itself; only a
+// deliberate sign-out lands on a plain /login.
+describe("loginRedirectSearch", () => {
+  it("carries a cold-load deep link, query included (the shared accept link)", () => {
+    expect(
+      loginRedirectSearch({
+        pathname: "/acme/cs101/assignments/a1/accept",
+        searchStr: "?k=SECRET",
+        signedOutDeliberately: false,
+      }),
+    ).toEqual({ redirect: "/acme/cs101/assignments/a1/accept?k=SECRET" })
+  })
+
+  it("carries a query-less destination (e.g. after a 401 session expiry)", () => {
+    expect(
+      loginRedirectSearch({
+        pathname: "/acme/cs101/assignments",
+        searchStr: "",
+        signedOutDeliberately: false,
+      }),
+    ).toEqual({ redirect: "/acme/cs101/assignments" })
+  })
+
+  it("drops the carry after a deliberate sign-out", () => {
+    expect(
+      loginRedirectSearch({
+        pathname: "/acme/cs101/assignments/a1/accept",
+        searchStr: "?k=SECRET",
+        signedOutDeliberately: true,
+      }),
+    ).toBeUndefined()
+  })
+
+  it("skips '/' — the post-login default — to avoid a noisy ?redirect=%2F", () => {
+    expect(
+      loginRedirectSearch({
+        pathname: "/",
+        searchStr: "",
+        signedOutDeliberately: false,
+      }),
+    ).toBeUndefined()
   })
 })

--- a/web/src/auth/authedPath.ts
+++ b/web/src/auth/authedPath.ts
@@ -23,3 +23,15 @@ export function isAuthedPath(pathname: string): boolean {
     path !== "/accessibility/"
   )
 }
+
+// Search for App's eager /login redirect: carry the destination through the
+// login round-trip (#71, #748) unless the sign-out was deliberate. "/" is
+// skipped — it's the post-login default (mirrors the _authed guard's isRoot).
+export function loginRedirectSearch(input: {
+  pathname: string
+  searchStr: string
+  signedOutDeliberately: boolean
+}): { redirect: string } | undefined {
+  if (input.signedOutDeliberately || input.pathname === "/") return undefined
+  return { redirect: input.pathname + input.searchStr }
+}

--- a/web/src/auth/useGithubAuth.signOutFlag.test.tsx
+++ b/web/src/auth/useGithubAuth.signOutFlag.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
+import { createElement } from "react"
+
+// Router is imported for the deep-link push effect; stub it so the test doesn't
+// pull the generated route tree.
+vi.mock("@/router", () => ({
+  default: { history: { push: vi.fn() } },
+}))
+
+const fetchGithubUserWithScopes =
+  vi.fn<(token: string) => Promise<{ user: unknown; scopes: string | null }>>()
+const fetchGithubUser = vi.fn<(token: string) => Promise<unknown>>()
+
+vi.mock("./github-user-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./github-user-api")>()
+  return {
+    ...actual,
+    fetchGithubUserWithScopes: (token: string) =>
+      fetchGithubUserWithScopes(token),
+    fetchGithubUser: (token: string) => fetchGithubUser(token),
+  }
+})
+
+const storage = {
+  token: null as string | null,
+  clientId: "",
+  scope: "",
+  authMethod: null as "oauth" | "pat" | null,
+}
+
+vi.mock("./storage", () => ({
+  getStoredGithubToken: () => storage.token,
+  getStoredGithubClientId: () => storage.clientId,
+  getStoredGithubScope: () => storage.scope,
+  getStoredAuthMethod: () => storage.authMethod,
+  persistGithubToken: vi.fn(),
+  persistGithubClientId: vi.fn(),
+  clearGithubToken: vi.fn(),
+  saveOAuthSession: vi.fn(),
+  consumeOAuthSession: () => ({
+    verifier: null,
+    expectedState: null,
+    clientId: null,
+    scope: null,
+    returnTo: null,
+  }),
+}))
+
+import { GitHubAuthProvider, useGithubAuth } from "./useGithubAuth"
+
+const FULL_SCOPES = "read:user repo workflow admin:org delete_repo"
+
+function wrapper({ children }: PropsWithChildren) {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  })
+  return createElement(
+    QueryClientProvider,
+    { client },
+    createElement(GitHubAuthProvider, null, children),
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv("DEV", false)
+  storage.token = null
+  storage.clientId = ""
+  storage.scope = ""
+  storage.authMethod = null
+  window.history.replaceState({}, "", "/")
+})
+
+// #748: the discriminator for App's /login redirect carry — false on a cold
+// load and on a 401 expiry (both carry ?redirect=), true only on signOut(),
+// reset once the next session signs in.
+describe("signedOutDeliberately", () => {
+  it("is false on a cold unauthenticated load (a deep link must carry ?redirect=)", async () => {
+    const { result } = renderHook(() => useGithubAuth(), { wrapper })
+
+    await waitFor(() => expect(result.current.status).toBe("unauthenticated"))
+    expect(result.current.signedOutDeliberately).toBe(false)
+  })
+
+  it("flips true on a deliberate signOut()", async () => {
+    storage.token = "stored-token"
+    fetchGithubUser.mockResolvedValue({ login: "octocat" })
+
+    const { result } = renderHook(() => useGithubAuth(), { wrapper })
+    await waitFor(() => expect(result.current.status).toBe("authenticated"))
+
+    act(() => result.current.signOut())
+
+    expect(result.current.signedOutDeliberately).toBe(true)
+    expect(result.current.sessionExpired).toBe(false)
+  })
+
+  it("stays false when a live 401 expires the session (re-auth should return the user)", async () => {
+    storage.token = "stored-token"
+    fetchGithubUser.mockResolvedValue({ login: "octocat" })
+
+    const { result } = renderHook(() => useGithubAuth(), { wrapper })
+    await waitFor(() => expect(result.current.status).toBe("authenticated"))
+
+    act(() => result.current.expireSession())
+
+    expect(result.current.signedOutDeliberately).toBe(false)
+    expect(result.current.sessionExpired).toBe(true)
+  })
+
+  it("resets once the next sign-in completes", async () => {
+    storage.token = "stored-token"
+    fetchGithubUser.mockResolvedValue({ login: "octocat" })
+    fetchGithubUserWithScopes.mockResolvedValue({
+      user: { login: "octocat" },
+      scopes: FULL_SCOPES,
+    })
+
+    const { result } = renderHook(() => useGithubAuth(), { wrapper })
+    await waitFor(() => expect(result.current.status).toBe("authenticated"))
+
+    act(() => result.current.signOut())
+    expect(result.current.signedOutDeliberately).toBe(true)
+
+    act(() => result.current.submitPat("ghp_next"))
+    await waitFor(() => expect(result.current.token).toBe("ghp_next"))
+    expect(result.current.signedOutDeliberately).toBe(false)
+  })
+})

--- a/web/src/auth/useGithubAuth.tsx
+++ b/web/src/auth/useGithubAuth.tsx
@@ -295,6 +295,9 @@ function useGithubAuthState() {
   // /login can explain why the user was signed out. A deliberate signOut()
   // clears it.
   const [sessionExpired, setSessionExpired] = useState(false)
+  // True only after a deliberate signOut(): the one case where App's /login
+  // redirect drops the ?redirect= carry (#748).
+  const [signedOutDeliberately, setSignedOutDeliberately] = useState(false)
 
   useEffect(() => {
     tokenRef.current = token
@@ -356,6 +359,7 @@ function useGithubAuthState() {
       setTokenScope(data.scope || "")
       setAuthMethod(data.authMethod)
       setSessionExpired(false)
+      setSignedOutDeliberately(false)
       setDevice(null)
       setScreen("authed")
 
@@ -901,6 +905,7 @@ function useGithubAuthState() {
       setError(null)
       setScreen("config")
       setSessionExpired(expired)
+      setSignedOutDeliberately(!expired)
       // Cancel in-flight ["github"] requests before evicting them so they don't
       // resolve into removed cache state after teardown.
       void queryClient.cancelQueries({ queryKey: ["github"] })
@@ -1049,6 +1054,7 @@ function useGithubAuthState() {
     signOut,
     expireSession,
     sessionExpired,
+    signedOutDeliberately,
     status,
     isValidatingStuck,
     retryUserValidation,


### PR DESCRIPTION
A first-time student — one who joined the org but never authorized the app — who opened a shared accept link landed on the dashboard after signing in, with the assignment lost. On a cold unauthenticated load the app redirects to /login before the router (and the `_authed` guard that attaches `?redirect=`) ever mounts, so the OAuth round-trip had no destination to restore.

The eager redirect now carries the destination itself, `?k=` capability secret included, decided by a new `loginRedirectSearch` helper and a `signedOutDeliberately` flag from `useGithubAuth`: cold loads and 401 session expiries return the user to where they were, while a deliberate sign-out still lands on a plain /login.

Validated with unit tests for the redirect decision and the flag's transitions (the downstream OAuth stash/restore plumbing was already covered); the full `npm run check` gate passes. The live GitHub authorization round-trip was not exercised.

Related: [discussion #748](https://github.com/foundation50/classroom50/discussions/748) (report), #124 (regression origin)
