### PR TITLE
fix(web): align members and roster rows with the shared table style

### DIFF
--- a/web/src/components/ui/TableShell.tsx
+++ b/web/src/components/ui/TableShell.tsx
@@ -17,6 +17,8 @@ export type TableShellProps = {
   // Scale-up entrance; disable when an ancestor already animates the block
   // (nesting two entrances reads as a double pop).
   animate?: boolean
+  // Rendered inside the frame before the table (e.g. a bulk-selection bar).
+  header?: ReactNode
   // Rendered inside the frame after the table (e.g. a pagination bar).
   footer?: ReactNode
   className?: string
@@ -27,6 +29,7 @@ export function TableShell({
   ariaBusy,
   padded = false,
   animate = true,
+  header,
   footer,
   className,
 }: TableShellProps) {
@@ -47,6 +50,7 @@ export function TableShell({
   if (!animate) {
     return (
       <div className={frameClass}>
+        {header}
         {table}
         {footer}
       </div>
@@ -54,6 +58,7 @@ export function TableShell({
   }
   return (
     <EnterDiv className={frameClass}>
+      {header}
       {table}
       {footer}
     </EnterDiv>

--- a/web/src/lib/motionComponents.tsx
+++ b/web/src/lib/motionComponents.tsx
@@ -79,26 +79,8 @@ export function CalloutText({
   )
 }
 
-/** Clickable list row with a pointer cursor and a subtle hover lift + shadow. */
-export function ClickableRow({
-  children,
-  className,
-  ...props
-}: ComponentPropsWithoutRef<typeof motion.li>) {
-  return (
-    <motion.li
-      whileHover={rowHover.whileHover}
-      transition={rowHover.transition}
-      className={`cursor-pointer ${className ?? ""}`}
-      {...props}
-    >
-      {children}
-    </motion.li>
-  )
-}
-
-/** ClickableRow's <tr> counterpart — the one hover + cursor treatment for
- *  table data rows (assignments, submissions, …). Pair with a `hover:bg-*`
+/** The one hover + cursor treatment for clickable table data rows
+ *  (assignments, submissions, members, roster, …). Pair with a `hover:bg-*`
  *  class. */
 export function ClickableTr({
   children,

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -658,6 +658,15 @@
     "noMatch": "No members match your search.",
     "noneWithStatus": "No {{status}} members.",
     "noneInSection": "No members in {{section}}.",
+    "table": {
+      "caption": "Classroom roster",
+      "colSelect": "Select",
+      "colMember": "Member",
+      "colRoles": "Role",
+      "colSection": "Section",
+      "colStatus": "Status",
+      "colActions": "Actions"
+    },
     "bulk": {
       "selectAll": "Select all students",
       "selectRow": "Select {{label}}",
@@ -3174,6 +3183,14 @@
     "invite": "Invite",
     "classroomCount_one": "{{count}} classroom",
     "classroomCount_other": "{{count}} classrooms",
+    "table": {
+      "caption": "Organization members",
+      "colSelect": "Select",
+      "colMember": "Member",
+      "colClassrooms": "Classrooms",
+      "colStatus": "Status",
+      "colActions": "Actions"
+    },
     "badgeNotMember": "Not an org member",
     "badgeInvitePending": "Invitation pending",
     "badgeNoClassroom": "No classroom",

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -15,12 +15,12 @@ import {
   AnimatedAlert,
   Badge,
   Button,
-  Card,
   Input,
   Select,
+  SkeletonRows,
+  TableShell,
   rtlFlip,
 } from "@/components/ui"
-import { ListSkeletonRows } from "@/components/list"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -39,8 +39,8 @@ import type { StudentCsvRow } from "@/domain/students"
 import type { GitHubUser } from "@/github-core/types"
 import { isSameGitHubUser } from "@/util/students"
 import { motion } from "motion/react"
-import { enterExit } from "@/lib/motion"
-import { ClickableRow } from "@/lib/motionComponents"
+import { blockEnter } from "@/lib/motion"
+import { ClickableTr } from "@/lib/motionComponents"
 import BulkActionsBar from "@/pages/orgMembers/BulkActionsBar"
 import MemberDetailModal from "@/pages/orgMembers/MemberDetailModal"
 import {
@@ -67,6 +67,17 @@ const CSV_RECONCILE_DELAY_MS = 4000
 // Sentinel classroom-filter value for "members on no roster". A real classroom
 // path can't collide (paths don't contain a leading colon).
 const NO_CLASSROOM_FILTER = ":none:"
+
+// One bar recipe per column: select, member, classrooms, status, actions.
+const SKELETON_BARS = [
+  "size-5",
+  "h-4 w-40",
+  "h-4 w-24",
+  "h-6 w-28",
+  "ms-auto h-4 w-4",
+]
+
+const MEMBERS_COL_COUNT = SKELETON_BARS.length
 
 const OrgMembersPage = () => {
   const { t } = useTranslation()
@@ -456,35 +467,17 @@ const OrgMembersPage = () => {
             </Select>
           </div>
 
-          <Card
-            className="mt-4 w-full overflow-hidden"
-            aria-busy={isLoading || undefined}
-          >
-            {isLoading ? (
-              <ListSkeletonRows rows={6} />
-            ) : isError ? (
-              <div className="px-6 py-10 text-center text-sm text-error">
-                {t("orgMembers.loadError")}
-              </div>
-            ) : filtered.length === 0 ? (
-              <EmptyState
-                variant="bare"
-                body={
-                  classroomFilter === NO_CLASSROOM_FILTER
-                    ? t("orgMembers.noMembersNoClassroom")
-                    : classroomFilter
-                      ? t("orgMembers.noMembersInClassroom", {
-                          classroom:
-                            classroomOptions.find(
-                              (c) => c.path === classroomFilter,
-                            )?.name ?? classroomFilter,
-                        })
-                      : t("orgMembers.noMatch")
-                }
-              />
-            ) : (
-              <>
-                {org ? (
+          {/* Primer DataTable treatment (matching the assignments/submissions
+              tables): the shared TableShell frame, labeled columns, and rows as
+              real <tr>s. The bulk-selection bar renders inside the frame above
+              the header row, keeping select-all adjacent to the rows it acts on. */}
+          <div className="mt-4">
+            <TableShell
+              animate={false}
+              padded
+              ariaBusy={isLoading}
+              header={
+                org && !isLoading && !isError && filtered.length > 0 ? (
                   <BulkActionsBar
                     org={org}
                     client={client}
@@ -498,43 +491,106 @@ const OrgMembersPage = () => {
                     onClearSelection={() => setSelectedKeys(new Set())}
                     onDone={handleBulkDone}
                   />
-                ) : null}
-                <motion.ul
-                  className="divide-y divide-base-300"
-                  variants={enterExit}
-                  initial="initial"
-                  animate="animate"
-                >
-                  {filtered.map((row) => (
-                    <ClickableRow
+                ) : undefined
+              }
+            >
+              <caption className="sr-only">
+                {t("orgMembers.table.caption")}
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col" className="w-0">
+                    <span className="sr-only">
+                      {t("orgMembers.table.colSelect")}
+                    </span>
+                  </th>
+                  <th scope="col">{t("orgMembers.table.colMember")}</th>
+                  <th scope="col" className="hidden sm:table-cell">
+                    {t("orgMembers.table.colClassrooms")}
+                  </th>
+                  <th scope="col">{t("orgMembers.table.colStatus")}</th>
+                  <th scope="col" className="w-0">
+                    <span className="sr-only">
+                      {t("orgMembers.table.colActions")}
+                    </span>
+                  </th>
+                </tr>
+              </thead>
+              {/* Same recipe as the assignments table: the body enters as one
+                  block and replays on data arrival / classroom-filter changes
+                  (not per search keystroke). */}
+              <motion.tbody
+                key={`${isLoading}:${classroomFilter}`}
+                variants={blockEnter}
+                initial="initial"
+                animate="animate"
+              >
+                {isLoading && <SkeletonRows rows={6} bars={SKELETON_BARS} />}
+                {!isLoading && isError && (
+                  <tr>
+                    <td
+                      colSpan={MEMBERS_COL_COUNT}
+                      className="py-10 text-center text-sm text-error"
+                    >
+                      {t("orgMembers.loadError")}
+                    </td>
+                  </tr>
+                )}
+                {!isLoading && !isError && filtered.length === 0 && (
+                  <tr>
+                    <td colSpan={MEMBERS_COL_COUNT}>
+                      <EmptyState
+                        variant="bare"
+                        body={
+                          classroomFilter === NO_CLASSROOM_FILTER
+                            ? t("orgMembers.noMembersNoClassroom")
+                            : classroomFilter
+                              ? t("orgMembers.noMembersInClassroom", {
+                                  classroom:
+                                    classroomOptions.find(
+                                      (c) => c.path === classroomFilter,
+                                    )?.name ?? classroomFilter,
+                                })
+                              : t("orgMembers.noMatch")
+                        }
+                      />
+                    </td>
+                  </tr>
+                )}
+                {!isLoading &&
+                  !isError &&
+                  filtered.map((row) => (
+                    <ClickableTr
                       key={row.key}
-                      className="group/row flex items-center justify-between gap-4 px-6 py-4 hover:bg-base-200"
+                      className="group/row hover:bg-base-200"
                       onClick={() => setSelectedKey(row.key)}
                     >
-                      <input
-                        type="checkbox"
-                        className="checkbox checkbox-sm size-6 shrink-0"
-                        aria-label={
-                          isSelf(row)
-                            ? t("orgMembers.bulk.selfNotSelectable")
-                            : t("orgMembers.bulk.selectRow", {
-                                label: row.username || row.email || row.name,
-                              })
-                        }
-                        disabled={isSelf(row)}
-                        title={
-                          isSelf(row)
-                            ? t("orgMembers.bulk.selfNotSelectable")
-                            : undefined
-                        }
-                        checked={selectedKeys.has(row.key)}
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          handleRowCheckboxClick(e, row.key)
-                        }}
-                        onChange={() => handleToggleRow(row.key)}
-                      />
-                      <div className="min-w-0 flex-1">
+                      <td className="w-0">
+                        <input
+                          type="checkbox"
+                          className="checkbox checkbox-sm size-6"
+                          aria-label={
+                            isSelf(row)
+                              ? t("orgMembers.bulk.selfNotSelectable")
+                              : t("orgMembers.bulk.selectRow", {
+                                  label: row.username || row.email || row.name,
+                                })
+                          }
+                          disabled={isSelf(row)}
+                          title={
+                            isSelf(row)
+                              ? t("orgMembers.bulk.selfNotSelectable")
+                              : undefined
+                          }
+                          checked={selectedKeys.has(row.key)}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleRowCheckboxClick(e, row.key)
+                          }}
+                          onChange={() => handleToggleRow(row.key)}
+                        />
+                      </td>
+                      <td className="min-w-0">
                         <Avatar
                           name={row.name || row.username || row.email}
                           github={row.username}
@@ -542,61 +598,72 @@ const OrgMembersPage = () => {
                           subtitle={<GitHubIdentity row={row} />}
                           onClick={() => setSelectedKey(row.key)}
                         />
-                      </div>
-                      <div className="flex shrink-0 items-center gap-3">
-                        {row.classification === "on-roster-not-member" &&
-                        row.github_id ? (
-                          <Button
-                            variant="primary"
-                            size="xs"
-                            loading={invitingKey === row.key}
-                            disabled={invitingKey === row.key}
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              void handleQuickInvite(row)
-                            }}
-                          >
-                            {invitingKey === row.key ? null : (
-                              <>
-                                <PersonAddIcon
-                                  aria-hidden="true"
-                                  className="size-4"
-                                />
-                                {t("orgMembers.invite")}
-                              </>
-                            )}
-                          </Button>
-                        ) : null}
-                        <span className="hidden text-xs text-base-content/70 sm:inline">
-                          {t("orgMembers.classroomCount", {
-                            count: row.classrooms.length,
-                          })}
-                        </span>
-                        {row.unprovisionedClassrooms.length > 0 ? (
-                          <Badge
-                            tone="warning"
-                            className="gap-1"
-                            title={t("orgMembers.unprovisionedTitle", {
-                              classrooms:
-                                row.unprovisionedClassrooms.join(", "),
-                            })}
-                          >
-                            <AlertIcon aria-hidden="true" className="size-3" />
-                            {t("orgMembers.unprovisionedBadge")}
-                          </Badge>
-                        ) : null}
-                        <ClassificationBadge row={row} isOwner={isOwner(row)} />
-                        <ChevronRightIcon
-                          aria-hidden="true"
-                          className={`size-4 text-base-content/30 transition-transform duration-150 ltr:group-hover/row:translate-x-0.5 rtl:group-hover/row:-translate-x-0.5 group-hover/row:text-base-content/70 ${rtlFlip}`}
-                        />
-                      </div>
-                    </ClickableRow>
+                      </td>
+                      <td className="hidden whitespace-nowrap text-xs text-base-content/70 sm:table-cell">
+                        {t("orgMembers.classroomCount", {
+                          count: row.classrooms.length,
+                        })}
+                      </td>
+                      <td>
+                        <div className="flex flex-wrap items-center gap-2">
+                          {row.unprovisionedClassrooms.length > 0 ? (
+                            <Badge
+                              tone="warning"
+                              className="gap-1"
+                              title={t("orgMembers.unprovisionedTitle", {
+                                classrooms:
+                                  row.unprovisionedClassrooms.join(", "),
+                              })}
+                            >
+                              <AlertIcon
+                                aria-hidden="true"
+                                className="size-3"
+                              />
+                              {t("orgMembers.unprovisionedBadge")}
+                            </Badge>
+                          ) : null}
+                          <ClassificationBadge
+                            row={row}
+                            isOwner={isOwner(row)}
+                          />
+                        </div>
+                      </td>
+                      <td className="w-0 ps-2">
+                        <div className="flex items-center justify-end gap-3">
+                          {row.classification === "on-roster-not-member" &&
+                          row.github_id ? (
+                            <Button
+                              variant="primary"
+                              size="xs"
+                              loading={invitingKey === row.key}
+                              disabled={invitingKey === row.key}
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                void handleQuickInvite(row)
+                              }}
+                            >
+                              {invitingKey === row.key ? null : (
+                                <>
+                                  <PersonAddIcon
+                                    aria-hidden="true"
+                                    className="size-4"
+                                  />
+                                  {t("orgMembers.invite")}
+                                </>
+                              )}
+                            </Button>
+                          ) : null}
+                          <ChevronRightIcon
+                            aria-hidden="true"
+                            className={`size-4 text-base-content/30 transition-transform duration-150 ltr:group-hover/row:translate-x-0.5 rtl:group-hover/row:-translate-x-0.5 group-hover/row:text-base-content/70 ${rtlFlip}`}
+                          />
+                        </div>
+                      </td>
+                    </ClickableTr>
                   ))}
-                </motion.ul>
-              </>
-            )}
-          </Card>
+              </motion.tbody>
+            </TableShell>
+          </div>
         </RequireRole>
       </PageShell>
 

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -2,6 +2,7 @@ import { useEffect, useId, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { ChevronRightIcon, PencilIcon, TrashIcon } from "@/components/ui/icons"
+import { EmptyState } from "@/components/list"
 import { useRevealOnExpand } from "@/hooks/useRevealOnExpand"
 import type { AssignmentForm } from "./assignmentFormModel"
 
@@ -14,6 +15,7 @@ import {
   Input,
   Modal,
   Select,
+  TableShell,
   Textarea,
   Heading,
 } from "@/components/ui"
@@ -509,8 +511,13 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                 </Button>
               </div>
             </div>
-            <Collapse open={expanded} bodyRef={bodyRef}>
-              <table className="table">
+            {/* Gap between the header row and the table lives on the animating
+                element (padding, not a child margin) so the collapse height
+                accounts for it. */}
+            <Collapse open={expanded} bodyRef={bodyRef} className="pt-4">
+              {/* Same TableShell frame as the app's other data tables, so the
+                  tests list can't drift from the house table treatment. */}
+              <TableShell animate={false} padded>
                 <caption className="sr-only">
                   {t("assignments.autograder.heading")}
                 </caption>
@@ -522,7 +529,7 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                       {t("assignments.autograder.runCommand")}
                     </th>
                     <th scope="col">{t("assignments.autograder.points")}</th>
-                    <th scope="col" className="w-28">
+                    <th scope="col" className="w-0">
                       <span className="sr-only">
                         {t("assignments.autograder.colActions")}
                       </span>
@@ -533,9 +540,11 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                   {field.state.value.length === 0 ? (
                     <tr>
                       <td colSpan={5}>
-                        <div className="rounded-box border border-dashed p-4 text-sm opacity-70">
-                          {t("assignments.autograder.empty")}
-                        </div>
+                        <EmptyState
+                          variant="bare"
+                          className="py-6"
+                          body={t("assignments.autograder.empty")}
+                        />
                       </td>
                     </tr>
                   ) : (
@@ -565,11 +574,12 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                             <Badge tone="primary">{test.points}</Badge>
                           </td>
 
-                          <td>
-                            <div className="flex justify-end gap-2">
+                          <td className="w-0 ps-2">
+                            <div className="flex items-center justify-end gap-1">
                               <Button
                                 variant="ghost"
                                 size="sm"
+                                shape="square"
                                 onClick={() => openEditEditor(index)}
                                 aria-label={t(
                                   "assignments.autograder.editTest",
@@ -587,6 +597,7 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                               <Button
                                 variant="ghost"
                                 size="sm"
+                                shape="square"
                                 className="text-error"
                                 onClick={() => field.removeValue(index)}
                                 aria-label={t(
@@ -606,7 +617,7 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                     )
                   )}
                 </tbody>
-              </table>
+              </TableShell>
             </Collapse>
 
             {editor && (

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -13,10 +13,11 @@ import {
   AnimatedAlert,
   Badge,
   Button,
-  Card,
+  SkeletonRows,
+  TableShell,
   Toolbar,
 } from "@/components/ui"
-import { EmptyState, ListSkeletonRows } from "@/components/list"
+import { EmptyState } from "@/components/list"
 import type { Student } from "@/types/classroom"
 import { useQueryClient } from "@tanstack/react-query"
 import type { RosterCsvProblem } from "@/domain/students"
@@ -69,7 +70,7 @@ import RosterBulkActionsBar, {
 } from "@/pages/students/RosterBulkActionsBar"
 import type { StudentCsvRow } from "@/domain/students"
 import { motion } from "motion/react"
-import { enterExit } from "@/lib/motion"
+import { blockEnter } from "@/lib/motion"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
@@ -82,6 +83,17 @@ import { RosterRow } from "./RosterRow"
 import { FailedInvitationsList } from "./FailedInvitationsList"
 import { RosterParseProblems } from "./RosterParseProblems"
 import { RosterWarnings } from "./RosterWarnings"
+
+// One bar recipe per column: select, member, roles, status, actions. Loading
+// starts with no rows, so the Section column (present only when some row has a
+// section) is never part of the skeleton.
+const SKELETON_BARS = [
+  "size-5",
+  "h-4 w-40",
+  "h-6 w-20",
+  "h-6 w-24",
+  "ms-auto h-4 w-4",
+]
 
 const EnrolledStudents = ({
   students = [],
@@ -459,6 +471,12 @@ const EnrolledStudents = ({
       suppressedLogins.remember(removed.map((r) => r.username))
   }
 
+  // The Section column exists only when some row carries a section label —
+  // derived from the status-independent sectionOptions so toggling a filter
+  // can't add/remove a column mid-view.
+  const showSection = sectionOptions.length > 0
+  const colCount = showSection ? 6 : 5
+
   const renderRow = (row: TeamRosterRow) => (
     <RosterRow
       key={row.key}
@@ -469,6 +487,7 @@ const EnrolledStudents = ({
       onOpen={setSelectedKey}
       onCheckboxClick={handleRowCheckboxClick}
       onToggle={handleToggleRow}
+      showSection={showSection}
     />
   )
 
@@ -651,61 +670,15 @@ const EnrolledStudents = ({
         </Toolbar>
       ) : null}
 
-      {/* The list card. */}
-      <Card
-        className="w-full overflow-hidden"
-        aria-busy={isLoading || undefined}
-      >
-        {isLoading ? (
-          // Skeleton rows shaped like the roster rows, so content fades into
-          // place instead of jumping in to replace a centered spinner.
-          <ListSkeletonRows className="divide-y divide-base-300" />
-        ) : isError ? (
-          <div
-            role="alert"
-            className="flex flex-col items-center gap-3 px-6 py-10 text-center"
-          >
-            <span className="flex items-center gap-2 text-sm text-error">
-              <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
-              {t("students.rosterLoadError")}
-            </span>
-            <Button variant="ghost" size="sm" onClick={() => refetchRoster()}>
-              {t("students.rosterRetry")}
-            </Button>
-          </div>
-        ) : isEmpty ? (
-          <EmptyState
-            variant="bare"
-            className="py-12"
-            icon={PeopleIcon}
-            titleAs="h3"
-            title={t("students.emptyTitle")}
-            body={t("students.emptyBody")}
-            action={
-              addActions ? (
-                <div className="flex justify-center gap-2">
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    onClick={addActions.onAddStudent}
-                  >
-                    <PlusIcon aria-hidden="true" className="size-4" />
-                    {t("students.addTitle")}
-                  </Button>
-                  <Button size="sm" onClick={addActions.onUploadRoster}>
-                    <UploadIcon aria-hidden="true" className="size-4" />
-                    {t("students.uploadTitle")}
-                  </Button>
-                  <Button size="sm" onClick={addActions.onInviteLinks}>
-                    <PaperAirplaneIcon aria-hidden="true" className="size-4" />
-                    {t("students.inviteStudents")}
-                  </Button>
-                </div>
-              ) : null
-            }
-          />
-        ) : (
-          <>
+      {/* The roster table: Primer DataTable treatment via the shared
+          TableShell frame (matching the assignments/submissions tables), with
+          the bulk-selection bar inside the frame above the header row. */}
+      <TableShell
+        animate={false}
+        padded
+        ariaBusy={isLoading}
+        header={
+          !isLoading && !isError && !isEmpty ? (
             <RosterBulkActionsBar
               org={org}
               classroom={classroom}
@@ -722,62 +695,157 @@ const EnrolledStudents = ({
               onGroupBySectionChange={setGroupBySection}
               canGroupBySection={hasSectionsInFiltered}
             />
-            {filtered.length === 0 ? (
-              <EmptyState
-                variant="bare"
-                body={
-                  query.trim()
-                    ? t("students.noMatch")
-                    : effectiveSection !== "all" && statusFilter === "all"
-                      ? t("students.noneInSection", {
-                          section:
-                            effectiveSection === NO_SECTION
-                              ? t("students.noSection")
-                              : effectiveSection,
-                        })
-                      : t("students.noneWithStatus", {
-                          status:
-                            statusOptions.find((o) => o.value === statusFilter)
-                              ?.label ?? statusFilter,
-                        })
-                }
-              />
-            ) : groupBySection && hasSectionsInFiltered ? (
-              <div className="divide-y divide-base-300">
-                {filteredBySection.map(({ section, students: group }) => (
-                  <div key={section}>
-                    <div className="flex items-center justify-between bg-base-200/60 px-6 py-2">
-                      <h3 className="text-sm font-semibold text-base-content/70">
-                        {section === NO_SECTION
-                          ? t("students.noSection")
-                          : section}
-                      </h3>
-                      <Badge ghost>{group.length}</Badge>
-                    </div>
-                    <motion.ul
-                      className="divide-y divide-base-300"
-                      variants={enterExit}
-                      initial="initial"
-                      animate="animate"
-                    >
-                      {group.map((row) => renderRow(row))}
-                    </motion.ul>
+          ) : undefined
+        }
+      >
+        <caption className="sr-only">{t("students.table.caption")}</caption>
+        <thead>
+          <tr>
+            <th scope="col" className="w-0">
+              <span className="sr-only">{t("students.table.colSelect")}</span>
+            </th>
+            <th scope="col">{t("students.table.colMember")}</th>
+            <th scope="col">{t("students.table.colRoles")}</th>
+            {showSection ? (
+              <th scope="col">{t("students.table.colSection")}</th>
+            ) : null}
+            <th scope="col">{t("students.table.colStatus")}</th>
+            <th scope="col" className="w-0">
+              <span className="sr-only">{t("students.table.colActions")}</span>
+            </th>
+          </tr>
+        </thead>
+        {isLoading ? (
+          // Skeleton rows shaped like the loaded columns, so content fades
+          // into place instead of jumping in to replace a centered spinner.
+          <tbody>
+            <SkeletonRows rows={5} bars={SKELETON_BARS} />
+          </tbody>
+        ) : isError ? (
+          <tbody>
+            <tr>
+              <td colSpan={colCount} className="px-6 py-10 text-center">
+                <span
+                  role="alert"
+                  className="inline-flex items-center gap-2 text-sm text-error"
+                >
+                  <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
+                  {t("students.rosterLoadError")}
+                </span>
+                <div className="mt-3">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => refetchRoster()}
+                  >
+                    {t("students.rosterRetry")}
+                  </Button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        ) : isEmpty ? (
+          <tbody>
+            <tr>
+              <td colSpan={colCount}>
+                <EmptyState
+                  variant="bare"
+                  className="py-12"
+                  icon={PeopleIcon}
+                  titleAs="h3"
+                  title={t("students.emptyTitle")}
+                  body={t("students.emptyBody")}
+                  action={
+                    addActions ? (
+                      <div className="flex justify-center gap-2">
+                        <Button
+                          variant="primary"
+                          size="sm"
+                          onClick={addActions.onAddStudent}
+                        >
+                          <PlusIcon aria-hidden="true" className="size-4" />
+                          {t("students.addTitle")}
+                        </Button>
+                        <Button size="sm" onClick={addActions.onUploadRoster}>
+                          <UploadIcon aria-hidden="true" className="size-4" />
+                          {t("students.uploadTitle")}
+                        </Button>
+                        <Button size="sm" onClick={addActions.onInviteLinks}>
+                          <PaperAirplaneIcon
+                            aria-hidden="true"
+                            className="size-4"
+                          />
+                          {t("students.inviteStudents")}
+                        </Button>
+                      </div>
+                    ) : null
+                  }
+                />
+              </td>
+            </tr>
+          </tbody>
+        ) : filtered.length === 0 ? (
+          <tbody>
+            <tr>
+              <td colSpan={colCount}>
+                <EmptyState
+                  variant="bare"
+                  body={
+                    query.trim()
+                      ? t("students.noMatch")
+                      : effectiveSection !== "all" && statusFilter === "all"
+                        ? t("students.noneInSection", {
+                            section:
+                              effectiveSection === NO_SECTION
+                                ? t("students.noSection")
+                                : effectiveSection,
+                          })
+                        : t("students.noneWithStatus", {
+                            status:
+                              statusOptions.find(
+                                (o) => o.value === statusFilter,
+                              )?.label ?? statusFilter,
+                          })
+                  }
+                />
+              </td>
+            </tr>
+          </tbody>
+        ) : groupBySection && hasSectionsInFiltered ? (
+          // One <tbody> per section, opened by a full-width rowgroup header —
+          // the table equivalent of the old section-divider list headers.
+          filteredBySection.map(({ section, students: group }) => (
+            <motion.tbody
+              key={section}
+              variants={blockEnter}
+              initial="initial"
+              animate="animate"
+            >
+              <tr className="bg-base-200/60">
+                <th
+                  scope="rowgroup"
+                  colSpan={colCount}
+                  className="py-2 text-sm font-semibold text-base-content/70"
+                >
+                  <div className="flex items-center justify-between">
+                    {section === NO_SECTION ? t("students.noSection") : section}
+                    <Badge ghost>{group.length}</Badge>
                   </div>
-                ))}
-              </div>
-            ) : (
-              <motion.ul
-                className="divide-y divide-base-300"
-                variants={enterExit}
-                initial="initial"
-                animate="animate"
-              >
-                {filtered.map((row) => renderRow(row))}
-              </motion.ul>
-            )}
-          </>
+                </th>
+              </tr>
+              {group.map((row) => renderRow(row))}
+            </motion.tbody>
+          ))
+        ) : (
+          <motion.tbody
+            variants={blockEnter}
+            initial="initial"
+            animate="animate"
+          >
+            {filtered.map((row) => renderRow(row))}
+          </motion.tbody>
         )}
-      </Card>
+      </TableShell>
 
       <RosterMemberModal
         open={Boolean(selected)}

--- a/web/src/pages/students/RosterRow.tsx
+++ b/web/src/pages/students/RosterRow.tsx
@@ -6,13 +6,21 @@ import { RoleBadges } from "./RoleBadges"
 import { GitHubIdentity } from "@/pages/orgMembers/memberPresentation"
 import { STATE_BADGE_TONE, STATE_LABEL_KEY } from "@/util/classroomRoleUI"
 import { rosterRowToMemberRow, rosterRowInitials } from "@/util/memberRow"
-import { ClickableRow } from "@/lib/motionComponents"
+import { ClickableTr } from "@/lib/motionComponents"
 import type { TeamRosterRow } from "@/util/teamRoster"
 
-// One roster row: avatar + identity, role/section/state badges, and the
-// selection checkbox (disabled for the viewer's own row and for rows the bulk
-// bar can't act on). Clicking the row opens the detail modal; the checkbox is
-// selection-only.
+// Primer-style placeholder for a cell with nothing to report (an enrolled
+// member's Status, a section-less row), so an empty cell reads as intentional.
+const CellPlaceholder = () => (
+  <span aria-hidden="true" className="text-base-content/60">
+    —
+  </span>
+)
+
+// One roster table row: selection checkbox, avatar + identity, then role /
+// section / state cells (the checkbox is disabled for the viewer's own row and
+// for rows the bulk bar can't act on). Clicking the row opens the detail
+// modal; the checkbox is selection-only.
 export const RosterRow = ({
   row,
   selfRow,
@@ -21,6 +29,7 @@ export const RosterRow = ({
   onCheckboxClick,
   onToggle,
   selectable = true,
+  showSection = false,
 }: {
   row: TeamRosterRow
   selfRow: boolean
@@ -34,6 +43,8 @@ export const RosterRow = ({
     key: string,
   ) => void
   onToggle: (key: string) => void
+  // Whether the table renders the Section column (only when some row has one).
+  showSection?: boolean
 }) => {
   const { t } = useTranslation()
   const member = rosterRowToMemberRow(row)
@@ -41,29 +52,40 @@ export const RosterRow = ({
   const displayHandle = row.username || row.email
   const displayInitials = rosterRowInitials(row)
 
+  // Enrolled/pending rows assert role(s) (the team is the authority), shown as
+  // one badge per role via RoleBadges. Needs-attention rows have no team role
+  // yet, so they render the empty-cell placeholder.
+  const hasRoles =
+    row.state !== "needs_attention_in_org" &&
+    row.state !== "needs_attention_not_in_org" &&
+    row.roles.length > 0
+  const section = row.section.trim()
+
   return (
-    <ClickableRow
-      className="group/row flex items-center justify-between gap-4 px-6 py-4 hover:bg-base-200"
+    <ClickableTr
+      className="group/row hover:bg-base-200"
       onClick={() => onOpen(row.key)}
     >
-      <input
-        type="checkbox"
-        className="checkbox checkbox-sm size-6 shrink-0"
-        aria-label={
-          selfRow
-            ? t("students.bulk.selfNotSelectable")
-            : t("students.bulk.selectRow", { label: displayHandle })
-        }
-        disabled={selfRow || !selectable}
-        title={selfRow ? t("students.bulk.selfNotSelectable") : undefined}
-        checked={checked}
-        onClick={(e) => {
-          e.stopPropagation()
-          onCheckboxClick(e, row.key)
-        }}
-        onChange={() => onToggle(row.key)}
-      />
-      <div className="min-w-0 flex-1">
+      <td className="w-0">
+        <input
+          type="checkbox"
+          className="checkbox checkbox-sm size-6"
+          aria-label={
+            selfRow
+              ? t("students.bulk.selfNotSelectable")
+              : t("students.bulk.selectRow", { label: displayHandle })
+          }
+          disabled={selfRow || !selectable}
+          title={selfRow ? t("students.bulk.selfNotSelectable") : undefined}
+          checked={checked}
+          onClick={(e) => {
+            e.stopPropagation()
+            onCheckboxClick(e, row.key)
+          }}
+          onChange={() => onToggle(row.key)}
+        />
+      </td>
+      <td className="min-w-0">
         <Avatar
           name={displayName}
           github={displayHandle}
@@ -71,34 +93,48 @@ export const RosterRow = ({
           subtitle={<GitHubIdentity row={member} />}
           onClick={() => onOpen(row.key)}
         />
-      </div>
-      <div className="flex shrink-0 items-center gap-2">
-        {/* Enrolled/pending rows assert role(s) (the team is the authority),
-            shown as one badge per role via RoleBadges. Needs-attention rows have
-            no team role yet, so they render no role badge. */}
-        {row.state === "needs_attention_in_org" ||
-        row.state === "needs_attention_not_in_org" ? null : (
-          <RoleBadges roles={row.roles} />
+      </td>
+      <td>
+        {hasRoles ? (
+          <div className="flex flex-wrap items-center gap-1">
+            <RoleBadges roles={row.roles} />
+          </div>
+        ) : (
+          <CellPlaceholder />
         )}
-        {row.section.trim() ? (
-          <Badge tone="info" className="shrink-0">
-            {row.section.trim()}
-          </Badge>
-        ) : null}
+      </td>
+      {showSection ? (
+        <td>
+          {section ? (
+            <Badge tone="info" className="whitespace-nowrap">
+              {section}
+            </Badge>
+          ) : (
+            <CellPlaceholder />
+          )}
+        </td>
+      ) : null}
+      <td>
         {row.state !== "enrolled" ? (
           <Badge
             size="sm"
             tone={STATE_BADGE_TONE[row.state]}
-            className="shrink-0"
+            className="whitespace-nowrap"
           >
             {t(STATE_LABEL_KEY[row.state])}
           </Badge>
-        ) : null}
-        <ChevronRightIcon
-          aria-hidden="true"
-          className={`size-4 text-base-content/30 transition-transform duration-150 ltr:group-hover/row:translate-x-0.5 rtl:group-hover/row:-translate-x-0.5 group-hover/row:text-base-content/70 ${rtlFlip}`}
-        />
-      </div>
-    </ClickableRow>
+        ) : (
+          <CellPlaceholder />
+        )}
+      </td>
+      <td className="w-0 ps-2">
+        <div className="flex items-center justify-end">
+          <ChevronRightIcon
+            aria-hidden="true"
+            className={`size-4 text-base-content/30 transition-transform duration-150 ltr:group-hover/row:translate-x-0.5 rtl:group-hover/row:-translate-x-0.5 group-hover/row:text-base-content/70 ${rtlFlip}`}
+          />
+        </div>
+      </td>
+    </ClickableTr>
   )
 }


### PR DESCRIPTION
## Summary

The organization Members page and the classroom roster rendered as hand-rolled card lists that had drifted from the assignment and submission tables. Both now render as real data tables on the shared `TableShell` frame, following Primer's DataTable guidance: labeled column headers (visually hidden for the select and actions columns), a trailing actions column, muted placeholders for empty cells, and table-native skeleton loading. The autograder tests table moves onto the same frame, so every data table in the app shares one recipe.

Behavior is unchanged: bulk selection (including shift-click ranges), row-click detail modals, quick invite, filters, and group-by-section all work as before — grouping now renders one `tbody` per section opened by a `rowgroup` header row. `TableShell` gained a `header` slot so the bulk-selection bars sit inside the table frame, and the now-unused `ClickableRow` motion wrapper is removed in favor of the single `ClickableTr` treatment.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [ ] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [ ] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
