### PR TITLE
fix(web): standardize modals on Primer dialog anatomy

### DIFF
--- a/web/src/auth/ElevatedAccessModal.tsx
+++ b/web/src/auth/ElevatedAccessModal.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next"
 import { useGithubAuth } from "./useGithubAuth"
 import { GitHubDevicePrompt } from "./GitHubDevicePrompt"
 import { RevokeAccessLink } from "./RevokeAccessLink"
-import { Alert, Button, Modal, Heading } from "@/components/ui"
+import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
 
 // Re-auth for a signed-in teacher who needs to change their delete_repo access.
 // See auth/constants.ts for the base/elevated policy.
@@ -127,7 +127,23 @@ export function ElevatedAccessModal({
   }
 
   return (
-    <Modal open={open} onClose={dismiss} size="lg" aria-label={title}>
+    <Modal
+      open={open}
+      onClose={dismiss}
+      size="lg"
+      // The device prompt renders its own heading, so the shared header only
+      // applies to the sign-in choice state; the dialog stays named either way.
+      title={showingDevice ? undefined : title}
+      subtitle={showingDevice ? undefined : body}
+      headerVisual={
+        showingDevice ? undefined : (
+          <ModalIcon>
+            <ShieldCheckIcon aria-hidden="true" className="size-6" />
+          </ModalIcon>
+        )
+      }
+      aria-label={showingDevice ? title : undefined}
+    >
       {showingDevice ? (
         <GitHubDevicePrompt
           device={device}
@@ -137,17 +153,7 @@ export function ElevatedAccessModal({
           onVerificationOpened={markVerificationOpened}
         />
       ) : (
-        <div className="space-y-5">
-          <div className="flex gap-4 border-b border-base-200 pb-5">
-            <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-primary/10 text-primary">
-              <ShieldCheckIcon aria-hidden="true" className="size-6" />
-            </div>
-            <div className="min-w-0">
-              <Heading as="h2">{title}</Heading>
-              <p className="mt-1 text-sm text-base-content/70">{body}</p>
-            </div>
-          </div>
-
+        <div className="mt-5 space-y-5">
           {error ? (
             <Alert tone="error" className="items-start text-sm">
               <span>{error}</span>

--- a/web/src/auth/LoginLanguageMenu.tsx
+++ b/web/src/auth/LoginLanguageMenu.tsx
@@ -3,7 +3,7 @@ import { InlineSpinner } from "@/components/Spinner"
 import { CheckIcon, GlobeIcon } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
 
-import { Button } from "@/components/ui"
+import { Button, DropdownMenu } from "@/components/ui"
 import { useLanguage } from "@/hooks/useLanguage"
 import { useLanguageRegistry } from "@/hooks/useLanguageRegistry"
 import { BASE_LANG, languageLabel } from "@/i18n/customLocale"
@@ -87,11 +87,7 @@ export function LoginLanguageMenu() {
       >
         <GlobeIcon aria-hidden="true" className="size-4" />
       </Button>{" "}
-      <ul
-        tabIndex={0}
-        role="menu"
-        className="dropdown-content menu z-10 mt-1 max-h-80 w-60 flex-nowrap overflow-y-auto rounded-box border border-base-300 bg-base-100 p-1 shadow"
-      >
+      <DropdownMenu className="max-h-80 w-60 flex-nowrap overflow-y-auto">
         <li className="menu-title text-xs">
           {t("language.switcherInstalled")}
         </li>
@@ -151,7 +147,7 @@ export function LoginLanguageMenu() {
             ))}
           </>
         )}
-      </ul>
+      </DropdownMenu>
     </div>
   )
 }

--- a/web/src/components/AboutDialog.tsx
+++ b/web/src/components/AboutDialog.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Link } from "@tanstack/react-router"
 import { LinkExternalIcon } from "@/components/ui/icons"
 
-import { CopyableDetails, Modal, Heading } from "@/components/ui"
+import { CopyableDetails, Modal } from "@/components/ui"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { buildDiagnostics } from "@/lib/diagnostics/snapshot"
 import {
@@ -79,8 +79,8 @@ function CopyableDiagnostics({
 // can point at precisely what shipped.
 export const AboutDialog = forwardRef<
   HTMLDialogElement,
-  { titleId: string; org?: string | null; planName?: string }
->(function AboutDialog({ titleId, org, planName }, ref) {
+  { org?: string | null; planName?: string }
+>(function AboutDialog({ org, planName }, ref) {
   const { t } = useTranslation()
   const release = releaseUrl()
 
@@ -89,16 +89,10 @@ export const AboutDialog = forwardRef<
       ref={ref}
       size="2xl"
       boxClassName="flex max-h-[85vh] flex-col overflow-y-auto text-base-content"
-      aria-labelledby={titleId}
+      title={t("nav.aboutDialogTitle")}
+      subtitle={t("nav.aboutDialogDescription")}
     >
-      <Heading as="h3" id={titleId}>
-        {t("nav.aboutDialogTitle")}
-      </Heading>
-      <p className="mt-1 mb-4 text-sm text-base-content/70">
-        {t("nav.aboutDialogDescription")}
-      </p>
-
-      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+      <dl className="mt-4 grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
         <dt className="text-base-content/60">{t("nav.aboutVersion")}</dt>
         <dd className="font-mono tabular-nums">
           {release ? (

--- a/web/src/components/DiagnosticsDialog.tsx
+++ b/web/src/components/DiagnosticsDialog.tsx
@@ -1,7 +1,6 @@
-import { useId } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button, Modal, Heading } from "@/components/ui"
+import { Button, Modal } from "@/components/ui"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { buildDiagnostics } from "@/lib/diagnostics/snapshot"
 import { CheckIcon, CopyIcon } from "@/components/ui/icons"
@@ -21,7 +20,6 @@ export function DiagnosticsDialog({
   planName?: string
 }) {
   const { t } = useTranslation()
-  const titleId = useId()
   const text = buildDiagnostics({ org, planName })
   const { copied, copy } = useCopyToClipboard(text)
 
@@ -31,20 +29,9 @@ export function DiagnosticsDialog({
       onClose={onClose}
       size="2xl"
       boxClassName="flex max-h-[85vh] flex-col overflow-y-auto text-base-content"
-      aria-labelledby={titleId}
-    >
-      <Heading as="h3" id={titleId}>
-        {t("orgActivity.diagnostics.title")}
-      </Heading>
-      <p className="mt-1 mb-4 text-sm text-base-content/70">
-        {t("orgActivity.diagnostics.description")}
-      </p>
-
-      <pre className="overflow-auto rounded-field bg-base-100 p-3 text-xs whitespace-pre-wrap">
-        {text}
-      </pre>
-
-      <div className="mt-4 flex justify-end">
+      title={t("orgActivity.diagnostics.title")}
+      subtitle={t("orgActivity.diagnostics.description")}
+      footer={
         <Button variant="outline" size="sm" onClick={() => void copy()}>
           {copied ? (
             <CheckIcon aria-hidden="true" className="size-4" />
@@ -55,7 +42,11 @@ export function DiagnosticsDialog({
             ? t("orgActivity.diagnostics.copied")
             : t("orgActivity.diagnostics.copy")}
         </Button>
-      </div>
+      }
+    >
+      <pre className="mt-4 overflow-auto rounded-field bg-base-100 p-3 text-xs whitespace-pre-wrap">
+        {text}
+      </pre>
     </Modal>
   )
 }

--- a/web/src/components/LanguageDialog.tsx
+++ b/web/src/components/LanguageDialog.tsx
@@ -1,40 +1,36 @@
 import { forwardRef } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Modal, Heading } from "@/components/ui"
+import { Modal } from "@/components/ui"
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher"
 
 // Language-pack modal shown from the sidebar footer. Extracted alongside
 // AboutDialog (same forwardRef<HTMLDialogElement> shape) so the footer wires two
 // consistent portalled dialogs. Closing on apply uses the caller's open ref.
-export const LanguageDialog = forwardRef<
-  HTMLDialogElement,
-  { titleId: string }
->(function LanguageDialog({ titleId }, ref) {
-  const { t } = useTranslation()
+export const LanguageDialog = forwardRef<HTMLDialogElement, object>(
+  function LanguageDialog(_props, ref) {
+    const { t } = useTranslation()
 
-  // Close via the forwarded ref once a pack is applied. It's a MutableRefObject
-  // here (caller passes useRef), so read .current; guard the RefCallback shape.
-  const close = () => {
-    if (typeof ref === "object" && ref !== null) {
-      ref.current?.close()
+    // Close via the forwarded ref once a pack is applied. It's a MutableRefObject
+    // here (caller passes useRef), so read .current; guard the RefCallback shape.
+    const close = () => {
+      if (typeof ref === "object" && ref !== null) {
+        ref.current?.close()
+      }
     }
-  }
 
-  return (
-    <Modal
-      ref={ref}
-      size="lg"
-      boxClassName="flex max-h-[85vh] flex-col overflow-y-auto text-base-content"
-      aria-labelledby={titleId}
-    >
-      <Heading as="h3" id={titleId}>
-        {t("nav.languageDialogTitle")}
-      </Heading>
-      <p className="mt-1 mb-4 text-sm text-base-content/70">
-        {t("nav.languageDialogDescription")}
-      </p>
-      <LanguageSwitcher onApplied={close} />
-    </Modal>
-  )
-})
+    return (
+      <Modal
+        ref={ref}
+        size="lg"
+        boxClassName="flex max-h-[85vh] flex-col overflow-y-auto text-base-content"
+        title={t("nav.languageDialogTitle")}
+        subtitle={t("nav.languageDialogDescription")}
+      >
+        <div className="mt-4">
+          <LanguageSwitcher onApplied={close} />
+        </div>
+      </Modal>
+    )
+  },
+)

--- a/web/src/components/OrgRepoCreationNotice.tsx
+++ b/web/src/components/OrgRepoCreationNotice.tsx
@@ -31,8 +31,8 @@ export const OrgRepoCreationNotice = ({
   return (
     <Alert
       tone="warning"
-      // Icon opted out and re-rendered inline: the stacked responsive layout
-      // lays the icon out with the text (the EmptyRosterNotice pattern).
+      // icon={null} + inline icon: the stacked responsive layout lays the
+      // icon out with the text (the EmptyRosterNotice pattern).
       icon={null}
       className={cx(
         "flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between",

--- a/web/src/components/OrgRepoCreationNotice.tsx
+++ b/web/src/components/OrgRepoCreationNotice.tsx
@@ -31,6 +31,9 @@ export const OrgRepoCreationNotice = ({
   return (
     <Alert
       tone="warning"
+      // Icon opted out and re-rendered inline: the stacked responsive layout
+      // lays the icon out with the text (the EmptyRosterNotice pattern).
+      icon={null}
       className={cx(
         "flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between",
         className,

--- a/web/src/components/SubmitUpload.tsx
+++ b/web/src/components/SubmitUpload.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { FileCheckIcon, UploadIcon, XIcon } from "@/components/ui/icons"
 
@@ -8,7 +8,6 @@ import {
   FileDropzone,
   Modal,
   type PickedFile,
-  Heading,
 } from "@/components/ui"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { useToast } from "@/context/notifications/NotificationProvider"
@@ -62,7 +61,6 @@ export function SubmitUpload({
 
   const [open, setOpen] = useState(false)
   const [picked, setPicked] = useState<Picked[]>([])
-  const titleId = useId()
   const submitting = mutation.isPending
 
   const addFiles = (files: PickedFile[]) => {
@@ -141,18 +139,39 @@ export function SubmitUpload({
         onClose={closeModal}
         closeDisabled={submitting}
         size="2xl"
-        aria-labelledby={titleId}
-      >
-        <div className="flex items-center gap-2">
-          <FileCheckIcon aria-hidden="true" className="size-4 text-primary" />
-          <Heading as="h3" id={titleId}>
+        title={
+          <span className="flex items-center gap-2">
+            <FileCheckIcon aria-hidden="true" className="size-4 text-primary" />
             {t("submissions.student.upload.title")}
-          </Heading>
-        </div>
-        <p className="mt-1 text-sm text-base-content/70">
-          {t("submissions.student.upload.intro")}
-        </p>
-
+          </span>
+        }
+        subtitle={t("submissions.student.upload.intro")}
+        footer={
+          <>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={submitting}
+              onClick={closeModal}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              loading={submitting}
+              loadingLabel={t("submissions.student.upload.submitting")}
+              disabled={submitting || !hasFiles}
+              onClick={() => void submit()}
+            >
+              {!submitting && (
+                <UploadIcon aria-hidden="true" className="size-4" />
+              )}
+              {t("submissions.student.upload.confirmSubmit")}
+            </Button>
+          </>
+        }
+      >
         <div className="mt-4 space-y-3">
           {hasFiles ? (
             <>
@@ -254,25 +273,6 @@ export function SubmitUpload({
               </div>
             </Alert>
           )}
-        </div>
-
-        <div className="mt-6 flex flex-wrap items-center justify-end gap-2">
-          <Button size="sm" disabled={submitting} onClick={closeModal}>
-            {t("common.cancel")}
-          </Button>
-          <Button
-            variant="primary"
-            size="sm"
-            loading={submitting}
-            loadingLabel={t("submissions.student.upload.submitting")}
-            disabled={submitting || !hasFiles}
-            onClick={() => void submit()}
-          >
-            {!submitting && (
-              <UploadIcon aria-hidden="true" className="size-4" />
-            )}
-            {t("submissions.student.upload.confirmSubmit")}
-          </Button>
         </div>
       </Modal>
     </>

--- a/web/src/components/SubmitUpload.tsx
+++ b/web/src/components/SubmitUpload.tsx
@@ -109,9 +109,7 @@ export function SubmitUpload({
     setOpen(false)
   }
 
-  // The picked list is cleared when OPENING, not on close: clearing at close
-  // would swap the file table back to the empty dropzone under the dialog's
-  // fade-out.
+  // Cleared on open, never at close — see the close-animation note in ui/Modal.
   const openModal = () => {
     setPicked([])
     setOpen(true)

--- a/web/src/components/SubmitUpload.tsx
+++ b/web/src/components/SubmitUpload.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   FileDropzone,
   Modal,
+  ModalIcon,
   type PickedFile,
 } from "@/components/ui"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
@@ -143,11 +144,11 @@ export function SubmitUpload({
         onClose={closeModal}
         closeDisabled={submitting}
         size="2xl"
-        title={
-          <span className="flex items-center gap-2">
-            <FileCheckIcon aria-hidden="true" className="size-4 text-primary" />
-            {t("submissions.student.upload.title")}
-          </span>
+        title={t("submissions.student.upload.title")}
+        headerVisual={
+          <ModalIcon>
+            <FileCheckIcon aria-hidden="true" className="size-4" />
+          </ModalIcon>
         }
         subtitle={t("submissions.student.upload.intro")}
         footer={

--- a/web/src/components/SubmitUpload.tsx
+++ b/web/src/components/SubmitUpload.tsx
@@ -107,7 +107,14 @@ export function SubmitUpload({
   const closeModal = () => {
     if (submitting) return
     setOpen(false)
+  }
+
+  // The picked list is cleared when OPENING, not on close: clearing at close
+  // would swap the file table back to the empty dropzone under the dialog's
+  // fade-out.
+  const openModal = () => {
     setPicked([])
+    setOpen(true)
   }
 
   const submit = () =>
@@ -115,7 +122,6 @@ export function SubmitUpload({
       await mutation.mutateAsync(
         picked.map(({ path, file }) => ({ path, file })),
       )
-      setPicked([])
       setOpen(false)
       notify({
         tone: "success",
@@ -129,7 +135,7 @@ export function SubmitUpload({
 
   return (
     <>
-      <Button variant="primary" size="sm" onClick={() => setOpen(true)}>
+      <Button variant="primary" size="sm" onClick={openModal}>
         <UploadIcon aria-hidden="true" className="size-4" />
         {t("submissions.student.upload.open")}
       </Button>

--- a/web/src/components/drawer/SidebarFooter.tsx
+++ b/web/src/components/drawer/SidebarFooter.tsx
@@ -19,7 +19,7 @@ import {
 } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { createPortal } from "react-dom"
-import { type MouseEvent, useId, useRef, useState } from "react"
+import { type MouseEvent, useRef, useState } from "react"
 import { useDismissOnOutsidePointerDown } from "@/hooks/useDismissOnOutsidePointerDown"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import duck from "@/assets/duck.png"
@@ -205,9 +205,7 @@ function PublicSidebarFooter() {
   const { collapsed } = useSidebarCollapse()
   const { isDark, toggleTheme } = useTheme()
   const langDialogRef = useRef<HTMLDialogElement | null>(null)
-  const langDialogTitleId = useId()
   const aboutDialogRef = useRef<HTMLDialogElement | null>(null)
-  const aboutDialogTitleId = useId()
 
   return (
     <div className="mt-auto border-t border-neutral-content/20 py-2">
@@ -223,8 +221,8 @@ function PublicSidebarFooter() {
 
       {createPortal(
         <>
-          <LanguageDialog ref={langDialogRef} titleId={langDialogTitleId} />
-          <AboutDialog ref={aboutDialogRef} titleId={aboutDialogTitleId} />
+          <LanguageDialog ref={langDialogRef} />
+          <AboutDialog ref={aboutDialogRef} />
         </>,
         document.body,
       )}
@@ -331,9 +329,7 @@ const AuthedSidebarFooter = () => {
   const [menuOpen, setMenuOpen] = useState(false)
   const footerRef = useRef<HTMLDivElement | null>(null)
   const langDialogRef = useRef<HTMLDialogElement | null>(null)
-  const langDialogTitleId = useId()
   const aboutDialogRef = useRef<HTMLDialogElement | null>(null)
-  const aboutDialogTitleId = useId()
   const { collapsed } = useSidebarCollapse()
   const { isDark, toggleTheme } = useTheme()
 
@@ -528,15 +524,11 @@ const AuthedSidebarFooter = () => {
         </button>
       </div>
 
-      {createPortal(
-        <LanguageDialog ref={langDialogRef} titleId={langDialogTitleId} />,
-        document.body,
-      )}
+      {createPortal(<LanguageDialog ref={langDialogRef} />, document.body)}
 
       {createPortal(
         <AboutDialog
           ref={aboutDialogRef}
-          titleId={aboutDialogTitleId}
           org={org}
           planName={orgPlanDetails?.plan?.name}
         />,

--- a/web/src/components/memberList/MemberDetailHeader.tsx
+++ b/web/src/components/memberList/MemberDetailHeader.tsx
@@ -1,6 +1,3 @@
-import { LinkExternalIcon } from "@/components/ui/icons"
-import { useTranslation } from "react-i18next"
-
 import Avatar from "@/components/avatar"
 import {
   GitHubIdentity,
@@ -8,42 +5,27 @@ import {
 } from "@/components/memberList/memberPresentation"
 import type { MemberListRow } from "@/util/memberRow"
 
-// The identity header shared by the Org Members detail modal and the classroom
-// roster detail modal: avatar + GitHub identity line + a "Manage on GitHub"
-// link. This is the genuinely common surface between the two otherwise-disjoint
-// modal bodies; everything below it (per-classroom access vs. metadata edit /
-// unenroll / resend) stays view-owned.
-const MemberDetailHeader = ({
-  row,
-  org,
-}: {
-  row: MemberListRow
-  org: string
-}) => {
-  const { t } = useTranslation()
+// The identity block shared by the Org Members detail modal and the classroom
+// roster detail modal: avatar + GitHub identity line + optional email. The
+// "Manage on GitHub" affordance lives in each modal's footer (the dialog action
+// row), not here.
+const MemberDetailHeader = ({ row }: { row: MemberListRow }) => {
   const label = row.username || row.email
 
   return (
-    <div className="flex flex-col gap-4">
-      <Avatar
-        name={row.name || label}
-        github={row.username}
-        initials={initialsFor(row)}
-        subtitle={<GitHubIdentity row={row} />}
-      />
-
-      <a
-        href={`https://github.com/orgs/${org}/people${
-          row.username ? `?query=${encodeURIComponent(row.username)}` : ""
-        }`}
-        target="_blank"
-        rel="noreferrer"
-        className="inline-flex w-fit items-center gap-1 text-sm text-primary hover:underline"
-      >
-        <LinkExternalIcon aria-hidden="true" className="size-4" />
-        {t("orgMembers.manageOnGitHub")}
-      </a>
-    </div>
+    <Avatar
+      name={row.name || label}
+      github={row.username}
+      initials={initialsFor(row)}
+      subtitle={
+        <span className="flex flex-col gap-0.5">
+          <GitHubIdentity row={row} />
+          {row.email ? (
+            <span className="text-xs text-base-content/70">{row.email}</span>
+          ) : null}
+        </span>
+      }
+    />
   )
 }
 

--- a/web/src/components/memberList/MemberDetailHeader.tsx
+++ b/web/src/components/memberList/MemberDetailHeader.tsx
@@ -5,10 +5,9 @@ import {
 } from "@/components/memberList/memberPresentation"
 import type { MemberListRow } from "@/util/memberRow"
 
-// The identity block shared by the Org Members detail modal and the classroom
-// roster detail modal: avatar + GitHub identity line + optional email. The
-// "Manage on GitHub" affordance lives in each modal's footer (the dialog action
-// row), not here.
+// The identity block shared by the Org Members and classroom roster detail
+// modals: avatar + GitHub identity line + optional email. The "Manage on
+// GitHub" affordance lives in each modal's footer, not here.
 const MemberDetailHeader = ({ row }: { row: MemberListRow }) => {
   const label = row.username || row.email
 

--- a/web/src/components/modals/BulkAutogradeStateModal.tsx
+++ b/web/src/components/modals/BulkAutogradeStateModal.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { PauseIcon, PlayIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Heading } from "@/components/ui"
+import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import {
   BulkResultSection,
@@ -60,7 +60,6 @@ export function BulkAutogradeStateModal({
   owners,
   students = [],
 }: BulkAutogradeStateModalProps) {
-  const titleId = useId()
   const { t } = useTranslation()
   const client = useGitHubClient()
   const runningRef = useRef(false)
@@ -215,35 +214,49 @@ export function BulkAutogradeStateModal({
       onClose={onClose}
       closeDisabled={busy}
       size="lg"
-      aria-labelledby={titleId}
-    >
-      <div className="flex items-start gap-4">
-        <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-primary/10 text-primary">
+      title={t(
+        isPause
+          ? "submissions.bulkAutograde.pauseTitle"
+          : "submissions.bulkAutograde.resumeTitle",
+      )}
+      subtitle={t(
+        isPause
+          ? "submissions.bulkAutograde.pauseSubtitle"
+          : "submissions.bulkAutograde.resumeSubtitle",
+        { count: total },
+      )}
+      headerVisual={
+        <ModalIcon>
           {isPause ? (
             <PauseIcon className="size-4" aria-hidden="true" />
           ) : (
             <PlayIcon className="size-4" aria-hidden="true" />
           )}
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" id={titleId}>
-            {t(
-              isPause
-                ? "submissions.bulkAutograde.pauseTitle"
-                : "submissions.bulkAutograde.resumeTitle",
+        </ModalIcon>
+      }
+      footer={
+        phase === "complete" || phase === "error" ? (
+          <Button variant="primary" onClick={() => onClose()}>
+            {t("common.done")}
+          </Button>
+        ) : (
+          <>
+            <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
+              {t("common.cancel")}
+            </Button>
+            {phase === "idle" && total > 0 && (
+              <Button variant="primary" onClick={() => void run()}>
+                {t(
+                  isPause
+                    ? "submissions.bulkAutograde.pauseApply"
+                    : "submissions.bulkAutograde.resumeApply",
+                )}
+              </Button>
             )}
-          </Heading>
-          <p className="mt-1 text-sm text-base-content/70">
-            {t(
-              isPause
-                ? "submissions.bulkAutograde.pauseSubtitle"
-                : "submissions.bulkAutograde.resumeSubtitle",
-              { count: total },
-            )}
-          </p>
-        </div>
-      </div>
-
+          </>
+        )
+      }
+    >
       {phase === "idle" && (
         <div className="mt-4 flex flex-col gap-4">
           {total === 0 ? (
@@ -297,23 +310,6 @@ export function BulkAutogradeStateModal({
           ))}
         </div>
       )}
-
-      <div className="modal-action">
-        <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
-          {phase === "complete" || phase === "error"
-            ? t("common.close")
-            : t("common.cancel")}
-        </Button>
-        {phase === "idle" && total > 0 && (
-          <Button variant="primary" onClick={() => void run()}>
-            {t(
-              isPause
-                ? "submissions.bulkAutograde.pauseApply"
-                : "submissions.bulkAutograde.resumeApply",
-            )}
-          </Button>
-        )}
-      </div>
     </Modal>
   )
 }

--- a/web/src/components/modals/BulkAutogradeStateModal.tsx
+++ b/web/src/components/modals/BulkAutogradeStateModal.tsx
@@ -80,6 +80,7 @@ export function BulkAutogradeStateModal({
   })
   const [result, setResult] = useState<BulkResultView | null>(null)
 
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (!open) return
     runningRef.current = false

--- a/web/src/components/modals/BulkAutogradeStateModal.tsx
+++ b/web/src/components/modals/BulkAutogradeStateModal.tsx
@@ -81,12 +81,11 @@ export function BulkAutogradeStateModal({
   const [result, setResult] = useState<BulkResultView | null>(null)
 
   useEffect(() => {
-    if (!open) {
-      runningRef.current = false
-      setPhase("idle")
-      setResult(null)
-      setProgress({ processed: 0, total: 0, message: "" })
-    }
+    if (!open) return
+    runningRef.current = false
+    setPhase("idle")
+    setResult(null)
+    setProgress({ processed: 0, total: 0, message: "" })
   }, [open])
 
   const total = owners.length

--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ShieldCheckIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Select, Heading } from "@/components/ui"
+import { Alert, Button, Modal, ModalIcon, Select } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import {
   BulkResultSection,
@@ -40,7 +40,6 @@ export function BulkRepoAccessModal({
   owners,
   students = [],
 }: BulkRepoAccessModalProps) {
-  const titleId = useId()
   const { t } = useTranslation()
   const addCollaboratorMutation = useAddRepoCollaborator()
   const runningRef = useRef(false)
@@ -181,22 +180,32 @@ export function BulkRepoAccessModal({
       onClose={onClose}
       closeDisabled={busy}
       size="lg"
-      aria-labelledby={titleId}
-    >
-      <div className="flex items-start gap-4">
-        <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-primary/10 text-primary">
+      title={t("submissions.bulkAccess.title")}
+      subtitle={t("submissions.bulkAccess.subtitle", { count: total })}
+      headerVisual={
+        <ModalIcon>
           <ShieldCheckIcon className="size-4" aria-hidden="true" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" id={titleId}>
-            {t("submissions.bulkAccess.title")}
-          </Heading>
-          <p className="mt-1 text-sm text-base-content/70">
-            {t("submissions.bulkAccess.subtitle", { count: total })}
-          </p>
-        </div>
-      </div>
-
+        </ModalIcon>
+      }
+      footer={
+        phase === "complete" || phase === "error" ? (
+          <Button variant="primary" onClick={() => onClose()}>
+            {t("common.done")}
+          </Button>
+        ) : (
+          <>
+            <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
+              {t("common.cancel")}
+            </Button>
+            {phase === "idle" && total > 0 && (
+              <Button variant="primary" onClick={() => void run()}>
+                {t("submissions.bulkAccess.apply")}
+              </Button>
+            )}
+          </>
+        )
+      }
+    >
       {phase === "idle" && (
         <div className="mt-4 flex flex-col gap-4">
           {total === 0 ? (
@@ -272,19 +281,6 @@ export function BulkRepoAccessModal({
           ))}
         </div>
       )}
-
-      <div className="modal-action">
-        <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
-          {phase === "complete" || phase === "error"
-            ? t("common.close")
-            : t("common.cancel")}
-        </Button>
-        {phase === "idle" && total > 0 && (
-          <Button variant="primary" onClick={() => void run()}>
-            {t("submissions.bulkAccess.apply")}
-          </Button>
-        )}
-      </div>
     </Modal>
   )
 }

--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -64,8 +64,7 @@ export function BulkRepoAccessModal({
   })
   const [result, setResult] = useState<BulkResultView | null>(null)
 
-  // Reset when OPENING, not on close — a close-time reset would swap the
-  // result view back to the idle form under the dialog's fade-out.
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (!open) return
     runningRef.current = false

--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -64,14 +64,15 @@ export function BulkRepoAccessModal({
   })
   const [result, setResult] = useState<BulkResultView | null>(null)
 
+  // Reset when OPENING, not on close — a close-time reset would swap the
+  // result view back to the idle form under the dialog's fade-out.
   useEffect(() => {
-    if (!open) {
-      runningRef.current = false
-      setPermission("push")
-      setPhase("idle")
-      setResult(null)
-      setProgress({ processed: 0, total: 0, message: "" })
-    }
+    if (!open) return
+    runningRef.current = false
+    setPermission("push")
+    setPhase("idle")
+    setResult(null)
+    setProgress({ processed: 0, total: 0, message: "" })
   }, [open])
 
   const total = owners.length

--- a/web/src/components/modals/BulkRepoFeaturesModal.tsx
+++ b/web/src/components/modals/BulkRepoFeaturesModal.tsx
@@ -108,18 +108,17 @@ export function BulkRepoFeaturesModal({
   const [result, setResult] = useState<BulkResultView | null>(null)
 
   useEffect(() => {
-    if (!open) {
-      runningRef.current = false
-      setChoices({
-        issues: "keep",
-        wiki: "keep",
-        projects: "keep",
-        pull_requests: "keep",
-      })
-      setPhase("idle")
-      setResult(null)
-      setProgress({ processed: 0, total: 0, message: "" })
-    }
+    if (!open) return
+    runningRef.current = false
+    setChoices({
+      issues: "keep",
+      wiki: "keep",
+      projects: "keep",
+      pull_requests: "keep",
+    })
+    setPhase("idle")
+    setResult(null)
+    setProgress({ processed: 0, total: 0, message: "" })
   }, [open])
 
   const total = owners.length

--- a/web/src/components/modals/BulkRepoFeaturesModal.tsx
+++ b/web/src/components/modals/BulkRepoFeaturesModal.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { SlidersIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Select, Heading } from "@/components/ui"
+import { Alert, Button, Modal, ModalIcon, Select } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import {
   BulkResultSection,
@@ -84,7 +84,6 @@ export function BulkRepoFeaturesModal({
   owners,
   students = [],
 }: BulkRepoFeaturesModalProps) {
-  const titleId = useId()
   const { t } = useTranslation()
   const setFeaturesMutation = useSetRepoFeatures()
   const runningRef = useRef(false)
@@ -243,22 +242,36 @@ export function BulkRepoFeaturesModal({
       onClose={onClose}
       closeDisabled={busy}
       size="lg"
-      aria-labelledby={titleId}
-    >
-      <div className="flex items-start gap-4">
-        <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-primary/10 text-primary">
+      title={t("submissions.bulkFeatures.title")}
+      subtitle={t("submissions.bulkFeatures.subtitle", { count: total })}
+      headerVisual={
+        <ModalIcon>
           <SlidersIcon className="size-4" aria-hidden="true" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" id={titleId}>
-            {t("submissions.bulkFeatures.title")}
-          </Heading>
-          <p className="mt-1 text-sm text-base-content/70">
-            {t("submissions.bulkFeatures.subtitle", { count: total })}
-          </p>
-        </div>
-      </div>
-
+        </ModalIcon>
+      }
+      footer={
+        phase === "complete" || phase === "error" ? (
+          <Button variant="primary" onClick={() => onClose()}>
+            {t("common.done")}
+          </Button>
+        ) : (
+          <>
+            <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
+              {t("common.cancel")}
+            </Button>
+            {phase === "idle" && total > 0 && (
+              <Button
+                variant="primary"
+                disabled={nothingSelected}
+                onClick={() => void run()}
+              >
+                {t("submissions.bulkFeatures.apply")}
+              </Button>
+            )}
+          </>
+        )
+      }
+    >
       {phase === "idle" && (
         <div className="mt-4 flex flex-col gap-4">
           {total === 0 ? (
@@ -338,23 +351,6 @@ export function BulkRepoFeaturesModal({
           ))}
         </div>
       )}
-
-      <div className="modal-action">
-        <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
-          {phase === "complete" || phase === "error"
-            ? t("common.close")
-            : t("common.cancel")}
-        </Button>
-        {phase === "idle" && total > 0 && (
-          <Button
-            variant="primary"
-            disabled={nothingSelected}
-            onClick={() => void run()}
-          >
-            {t("submissions.bulkFeatures.apply")}
-          </Button>
-        )}
-      </div>
     </Modal>
   )
 }

--- a/web/src/components/modals/BulkRepoFeaturesModal.tsx
+++ b/web/src/components/modals/BulkRepoFeaturesModal.tsx
@@ -107,6 +107,7 @@ export function BulkRepoFeaturesModal({
   })
   const [result, setResult] = useState<BulkResultView | null>(null)
 
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (!open) return
     runningRef.current = false

--- a/web/src/components/modals/BulkSubmissionTriggerModal.tsx
+++ b/web/src/components/modals/BulkSubmissionTriggerModal.tsx
@@ -88,6 +88,7 @@ export function BulkSubmissionTriggerModal({
   })
   const [result, setResult] = useState<BulkResultView | null>(null)
 
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (!open) return
     runningRef.current = false

--- a/web/src/components/modals/BulkSubmissionTriggerModal.tsx
+++ b/web/src/components/modals/BulkSubmissionTriggerModal.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { GitBranchIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Heading } from "@/components/ui"
+import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import {
   BulkResultSection,
@@ -68,7 +68,6 @@ export function BulkSubmissionTriggerModal({
   owners,
   students = [],
 }: BulkSubmissionTriggerModalProps) {
-  const titleId = useId()
   const { t } = useTranslation()
   const client = useGitHubClient()
   const runningRef = useRef(false)
@@ -251,25 +250,35 @@ export function BulkSubmissionTriggerModal({
       onClose={onClose}
       closeDisabled={busy}
       size="lg"
-      aria-labelledby={titleId}
-    >
-      <div className="flex items-start gap-4">
-        <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-primary/10 text-primary">
+      title={t("submissions.bulkTrigger.title")}
+      subtitle={t("submissions.bulkTrigger.subtitle", {
+        count: total,
+        mode: modeLabel,
+      })}
+      headerVisual={
+        <ModalIcon>
           <GitBranchIcon className="size-4" aria-hidden="true" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" id={titleId}>
-            {t("submissions.bulkTrigger.title")}
-          </Heading>
-          <p className="mt-1 text-sm text-base-content/70">
-            {t("submissions.bulkTrigger.subtitle", {
-              count: total,
-              mode: modeLabel,
-            })}
-          </p>
-        </div>
-      </div>
-
+        </ModalIcon>
+      }
+      footer={
+        phase === "complete" || phase === "error" ? (
+          <Button variant="primary" onClick={() => onClose()}>
+            {t("common.done")}
+          </Button>
+        ) : (
+          <>
+            <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
+              {t("common.cancel")}
+            </Button>
+            {phase === "idle" && total > 0 && (
+              <Button variant="primary" onClick={() => void run()}>
+                {t("submissions.bulkTrigger.apply")}
+              </Button>
+            )}
+          </>
+        )
+      }
+    >
       {phase === "idle" && (
         <div className="mt-4 flex flex-col gap-4">
           {total === 0 ? (
@@ -321,19 +330,6 @@ export function BulkSubmissionTriggerModal({
           ))}
         </div>
       )}
-
-      <div className="modal-action">
-        <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
-          {phase === "complete" || phase === "error"
-            ? t("common.close")
-            : t("common.cancel")}
-        </Button>
-        {phase === "idle" && total > 0 && (
-          <Button variant="primary" onClick={() => void run()}>
-            {t("submissions.bulkTrigger.apply")}
-          </Button>
-        )}
-      </div>
     </Modal>
   )
 }

--- a/web/src/components/modals/BulkSubmissionTriggerModal.tsx
+++ b/web/src/components/modals/BulkSubmissionTriggerModal.tsx
@@ -89,12 +89,11 @@ export function BulkSubmissionTriggerModal({
   const [result, setResult] = useState<BulkResultView | null>(null)
 
   useEffect(() => {
-    if (!open) {
-      runningRef.current = false
-      setPhase("idle")
-      setResult(null)
-      setProgress({ processed: 0, total: 0, message: "" })
-    }
+    if (!open) return
+    runningRef.current = false
+    setPhase("idle")
+    setResult(null)
+    setProgress({ processed: 0, total: 0, message: "" })
   }, [open])
 
   const total = owners.length

--- a/web/src/components/modals/CloseSubmissionModal.tsx
+++ b/web/src/components/modals/CloseSubmissionModal.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { CalendarIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Heading } from "@/components/ui"
+import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import {
   BulkResultSection,
@@ -46,7 +46,6 @@ export function CloseSubmissionModal({
   owners,
   students = [],
 }: CloseSubmissionModalProps) {
-  const titleId = useId()
   const { t } = useTranslation()
   const closing = mode === "close"
   const permission: RepoPermission = closing ? "pull" : "push"
@@ -219,28 +218,61 @@ export function CloseSubmissionModal({
       onClose={onClose}
       closeDisabled={busy}
       size="lg"
-      aria-labelledby={titleId}
-    >
-      <div className="flex items-start gap-4">
-        <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-warning/10 text-warning">
+      title={
+        closing
+          ? t("submissions.closeSubmission.title")
+          : t("submissions.closeSubmission.reopenTitle")
+      }
+      subtitle={
+        closing
+          ? t("submissions.closeSubmission.subtitle", { count: total })
+          : t("submissions.closeSubmission.reopenSubtitle", {
+              count: total,
+            })
+      }
+      headerVisual={
+        <ModalIcon tone="warning">
           <CalendarIcon className="size-4" aria-hidden="true" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" id={titleId}>
-            {closing
-              ? t("submissions.closeSubmission.title")
-              : t("submissions.closeSubmission.reopenTitle")}
-          </Heading>
-          <p className="mt-1 text-sm text-base-content/70">
-            {closing
-              ? t("submissions.closeSubmission.subtitle", { count: total })
-              : t("submissions.closeSubmission.reopenSubtitle", {
-                  count: total,
-                })}
-          </p>
-        </div>
-      </div>
-
+        </ModalIcon>
+      }
+      footer={
+        phase === "complete" || phase === "error" ? (
+          fanOutIncomplete ? (
+            <>
+              <Button variant="ghost" onClick={() => onClose()}>
+                {t("common.close")}
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => void run({ flipFlag: false })}
+              >
+                {t("submissions.closeSubmission.finishApply")}
+              </Button>
+            </>
+          ) : (
+            <Button variant="primary" onClick={() => onClose()}>
+              {t("common.done")}
+            </Button>
+          )
+        ) : (
+          <>
+            <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
+              {t("common.cancel")}
+            </Button>
+            {phase === "idle" && (
+              <Button
+                variant="primary"
+                onClick={() => void run({ flipFlag: true })}
+              >
+                {closing
+                  ? t("submissions.closeSubmission.apply")
+                  : t("submissions.closeSubmission.reopenApply")}
+              </Button>
+            )}
+          </>
+        )
+      }
+    >
       {phase === "idle" && (
         <div className="mt-4 flex flex-col gap-4">
           {total === 0 ? (
@@ -311,32 +343,6 @@ export function CloseSubmissionModal({
           )}
         </div>
       )}
-
-      <div className="modal-action">
-        <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
-          {phase === "complete" || phase === "error"
-            ? t("common.close")
-            : t("common.cancel")}
-        </Button>
-        {phase === "idle" && (
-          <Button
-            variant="primary"
-            onClick={() => void run({ flipFlag: true })}
-          >
-            {closing
-              ? t("submissions.closeSubmission.apply")
-              : t("submissions.closeSubmission.reopenApply")}
-          </Button>
-        )}
-        {fanOutIncomplete && !busy && (
-          <Button
-            variant="primary"
-            onClick={() => void run({ flipFlag: false })}
-          >
-            {t("submissions.closeSubmission.finishApply")}
-          </Button>
-        )}
-      </div>
     </Modal>
   )
 }

--- a/web/src/components/modals/CloseSubmissionModal.tsx
+++ b/web/src/components/modals/CloseSubmissionModal.tsx
@@ -77,14 +77,13 @@ export function CloseSubmissionModal({
   const [fanOutIncomplete, setFanOutIncomplete] = useState(false)
 
   useEffect(() => {
-    if (!open) {
-      runningRef.current = false
-      setPhase("idle")
-      setResult(null)
-      setFlagError(false)
-      setFanOutIncomplete(false)
-      setProgress({ processed: 0, total: 0, message: "" })
-    }
+    if (!open) return
+    runningRef.current = false
+    setPhase("idle")
+    setResult(null)
+    setFlagError(false)
+    setFanOutIncomplete(false)
+    setProgress({ processed: 0, total: 0, message: "" })
   }, [open])
 
   const total = owners.length

--- a/web/src/components/modals/CloseSubmissionModal.tsx
+++ b/web/src/components/modals/CloseSubmissionModal.tsx
@@ -76,6 +76,7 @@ export function CloseSubmissionModal({
   // closing" affordance so a throttled close isn't stuck offering only Reopen.
   const [fanOutIncomplete, setFanOutIncomplete] = useState(false)
 
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (!open) return
     runningRef.current = false

--- a/web/src/components/modals/FreePlanInfoModal.tsx
+++ b/web/src/components/modals/FreePlanInfoModal.tsx
@@ -1,8 +1,7 @@
 import { LinkExternalIcon } from "@/components/ui/icons"
-import { useId } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button, Modal, Heading } from "@/components/ui"
+import { Button, Modal } from "@/components/ui"
 
 // Explains why a Free-plan org can't be set up and points the teacher at the
 // GitHub Education benefit that upgrades an org to Team for free. Opened from a
@@ -18,19 +17,22 @@ function FreePlanInfoModal({
   onClose: () => void
 }) {
   const { t } = useTranslation()
-  const titleId = useId()
 
   return (
-    <Modal open={open} onClose={onClose} size="md" aria-labelledby={titleId}>
-      <Heading as="h3" id={titleId}>
-        {t("orgs.newOrg.freePlanInfo.title")}
-      </Heading>
-      {orgLogin && (
-        <p className="mt-1 font-mono text-sm text-base-content/60">
-          {orgLogin}
-        </p>
-      )}
-
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="md"
+      title={t("orgs.newOrg.freePlanInfo.title")}
+      subtitle={
+        orgLogin ? <span className="font-mono">{orgLogin}</span> : undefined
+      }
+      footer={
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          {t("orgs.newOrg.freePlanInfo.dismiss")}
+        </Button>
+      }
+    >
       <p className="mt-4 text-sm leading-6 text-base-content/80">
         {t("orgs.newOrg.freePlanInfo.body")}
       </p>
@@ -53,12 +55,6 @@ function FreePlanInfoModal({
         >
           {t("orgs.newOrg.freePlanInfo.educationCta")}
           <LinkExternalIcon aria-hidden="true" className="size-4" />
-        </Button>
-      </div>
-
-      <div className="modal-action">
-        <Button variant="ghost" size="sm" onClick={onClose}>
-          {t("orgs.newOrg.freePlanInfo.dismiss")}
         </Button>
       </div>
     </Modal>

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -139,12 +139,11 @@ export function GroupCollaboratorsModal({
   }, [open, repoName, loadingCollaborators, initialCollaborators])
 
   useEffect(() => {
-    if (!open) {
-      setNewCollaborator("")
-      setSubmitError(null)
-      setSaved(false)
-      setInvalidCollaborators(new Set())
-    }
+    if (!open) return
+    setNewCollaborator("")
+    setSubmitError(null)
+    setSaved(false)
+    setInvalidCollaborators(new Set())
   }, [open])
 
   useEffect(

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -138,6 +138,7 @@ export function GroupCollaboratorsModal({
     setDraftCollaborators(initialCollaborators)
   }, [open, repoName, loadingCollaborators, initialCollaborators])
 
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (!open) return
     setNewCollaborator("")

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import {
@@ -16,8 +16,8 @@ import {
   Button,
   Input,
   Modal,
+  ModalIcon,
   MonoLtr,
-  Heading,
 } from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import useGetRepo from "@/hooks/useGetRepo"
@@ -73,7 +73,6 @@ export function GroupCollaboratorsModal({
   maxGroupSize,
   students = [],
 }: GroupCollaboratorsModalProps) {
-  const titleId = useId()
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Synchronous re-entrancy guard: isSaving (mutation.isPending) updates a tick
   // late, so a rapid double-click could start two overlapping saves.
@@ -358,31 +357,61 @@ export function GroupCollaboratorsModal({
       onClose={onClose}
       closeDisabled={isSaving}
       size="xl"
-      aria-labelledby={titleId}
-    >
-      <div className="flex items-start gap-4">
-        <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-primary/10 text-primary">
+      title={assignmentName || t("components.modals.groupCollaborators.title")}
+      subtitle={
+        repoName ? (
+          <a
+            className="link inline-flex items-center gap-1.5"
+            href={repoUrl || `https://github.com/${org}/${repoName}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <MarkGithubIcon aria-hidden="true" className="size-4" />
+            {t("components.modals.groupCollaborators.viewRepository")}
+          </a>
+        ) : undefined
+      }
+      headerVisual={
+        <ModalIcon>
           <PeopleIcon className="size-4" aria-hidden="true" />
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" id={titleId}>
-            {assignmentName || t("components.modals.groupCollaborators.title")}
-          </Heading>
-          {repoName && (
-            <a
-              className="link mt-1 inline-flex items-center gap-1.5 text-sm"
-              href={repoUrl || `https://github.com/${org}/${repoName}`}
-              target="_blank"
-              rel="noreferrer"
+        </ModalIcon>
+      }
+      footer={
+        <>
+          <Button variant="ghost" disabled={isSaving} onClick={() => onClose()}>
+            {t("common.cancel")}
+          </Button>
+          {canManage && hasChanges && (
+            <Button
+              variant="ghost"
+              disabled={isSaving}
+              onClick={discardChanges}
             >
-              <MarkGithubIcon aria-hidden="true" className="size-4" />
-              {t("components.modals.groupCollaborators.viewRepository")}
-            </a>
+              {t("components.modals.groupCollaborators.discardChanges")}
+            </Button>
           )}
-        </div>
-      </div>
-
+          {canManage && (
+            <Button
+              variant="primary"
+              disabled={
+                loadingCollaborators ||
+                isSaving ||
+                tooMany ||
+                hasDuplicates ||
+                !hasChanges
+              }
+              loading={isSaving}
+              loadingLabel={t(
+                "components.modals.groupCollaborators.saveCollaborators",
+              )}
+              onClick={() => void handleSave()}
+            >
+              {t("components.modals.groupCollaborators.saveCollaborators")}
+            </Button>
+          )}
+        </>
+      }
+    >
       {loadingCollaborators ? (
         <div className="flex py-10">
           <Spinner
@@ -595,36 +624,6 @@ export function GroupCollaboratorsModal({
           </div>
         </>
       )}
-
-      <div className="modal-action">
-        <Button variant="ghost" disabled={isSaving} onClick={() => onClose()}>
-          {t("common.cancel")}
-        </Button>
-        {canManage && hasChanges && (
-          <Button variant="ghost" disabled={isSaving} onClick={discardChanges}>
-            {t("components.modals.groupCollaborators.discardChanges")}
-          </Button>
-        )}
-        {canManage && (
-          <Button
-            variant="primary"
-            disabled={
-              loadingCollaborators ||
-              isSaving ||
-              tooMany ||
-              hasDuplicates ||
-              !hasChanges
-            }
-            loading={isSaving}
-            loadingLabel={t(
-              "components.modals.groupCollaborators.saveCollaborators",
-            )}
-            onClick={() => void handleSave()}
-          >
-            {t("components.modals.groupCollaborators.saveCollaborators")}
-          </Button>
-        )}
-      </div>
     </Modal>
   )
 }

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -175,11 +175,9 @@ function NewOrgModal({
   const navigate = useNavigate()
   const [freePlanOrg, setFreePlanOrg] = useState<string | null>(null)
 
-  // Keep the body mounted through the dialog's close animation (unmounting on
-  // `open` alone collapses the fading box to its header), while still
-  // remounting it per open: the notice's defaultOpen and the picker's
-  // seenOnOpen snapshot are open-time latches, so each open gets a fresh mount
-  // via the sequence key.
+  // Body stays mounted through the close fade (useLingeringOpen) but remounts
+  // per open via the sequence key: the notice's defaultOpen and the picker's
+  // seenOnOpen snapshot are open-time latches.
   const contentMounted = useLingeringOpen(open)
   const [openSeq, setOpenSeq] = useState(0)
   const [wasOpen, setWasOpen] = useState(open)

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "@tanstack/react-router"
 import { LinkExternalIcon, SyncIcon } from "@/components/ui/icons"
-import { useState } from "react"
+import { Fragment, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import PlanBadge from "@/components/PlanBadge"
@@ -9,6 +9,7 @@ import FreePlanInfoModal from "@/components/modals/FreePlanInfoModal"
 import { Badge, Button, Modal, Spinner, cx } from "@/components/ui"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
 import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
+import { useLingeringOpen } from "@/hooks/useLingeringOpen"
 import useScrollFade from "@/hooks/useScrollFade"
 import { classifyPlan } from "@/lib/orgPlan"
 
@@ -174,6 +175,19 @@ function NewOrgModal({
   const navigate = useNavigate()
   const [freePlanOrg, setFreePlanOrg] = useState<string | null>(null)
 
+  // Keep the body mounted through the dialog's close animation (unmounting on
+  // `open` alone collapses the fading box to its header), while still
+  // remounting it per open: the notice's defaultOpen and the picker's
+  // seenOnOpen snapshot are open-time latches, so each open gets a fresh mount
+  // via the sequence key.
+  const contentMounted = useLingeringOpen(open)
+  const [openSeq, setOpenSeq] = useState(0)
+  const [wasOpen, setWasOpen] = useState(open)
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) setOpenSeq((n) => n + 1)
+  }
+
   const handleSelect = (login: string) => {
     onClose()
     void navigate({ to: "/$org/setup", params: { org: login } })
@@ -201,8 +215,8 @@ function NewOrgModal({
           </Button>
         }
       >
-        {open && (
-          <>
+        {contentMounted && (
+          <Fragment key={openSeq}>
             <div className="mt-6">
               <MissingOrgNotice
                 onRefresh={onRefresh}
@@ -219,7 +233,7 @@ function NewOrgModal({
               onSelect={handleSelect}
               onFreePlan={setFreePlanOrg}
             />
-          </>
+          </Fragment>
         )}
       </Modal>
 

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -1,12 +1,12 @@
 import { useNavigate } from "@tanstack/react-router"
 import { LinkExternalIcon, SyncIcon } from "@/components/ui/icons"
-import { useId, useState } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import PlanBadge from "@/components/PlanBadge"
 import MissingOrgNotice from "@/components/MissingOrgNotice"
 import FreePlanInfoModal from "@/components/modals/FreePlanInfoModal"
-import { Badge, Button, Modal, Spinner, cx, Heading } from "@/components/ui"
+import { Badge, Button, Modal, Spinner, cx } from "@/components/ui"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
 import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
 import useScrollFade from "@/hooks/useScrollFade"
@@ -172,7 +172,6 @@ function NewOrgModal({
 }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const titleId = useId()
   const [freePlanOrg, setFreePlanOrg] = useState<string | null>(null)
 
   const handleSelect = (login: string) => {
@@ -182,18 +181,26 @@ function NewOrgModal({
 
   return (
     <>
-      <Modal open={open} onClose={onClose} size="2xl" aria-labelledby={titleId}>
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <Heading as="h3" id={titleId}>
-              {t("orgs.newOrg.title")}
-            </Heading>
-            <p className="mt-1 text-sm text-base-content/70">
-              {t("orgs.newOrg.description")}
-            </p>
-          </div>
-        </div>
-
+      <Modal
+        open={open}
+        onClose={onClose}
+        size="2xl"
+        title={t("orgs.newOrg.title")}
+        subtitle={t("orgs.newOrg.description")}
+        footer={
+          <Button
+            as="a"
+            href="https://github.com/organizations/new"
+            target="_blank"
+            rel="noreferrer"
+            variant="ghost"
+            size="sm"
+          >
+            {t("orgs.newOrg.createOnGitHub")}
+            <LinkExternalIcon aria-hidden="true" className="size-4" />
+          </Button>
+        }
+      >
         {open && (
           <>
             <div className="mt-6">
@@ -214,20 +221,6 @@ function NewOrgModal({
             />
           </>
         )}
-
-        <div className="modal-action">
-          <Button
-            as="a"
-            href="https://github.com/organizations/new"
-            target="_blank"
-            rel="noreferrer"
-            variant="ghost"
-            size="sm"
-          >
-            {t("orgs.newOrg.createOnGitHub")}
-            <LinkExternalIcon aria-hidden="true" className="size-4" />
-          </Button>
-        </div>
       </Modal>
 
       <FreePlanInfoModal

--- a/web/src/components/modals/OrgDetailsModal.tsx
+++ b/web/src/components/modals/OrgDetailsModal.tsx
@@ -3,14 +3,7 @@ import { useId, useState } from "react"
 import { useForm } from "@tanstack/react-form"
 import { useTranslation } from "react-i18next"
 
-import {
-  Button,
-  FormField,
-  Input,
-  Modal,
-  Textarea,
-  Heading,
-} from "@/components/ui"
+import { Button, FormField, Input, Modal, Textarea } from "@/components/ui"
 import { GitHubLink } from "@/components/GitHubLink"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
@@ -58,7 +51,9 @@ function OrgDetailsModal({
 }) {
   const { t } = useTranslation()
   const { notify } = useToast()
-  const titleId = useId()
+  // Ties the footer's submit button (outside the <form> element) to the edit
+  // form via the button's `form` attribute.
+  const formId = useId()
   const { org, membership } = summary
   const [editing, setEditing] = useState(false)
 
@@ -134,12 +129,15 @@ function OrgDetailsModal({
       open={open}
       onClose={handleClose}
       size="2xl"
-      aria-labelledby={titleId}
-    >
-      {/* Header: avatar + name, with an owner-only pencil badge on the avatar
-          in edit mode (links to GitHub settings — the REST API can't set an org
-          avatar). pe-8 keeps the row clear of the Modal's close X. */}
-      <div className="flex items-center gap-3 pe-8">
+      title={<span className="block truncate">{heading}</span>}
+      subtitle={
+        <span className="block truncate font-mono text-xs text-base-content/50">
+          {org.login}
+        </span>
+      }
+      headerVisual={
+        // Avatar with an owner-only pencil badge in edit mode (links to GitHub
+        // settings — the REST API can't set an org avatar).
         <div className="relative shrink-0">
           <img
             src={org.avatar_url}
@@ -159,19 +157,55 @@ function OrgDetailsModal({
             </a>
           )}
         </div>
-
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" className="truncate" id={titleId}>
-            {heading}
-          </Heading>
-          <p className="truncate font-mono text-xs text-base-content/50">
-            {org.login}
-          </p>
-        </div>
-      </div>
-
+      }
+      footer={
+        editing ? (
+          <>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={stopEditing}
+              disabled={updateProfile.isPending}
+            >
+              {t("orgs.detailsModal.cancel")}
+            </Button>
+            <Button
+              type="submit"
+              form={formId}
+              variant="primary"
+              size="sm"
+              loading={updateProfile.isPending}
+              loadingLabel={t("orgs.detailsModal.saving")}
+            >
+              {t("orgs.detailsModal.save")}
+            </Button>
+          </>
+        ) : (
+          <>
+            {isOwner && (
+              <GitHubLink
+                href={githubOrgSettingsUrl(org.login)}
+                label={t("orgs.detailsModal.manageOnGitHub")}
+                className="me-auto self-center"
+              />
+            )}
+            <Button variant="ghost" size="sm" onClick={handleClose}>
+              {t("orgs.detailsModal.close")}
+            </Button>
+            {isOwner && (
+              <Button variant="primary" size="sm" onClick={startEditing}>
+                <PencilIcon aria-hidden="true" className="size-4" />
+                {t("orgs.detailsModal.edit")}
+              </Button>
+            )}
+          </>
+        )
+      }
+    >
       {editing ? (
         <form
+          id={formId}
           className="mt-5 flex flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault()
@@ -305,125 +339,79 @@ function OrgDetailsModal({
               )}
             </form.Field>
           </div>
-
-          <div className="modal-action">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={stopEditing}
-              disabled={updateProfile.isPending}
-            >
-              {t("orgs.detailsModal.cancel")}
-            </Button>
-            <Button
-              type="submit"
-              variant="primary"
-              size="sm"
-              loading={updateProfile.isPending}
-              loadingLabel={t("orgs.detailsModal.saving")}
-            >
-              {t("orgs.detailsModal.save")}
-            </Button>
-          </div>
         </form>
       ) : (
-        <>
-          <div className="mt-5 flex flex-col gap-3">
-            {/* Description spans full width; Website + Email follow as a pair. */}
-            <InfoRow
-              label={t("orgs.detailsModal.description")}
-              value={details?.description}
-            />
+        <div className="mt-5 flex flex-col gap-3">
+          {/* Description spans full width; Website + Email follow as a pair. */}
+          <InfoRow
+            label={t("orgs.detailsModal.description")}
+            value={details?.description}
+          />
 
-            <dl className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
-              <InfoRow
-                label={t("orgs.detailsModal.website")}
-                value={
-                  websiteHref ? (
-                    <a
-                      href={websiteHref}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-primary hover:underline"
-                    >
-                      {details?.blog}
-                    </a>
-                  ) : (
-                    details?.blog
-                  )
-                }
-              />
-              <InfoRow
-                label={t("orgs.detailsModal.email")}
-                value={
-                  details?.email ? (
-                    <a
-                      href={`mailto:${encodeURIComponent(details.email)}`}
-                      className="text-primary hover:underline"
-                    >
-                      {details.email}
-                    </a>
-                  ) : null
-                }
-              />
-              <InfoRow
-                label={t("orgs.detailsModal.location")}
-                value={details?.location}
-              />
-              <InfoRow
-                label={t("orgs.detailsModal.school")}
-                value={details?.company}
-              />
-              {/* Plan and org ID are owner-facing details. Plan is only
+          <dl className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+            <InfoRow
+              label={t("orgs.detailsModal.website")}
+              value={
+                websiteHref ? (
+                  <a
+                    href={websiteHref}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-primary hover:underline"
+                  >
+                    {details?.blog}
+                  </a>
+                ) : (
+                  details?.blog
+                )
+              }
+            />
+            <InfoRow
+              label={t("orgs.detailsModal.email")}
+              value={
+                details?.email ? (
+                  <a
+                    href={`mailto:${encodeURIComponent(details.email)}`}
+                    className="text-primary hover:underline"
+                  >
+                    {details.email}
+                  </a>
+                ) : null
+              }
+            />
+            <InfoRow
+              label={t("orgs.detailsModal.location")}
+              value={details?.location}
+            />
+            <InfoRow
+              label={t("orgs.detailsModal.school")}
+              value={details?.company}
+            />
+            {/* Plan and org ID are owner-facing details. Plan is only
                   returned to owners anyway; org ID is hidden from members to
                   keep the member view focused on the public profile. */}
-              {isOwner && (
-                <InfoRow
-                  label={t("orgs.detailsModal.plan")}
-                  value={details?.plan?.name}
-                />
-              )}
-              {isOwner && (
-                <InfoRow
-                  label={t("orgs.detailsModal.orgId")}
-                  value={String(org.id)}
-                />
-              )}
+            {isOwner && (
               <InfoRow
-                label={t("orgs.detailsModal.role")}
-                value={
-                  isOwner
-                    ? t("orgs.detailsModal.roleAdmin")
-                    : t("orgs.detailsModal.roleMember")
-                }
+                label={t("orgs.detailsModal.plan")}
+                value={details?.plan?.name}
               />
-            </dl>
-          </div>
-
-          <div className="modal-action items-center justify-between">
-            {isOwner ? (
-              <GitHubLink
-                href={githubOrgSettingsUrl(org.login)}
-                label={t("orgs.detailsModal.manageOnGitHub")}
-              />
-            ) : (
-              // Keep the buttons right-aligned when the manage link is hidden.
-              <span />
             )}
-            <div className="flex items-center gap-2">
-              <Button variant="ghost" size="sm" onClick={handleClose}>
-                {t("orgs.detailsModal.close")}
-              </Button>
-              {isOwner && (
-                <Button variant="primary" size="sm" onClick={startEditing}>
-                  <PencilIcon aria-hidden="true" className="size-4" />
-                  {t("orgs.detailsModal.edit")}
-                </Button>
-              )}
-            </div>
-          </div>
-        </>
+            {isOwner && (
+              <InfoRow
+                label={t("orgs.detailsModal.orgId")}
+                value={String(org.id)}
+              />
+            )}
+            <InfoRow
+              label={t("orgs.detailsModal.role")}
+              value={
+                isOwner
+                  ? t("orgs.detailsModal.roleAdmin")
+                  : t("orgs.detailsModal.roleMember")
+              }
+            />
+          </dl>
+        </div>
       )}
     </Modal>
   )

--- a/web/src/components/modals/OrgDetailsModal.tsx
+++ b/web/src/components/modals/OrgDetailsModal.tsx
@@ -123,14 +123,10 @@ function OrgDetailsModal({
     if (open) setEditing(false)
   }, [open])
 
-  const handleClose = () => {
-    onClose()
-  }
-
   return (
     <Modal
       open={open}
-      onClose={handleClose}
+      onClose={onClose}
       size="2xl"
       title={<span className="block truncate">{heading}</span>}
       subtitle={
@@ -193,7 +189,7 @@ function OrgDetailsModal({
                 className="me-auto self-center"
               />
             )}
-            <Button variant="ghost" size="sm" onClick={handleClose}>
+            <Button variant="ghost" size="sm" onClick={onClose}>
               {t("orgs.detailsModal.close")}
             </Button>
             {isOwner && (

--- a/web/src/components/modals/OrgDetailsModal.tsx
+++ b/web/src/components/modals/OrgDetailsModal.tsx
@@ -51,8 +51,7 @@ function OrgDetailsModal({
 }) {
   const { t } = useTranslation()
   const { notify } = useToast()
-  // Ties the footer's submit button (outside the <form> element) to the edit
-  // form via the button's `form` attribute.
+  // Ties the footer's submit button (outside the <form> element) to the form.
   const formId = useId()
   const { org, membership } = summary
   const [editing, setEditing] = useState(false)
@@ -119,8 +118,7 @@ function OrgDetailsModal({
     setEditing(false)
   }
 
-  // Leave edit mode when OPENING, not at close — flipping at close would swap
-  // the form back to the read-only view under the dialog's fade-out.
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (open) setEditing(false)
   }, [open])

--- a/web/src/components/modals/OrgDetailsModal.tsx
+++ b/web/src/components/modals/OrgDetailsModal.tsx
@@ -1,5 +1,5 @@
 import { PencilIcon } from "@/components/ui/icons"
-import { useId, useState } from "react"
+import { useEffect, useId, useState } from "react"
 import { useForm } from "@tanstack/react-form"
 import { useTranslation } from "react-i18next"
 
@@ -119,8 +119,13 @@ function OrgDetailsModal({
     setEditing(false)
   }
 
+  // Leave edit mode when OPENING, not at close — flipping at close would swap
+  // the form back to the read-only view under the dialog's fade-out.
+  useEffect(() => {
+    if (open) setEditing(false)
+  }, [open])
+
   const handleClose = () => {
-    setEditing(false)
     onClose()
   }
 

--- a/web/src/components/modals/ProvisioningChangeConfirmModal.tsx
+++ b/web/src/components/modals/ProvisioningChangeConfirmModal.tsx
@@ -1,8 +1,7 @@
-import { useId } from "react"
 import { useTranslation } from "react-i18next"
 import { AlertIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Heading } from "@/components/ui"
+import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
 
 type ProvisioningChangeConfirmModalProps = {
   open: boolean
@@ -27,7 +26,6 @@ export function ProvisioningChangeConfirmModal({
   acceptedCount,
   saving = false,
 }: ProvisioningChangeConfirmModalProps) {
-  const titleId = useId()
   const { t } = useTranslation()
 
   return (
@@ -36,37 +34,34 @@ export function ProvisioningChangeConfirmModal({
       onClose={onClose}
       closeDisabled={saving}
       size="lg"
-      aria-labelledby={titleId}
-    >
-      <div className="flex items-start gap-4">
-        <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-warning/10 text-warning">
+      role="alertdialog"
+      title={t("assignmentSettings.provisioningConfirm.title")}
+      headerVisual={
+        <ModalIcon tone="warning">
           <AlertIcon className="size-4" aria-hidden="true" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" id={titleId}>
-            {t("assignmentSettings.provisioningConfirm.title")}
-          </Heading>
-          <Alert tone="warning" className="mt-3 text-sm">
-            {t("assignmentSettings.provisioningConfirm.body", {
-              count: acceptedCount,
-            })}
-          </Alert>
-        </div>
-      </div>
-
-      <div className="modal-action">
-        <Button variant="ghost" disabled={saving} onClick={onClose}>
-          {t("assignmentSettings.provisioningConfirm.cancel")}
-        </Button>
-        <Button
-          variant="warning"
-          loading={saving}
-          disabled={saving}
-          onClick={onConfirm}
-        >
-          {t("assignmentSettings.provisioningConfirm.confirm")}
-        </Button>
-      </div>
+        </ModalIcon>
+      }
+      footer={
+        <>
+          <Button variant="ghost" disabled={saving} onClick={onClose}>
+            {t("assignmentSettings.provisioningConfirm.cancel")}
+          </Button>
+          <Button
+            variant="warning"
+            loading={saving}
+            disabled={saving}
+            onClick={onConfirm}
+          >
+            {t("assignmentSettings.provisioningConfirm.confirm")}
+          </Button>
+        </>
+      }
+    >
+      <Alert tone="warning" className="mt-4 text-sm">
+        {t("assignmentSettings.provisioningConfirm.body", {
+          count: acceptedCount,
+        })}
+      </Alert>
     </Modal>
   )
 }

--- a/web/src/components/modals/RenameAssignmentModal.tsx
+++ b/web/src/components/modals/RenameAssignmentModal.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useRef, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { PencilIcon } from "@/components/ui/icons"
 
@@ -9,7 +9,7 @@ import {
   FormField,
   Input,
   Modal,
-  Heading,
+  ModalIcon,
 } from "@/components/ui"
 import { Spinner } from "@/components/Spinner"
 import { BulkResultSection } from "@/components/bulk/resultView"
@@ -59,7 +59,6 @@ export function RenameAssignmentModal({
   assignments,
   mode,
 }: RenameAssignmentModalProps) {
-  const titleId = useId()
   const { t } = useTranslation()
   const finish = mode === "finish"
   const oldSlug = finish ? (assignment.renamed_from ?? "") : assignment.slug
@@ -168,41 +167,76 @@ export function RenameAssignmentModal({
       onClose={onClose}
       closeDisabled={busy}
       size="2xl"
-      aria-labelledby={titleId}
-    >
-      <div className="flex items-start gap-4">
-        <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-warning/10 text-warning">
+      title={
+        finish
+          ? t("assignments.rename.finishTitle")
+          : t("assignments.rename.title")
+      }
+      subtitle={
+        <span className="break-all">
+          {finish ? (
+            <Trans
+              i18nKey="assignments.rename.finishSubtitle"
+              values={{ old: oldSlug, new: newSlug }}
+              components={{
+                old: <EmphasisLtr className="font-mono font-bold" />,
+                new: <EmphasisLtr className="font-mono font-bold" />,
+              }}
+            />
+          ) : (
+            <Trans
+              i18nKey="assignments.rename.subtitle"
+              values={{ old: oldSlug }}
+              components={{
+                old: <EmphasisLtr className="font-mono font-bold" />,
+              }}
+            />
+          )}
+        </span>
+      }
+      headerVisual={
+        <ModalIcon tone="warning">
           <PencilIcon className="size-4" aria-hidden="true" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" id={titleId}>
-            {finish
-              ? t("assignments.rename.finishTitle")
-              : t("assignments.rename.title")}
-          </Heading>
-          <p className="mt-1 break-all text-sm text-base-content/70">
-            {finish ? (
-              <Trans
-                i18nKey="assignments.rename.finishSubtitle"
-                values={{ old: oldSlug, new: newSlug }}
-                components={{
-                  old: <EmphasisLtr className="font-mono font-bold" />,
-                  new: <EmphasisLtr className="font-mono font-bold" />,
-                }}
-              />
-            ) : (
-              <Trans
-                i18nKey="assignments.rename.subtitle"
-                values={{ old: oldSlug }}
-                components={{
-                  old: <EmphasisLtr className="font-mono font-bold" />,
-                }}
-              />
+        </ModalIcon>
+      }
+      footer={
+        summary !== null && summary.failed > 0 ? (
+          <>
+            <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
+              {t("common.close")}
+            </Button>
+            <Button
+              variant="primary"
+              disabled={busy}
+              onClick={() => void run()}
+            >
+              {t("assignments.rename.finishApply")}
+            </Button>
+          </>
+        ) : done ? (
+          <Button variant="primary" onClick={() => onClose()}>
+            {t("common.done")}
+          </Button>
+        ) : (
+          <>
+            <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
+              {t("common.cancel")}
+            </Button>
+            {!busy && (
+              <Button
+                variant="primary"
+                disabled={!canRun}
+                onClick={() => void run()}
+              >
+                {finish
+                  ? t("assignments.rename.finishApply")
+                  : t("assignments.rename.apply")}
+              </Button>
             )}
-          </p>
-        </div>
-      </div>
-
+          </>
+        )
+      }
+    >
       {!busy && !done && (
         <div className="mt-4 flex flex-col gap-4">
           {!finish && (
@@ -275,28 +309,6 @@ export function RenameAssignmentModal({
       )}
 
       {summary && <RenameResult summary={summary} newSlug={newSlug} />}
-
-      <div className="modal-action">
-        <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
-          {done ? t("common.close") : t("common.cancel")}
-        </Button>
-        {!busy && !done && (
-          <Button
-            variant="primary"
-            disabled={!canRun}
-            onClick={() => void run()}
-          >
-            {finish
-              ? t("assignments.rename.finishApply")
-              : t("assignments.rename.apply")}
-          </Button>
-        )}
-        {!busy && summary !== null && summary.failed > 0 && (
-          <Button variant="primary" onClick={() => void run()}>
-            {t("assignments.rename.finishApply")}
-          </Button>
-        )}
-      </div>
     </Modal>
   )
 }

--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -182,13 +182,12 @@ export function RepoAccessModal({
   }, [open, repoName, loadingCollaborators, initialEntries])
 
   useEffect(() => {
-    if (!open) {
-      setNewCollaborator("")
-      setNewPermission("push")
-      setSubmitError(null)
-      setSaved(false)
-      setInvalidLogins(new Set())
-    }
+    if (!open) return
+    setNewCollaborator("")
+    setNewPermission("push")
+    setSubmitError(null)
+    setSaved(false)
+    setInvalidLogins(new Set())
   }, [open])
 
   useEffect(

--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -181,6 +181,7 @@ export function RepoAccessModal({
     setDraft(initialEntries)
   }, [open, repoName, loadingCollaborators, initialEntries])
 
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (!open) return
     setNewCollaborator("")

--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import {
@@ -16,8 +16,8 @@ import {
   Button,
   Input,
   Modal,
+  ModalIcon,
   Select,
-  Heading,
 } from "@/components/ui"
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import useGetRepo from "@/hooks/useGetRepo"
@@ -112,7 +112,6 @@ export function RepoAccessModal({
   assignmentName,
   students = [],
 }: RepoAccessModalProps) {
-  const titleId = useId()
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const savingRef = useRef(false)
   const { user } = useGithubAuth()
@@ -394,34 +393,57 @@ export function RepoAccessModal({
       onClose={onClose}
       closeDisabled={isSaving}
       size="xl"
-      aria-labelledby={titleId}
-    >
-      <div className="flex items-start gap-4">
-        <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-primary/10 text-primary">
+      title={t("components.modals.repoAccess.title")}
+      subtitle={
+        repoName ? (
+          <a
+            className="link inline-flex items-center gap-1.5"
+            href={repoUrl || `https://github.com/${org}/${repoName}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <MarkGithubIcon aria-hidden="true" className="size-4" />
+            {assignmentName
+              ? t("components.modals.repoAccess.viewRepoNamed", {
+                  name: assignmentName,
+                })
+              : t("components.modals.groupCollaborators.viewRepository")}
+          </a>
+        ) : undefined
+      }
+      headerVisual={
+        <ModalIcon>
           <ShieldCheckIcon className="size-4" aria-hidden="true" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" id={titleId}>
-            {t("components.modals.repoAccess.title")}
-          </Heading>
-          {repoName && (
-            <a
-              className="link mt-1 inline-flex items-center gap-1.5 text-sm"
-              href={repoUrl || `https://github.com/${org}/${repoName}`}
-              target="_blank"
-              rel="noreferrer"
+        </ModalIcon>
+      }
+      footer={
+        <>
+          <Button variant="ghost" disabled={isSaving} onClick={() => onClose()}>
+            {t("common.cancel")}
+          </Button>
+          {canManage && hasChanges && (
+            <Button
+              variant="ghost"
+              disabled={isSaving}
+              onClick={discardChanges}
             >
-              <MarkGithubIcon aria-hidden="true" className="size-4" />
-              {assignmentName
-                ? t("components.modals.repoAccess.viewRepoNamed", {
-                    name: assignmentName,
-                  })
-                : t("components.modals.groupCollaborators.viewRepository")}
-            </a>
+              {t("components.modals.groupCollaborators.discardChanges")}
+            </Button>
           )}
-        </div>
-      </div>
-
+          {canManage && (
+            <Button
+              variant="primary"
+              disabled={loadingCollaborators || isSaving || !hasChanges}
+              loading={isSaving}
+              loadingLabel={t("components.modals.repoAccess.save")}
+              onClick={() => void handleSave()}
+            >
+              {t("components.modals.repoAccess.save")}
+            </Button>
+          )}
+        </>
+      }
+    >
       {loadingCollaborators ? (
         <div className="flex py-10">
           <Spinner
@@ -595,28 +617,6 @@ export function RepoAccessModal({
           )}
         </>
       )}
-
-      <div className="modal-action">
-        <Button variant="ghost" disabled={isSaving} onClick={() => onClose()}>
-          {t("common.cancel")}
-        </Button>
-        {canManage && hasChanges && (
-          <Button variant="ghost" disabled={isSaving} onClick={discardChanges}>
-            {t("components.modals.groupCollaborators.discardChanges")}
-          </Button>
-        )}
-        {canManage && (
-          <Button
-            variant="primary"
-            disabled={loadingCollaborators || isSaving || !hasChanges}
-            loading={isSaving}
-            loadingLabel={t("components.modals.repoAccess.save")}
-            onClick={() => void handleSave()}
-          >
-            {t("components.modals.repoAccess.save")}
-          </Button>
-        )}
-      </div>
     </Modal>
   )
 }

--- a/web/src/components/modals/ReuseModalShell.tsx
+++ b/web/src/components/modals/ReuseModalShell.tsx
@@ -1,9 +1,9 @@
 import { AlertIcon, CopyIcon } from "@/components/ui/icons"
-import { useEffect, useId, type ReactNode, type RefObject } from "react"
+import { useEffect, type ReactNode, type RefObject } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 
-import { AnimatedAlert, Button, Modal, Heading } from "@/components/ui"
+import { AnimatedAlert, Button, Modal, ModalIcon } from "@/components/ui"
 
 // Shared chrome for the two reuse modals — close button, header, error/warning
 // alerts, Cancel/Reuse footer — so each supplies only its title, description,
@@ -42,7 +42,6 @@ export const ReuseModalShell = ({
   }, [dialogRef])
 
   const closeDialog = () => dialogRef.current?.close()
-  const titleId = useId()
   const { t } = useTranslation()
 
   return (
@@ -50,20 +49,39 @@ export const ReuseModalShell = ({
       dialogRef={dialogRef}
       onClose={onClose}
       closeDisabled={isPending}
-      aria-labelledby={titleId}
-    >
-      <div className="flex items-start gap-4">
-        <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-primary/10 text-primary">
+      title={title}
+      subtitle={description}
+      headerVisual={
+        <ModalIcon>
           <CopyIcon className="size-4" aria-hidden="true" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" id={titleId}>
-            {title}
-          </Heading>
-          <p className="mt-1 text-sm text-base-content/70">{description}</p>
-        </div>
-      </div>
-
+        </ModalIcon>
+      }
+      footer={
+        <>
+          <Button variant="ghost" disabled={isPending} onClick={closeDialog}>
+            {warning ? t("common.done") : t("common.cancel")}
+          </Button>
+          {showSubmit && !warning ? (
+            <Button
+              variant="primary"
+              disabled={!canSubmit}
+              loading={isPending}
+              loadingLabel={t("components.modals.reuseShell.copying")}
+              onClick={onSubmit}
+            >
+              {isPending ? (
+                t("components.modals.reuseShell.copying")
+              ) : (
+                <>
+                  <CopyIcon aria-hidden="true" className="size-4" />{" "}
+                  {t("components.modals.reuseShell.reuseAssignment")}
+                </>
+              )}
+            </Button>
+          ) : null}
+        </>
+      }
+    >
       {children}
 
       <AnimatedAlert
@@ -82,30 +100,6 @@ export const ReuseModalShell = ({
         <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
         <span>{warning}</span>
       </AnimatedAlert>
-
-      <div className="modal-action">
-        <Button variant="ghost" disabled={isPending} onClick={closeDialog}>
-          {warning ? t("common.done") : t("common.cancel")}
-        </Button>
-        {showSubmit && !warning ? (
-          <Button
-            variant="primary"
-            disabled={!canSubmit}
-            loading={isPending}
-            loadingLabel={t("components.modals.reuseShell.copying")}
-            onClick={onSubmit}
-          >
-            {isPending ? (
-              t("components.modals.reuseShell.copying")
-            ) : (
-              <>
-                <CopyIcon aria-hidden="true" className="size-4" />{" "}
-                {t("components.modals.reuseShell.reuseAssignment")}
-              </>
-            )}
-          </Button>
-        ) : null}
-      </div>
     </Modal>
   )
 }

--- a/web/src/components/modals/ReuseModalShell.tsx
+++ b/web/src/components/modals/ReuseModalShell.tsx
@@ -1,4 +1,4 @@
-import { AlertIcon, CopyIcon } from "@/components/ui/icons"
+import { CopyIcon } from "@/components/ui/icons"
 import { useEffect, type ReactNode, type RefObject } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
@@ -97,7 +97,6 @@ export const ReuseModalShell = ({
         show={!!warning}
         className="mt-4 items-start text-sm"
       >
-        <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
         <span>{warning}</span>
       </AnimatedAlert>
     </Modal>

--- a/web/src/components/modals/StudentProfileModal.tsx
+++ b/web/src/components/modals/StudentProfileModal.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useId, useRef } from "react"
+import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { LinkExternalIcon, MarkGithubIcon } from "@/components/ui/icons"
 
-import { Badge, Button, Modal, Heading } from "@/components/ui"
+import { Badge, Button, Modal } from "@/components/ui"
 import type { Student } from "@/types/classroom"
 import { getName, getInitials, firstGrapheme } from "@/util/students"
 
@@ -25,7 +25,6 @@ export const StudentProfileModal = ({
   repoName?: string
 }) => {
   const dialogRef = useRef<HTMLDialogElement | null>(null)
-  const titleId = useId()
   const { t } = useTranslation()
 
   // Mounted only while a profile is selected (caller gates + remounts via
@@ -75,24 +74,20 @@ export const StudentProfileModal = ({
       dialogRef={dialogRef}
       onClose={onClose}
       size="md"
-      aria-labelledby={titleId}
-    >
-      <div className="flex items-center gap-4">
+      title={<span className="block truncate">{name}</span>}
+      subtitle={
+        student.section?.trim() ? (
+          <Badge ghost>{student.section.trim()}</Badge>
+        ) : undefined
+      }
+      headerVisual={
         <div className="avatar avatar-placeholder">
           <div className="bg-base-200 text-primary rounded-full w-14">
             <span className="text-lg">{initials}</span>
           </div>
         </div>
-        <div className="min-w-0">
-          <Heading as="h3" className="truncate" id={titleId}>
-            {name}
-          </Heading>
-          {student.section?.trim() ? (
-            <Badge ghost>{student.section.trim()}</Badge>
-          ) : null}
-        </div>
-      </div>
-
+      }
+    >
       <dl className="mt-6 divide-y divide-base-200">
         {rows.map((row) => (
           <div

--- a/web/src/components/modals/TemplateAccessModal.tsx
+++ b/web/src/components/modals/TemplateAccessModal.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useQuery } from "@tanstack/react-query"
 import {
@@ -7,7 +7,7 @@ import {
   ShieldCheckIcon,
 } from "@/components/ui/icons"
 
-import { Badge, Button, Modal, Spinner, Heading } from "@/components/ui"
+import { Badge, Button, Modal, ModalIcon, Spinner } from "@/components/ui"
 import type { Assignment } from "@/types/classroom"
 import type { GitHubRepoTeam } from "@/github-core/types"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
@@ -43,7 +43,6 @@ export const TemplateAccessModal = ({
   onClose: () => void
 }) => {
   const { t } = useTranslation()
-  const titleId = useId()
   const client = useGitHubClient()
   const { notify } = useToast()
   const { githubOrgRole } = useGitHubOrgRole()
@@ -122,27 +121,59 @@ export const TemplateAccessModal = ({
   }
 
   return (
-    <Modal open onClose={onClose} size="lg" aria-labelledby={titleId}>
-      <div className="flex items-start gap-4">
-        <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-primary/10 text-primary">
+    <Modal
+      open
+      onClose={onClose}
+      size="lg"
+      title={t("assignments.template.accessModal.title")}
+      subtitle={t("assignments.template.accessModal.description")}
+      headerVisual={
+        <ModalIcon>
           <ShieldCheckIcon className="size-4" aria-hidden="true" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3" id={titleId}>
-            {t("assignments.template.accessModal.title")}
-          </Heading>
-          <p className="mt-1 text-sm text-base-content/70">
-            {t("assignments.template.accessModal.description")}
-          </p>
-        </div>
-      </div>
-
+        </ModalIcon>
+      }
+      footer={
+        <>
+          {inOrg && !isOwner && (
+            <p className="me-auto self-center text-xs text-base-content/60">
+              {t("assignments.template.accessModal.ownerOnlyNote")}
+            </p>
+          )}
+          <form method="dialog">
+            <Button
+              type="submit"
+              variant="ghost"
+              disabled={reconcile.isPending}
+            >
+              {t("assignments.template.accessModal.close")}
+            </Button>
+          </form>
+          {inOrg && isOwner && (
+            <Button
+              variant="primary"
+              loading={reconcile.isPending}
+              loadingLabel={t("assignments.template.reconcile.pending")}
+              disabled={reconcile.isPending || satisfied}
+              title={
+                satisfied
+                  ? t("assignments.template.accessModal.fixSatisfied")
+                  : t("assignments.template.accessModal.fixHint")
+              }
+              onClick={handleFix}
+            >
+              {t("assignments.template.accessModal.fixAction")}
+            </Button>
+          )}
+        </>
+      }
+    >
       <section className="mt-5">
         <div className="flex items-center justify-between gap-3">
           <h4 className="text-sm font-semibold text-base-content/80">
             {t("assignments.template.accessModal.templateHeading")}
           </h4>
-          <a
+          <Button
+            as="a"
             href={githubTemplateRepoUrl(
               template.owner,
               template.repo,
@@ -150,12 +181,14 @@ export const TemplateAccessModal = ({
             )}
             target="_blank"
             rel="noreferrer"
-            className="btn btn-xs btn-ghost shrink-0"
+            variant="ghost"
+            size="xs"
+            className="shrink-0"
           >
             <MarkGithubIcon aria-hidden="true" className="size-4" />
             {t("assignments.template.accessModal.openOnGitHub")}
             <LinkExternalIcon aria-hidden="true" className="size-4" />
-          </a>
+          </Button>
         </div>
         <div className="mt-2 rounded-box border border-base-content/10 bg-base-200/40 px-3 py-2">
           <div className="break-all font-mono text-sm">
@@ -190,35 +223,6 @@ export const TemplateAccessModal = ({
           }
         />
       </section>
-
-      <div className="modal-action mt-6 items-center">
-        {inOrg && !isOwner && (
-          <p className="me-auto text-xs text-base-content/60">
-            {t("assignments.template.accessModal.ownerOnlyNote")}
-          </p>
-        )}
-        <form method="dialog">
-          <Button type="submit" variant="ghost" disabled={reconcile.isPending}>
-            {t("assignments.template.accessModal.close")}
-          </Button>
-        </form>
-        {inOrg && isOwner && (
-          <Button
-            variant="primary"
-            loading={reconcile.isPending}
-            loadingLabel={t("assignments.template.reconcile.pending")}
-            disabled={reconcile.isPending || satisfied}
-            title={
-              satisfied
-                ? t("assignments.template.accessModal.fixSatisfied")
-                : t("assignments.template.accessModal.fixHint")
-            }
-            onClick={handleFix}
-          >
-            {t("assignments.template.accessModal.fixAction")}
-          </Button>
-        )}
-      </div>
     </Modal>
   )
 }

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -70,14 +70,17 @@ export function ConfirmModal({
     if (hasAcknowledged) confirmInputRef.current?.focus()
   }, [hasAcknowledged])
 
+  // Reset transient state when OPENING, not on close: a close-time reset would
+  // repaint the previous step/error under the dialog's fade-out. The stale
+  // content from the last run is invisible while closed and replaced before
+  // the reopen paints.
   useEffect(() => {
-    if (!open) {
-      setHasAcknowledged(false)
-      setTypedText("")
-      setIsSubmitting(false)
-      submittingRef.current = false
-      setError(null)
-    }
+    if (!open) return
+    setHasAcknowledged(false)
+    setTypedText("")
+    setIsSubmitting(false)
+    submittingRef.current = false
+    setError(null)
   }, [open])
 
   const handleClose = (event?: React.SyntheticEvent | Event) => {

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -70,10 +70,7 @@ export function ConfirmModal({
     if (hasAcknowledged) confirmInputRef.current?.focus()
   }, [hasAcknowledged])
 
-  // Reset transient state when OPENING, not on close: a close-time reset would
-  // repaint the previous step/error under the dialog's fade-out. The stale
-  // content from the last run is invisible while closed and replaced before
-  // the reopen paints.
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (!open) return
     setHasAcknowledged(false)

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -6,9 +6,10 @@ import {
   Button,
   AnimatedAlert,
   Input,
+  Modal,
+  ModalIcon,
   MonoLtr,
   type ButtonVariant,
-  Heading,
 } from "@/components/ui"
 
 type ConfirmModalProps = {
@@ -25,6 +26,9 @@ type ConfirmModalProps = {
   onClose: () => void
 }
 
+// Primer-style ConfirmationDialog built on the shared Modal primitive
+// (role="alertdialog", exactly two footer buttons: ghost Cancel left,
+// error/warning/primary confirm right).
 export function ConfirmModal({
   open,
   title,
@@ -37,7 +41,6 @@ export function ConfirmModal({
   onConfirm,
   onClose,
 }: ConfirmModalProps) {
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
   const confirmInputRef = useRef<HTMLInputElement | null>(null)
   const { t } = useTranslation()
   const resolvedConfirmLabel =
@@ -58,21 +61,7 @@ export function ConfirmModal({
 
   const matches = typedText === confirmText
   const canSubmit = !needsConfirm || matches
-  const titleId = useId()
   const confirmHintId = useId()
-
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-
-    if (open && !dialog.open) {
-      dialog.showModal()
-    }
-
-    if (!open && dialog.open) {
-      dialog.close()
-    }
-  }, [open])
 
   // The acknowledge → confirm step swaps content in the same open dialog, so the
   // input's `autoFocus` won't re-fire. Focus it explicitly so a keyboard/SR user
@@ -128,156 +117,123 @@ export function ConfirmModal({
     : "warning"
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="modal"
-      aria-labelledby={titleId}
-      onClose={(event) => handleClose(event)}
-      onCancel={(event) => {
-        if (isSubmitting) {
-          event.preventDefault()
-          return
-        }
-
-        handleClose(event)
-      }}
-    >
-      <div className="modal-box max-w-lg">
-        <div className="flex items-start gap-4">
-          <div
-            className={[
-              "flex size-11 shrink-0 items-center justify-center rounded-box",
-              dangerous
-                ? "bg-error/10 text-error"
-                : "bg-warning/10 text-warning",
-            ].join(" ")}
-          >
-            <AlertIcon className="size-4" aria-hidden="true" />
-          </div>
-
-          <div className="min-w-0 flex-1">
-            <Heading as="h3" id={titleId}>
-              {title}
-            </Heading>
-
-            {description ? (
-              <div className="mt-2 text-sm leading-6 text-base-content/70">
-                {description}
-              </div>
-            ) : null}
-          </div>
-        </div>
-
-        {!hasAcknowledged ? (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      role="alertdialog"
+      closeDisabled={isSubmitting}
+      title={title}
+      subtitle={description}
+      headerVisual={
+        <ModalIcon tone={dangerous ? "error" : "warning"}>
+          <AlertIcon className="size-4" aria-hidden="true" />
+        </ModalIcon>
+      }
+      footer={
+        !hasAcknowledged ? (
           <>
-            {dangerous ? (
-              <div className="mt-6 rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
-                {t("components.confirmModal.dangerousPrompt")}
-              </div>
-            ) : null}
+            <Button
+              variant="ghost"
+              disabled={isSubmitting}
+              onClick={handleClose}
+            >
+              {acknowledgeCancelLabel}
+            </Button>
 
-            <AnimatedAlert tone="error" show={!!error} className="mt-4 text-sm">
-              {error}
-            </AnimatedAlert>
+            <Button
+              variant={acknowledgeButtonVariant}
+              disabled={isSubmitting}
+              loading={isSubmitting && !needsConfirm}
+              loadingLabel={t("common.working")}
+              onClick={(event) => {
+                event.stopPropagation()
 
-            <div className="modal-action">
-              <Button
-                variant="ghost"
-                disabled={isSubmitting}
-                onClick={handleClose}
-              >
-                {acknowledgeCancelLabel}
-              </Button>
+                if (needsConfirm) {
+                  setHasAcknowledged(true)
+                  return
+                }
 
-              <Button
-                variant={acknowledgeButtonVariant}
-                disabled={isSubmitting}
-                loading={isSubmitting && !needsConfirm}
-                loadingLabel={t("common.working")}
-                onClick={(event) => {
-                  event.stopPropagation()
-
-                  if (needsConfirm) {
-                    setHasAcknowledged(true)
-                    return
-                  }
-
-                  void handleSubmit()
-                }}
-              >
-                {isSubmitting && !needsConfirm
-                  ? t("common.working")
-                  : needsConfirm
-                    ? t("components.confirmModal.yesContinue")
-                    : resolvedConfirmLabel}
-              </Button>
-            </div>
+                void handleSubmit()
+              }}
+            >
+              {isSubmitting && !needsConfirm
+                ? t("common.working")
+                : needsConfirm
+                  ? t("components.confirmModal.yesContinue")
+                  : resolvedConfirmLabel}
+            </Button>
           </>
         ) : (
           <>
-            <div className="mt-6 space-y-3">
-              <p id={confirmHintId} className="text-sm text-base-content/70">
-                <Trans
-                  i18nKey="components.confirmModal.typeToConfirm"
-                  values={{ text: confirmText }}
-                  components={{
-                    text: (
-                      <MonoLtr className="font-semibold text-base-content" />
-                    ),
-                  }}
-                />
-              </p>
+            <Button
+              variant="ghost"
+              disabled={isSubmitting}
+              onClick={handleClose}
+            >
+              {resolvedCancelLabel}
+            </Button>
 
-              <Input
-                ref={confirmInputRef}
-                type="text"
-                className="font-mono"
-                value={typedText}
-                disabled={isSubmitting}
-                autoFocus
-                aria-label={t("components.confirmModal.typeAriaLabel", {
-                  text: confirmText,
-                })}
-                aria-describedby={confirmHintId}
-                onChange={(event) => setTypedText(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" && matches) {
-                    void handleSubmit()
-                  }
-                }}
-              />
-
-              <AnimatedAlert tone="error" show={!!error} className="text-sm">
-                {error}
-              </AnimatedAlert>
-            </div>
-
-            <div className="modal-action">
-              <Button
-                variant="ghost"
-                disabled={isSubmitting}
-                onClick={handleClose}
-              >
-                {resolvedCancelLabel}
-              </Button>
-
-              <Button
-                variant={confirmButtonVariant}
-                disabled={!canSubmit || isSubmitting}
-                loading={isSubmitting}
-                loadingLabel={t("common.working")}
-                onClick={() => void handleSubmit()}
-              >
-                {isSubmitting ? t("common.working") : resolvedConfirmLabel}
-              </Button>
-            </div>
+            <Button
+              variant={confirmButtonVariant}
+              disabled={!canSubmit || isSubmitting}
+              loading={isSubmitting}
+              loadingLabel={t("common.working")}
+              onClick={() => void handleSubmit()}
+            >
+              {isSubmitting ? t("common.working") : resolvedConfirmLabel}
+            </Button>
           </>
-        )}
-      </div>
+        )
+      }
+    >
+      {!hasAcknowledged ? (
+        <>
+          {dangerous ? (
+            <div className="mt-6 rounded-box border border-base-300 bg-base-200/50 p-4 text-sm text-base-content/70">
+              {t("components.confirmModal.dangerousPrompt")}
+            </div>
+          ) : null}
 
-      <form method="dialog" className="modal-backdrop">
-        <button disabled={isSubmitting}>{t("common.close")}</button>
-      </form>
-    </dialog>
+          <AnimatedAlert tone="error" show={!!error} className="mt-4 text-sm">
+            {error}
+          </AnimatedAlert>
+        </>
+      ) : (
+        <div className="mt-6 space-y-3">
+          <p id={confirmHintId} className="text-sm text-base-content/70">
+            <Trans
+              i18nKey="components.confirmModal.typeToConfirm"
+              values={{ text: confirmText }}
+              components={{
+                text: <MonoLtr className="font-semibold text-base-content" />,
+              }}
+            />
+          </p>
+
+          <Input
+            ref={confirmInputRef}
+            type="text"
+            className="font-mono"
+            value={typedText}
+            disabled={isSubmitting}
+            autoFocus
+            aria-label={t("components.confirmModal.typeAriaLabel", {
+              text: confirmText,
+            })}
+            aria-describedby={confirmHintId}
+            onChange={(event) => setTypedText(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && matches) {
+                void handleSubmit()
+              }
+            }}
+          />
+
+          <AnimatedAlert tone="error" show={!!error} className="text-sm">
+            {error}
+          </AnimatedAlert>
+        </div>
+      )}
+    </Modal>
   )
 }

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -174,18 +174,13 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
         open={descriptionOpen && Boolean(description)}
         onClose={() => setDescriptionOpen(false)}
         size="2xl"
-        aria-label={t("classes.repo.descriptionModalTitle")}
+        title={title}
+        subtitle={t("classes.repo.descriptionModalTitle")}
       >
-        <div className="mb-4 pe-8">
-          <p className="text-xs font-medium uppercase tracking-wide text-base-content/50">
-            {t("classes.repo.descriptionModalTitle")}
-          </p>
-          <Heading as="h3">{title}</Heading>
-        </div>
         {description ? (
           <Markdown
             content={description}
-            className="max-h-[70vh] overflow-y-auto pe-1"
+            className="mt-4 max-h-[70vh] overflow-y-auto pe-1"
           />
         ) : null}
       </Modal>

--- a/web/src/components/submissions/SubmissionDetailsModal.tsx
+++ b/web/src/components/submissions/SubmissionDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef } from "react"
+import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import {
   GitCommitIcon,
@@ -7,7 +7,7 @@ import {
   TagIcon,
 } from "@/components/ui/icons"
 
-import { Button, Modal, MonoLtr, Heading } from "@/components/ui"
+import { Button, Modal, MonoLtr } from "@/components/ui"
 
 // One row in the submission-details list. `kind` picks the icon and action
 // label ("View tag" vs "View commit"); `href` is the already-built, safe GitHub
@@ -71,7 +71,6 @@ export function SubmissionDetailsModal({
   emptyLinkHref?: string
 }) {
   const dialogRef = useRef<HTMLDialogElement | null>(null)
-  const titleId = useId()
   const { t } = useTranslation()
 
   useEffect(() => {
@@ -83,16 +82,15 @@ export function SubmissionDetailsModal({
       dialogRef={dialogRef}
       onClose={onClose}
       size="lg"
-      aria-labelledby={titleId}
+      title={<span className="block truncate">{title}</span>}
+      subtitle={
+        subtitle ? (
+          <span className="block truncate text-base-content/60">
+            {subtitle}
+          </span>
+        ) : undefined
+      }
     >
-      <Heading as="h3" className="truncate pe-8" id={titleId}>
-        {title}
-      </Heading>
-      {subtitle ? (
-        <p className="mt-0.5 truncate text-sm text-base-content/60">
-          {subtitle}
-        </p>
-      ) : null}
       {repoHref ? (
         <a
           className="link link-hover mt-2 inline-flex w-fit max-w-full items-center gap-1.5"

--- a/web/src/components/ui/DropdownMenu.tsx
+++ b/web/src/components/ui/DropdownMenu.tsx
@@ -2,10 +2,9 @@ import type { ComponentPropsWithRef } from "react"
 
 import { cx } from "./cx"
 
-// Single source for the DaisyUI dropdown menu surface (`dropdown-content menu`
-// recipe) so the popover chrome can't drift across call sites. Callers keep
-// owning the `dropdown` wrapper and its trigger button; pass sizing utilities
-// (width, max-height, overflow) via className.
+// Single source for the DaisyUI dropdown menu surface so the popover chrome
+// can't drift. Callers own the `dropdown` wrapper and trigger; pass sizing
+// utilities (width, max-height, overflow) via className.
 export type DropdownMenuProps = ComponentPropsWithRef<"ul">
 
 export function DropdownMenu({

--- a/web/src/components/ui/DropdownMenu.tsx
+++ b/web/src/components/ui/DropdownMenu.tsx
@@ -1,0 +1,31 @@
+import type { ComponentPropsWithRef } from "react"
+
+import { cx } from "./cx"
+
+// Single source for the DaisyUI dropdown menu surface (`dropdown-content menu`
+// recipe) so the popover chrome can't drift across call sites. Callers keep
+// owning the `dropdown` wrapper and its trigger button; pass sizing utilities
+// (width, max-height, overflow) via className.
+export type DropdownMenuProps = ComponentPropsWithRef<"ul">
+
+export function DropdownMenu({
+  className,
+  children,
+  ...props
+}: DropdownMenuProps) {
+  return (
+    <ul
+      tabIndex={0}
+      role="menu"
+      className={cx(
+        "dropdown-content menu z-10 mt-1 rounded-box border border-base-300 bg-base-100 p-1 shadow",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ul>
+  )
+}
+
+export default DropdownMenu

--- a/web/src/components/ui/Modal.test.tsx
+++ b/web/src/components/ui/Modal.test.tsx
@@ -197,4 +197,74 @@ describe("Modal", () => {
     dialog.close()
     expect(onClose).toHaveBeenCalledTimes(1)
   })
+
+  it("wires title to aria-labelledby and subtitle to aria-describedby automatically", () => {
+    const { container } = render(
+      <Modal open title="My dialog" subtitle="More context">
+        body
+      </Modal>,
+    )
+    const dialog = container.querySelector("dialog") as HTMLDialogElement
+
+    const heading = screen.getByRole("heading", { name: "My dialog" })
+    expect(heading.tagName).toBe("H3")
+    expect(dialog.getAttribute("aria-labelledby")).toBe(heading.id)
+
+    const subtitle = screen.getByText("More context")
+    expect(dialog.getAttribute("aria-describedby")).toBe(subtitle.id)
+  })
+
+  it("lets an explicit aria-labelledby win over the title wiring", () => {
+    const { container } = render(
+      <Modal open title="My dialog" aria-labelledby="external-id">
+        body
+      </Modal>,
+    )
+    const dialog = container.querySelector("dialog") as HTMLDialogElement
+    expect(dialog.getAttribute("aria-labelledby")).toBe("external-id")
+  })
+
+  it("renders the footer slot inside the canonical modal-action row", () => {
+    const { container } = render(
+      <Modal open title="t" footer={<button type="button">Save</button>}>
+        body
+      </Modal>,
+    )
+    const action = container.querySelector(".modal-action")
+    expect(action).not.toBeNull()
+    expect(action?.textContent).toContain("Save")
+  })
+
+  it("passes role through for confirmation dialogs", () => {
+    const { container } = render(
+      <Modal open title="t" role="alertdialog">
+        body
+      </Modal>,
+    )
+    expect(container.querySelector("dialog")?.getAttribute("role")).toBe(
+      "alertdialog",
+    )
+  })
+
+  it("tolerates block-level subtitle content (ConfirmModal descriptions)", () => {
+    render(
+      <Modal
+        open
+        title="t"
+        subtitle={
+          <div>
+            <ul>
+              <li>consequence</li>
+            </ul>
+          </div>
+        }
+      >
+        body
+      </Modal>,
+    )
+    // The subtitle wrapper is a <div>, so the block content stays inside the
+    // described-by element instead of being split out of an auto-closed <p>.
+    const item = screen.getByText("consequence")
+    expect(item.closest("[id]")?.textContent).toContain("consequence")
+  })
 })

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next"
 
 import { Button } from "./Button"
 import { cx } from "./cx"
+import { Heading } from "./Heading"
 
 // The canonical dialog. Wraps the native `<dialog className="modal">` idiom the
 // app uses everywhere: it owns the `modal-box` (sized via `size`), the top-right
@@ -21,6 +22,12 @@ import { cx } from "./cx"
 //   - ref-driven: pass a `dialogRef` you open imperatively (e.g., a hook that
 //     needs the element). `open` may be omitted.
 // `onClose` fires on the native dialog close (Esc, backdrop, close button).
+//
+// Anatomy follows Primer's Dialog (primer.style/product/components/dialog):
+// header (title + optional subtitle + close X), body (`children` — the
+// modal-box itself scrolls), and a right-aligned `footer` action row. Passing
+// `title` wires aria-labelledby automatically; `subtitle` wires
+// aria-describedby. Prefer these slots over hand-rolling a header/footer.
 
 export type ModalSize =
   "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "5xl"
@@ -40,6 +47,21 @@ export type ModalProps = {
   open?: boolean
   onClose?: () => void
   size?: ModalSize
+  // Header slot: rendered as the dialog's h3 title and auto-wired to
+  // aria-labelledby. Callers with a `title` must not pass aria props by hand.
+  title?: ReactNode
+  // Rendered below the title in smaller, lower-contrast type; auto-wired to
+  // aria-describedby (Primer Dialog subtitle).
+  subtitle?: ReactNode
+  // Leading visual for the header (an icon chip). Decorative — mark icons
+  // aria-hidden.
+  headerVisual?: ReactNode
+  // Footer action row, rendered inside the canonical `modal-action`
+  // (right-aligned). Convention: ghost Cancel/Close left, primary/confirm
+  // rightmost; destructive confirms use variant="error".
+  footer?: ReactNode
+  // Confirmation dialogs interrupting the user should pass "alertdialog".
+  role?: "dialog" | "alertdialog"
   // Hide the built-in top-right close X (some modals render their own header
   // affordance or must block dismissal while submitting).
   hideCloseButton?: boolean
@@ -47,6 +69,7 @@ export type ModalProps = {
   // close, vetoes Esc (see the onCancel guard below), and holds the dialog open
   // against a controlled `open=false` transition (see the open-sync effect).
   closeDisabled?: boolean
+  // Legacy escape hatches — prefer `title`, which wires labeling automatically.
   "aria-labelledby"?: string
   "aria-label"?: string
   // Forwarded to the dialog element. Lets a caller repurpose keys (e.g. Enter)
@@ -63,6 +86,11 @@ export function Modal({
   open,
   onClose,
   size = "lg",
+  title,
+  subtitle,
+  headerVisual,
+  footer,
+  role,
   hideCloseButton = false,
   closeDisabled = false,
   boxClassName,
@@ -75,6 +103,12 @@ export function Modal({
   const { t } = useTranslation()
   const internalRef = useRef<HTMLDialogElement | null>(null)
   const closeId = useId()
+  const titleId = useId()
+  const subtitleId = useId()
+
+  const labelledBy =
+    aria["aria-labelledby"] ?? (title !== undefined ? titleId : undefined)
+  const describedBy = subtitle !== undefined ? subtitleId : undefined
 
   // Keep the native dialog in sync with `open` (controlled mode). Skipped when
   // the caller drives the dialog through `dialogRef` and never passes `open`.
@@ -106,7 +140,10 @@ export function Modal({
         // matching the hand-rolled modals' Esc guard.
         if (closeDisabled) event.preventDefault()
       }}
-      {...aria}
+      role={role}
+      aria-label={aria["aria-label"]}
+      aria-labelledby={labelledBy}
+      aria-describedby={describedBy}
     >
       <div className={cx("modal-box", SIZE_CLASS[size], boxClassName)}>
         {!hideCloseButton && (
@@ -125,7 +162,28 @@ export function Modal({
             </Button>
           </form>
         )}
+        {title !== undefined && (
+          <div
+            className={cx("flex items-start gap-4", !hideCloseButton && "pe-8")}
+          >
+            {headerVisual}
+            <div className="min-w-0 flex-1">
+              <Heading as="h3" id={titleId}>
+                {title}
+              </Heading>
+              {subtitle !== undefined && (
+                <p
+                  id={subtitleId}
+                  className="mt-1 text-sm text-base-content/70"
+                >
+                  {subtitle}
+                </p>
+              )}
+            </div>
+          </div>
+        )}
         {children}
+        {footer !== undefined && <div className="modal-action">{footer}</div>}
       </div>
 
       {/* DaisyUI's click-outside-to-close backdrop. The button is a mouse
@@ -142,3 +200,32 @@ export function Modal({
 }
 
 export default Modal
+
+// Single source for the header icon chip used as `headerVisual` — callers must
+// not hand-roll the size/tone recipe.
+export type ModalIconTone = "primary" | "warning" | "error"
+
+const MODAL_ICON_TONE_CLASS: Record<ModalIconTone, string> = {
+  primary: "bg-primary/10 text-primary",
+  warning: "bg-warning/10 text-warning",
+  error: "bg-error/10 text-error",
+}
+
+export function ModalIcon({
+  tone = "primary",
+  children,
+}: {
+  tone?: ModalIconTone
+  children?: ReactNode
+}) {
+  return (
+    <div
+      className={cx(
+        "flex size-11 shrink-0 items-center justify-center rounded-box",
+        MODAL_ICON_TONE_CLASS[tone],
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -170,8 +170,11 @@ export function Modal({
           <div
             className={cx(
               // Full-bleed header divider: -mx-6/ps-6 counteract the modal-box
-              // padding; pe-14 keeps the title clear of the close X.
-              "-mx-6 flex items-start gap-4 border-b border-base-300 ps-6 pb-4",
+              // padding; pe-14 keeps the title clear of the close X. A lone
+              // title centers against the header visual; with a subtitle the
+              // block top-aligns.
+              "-mx-6 flex gap-4 border-b border-base-300 ps-6 pb-4",
+              subtitle !== undefined ? "items-start" : "items-center",
               hideCloseButton ? "pe-6" : "pe-14",
             )}
           >

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -28,6 +28,11 @@ import { Heading } from "./Heading"
 // modal-box itself scrolls), and a right-aligned `footer` action row. Passing
 // `title` wires aria-labelledby automatically; `subtitle` wires
 // aria-describedby. Prefer these slots over hand-rolling a header/footer.
+//
+// Close-animation invariant: the dialog keeps painting through its ~200ms
+// fade-out, so callers must not mutate content at close — reset transient
+// state when OPENING, retain cleared row data through the fade, and gate
+// open-only content with useLingeringOpen.
 
 export type ModalSize =
   "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "5xl"
@@ -136,8 +141,7 @@ export function Modal({
       onKeyDown={onKeyDown}
       onCancel={(event) => {
         // Esc triggers `cancel` before `close`. When dismissal is blocked
-        // (e.g., a submit is in flight), veto it so the dialog stays open —
-        // matching the hand-rolled modals' Esc guard.
+        // (e.g., a submit is in flight), veto it so the dialog stays open.
         if (closeDisabled) event.preventDefault()
       }}
       role={role}
@@ -165,9 +169,8 @@ export function Modal({
         {title !== undefined && (
           <div
             className={cx(
-              // Full-bleed divider under the header (Primer Dialog anatomy):
-              // -mx-6/ps-6 counteract the modal-box padding so the 1px border
-              // spans edge to edge; pe-14 keeps the title clear of the close X.
+              // Full-bleed header divider: -mx-6/ps-6 counteract the modal-box
+              // padding; pe-14 keeps the title clear of the close X.
               "-mx-6 flex items-start gap-4 border-b border-base-300 ps-6 pb-4",
               hideCloseButton ? "pe-6" : "pe-14",
             )}

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -43,6 +43,13 @@ const SIZE_CLASS: Record<ModalSize, string> = {
   "5xl": "max-w-5xl",
 }
 
+// The canonical footer row, with a full-bleed top divider mirroring the header
+// divider (Primer Dialog anatomy). Exported for the few in-body action rows
+// (multi-step modal content) that can't use the `footer` slot, so the recipe
+// stays single-sourced.
+export const modalActionClass =
+  "modal-action -mx-6 border-t border-base-300 px-6 pt-4"
+
 export type ModalProps = {
   open?: boolean
   onClose?: () => void
@@ -164,7 +171,13 @@ export function Modal({
         )}
         {title !== undefined && (
           <div
-            className={cx("flex items-start gap-4", !hideCloseButton && "pe-8")}
+            className={cx(
+              // Full-bleed divider under the header (Primer Dialog anatomy):
+              // -mx-6/ps-6 counteract the modal-box padding so the 1px border
+              // spans edge to edge; pe-14 keeps the title clear of the close X.
+              "-mx-6 flex items-start gap-4 border-b border-base-300 ps-6 pb-4",
+              hideCloseButton ? "pe-6" : "pe-14",
+            )}
           >
             {headerVisual}
             <div className="min-w-0 flex-1">
@@ -183,7 +196,9 @@ export function Modal({
           </div>
         )}
         {children}
-        {footer !== undefined && <div className="modal-action">{footer}</div>}
+        {footer !== undefined && (
+          <div className={modalActionClass}>{footer}</div>
+        )}
       </div>
 
       {/* DaisyUI's click-outside-to-close backdrop. The button is a mouse

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -181,12 +181,15 @@ export function Modal({
                 {title}
               </Heading>
               {subtitle !== undefined && (
-                <p
+                // A div, not <p>: ConfirmModal forwards arbitrary description
+                // nodes here, and block content inside <p> is invalid HTML the
+                // parser splits apart.
+                <div
                   id={subtitleId}
                   className="mt-1 text-sm text-base-content/70"
                 >
                   {subtitle}
-                </p>
+                </div>
               )}
             </div>
           </div>

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -43,13 +43,6 @@ const SIZE_CLASS: Record<ModalSize, string> = {
   "5xl": "max-w-5xl",
 }
 
-// The canonical footer row, with a full-bleed top divider mirroring the header
-// divider (Primer Dialog anatomy). Exported for the few in-body action rows
-// (multi-step modal content) that can't use the `footer` slot, so the recipe
-// stays single-sourced.
-export const modalActionClass =
-  "modal-action -mx-6 border-t border-base-300 px-6 pt-4"
-
 export type ModalProps = {
   open?: boolean
   onClose?: () => void
@@ -196,9 +189,7 @@ export function Modal({
           </div>
         )}
         {children}
-        {footer !== undefined && (
-          <div className={modalActionClass}>{footer}</div>
-        )}
+        {footer !== undefined && <div className="modal-action">{footer}</div>}
       </div>
 
       {/* DaisyUI's click-outside-to-close backdrop. The button is a mouse

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -38,7 +38,7 @@ export type { HelpTooltipPosition } from "./FormField"
 export { Heading, headingVariantClass } from "./Heading"
 export type { HeadingProps, HeadingVariant } from "./Heading"
 
-export { Modal, ModalIcon, modalActionClass } from "./Modal"
+export { Modal, ModalIcon } from "./Modal"
 export type { ModalProps, ModalSize, ModalIconTone } from "./Modal"
 
 export { DropdownMenu } from "./DropdownMenu"

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -38,8 +38,11 @@ export type { HelpTooltipPosition } from "./FormField"
 export { Heading, headingVariantClass } from "./Heading"
 export type { HeadingProps, HeadingVariant } from "./Heading"
 
-export { Modal } from "./Modal"
-export type { ModalProps, ModalSize } from "./Modal"
+export { Modal, ModalIcon } from "./Modal"
+export type { ModalProps, ModalSize, ModalIconTone } from "./Modal"
+
+export { DropdownMenu } from "./DropdownMenu"
+export type { DropdownMenuProps } from "./DropdownMenu"
 
 export { Alert, ALERT_TONE_ICON, alertToneClass, alertToneRole } from "./Alert"
 export type { AlertProps, AlertTone } from "./Alert"

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -38,7 +38,7 @@ export type { HelpTooltipPosition } from "./FormField"
 export { Heading, headingVariantClass } from "./Heading"
 export type { HeadingProps, HeadingVariant } from "./Heading"
 
-export { Modal, ModalIcon } from "./Modal"
+export { Modal, ModalIcon, modalActionClass } from "./Modal"
 export type { ModalProps, ModalSize, ModalIconTone } from "./Modal"
 
 export { DropdownMenu } from "./DropdownMenu"

--- a/web/src/hooks/mutations/useDownloadAllSubmissions.test.ts
+++ b/web/src/hooks/mutations/useDownloadAllSubmissions.test.ts
@@ -225,4 +225,54 @@ describe("useDownloadAllSubmissions", () => {
     expect(streamSubmissionsToDirectory).not.toHaveBeenCalled()
     expect(downloadAllSubmissions).not.toHaveBeenCalled()
   })
+
+  it("reports an aborted run as cancelled, not as an error", async () => {
+    downloadAllSubmissions.mockRejectedValue(
+      new DOMException("Aborted", "AbortError"),
+    )
+    const queryClient = freshClient()
+    const { result: hook } = renderHook(() => useDownloadAllSubmissions(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    hook.current.mutate({
+      org: ORG,
+      classroom: "cs101",
+      assignment: "hw1",
+      owners: ["alice"],
+    })
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true))
+
+    expect(hook.current.data).toEqual({ status: "cancelled" })
+    expect(hook.current.isError).toBe(false)
+  })
+
+  it("keeps reset referentially stable across renders so a reset-on-open effect can't re-fire mid-run", async () => {
+    downloadAllSubmissions.mockResolvedValue(result())
+    const queryClient = freshClient()
+    const { result: hook, rerender } = renderHook(
+      () => useDownloadAllSubmissions(),
+      { wrapper: wrapperWith(queryClient) },
+    )
+
+    const firstReset = hook.current.reset
+    rerender()
+    expect(hook.current.reset).toBe(firstReset)
+
+    // A run's own re-renders (isPending/progress flips) must not mint a new
+    // reset either — the modal keys `if (open) reset()` on this identity, and
+    // an unstable one wiped the in-flight run and neutered cancel.
+    hook.current.mutate({
+      org: ORG,
+      classroom: "cs101",
+      assignment: "hw1",
+      owners: ["alice"],
+    })
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true))
+    expect(hook.current.reset).toBe(firstReset)
+
+    hook.current.reset()
+    await waitFor(() => expect(hook.current.isIdle).toBe(true))
+    expect(hook.current.progress).toBeNull()
+  })
 })

--- a/web/src/hooks/mutations/useDownloadAllSubmissions.ts
+++ b/web/src/hooks/mutations/useDownloadAllSubmissions.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react"
+import { useCallback, useRef, useState } from "react"
 import { useMutation } from "@tanstack/react-query"
 
 import {
@@ -51,45 +51,61 @@ export function useDownloadAllSubmissions() {
       abortRef.current = controller
       setProgress({ done: 0, total: owners.length })
 
-      if (directory) {
-        const summary = await streamSubmissionsToDirectory({
+      // A close-time cancel aborts the batch; report it as a cancelled outcome
+      // rather than an error, so a late-settling rejection can't surface a
+      // stale error banner after the modal was reopened.
+      try {
+        if (directory) {
+          const summary = await streamSubmissionsToDirectory({
+            client,
+            org,
+            classroom,
+            assignment,
+            owners,
+            directory,
+            onProgress: setProgress,
+            signal: controller.signal,
+          })
+          return { status: "done", summary, toDirectory: true }
+        }
+
+        const { blob, summary } = await downloadAllSubmissions({
           client,
           org,
           classroom,
           assignment,
           owners,
-          directory,
           onProgress: setProgress,
           signal: controller.signal,
         })
-        return { status: "done", summary, toDirectory: true }
+        if (summary.fetched > 0) {
+          downloadBlob(blob, `${classroom}-${assignment}-submissions.zip`)
+        }
+        return { status: "done", summary, toDirectory: false }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          return { status: "cancelled" }
+        }
+        throw err
       }
-
-      const { blob, summary } = await downloadAllSubmissions({
-        client,
-        org,
-        classroom,
-        assignment,
-        owners,
-        onProgress: setProgress,
-        signal: controller.signal,
-      })
-      if (summary.fetched > 0) {
-        downloadBlob(blob, `${classroom}-${assignment}-submissions.zip`)
-      }
-      return { status: "done", summary, toDirectory: false }
     },
   })
+
+  // Stable identity: callers key reset-on-open effects on this function, so a
+  // per-render closure would re-fire the effect on every render while open and
+  // reset the mutation mid-run (RQ v5's mutation.reset is already stable).
+  const mutationReset = mutation.reset
+  const reset = useCallback(() => {
+    abortRef.current = null
+    setProgress(null)
+    mutationReset()
+  }, [mutationReset])
 
   return {
     ...mutation,
     progress,
     cancel: () => abortRef.current?.abort(),
-    reset: () => {
-      abortRef.current = null
-      setProgress(null)
-      mutation.reset()
-    },
+    reset,
   }
 }
 

--- a/web/src/hooks/mutations/useEnrollOrInviteStudent.ts
+++ b/web/src/hooks/mutations/useEnrollOrInviteStudent.ts
@@ -7,12 +7,13 @@ import {
   useSeedTeamMember,
 } from "@/hooks/useTeamRoster"
 import { enrollStudentInClassroom, inviteByEmail } from "@/domain/students"
-import { splitName, toStudent } from "@/util/roster"
+import { toStudent } from "@/util/roster"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { rosterPath } from "@/util/rosterPath"
 
 export type EnrollOrInviteFormValues = {
-  name: string
+  first_name: string
+  last_name: string
   username: string
   email: string
   section: string
@@ -41,7 +42,8 @@ export function useEnrollOrInviteStudent(
 
   return useMutation({
     mutationFn: async (value: EnrollOrInviteFormValues) => {
-      const { first_name, last_name } = splitName(value.name)
+      const first_name = value.first_name.trim()
+      const last_name = value.last_name.trim()
       const username = value.username.trim()
       const email = value.email.trim()
       const section = value.section.trim()

--- a/web/src/hooks/mutations/useOpenAllFeedbackPrs.test.ts
+++ b/web/src/hooks/mutations/useOpenAllFeedbackPrs.test.ts
@@ -108,4 +108,28 @@ describe("useOpenAllFeedbackPrs", () => {
       }),
     )
   })
+
+  it("keeps reset referentially stable across renders so a reset-on-open effect can't re-fire mid-run", async () => {
+    openAllFeedbackPullRequests.mockResolvedValue(summary())
+    const queryClient = freshClient()
+    const { result, rerender } = renderHook(() => useOpenAllFeedbackPrs(), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    const firstReset = result.current.reset
+    rerender()
+    expect(result.current.reset).toBe(firstReset)
+
+    // A run's own re-renders (isPending/progress flips) must not mint a new
+    // reset either — the modal keys `if (open) reset()` on this identity, and
+    // an unstable one wiped the in-flight run.
+    result.current.mutate({ org: ORG, repos: ["a"], mode: "individual" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.reset).toBe(firstReset)
+
+    // The stable reset still clears both the mutation and progress.
+    result.current.reset()
+    await waitFor(() => expect(result.current.isIdle).toBe(true))
+    expect(result.current.progress).toBeNull()
+  })
 })

--- a/web/src/hooks/mutations/useOpenAllFeedbackPrs.ts
+++ b/web/src/hooks/mutations/useOpenAllFeedbackPrs.ts
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useCallback, useState } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 import { openAllFeedbackPullRequests } from "@/domain/assignments"
@@ -55,14 +55,20 @@ export function useOpenAllFeedbackPrs() {
     },
   })
 
+  // Stable identity: callers key reset-on-open effects on this function, so a
+  // per-render closure would re-fire the effect on every render while open and
+  // reset the mutation mid-run (RQ v5's mutation.reset is already stable).
+  const mutationReset = mutation.reset
+  const reset = useCallback(() => {
+    setProgress(null)
+    mutationReset()
+  }, [mutationReset])
+
   return {
     ...mutation,
     progress,
     // Clear progress + result when reopening the modal for a fresh run.
-    reset: () => {
-      setProgress(null)
-      mutation.reset()
-    },
+    reset,
   }
 }
 

--- a/web/src/hooks/useLingeringOpen.test.ts
+++ b/web/src/hooks/useLingeringOpen.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest"
+import { renderHook, act, cleanup } from "@testing-library/react"
+
+import { useLingeringOpen } from "./useLingeringOpen"
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe("useLingeringOpen", () => {
+  it("is true immediately when open, without waiting for an effect tick", () => {
+    const { result } = renderHook(({ open }) => useLingeringOpen(open), {
+      initialProps: { open: true },
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it("lingers true after open flips false, then settles false after the delay", () => {
+    const { result, rerender } = renderHook(
+      ({ open }) => useLingeringOpen(open, 300),
+      { initialProps: { open: true } },
+    )
+
+    rerender({ open: false })
+    // Still true through the close animation window.
+    expect(result.current).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(299)
+    })
+    expect(result.current).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it("cancels the pending timer on a rapid reopen inside the linger window", () => {
+    const { result, rerender } = renderHook(
+      ({ open }) => useLingeringOpen(open, 300),
+      { initialProps: { open: true } },
+    )
+
+    rerender({ open: false })
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    rerender({ open: true })
+
+    // The stale close timer must not fire and flip the reopened content off.
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it("starts false when mounted closed", () => {
+    const { result } = renderHook(({ open }) => useLingeringOpen(open), {
+      initialProps: { open: false },
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it("clears its timer on unmount during the linger window", () => {
+    const { rerender, unmount } = renderHook(
+      ({ open }) => useLingeringOpen(open, 300),
+      { initialProps: { open: true } },
+    )
+    rerender({ open: false })
+    unmount()
+    // Firing the timer after unmount must not warn/setState; advancing proves
+    // the cleanup ran (vitest fails on unhandled errors).
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/web/src/hooks/useLingeringOpen.ts
+++ b/web/src/hooks/useLingeringOpen.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react"
+
+// Returns true while `open` is true and for `ms` after it flips false, so
+// content gated on an open flag can stay mounted through a dialog's close
+// animation instead of vanishing mid-fade. `ms` tracks the DaisyUI modal
+// transition (~200ms) with headroom.
+export function useLingeringOpen(open: boolean, ms = 300): boolean {
+  const [lingering, setLingering] = useState(open)
+  // Render-phase adjustment (not an effect) so an open never paints unmounted.
+  if (open && !lingering) setLingering(true)
+  useEffect(() => {
+    if (open) return
+    const id = setTimeout(() => setLingering(false), ms)
+    return () => clearTimeout(id)
+  }, [open, ms])
+  return open || lingering
+}
+
+export default useLingeringOpen

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -526,7 +526,6 @@
     "addHint": "Enter a GitHub username to add a student with their details, or an email to send an organization invite. An email invite keeps the name and section you enter on a pending roster row until the student accepts.",
     "addRoleLabel": "Role",
     "addStaffHint": "Teachers, head TAs, and TAs are added by GitHub username. Teachers and head TAs get write access to the classroom50 repository; TAs get read-only. A teacher is granted organization owner.",
-    "namePlaceholder": "Ada Lovelace",
     "usernamePlaceholder": "github-username",
     "emailPlaceholder": "student@university.edu",
     "sectionPlaceholder": "e.g. Period 3",
@@ -867,7 +866,6 @@
     "resultRoleChangeFailures": "Role changes failed",
     "done": "Done",
     "chooseAnotherFile": "Choose another file",
-    "nameLabel": "Name",
     "usernameLabel": "GitHub username",
     "firstNameLabel": "First name",
     "lastNameLabel": "Last name"

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -25,7 +25,7 @@ import type { GitHubUser } from "@/github-core/types"
 import { Link, useParams, useSearch } from "@tanstack/react-router"
 import { useAcceptAssignment } from "@/hooks/mutations/useAcceptAssignment"
 import { useGithubAuth } from "@/auth/useGithubAuth"
-import { useId, useRef, useState } from "react"
+import { useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import confetti from "canvas-confetti"
 import { type AcceptStepId, type AcceptStepStatus } from "@/domain/assignments"
@@ -70,7 +70,6 @@ const initialsFor = (user: GitHubUser | null) => {
 const AcceptNavbar = () => {
   const { t } = useTranslation()
   const langDialogRef = useRef<HTMLDialogElement>(null)
-  const langDialogTitleId = useId()
   return (
     <div className="navbar bg-base-100 shadow-sm">
       <div className="flex-1">
@@ -92,7 +91,7 @@ const AcceptNavbar = () => {
           <span className="hidden sm:inline">{t("nav.language")}</span>
         </Button>
       </div>
-      <LanguageDialog ref={langDialogRef} titleId={langDialogTitleId} />
+      <LanguageDialog ref={langDialogRef} />
     </div>
   )
 }

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -13,7 +13,7 @@ import {
   type AssignmentFilters,
   type AssignmentSort,
 } from "@/pages/assignments/assignmentList"
-import { Badge, Button, EmphasisLtr } from "@/components/ui"
+import { Badge, Button, DropdownMenu, EmphasisLtr } from "@/components/ui"
 import {
   NoSearchResults,
   SkeletonRegion,
@@ -71,11 +71,7 @@ const NewAssignmentButton = ({
           >
             <ChevronDownIcon aria-hidden="true" className="size-4" />
           </Button>
-          <ul
-            tabIndex={0}
-            role="menu"
-            className="dropdown-content menu z-10 mt-1 w-max rounded-box border border-base-300 bg-base-100 p-1 shadow"
-          >
+          <DropdownMenu className="w-max">
             <li>
               <button
                 type="button"
@@ -90,7 +86,7 @@ const NewAssignmentButton = ({
                 {t("assignments.newButton.reuse")}
               </button>
             </li>
-          </ul>
+          </DropdownMenu>
         </div>
       </div>
 

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -17,7 +17,7 @@ import {
   SkeletonRegion,
   ToolbarSkeleton,
 } from "@/components/list"
-import { Alert, Button, Card, EmphasisLtr } from "@/components/ui"
+import { Alert, Button, Card, DropdownMenu, EmphasisLtr } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import MissingParams from "@/components/MissingParams"
 import { useOrgStaff } from "@/hooks/useOrgStaff"
@@ -59,11 +59,7 @@ const NewClassroomButton = ({ org }: { org: string }) => {
         >
           <ChevronDownIcon aria-hidden="true" className="size-4" />
         </Button>
-        <ul
-          tabIndex={0}
-          role="menu"
-          className="dropdown-content menu z-10 mt-1 w-max rounded-box border border-base-300 bg-base-100 p-1 shadow"
-        >
+        <DropdownMenu className="w-max">
           {/* FEATURE: github-classroom-migration — removable entry point (#312) */}
           <li>
             <Link to="/$org/import" params={{ org }}>
@@ -71,7 +67,7 @@ const NewClassroomButton = ({ org }: { org: string }) => {
               {t("migration.entryButton")}
             </Link>
           </li>
-        </ul>
+        </DropdownMenu>
       </div>
     </div>
   )

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -431,7 +431,6 @@ const OrgMembersPage = () => {
             className="mt-6 text-sm"
             role="status"
           >
-            <AlertIcon className="size-4" aria-hidden="true" />
             <span>
               {t("orgMembers.discrepancy", { count: discrepancyCount })}
             </span>

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -7,7 +7,6 @@ import {
   Input,
   Modal,
   cx,
-  Heading,
 } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
@@ -265,16 +264,10 @@ function SetTokenModal({
       open={open}
       onClose={onClose}
       size="2xl"
-      aria-label={t("orgSettings.serviceToken.setModalTitle")}
+      title={t("orgSettings.serviceToken.setModalTitle")}
+      subtitle={t("orgSettings.serviceToken.setModalSubtitle")}
       closeDisabled={saveMutation.isPending}
     >
-      <div className="pe-8">
-        <Heading as="h3">{t("orgSettings.serviceToken.setModalTitle")}</Heading>
-        <p className="mt-1 text-sm text-base-content/70">
-          {t("orgSettings.serviceToken.setModalSubtitle")}
-        </p>
-      </div>
-
       <form
         className="mt-6 flex flex-col gap-6"
         onSubmit={(e) => {

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -45,6 +45,7 @@ import {
   Badge,
   Button,
   Card,
+  DropdownMenu,
   Toolbar,
   cx,
   Heading,
@@ -261,11 +262,7 @@ function HideOrgMenu({
         >
           <KebabHorizontalIcon aria-hidden="true" className="size-4" />
         </Button>
-        <ul
-          tabIndex={0}
-          role="menu"
-          className="menu dropdown-content z-10 mt-1 w-48 rounded-box border border-base-300 bg-base-100 p-1 shadow"
-        >
+        <DropdownMenu className="w-48">
           {canManageToken && (
             <li>
               <Link
@@ -297,7 +294,7 @@ function HideOrgMenu({
               {t("orgs.card.hide")}
             </button>
           </li>
-        </ul>
+        </DropdownMenu>
       </div>
 
       <OrgDetailsModal

--- a/web/src/pages/accessibility/ContrastSection.tsx
+++ b/web/src/pages/accessibility/ContrastSection.tsx
@@ -87,13 +87,14 @@ function PairDetailModal({ row, onClose }: { row: Row; onClose: () => void }) {
   }, [])
 
   return (
-    <Modal dialogRef={dialogRef} onClose={onClose} size="lg">
-      <div className="flex flex-col gap-4">
-        <div>
-          <h3 className="font-mono text-sm font-semibold">{row.id}</h3>
-          <p className="text-sm text-base-content/70">{row.label}</p>
-        </div>
-
+    <Modal
+      dialogRef={dialogRef}
+      onClose={onClose}
+      size="lg"
+      title={<span className="font-mono">{row.id}</span>}
+      subtitle={row.label}
+    >
+      <div className="mt-4 flex flex-col gap-4">
         {/* The combined sample: real foreground on the real surface — the way
             WebAIM and other contrast tools preview a pair, because contrast is
             a property of the combination, not two isolated swatches. */}

--- a/web/src/pages/assignments/AdvancedRuntimeFields.tsx
+++ b/web/src/pages/assignments/AdvancedRuntimeFields.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/icons"
 import { orgRunnersQuery } from "@/github-core/queries"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
-import { Button, HelpTooltip, Input } from "@/components/ui"
+import { Button, DropdownMenu, HelpTooltip, Input } from "@/components/ui"
 import type { HelpTooltipPosition } from "@/components/ui"
 import {
   isKnownHostedRunnerLabel,
@@ -125,11 +125,7 @@ export const LanguageVersionField = ({
                 </Button>
               </div>
               {!disabled && (
-                <ul
-                  tabIndex={0}
-                  role="menu"
-                  className="dropdown-content menu z-10 mt-1 w-full rounded-box border border-base-300 bg-base-100 p-1 shadow"
-                >
+                <DropdownMenu className="w-full">
                   {meta.versions.map((version) => (
                     <li key={version}>
                       <button
@@ -158,7 +154,7 @@ export const LanguageVersionField = ({
                       </button>
                     </li>
                   ))}
-                </ul>
+                </DropdownMenu>
               )}
             </div>
             {error ? (

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -17,7 +17,6 @@ import {
   Select,
   TableShell,
   Textarea,
-  Heading,
 } from "@/components/ui"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import {
@@ -72,7 +71,6 @@ const AutogradingTestModal = ({
   onCommit,
 }: AutogradingTestModalProps) => {
   const { t } = useTranslation()
-  const titleId = useId()
   const fieldId = useId()
   const [draft, setDraft] = useState<AssignmentTestDraft>(editor.baseline)
   const [errors, setErrors] = useState<TestErrors>({})
@@ -97,7 +95,20 @@ const AutogradingTestModal = ({
       dialogRef={dialogRef}
       size="3xl"
       boxClassName="max-h-[90vh]"
-      aria-labelledby={titleId}
+      title={t("assignments.autograder.editTest", { number: editor.index + 1 })}
+      subtitle={t("assignments.autograder.editTestHint")}
+      footer={
+        <>
+          <Button variant="ghost" onClick={onCancel}>
+            {t("common.cancel")}
+          </Button>
+          <Button variant="primary" onClick={handleCommit} disabled={!dirty}>
+            {editor.mode === "new"
+              ? t("assignments.autograder.addTest")
+              : t("common.save")}
+          </Button>
+        </>
+      }
       onClose={onCancel}
       onKeyDown={(e) => {
         // Enter inside a modal input would implicitly submit the surrounding
@@ -114,16 +125,7 @@ const AutogradingTestModal = ({
         }
       }}
     >
-      <div className="mb-6">
-        <Heading as="h3" id={titleId}>
-          {t("assignments.autograder.editTest", { number: editor.index + 1 })}
-        </Heading>
-        <p className="text-sm opacity-70">
-          {t("assignments.autograder.editTestHint")}
-        </p>
-      </div>
-
-      <div className="space-y-5">
+      <div className="mt-6 space-y-5">
         <FormField
           htmlFor={field("name")}
           label={t("assignments.autograder.testName")}
@@ -363,17 +365,6 @@ const AutogradingTestModal = ({
             )}
           </FormField>
         </div>
-      </div>
-
-      <div className="modal-action">
-        <Button variant="ghost" onClick={onCancel}>
-          {t("common.cancel")}
-        </Button>
-        <Button variant="primary" onClick={handleCommit} disabled={!dirty}>
-          {editor.mode === "new"
-            ? t("assignments.autograder.addTest")
-            : t("common.save")}
-        </Button>
       </div>
     </Modal>
   )

--- a/web/src/pages/assignments/ClassroomCollectButton.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.tsx
@@ -1,8 +1,9 @@
-import { AlertIcon, SyncIcon } from "@/components/ui/icons"
-import { useEffect, useId, useMemo, useState } from "react"
+import { SyncIcon } from "@/components/ui/icons"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button, Modal, Heading } from "@/components/ui"
+import { Button } from "@/components/ui"
+import { ConfirmModal } from "@/components/modals"
 import { SubmissionFreshnessLine } from "@/components/SubmissionFreshnessLine"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { GitHubAPIError } from "@/github-core/errors"
@@ -60,7 +61,6 @@ export function ClassroomCollectButton({
   // every assignment, and Actions minutes scale with the classroom), so the
   // click confirms before dispatching instead of firing straight away.
   const [confirmOpen, setConfirmOpen] = useState(false)
-  const confirmTitleId = useId()
 
   // Classroom-level freshness: the newest per-bucket collected_at stamp — any
   // collect that walked this classroom moved at least one. scores.json is
@@ -230,41 +230,19 @@ export function ClassroomCollectButton({
 
       {/* Sibling, not child: the strip is a role="status" live region, and a
           dialog nested inside it gets re-announced as a status update. */}
-      <Modal
+      <ConfirmModal
         open={confirmOpen}
+        title={t("assignments.collect.confirmTitle")}
+        description={t("assignments.collect.confirmBody")}
+        confirmLabel={t("assignments.collect.confirmAction")}
+        cancelLabel={t("common.cancel")}
+        dangerous={false}
+        needsConfirm={false}
+        onConfirm={async () => {
+          collect.collect()
+        }}
         onClose={() => setConfirmOpen(false)}
-        size="lg"
-        aria-labelledby={confirmTitleId}
-      >
-        <div className="flex items-start gap-4">
-          <div className="flex size-11 shrink-0 items-center justify-center rounded-box bg-warning/10 text-warning">
-            <AlertIcon className="size-4" aria-hidden="true" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <Heading as="h3" id={confirmTitleId}>
-              {t("assignments.collect.confirmTitle")}
-            </Heading>
-            <p className="mt-3 text-sm text-base-content/80">
-              {t("assignments.collect.confirmBody")}
-            </p>
-          </div>
-        </div>
-
-        <div className="modal-action">
-          <Button variant="ghost" onClick={() => setConfirmOpen(false)}>
-            {t("common.cancel")}
-          </Button>
-          <Button
-            variant="primary"
-            onClick={() => {
-              setConfirmOpen(false)
-              collect.collect()
-            }}
-          >
-            {t("assignments.collect.confirmAction")}
-          </Button>
-        </div>
-      </Modal>
+      />
     </>
   )
 }

--- a/web/src/pages/assignments/ManageAssignmentModal.tsx
+++ b/web/src/pages/assignments/ManageAssignmentModal.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useId, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "@tanstack/react-router"
 import { EyeIcon, LockIcon, PencilIcon } from "@/components/ui/icons"
 
-import { Badge, Heading, Modal, MonoLtr } from "@/components/ui"
+import { Badge, Modal, MonoLtr } from "@/components/ui"
 import { ActionListRow } from "@/pages/submissions/actionLayout"
 import {
   assignmentName,
@@ -48,7 +48,6 @@ export const ManageAssignmentModal = ({
   onDeleteAssignment: () => void
 }) => {
   const dialogRef = useRef<HTMLDialogElement | null>(null)
-  const titleId = useId()
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [subModalOpen, setSubModalOpen] = useState(false)
@@ -66,26 +65,26 @@ export const ManageAssignmentModal = ({
       // so the two modal boxes don't visibly layer. The sub-modal renders its
       // own backdrop on top; dismissing it un-hides this box.
       boxClassName={subModalOpen ? "invisible" : undefined}
-      aria-labelledby={titleId}
+      title={
+        <span className="block truncate">{assignmentName(assignment)}</span>
+      }
+      subtitle={
+        <span className="flex items-center gap-2">
+          <MonoLtr className="truncate">{assignment.slug}</MonoLtr>
+          {assignment.locked && (
+            <Badge
+              tone="warning"
+              size="sm"
+              className="gap-1 whitespace-nowrap"
+              title={t("assignments.table.lockedBadgeTitle")}
+            >
+              <LockIcon aria-hidden="true" className="size-3" />
+              {t("assignments.table.lockedBadge")}
+            </Badge>
+          )}
+        </span>
+      }
     >
-      <Heading as="h3" className="truncate pe-8" id={titleId}>
-        {assignmentName(assignment)}
-      </Heading>
-      <p className="mt-0.5 flex items-center gap-2 text-sm text-base-content/60">
-        <MonoLtr className="truncate">{assignment.slug}</MonoLtr>
-        {assignment.locked && (
-          <Badge
-            tone="warning"
-            size="sm"
-            className="gap-1 whitespace-nowrap"
-            title={t("assignments.table.lockedBadgeTitle")}
-          >
-            <LockIcon aria-hidden="true" className="size-3" />
-            {t("assignments.table.lockedBadge")}
-          </Badge>
-        )}
-      </p>
-
       <div className="mt-4 flex flex-col">
         <ActionListRow
           icon={canMutate ? PencilIcon : EyeIcon}

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -11,7 +11,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { EmptyState, NoSearchResults, ViewToggle } from "@/components/list"
-import { Button, cx, Input, LabeledControl, Select } from "@/components/ui"
+import {
+  Button,
+  cx,
+  DropdownMenu,
+  Input,
+  LabeledControl,
+  Select,
+} from "@/components/ui"
 import useClassroomSummaries, {
   classroomDisplayName,
   type ClassroomSummary,
@@ -271,11 +278,7 @@ const ClassroomList = ({
             >
               <ChevronDownIcon aria-hidden="true" className="size-4" />
             </Button>
-            <ul
-              tabIndex={0}
-              role="menu"
-              className="dropdown-content menu z-10 mt-1 w-max rounded-box border border-base-300 bg-base-100 p-1 shadow"
-            >
+            <DropdownMenu className="w-max">
               {/* FEATURE: github-classroom-migration — removable entry point (#312) */}
               <li>
                 <Link to="/$org/import" params={{ org }}>
@@ -283,7 +286,7 @@ const ClassroomList = ({
                   {t("migration.entryButton")}
                 </Link>
               </li>
-            </ul>
+            </DropdownMenu>
           </div>
         </div>
       </div>

--- a/web/src/pages/migration/ConfirmStep.tsx
+++ b/web/src/pages/migration/ConfirmStep.tsx
@@ -28,7 +28,6 @@ import {
   Modal,
   Spinner,
   Toolbar,
-  Heading,
 } from "@/components/ui"
 import { useDebouncedValue } from "@/hooks/useDebouncedValue"
 import {
@@ -776,12 +775,28 @@ export const ConfirmStep = ({
         open={showConfirm}
         onClose={() => setShowConfirm(false)}
         size="md"
-        aria-label={t("migration.confirm.modalTitle")}
+        role="alertdialog"
+        title={
+          <span className="flex items-center gap-2">
+            <AlertIcon aria-hidden="true" className="size-4 text-warning" />
+            {t("migration.confirm.modalTitle")}
+          </span>
+        }
+        footer={
+          <>
+            <Button variant="ghost" onClick={() => setShowConfirm(false)}>
+              {t("migration.confirm.modalCancel")}
+            </Button>
+            <Button
+              variant="primary"
+              disabled={!canImport}
+              onClick={startImport}
+            >
+              {t("migration.confirm.modalConfirm")}
+            </Button>
+          </>
+        }
       >
-        <Heading as="h3" className="flex items-center gap-2">
-          <AlertIcon aria-hidden="true" className="size-4 text-warning" />
-          {t("migration.confirm.modalTitle")}
-        </Heading>
         <p className="mt-2 text-sm text-base-content/80">
           {t("migration.confirm.modalSummary", {
             count: selectedCount,
@@ -806,14 +821,6 @@ export const ConfirmStep = ({
         <p className="mt-3 text-sm font-medium text-base-content/80">
           {t("migration.confirm.modalConfirmQuestion")}
         </p>
-        <div className="mt-6 flex justify-end gap-2">
-          <Button variant="ghost" onClick={() => setShowConfirm(false)}>
-            {t("migration.confirm.modalCancel")}
-          </Button>
-          <Button variant="primary" disabled={!canImport} onClick={startImport}>
-            {t("migration.confirm.modalConfirm")}
-          </Button>
-        </div>
       </Modal>
     </Card>
   )

--- a/web/src/pages/migration/ConfirmStep.tsx
+++ b/web/src/pages/migration/ConfirmStep.tsx
@@ -21,6 +21,7 @@ import {
   InlineMessage,
   Input,
   Modal,
+  ModalIcon,
   Spinner,
   Toolbar,
 } from "@/components/ui"
@@ -765,11 +766,11 @@ export const ConfirmStep = ({
         onClose={() => setShowConfirm(false)}
         size="md"
         role="alertdialog"
-        title={
-          <span className="flex items-center gap-2">
-            <AlertIcon aria-hidden="true" className="size-4 text-warning" />
-            {t("migration.confirm.modalTitle")}
-          </span>
+        title={t("migration.confirm.modalTitle")}
+        headerVisual={
+          <ModalIcon tone="warning">
+            <AlertIcon aria-hidden="true" className="size-4" />
+          </ModalIcon>
         }
         footer={
           <>

--- a/web/src/pages/migration/ConfirmStep.tsx
+++ b/web/src/pages/migration/ConfirmStep.tsx
@@ -9,12 +9,7 @@ import { useMemo, useState } from "react"
 import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { Trans, useTranslation } from "react-i18next"
-import {
-  AlertIcon,
-  CheckCircleIcon,
-  LinkExternalIcon,
-  SyncIcon,
-} from "@/components/ui/icons"
+import { AlertIcon, LinkExternalIcon, SyncIcon } from "@/components/ui/icons"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { githubOAuthGrantUrl, githubOrgOAuthPolicyUrl } from "@/auth/constants"
@@ -703,12 +698,6 @@ export const ConfirmStep = ({
                 tone={hadSkips ? "warning" : "success"}
                 className="mt-6 items-start"
               >
-                {!hadSkips && (
-                  <CheckCircleIcon
-                    aria-hidden="true"
-                    className="size-4 shrink-0"
-                  />
-                )}
                 <div>
                   <p className="font-medium">
                     {hadSkips

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -2,7 +2,7 @@ import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { PlusIcon, XIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Select, Toolbar, Heading } from "@/components/ui"
+import { Alert, Button, Modal, Select, Toolbar } from "@/components/ui"
 import type { GitHubClient } from "@/github-core/client"
 import type { GitHubUser } from "@/github-core/types"
 import type { StudentCsvRow } from "@/domain/students"
@@ -178,7 +178,7 @@ const BulkActionsBar = ({
   }) => void
 }) => {
   const { t } = useTranslation()
-  const titleId = useId()
+  const pickerId = useId()
 
   const [classroom, setClassroom] = useState("")
   const [action, setAction] = useState<"add" | "remove" | null>(null)
@@ -295,13 +295,13 @@ const BulkActionsBar = ({
           {hasSelection ? (
             <>
               <label
-                htmlFor={`${titleId}-picker`}
+                htmlFor={`${pickerId}-picker`}
                 className="text-sm text-base-content/60"
               >
                 {t("orgMembers.bulk.classroomLabel")}
               </label>
               <Select
-                id={`${titleId}-picker`}
+                id={`${pickerId}-picker`}
                 selectSize="sm"
                 className="max-w-[12rem] w-auto"
                 value={effectiveClassroom}
@@ -417,20 +417,27 @@ const BulkActionsBar = ({
         onClose={closeModal}
         closeDisabled={phase === "working"}
         size="2xl"
-        aria-labelledby={titleId}
+        title={
+          action === "remove"
+            ? t("orgMembers.bulk.removeTitle", {
+                classroom: effectiveClassroom,
+              })
+            : t("orgMembers.bulk.addTitle", {
+                classroom: effectiveClassroom,
+              })
+        }
+        footer={
+          phase === "complete" ? (
+            <Button variant="primary" onClick={closeModal}>
+              {t("orgMembers.bulk.done")}
+            </Button>
+          ) : phase === "error" ? (
+            <Button variant="primary" onClick={closeModal}>
+              {t("common.done")}
+            </Button>
+          ) : undefined
+        }
       >
-        <div className="flex items-start justify-between gap-4">
-          <Heading as="h3" id={titleId}>
-            {action === "remove"
-              ? t("orgMembers.bulk.removeTitle", {
-                  classroom: effectiveClassroom,
-                })
-              : t("orgMembers.bulk.addTitle", {
-                  classroom: effectiveClassroom,
-                })}
-          </Heading>
-        </div>
-
         {phase === "working" && (
           <div className="mt-6">
             <p className="mb-2 font-medium">{progress.message}</p>
@@ -466,11 +473,6 @@ const BulkActionsBar = ({
                 rows={section.rows}
               />
             ))}
-            <div className="modal-action">
-              <Button variant="primary" onClick={closeModal}>
-                {t("orgMembers.bulk.done")}
-              </Button>
-            </div>
           </div>
         )}
 
@@ -479,11 +481,6 @@ const BulkActionsBar = ({
             <Alert tone="error">
               <span>{error ?? t("orgMembers.somethingWrong")}</span>
             </Alert>
-            <div className="modal-action">
-              <Button variant="ghost" onClick={closeModal}>
-                {t("common.close")}
-              </Button>
-            </div>
           </div>
         )}
       </Modal>

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -203,20 +203,22 @@ const BulkActionsBar = ({
   const effectiveClassroom =
     classroom || (classrooms.length > 0 ? classrooms[0].path : "")
 
-  const isOpen = phase !== "idle"
+  // The progress dialog's visibility is its own flag, decoupled from `phase`:
+  // closing must not reset phase/result/action, or the fading dialog would
+  // collapse to just its title mid-animation. Each run resets them anyway.
+  const [modalOpen, setModalOpen] = useState(false)
+  const isOpen = modalOpen
 
   const closeModal = () => {
     if (phase === "working") return
-    setPhase("idle")
-    setResult(null)
-    setError(null)
-    setAction(null)
+    setModalOpen(false)
   }
 
   const run = async (which: "add" | "remove") => {
     if (!effectiveClassroom || selectedRows.length === 0) return
     setAction(which)
     setPhase("working")
+    setModalOpen(true)
     setError(null)
     setResult(null)
     setProgress({

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -203,9 +203,8 @@ const BulkActionsBar = ({
   const effectiveClassroom =
     classroom || (classrooms.length > 0 ? classrooms[0].path : "")
 
-  // The progress dialog's visibility is its own flag, decoupled from `phase`:
-  // closing must not reset phase/result/action, or the fading dialog would
-  // collapse to just its title mid-animation. Each run resets them anyway.
+  // Visibility is its own flag: closing must not reset phase/result/action
+  // (close-animation note in ui/Modal); each run resets them anyway.
   const [modalOpen, setModalOpen] = useState(false)
   const isOpen = modalOpen
 

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -205,8 +205,7 @@ const BulkActionsBar = ({
 
   // Visibility is its own flag: closing must not reset phase/result/action
   // (close-animation note in ui/Modal); each run resets them anyway.
-  const [modalOpen, setModalOpen] = useState(false)
-  const isOpen = modalOpen
+  const [isOpen, setModalOpen] = useState(false)
 
   const closeModal = () => {
     if (phase === "working") return
@@ -383,10 +382,9 @@ const BulkActionsBar = ({
         })}
         confirmLabel={t("orgMembers.bulk.remove")}
         onConfirm={async () => {
-          // Close the confirm dialog first, then start the run next tick: two
-          // open <dialog showModal> at once is invalid (the second throws), so
-          // let the confirm close settle before run() opens the progress dialog.
-          // Not awaited — run() drives its own dialog.
+          // Close the confirm dialog first, then start the run next tick, so
+          // the progress dialog doesn't stack its box and backdrop over the
+          // still-closing confirm. Not awaited — run() drives its own dialog.
           setConfirmingRemove(false)
           setTimeout(() => void run("remove"), 0)
         }}

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -72,6 +72,17 @@ const MemberDetailModal = ({
     setInviting(false)
   }, [open])
 
+  // Disarm the confirm panels during render when the row identity changes
+  // without an intervening close (RosterMemberModal's draftRowKey pattern), so
+  // an armed "remove from org" can never carry onto a re-pointed member.
+  const rowKey = rowProp ? rowProp.username || rowProp.email : null
+  const [draftRowKey, setDraftRowKey] = useState<string | null>(rowKey)
+  if (rowKey !== null && rowKey !== draftRowKey) {
+    setDraftRowKey(rowKey)
+    setConfirming(false)
+    setConfirmingInvite(false)
+  }
+
   const handleClose = () => {
     if (working) return
     onClose()

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -157,7 +157,7 @@ const MemberDetailModal = ({
       open={open}
       onClose={handleClose}
       closeDisabled={working}
-      size="lg"
+      size="2xl"
       title={t("orgMembers.detailTitle")}
       footer={
         <>

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { Link } from "@tanstack/react-router"
 import {
@@ -10,6 +10,7 @@ import {
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { Badge, Button, EmphasisLtr, Modal, rtlFlip } from "@/components/ui"
+import { GitHubLink } from "@/components/GitHubLink"
 import { removeMemberFromOrg } from "@/domain/orgMembers/removeMemberFromOrg"
 import {
   ClassificationBadge,
@@ -26,7 +27,7 @@ import type { OrgMemberRow } from "@/util/orgMembers"
 const MemberDetailModal = ({
   open,
   org,
-  row,
+  row: rowProp,
   isSelf,
   isOwner,
   onClose,
@@ -55,19 +56,33 @@ const MemberDetailModal = ({
   const [working, setWorking] = useState(false)
   const [inviting, setInviting] = useState(false)
 
-  // Close and reset transient confirm/in-flight state in one place. Every close
-  // path (X, backdrop, Escape via onCancel) routes here, so a reopened modal
-  // never shows a stale "confirm remove" panel — no reset-in-effect needed.
-  const handleClose = () => {
-    if (working) return
+  // Retain the last non-null row so the modal keeps rendering its real content
+  // through the close animation. Without this, clearing the selection swaps in
+  // a structurally-empty <Modal> for the frames the dialog is still fading out,
+  // collapsing it to just the title. `open` still drives the actual close.
+  const [lastRow, setLastRow] = useState<OrgMemberRow | null>(null)
+  useEffect(() => {
+    if (rowProp) setLastRow(rowProp)
+  }, [rowProp])
+  const row = rowProp ?? lastRow
+
+  // Reset transient confirm/in-flight state when OPENING (a close-time reset
+  // would collapse an open confirm panel under the dialog's fade-out), so a
+  // reopened modal never shows a stale "confirm remove" panel.
+  useEffect(() => {
+    if (!open) return
     setConfirming(false)
     setConfirmingInvite(false)
     setInviting(false)
+  }, [open])
+
+  const handleClose = () => {
+    if (working) return
     onClose()
   }
 
   if (!row) {
-    // Still mounted (empty) so the close animation can run.
+    // Never had a row (initial mount, closed): nothing to show.
     return (
       <Modal
         open={open}
@@ -133,6 +148,10 @@ const MemberDetailModal = ({
     }
   }
 
+  // The destructive trigger lives in the footer; the inline confirm panel it
+  // opens stays in the body (a nested <dialog> can't stack on an open one).
+  const canRemove = !isSelf && row.isMember
+
   return (
     <Modal
       open={open}
@@ -140,15 +159,35 @@ const MemberDetailModal = ({
       closeDisabled={working}
       size="lg"
       title={t("orgMembers.detailTitle")}
+      footer={
+        <>
+          <GitHubLink
+            href={`https://github.com/orgs/${org}/people${
+              row.username ? `?query=${encodeURIComponent(row.username)}` : ""
+            }`}
+            label={t("orgMembers.manageOnGitHub")}
+            className="me-auto self-center"
+          />
+          <Button variant="ghost" size="sm" onClick={handleClose}>
+            {t("common.close")}
+          </Button>
+          {canRemove && (
+            <Button
+              variant="error"
+              size="sm"
+              disabled={working || confirming}
+              onClick={() => setConfirming(true)}
+            >
+              {t("orgMembers.removeFromOrg")}
+            </Button>
+          )}
+        </>
+      }
     >
       <div className="mt-4 flex flex-col gap-4">
-        <MemberDetailHeader row={row} org={org} />
-
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <MemberDetailHeader row={row} />
           <ClassificationBadge row={row} isOwner={isOwner} />
-          {row.email ? (
-            <span className="text-sm text-base-content/70">{row.email}</span>
-          ) : null}
         </div>
 
         <div>
@@ -329,16 +368,7 @@ const MemberDetailModal = ({
               </Button>
             </div>
           </div>
-        ) : (
-          <Button
-            variant="error"
-            size="sm"
-            className="self-start"
-            onClick={() => setConfirming(true)}
-          >
-            {t("orgMembers.removeFromOrg")}
-          </Button>
-        )}
+        ) : null}
       </div>
     </Modal>
   )

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -1,23 +1,15 @@
-import { useId, useState } from "react"
+import { useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { Link } from "@tanstack/react-router"
 import {
   AlertIcon,
   ChevronRightIcon,
   PersonAddIcon,
-  XIcon,
 } from "@/components/ui/icons"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
-import {
-  Badge,
-  Button,
-  EmphasisLtr,
-  Modal,
-  rtlFlip,
-  Heading,
-} from "@/components/ui"
+import { Badge, Button, EmphasisLtr, Modal, rtlFlip } from "@/components/ui"
 import { removeMemberFromOrg } from "@/domain/orgMembers/removeMemberFromOrg"
 import {
   ClassificationBadge,
@@ -58,7 +50,6 @@ const MemberDetailModal = ({
   const { t } = useTranslation()
   const client = useGitHubClient()
   const { notify } = useToast()
-  const titleId = useId()
   const [confirming, setConfirming] = useState(false)
   const [confirmingInvite, setConfirmingInvite] = useState(false)
   const [working, setWorking] = useState(false)
@@ -77,7 +68,13 @@ const MemberDetailModal = ({
 
   if (!row) {
     // Still mounted (empty) so the close animation can run.
-    return <Modal open={open} onClose={handleClose} aria-labelledby={titleId} />
+    return (
+      <Modal
+        open={open}
+        onClose={handleClose}
+        title={t("orgMembers.detailTitle")}
+      />
+    )
   }
 
   const label = row.username || row.email
@@ -141,28 +138,10 @@ const MemberDetailModal = ({
       open={open}
       onClose={handleClose}
       closeDisabled={working}
-      hideCloseButton
       size="lg"
-      boxClassName="p-0"
-      aria-labelledby={titleId}
+      title={t("orgMembers.detailTitle")}
     >
-      <div className="flex items-start justify-between gap-4 border-b border-base-300 px-6 py-4">
-        <Heading as="h2" id={titleId}>
-          {t("orgMembers.detailTitle")}
-        </Heading>
-        <Button
-          variant="ghost"
-          size="sm"
-          shape="square"
-          onClick={handleClose}
-          disabled={working}
-          aria-label={t("common.close")}
-        >
-          <XIcon aria-hidden="true" className="size-4" />
-        </Button>
-      </div>
-
-      <div className="flex flex-col gap-4 px-6 py-5">
+      <div className="mt-4 flex flex-col gap-4">
         <MemberDetailHeader row={row} org={org} />
 
         <div className="flex flex-wrap items-center gap-2">
@@ -352,9 +331,9 @@ const MemberDetailModal = ({
           </div>
         ) : (
           <Button
-            variant="outline"
+            variant="error"
             size="sm"
-            className="btn-error self-start"
+            className="self-start"
             onClick={() => setConfirming(true)}
           >
             {t("orgMembers.removeFromOrg")}

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -56,19 +56,15 @@ const MemberDetailModal = ({
   const [working, setWorking] = useState(false)
   const [inviting, setInviting] = useState(false)
 
-  // Retain the last non-null row so the modal keeps rendering its real content
-  // through the close animation. Without this, clearing the selection swaps in
-  // a structurally-empty <Modal> for the frames the dialog is still fading out,
-  // collapsing it to just the title. `open` still drives the actual close.
+  // Retain the last non-null row so the fading dialog keeps its content after
+  // the parent clears the selection (close-animation note in ui/Modal).
   const [lastRow, setLastRow] = useState<OrgMemberRow | null>(null)
   useEffect(() => {
     if (rowProp) setLastRow(rowProp)
   }, [rowProp])
   const row = rowProp ?? lastRow
 
-  // Reset transient confirm/in-flight state when OPENING (a close-time reset
-  // would collapse an open confirm panel under the dialog's fade-out), so a
-  // reopened modal never shows a stale "confirm remove" panel.
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (!open) return
     setConfirming(false)

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -1,9 +1,3 @@
-import {
-  MailIcon,
-  MarkGithubIcon,
-  PeopleIcon,
-  PersonIcon,
-} from "@/components/ui/icons"
 import { revalidateLogic, useForm } from "@tanstack/react-form"
 import { useEffect, useId, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -42,7 +36,8 @@ type AddStudentProps = {
 }
 
 type AddStudentFormValues = {
-  name: string
+  first_name: string
+  last_name: string
   username: string
   email: string
   section: string
@@ -80,7 +75,8 @@ const AddStudent = ({
 
   const form = useForm({
     defaultValues: {
-      name: "",
+      first_name: "",
+      last_name: "",
       username: "",
       email: "",
       section: "",
@@ -211,7 +207,7 @@ const AddStudent = ({
       open={open}
       onClose={closeDialog}
       closeDisabled={submitting}
-      size="lg"
+      size="2xl"
       title={t("students.addTitle")}
       subtitle={
         isStaffRole ? t("students.addStaffHint") : t("students.addHint")
@@ -280,31 +276,53 @@ const AddStudent = ({
           </div>
 
           {!isStaffRole && (
-            <form.Field name="name">
-              {(field) => (
-                <FormField htmlFor={field.name} label={t("students.nameLabel")}>
-                  {({ id, describedById, invalid }) => (
-                    <Input
-                      leadingIcon={
-                        <PersonIcon
-                          className="size-4 text-base-content/50"
-                          aria-hidden="true"
-                        />
-                      }
-                      id={id}
-                      name={field.name}
-                      type="text"
-                      placeholder={t("students.namePlaceholder")}
-                      aria-describedby={describedById}
-                      invalid={invalid}
-                      value={field.state.value}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                    />
-                  )}
-                </FormField>
-              )}
-            </form.Field>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <form.Field name="first_name">
+                {(field) => (
+                  <FormField
+                    htmlFor={field.name}
+                    label={t("students.firstNameLabel")}
+                  >
+                    {({ id, describedById, invalid }) => (
+                      <Input
+                        id={id}
+                        name={field.name}
+                        type="text"
+                        placeholder={t("students.firstNamePlaceholder")}
+                        aria-describedby={describedById}
+                        invalid={invalid}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                      />
+                    )}
+                  </FormField>
+                )}
+              </form.Field>
+
+              <form.Field name="last_name">
+                {(field) => (
+                  <FormField
+                    htmlFor={field.name}
+                    label={t("students.lastNameLabel")}
+                  >
+                    {({ id, describedById, invalid }) => (
+                      <Input
+                        id={id}
+                        name={field.name}
+                        type="text"
+                        placeholder={t("students.lastNamePlaceholder")}
+                        aria-describedby={describedById}
+                        invalid={invalid}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                      />
+                    )}
+                  </FormField>
+                )}
+              </form.Field>
+            </div>
           )}
 
           <form.Field name="username">
@@ -320,12 +338,6 @@ const AddStudent = ({
               >
                 {({ id, describedById, invalid }) => (
                   <Input
-                    leadingIcon={
-                      <MarkGithubIcon
-                        className="size-4 opacity-40"
-                        aria-hidden="true"
-                      />
-                    }
                     id={id}
                     name={field.name}
                     type="text"
@@ -356,12 +368,6 @@ const AddStudent = ({
                 >
                   {({ id, describedById, invalid }) => (
                     <Input
-                      leadingIcon={
-                        <MailIcon
-                          className="size-4 text-base-content/50"
-                          aria-hidden="true"
-                        />
-                      }
                       id={id}
                       name={field.name}
                       type="email"
@@ -387,12 +393,6 @@ const AddStudent = ({
                 >
                   {({ id, describedById, invalid }) => (
                     <Input
-                      leadingIcon={
-                        <PeopleIcon
-                          className="size-4 text-base-content/50"
-                          aria-hidden="true"
-                        />
-                      }
                       id={id}
                       name={field.name}
                       type="text"

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -187,8 +187,7 @@ const AddStudent = ({
 
   const submitting = form.state.isSubmitting || addStaffMutation.isPending
 
-  // Reset transient state whenever the modal opens (Modal owns the open/close
-  // sync now).
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (!open) return
     setWarning("")

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -25,7 +25,6 @@ import {
   Input,
   Modal,
   Select,
-  Heading,
 } from "@/components/ui"
 
 // Roster "Add member" roles, in display order. Student (default) enrolls via the
@@ -66,7 +65,8 @@ const AddStudent = ({
   const { team } = useEnsureTeam(org, classroom)
   const { t } = useTranslation()
   const { notify } = useToast()
-  const titleId = useId()
+  // Ties the footer's submit button (outside the <form> element) to the form.
+  const formId = useId()
   const roleId = useId()
   const [warning, setWarning] = useState("")
   const [success, setSuccess] = useState("")
@@ -212,20 +212,41 @@ const AddStudent = ({
       onClose={closeDialog}
       closeDisabled={submitting}
       size="lg"
-      aria-labelledby={titleId}
+      title={t("students.addTitle")}
+      subtitle={
+        isStaffRole ? t("students.addStaffHint") : t("students.addHint")
+      }
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={submitting}
+            onClick={closeDialog}
+          >
+            {t("common.close")}
+          </Button>
+          <form.Subscribe
+            selector={(state) => [state.canSubmit, state.isSubmitting]}
+          >
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                type="submit"
+                form={formId}
+                disabled={!canSubmit || isSubmitting || (!isStaffRole && !team)}
+                variant="primary"
+              >
+                {!isSubmitting
+                  ? t("students.addButton")
+                  : t("students.submitting")}
+              </Button>
+            )}
+          </form.Subscribe>
+        </>
+      }
     >
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <Heading as="h3" id={titleId}>
-            {t("students.addTitle")}
-          </Heading>
-          <p className="mt-1 text-sm text-base-content/70">
-            {isStaffRole ? t("students.addStaffHint") : t("students.addHint")}
-          </p>
-        </div>
-      </div>
-
       <form
+        id={formId}
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
@@ -387,32 +408,6 @@ const AddStudent = ({
               )}
             </form.Field>
           )}
-        </div>
-
-        <div className="modal-action">
-          <Button
-            type="button"
-            variant="ghost"
-            disabled={submitting}
-            onClick={closeDialog}
-          >
-            {t("common.close")}
-          </Button>
-          <form.Subscribe
-            selector={(state) => [state.canSubmit, state.isSubmitting]}
-          >
-            {([canSubmit, isSubmitting]) => (
-              <Button
-                type="submit"
-                disabled={!canSubmit || isSubmitting || (!isStaffRole && !team)}
-                variant="primary"
-              >
-                {!isSubmitting
-                  ? t("students.addButton")
-                  : t("students.submitting")}
-              </Button>
-            )}
-          </form.Subscribe>
         </div>
       </form>
     </Modal>

--- a/web/src/pages/students/EditStudentForm.tsx
+++ b/web/src/pages/students/EditStudentForm.tsx
@@ -19,6 +19,7 @@ import {
   AnimatedAlert,
   Button,
   Input,
+  modalActionClass,
   MonoLtr,
 } from "@/components/ui"
 
@@ -303,7 +304,7 @@ const EditStudentForm = ({
         {error}
       </AnimatedAlert>
 
-      <div className="modal-action">
+      <div className={modalActionClass}>
         <Button
           type="button"
           variant="ghost"

--- a/web/src/pages/students/EditStudentForm.tsx
+++ b/web/src/pages/students/EditStudentForm.tsx
@@ -1,9 +1,4 @@
-import {
-  MailIcon,
-  MarkGithubIcon,
-  PeopleIcon,
-  PersonIcon,
-} from "@/components/ui/icons"
+import { MarkGithubIcon } from "@/components/ui/icons"
 import { revalidateLogic, useForm } from "@tanstack/react-form"
 import { useCallback, useEffect, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
@@ -170,22 +165,16 @@ const EditStudentForm = ({
               label={t("students.firstNameLabel")}
             >
               {({ id, describedById, invalid }) => (
-                <div className="flex items-center">
-                  <PersonIcon
-                    className="me-2 text-base-content/70"
-                    aria-hidden="true"
-                  />
-                  <Input
-                    id={id}
-                    name={field.name}
-                    placeholder={t("students.firstNamePlaceholder")}
-                    aria-describedby={describedById}
-                    invalid={invalid}
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </div>
+                <Input
+                  id={id}
+                  name={field.name}
+                  placeholder={t("students.firstNamePlaceholder")}
+                  aria-describedby={describedById}
+                  invalid={invalid}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
               )}
             </FormField>
           )}
@@ -195,22 +184,16 @@ const EditStudentForm = ({
           {(field) => (
             <FormField htmlFor={field.name} label={t("students.lastNameLabel")}>
               {({ id, describedById, invalid }) => (
-                <div className="flex items-center">
-                  <PersonIcon
-                    className="me-2 text-base-content/70"
-                    aria-hidden="true"
-                  />
-                  <Input
-                    id={id}
-                    name={field.name}
-                    placeholder={t("students.lastNamePlaceholder")}
-                    aria-describedby={describedById}
-                    invalid={invalid}
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </div>
+                <Input
+                  id={id}
+                  name={field.name}
+                  placeholder={t("students.lastNamePlaceholder")}
+                  aria-describedby={describedById}
+                  invalid={invalid}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
               )}
             </FormField>
           )}
@@ -229,28 +212,22 @@ const EditStudentForm = ({
               hint={lockEmail ? t("students.inviteEmailLocked") : undefined}
             >
               {({ id, describedById, invalid }) => (
-                <div className="flex items-center">
-                  <MailIcon
-                    className="size-6 me-2 text-base-content/70"
-                    aria-hidden="true"
-                  />
-                  <Input
-                    id={id}
-                    name={field.name}
-                    type="email"
-                    placeholder={t("students.editEmailPlaceholder")}
-                    readOnly={lockEmail}
-                    disabled={lockEmail}
-                    title={
-                      lockEmail ? t("students.inviteEmailLocked") : undefined
-                    }
-                    invalid={invalid}
-                    aria-describedby={describedById}
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </div>
+                <Input
+                  id={id}
+                  name={field.name}
+                  type="email"
+                  placeholder={t("students.editEmailPlaceholder")}
+                  readOnly={lockEmail}
+                  disabled={lockEmail}
+                  title={
+                    lockEmail ? t("students.inviteEmailLocked") : undefined
+                  }
+                  invalid={invalid}
+                  aria-describedby={describedById}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
               )}
             </FormField>
           )}
@@ -260,22 +237,16 @@ const EditStudentForm = ({
           {(field) => (
             <FormField htmlFor={field.name} label={t("students.sectionLabel")}>
               {({ id, describedById, invalid }) => (
-                <div className="flex items-center">
-                  <PeopleIcon
-                    className="me-2 text-base-content/70"
-                    aria-hidden="true"
-                  />
-                  <Input
-                    id={id}
-                    name={field.name}
-                    placeholder={t("students.editSectionPlaceholder")}
-                    aria-describedby={describedById}
-                    invalid={invalid}
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </div>
+                <Input
+                  id={id}
+                  name={field.name}
+                  placeholder={t("students.editSectionPlaceholder")}
+                  aria-describedby={describedById}
+                  invalid={invalid}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
               )}
             </FormField>
           )}

--- a/web/src/pages/students/EditStudentForm.tsx
+++ b/web/src/pages/students/EditStudentForm.tsx
@@ -19,7 +19,6 @@ import {
   AnimatedAlert,
   Button,
   Input,
-  modalActionClass,
   MonoLtr,
 } from "@/components/ui"
 
@@ -304,7 +303,7 @@ const EditStudentForm = ({
         {error}
       </AnimatedAlert>
 
-      <div className={modalActionClass}>
+      <div className="modal-action">
         <Button
           type="button"
           variant="ghost"

--- a/web/src/pages/students/ImportProblemsReport.tsx
+++ b/web/src/pages/students/ImportProblemsReport.tsx
@@ -1,5 +1,5 @@
 import { Trans, useTranslation } from "react-i18next"
-import { Alert, Button, modalActionClass, MonoLtr } from "@/components/ui"
+import { Alert, Button, MonoLtr } from "@/components/ui"
 import type { ImportProblem } from "@/pages/students/importProblems"
 
 // The per-line list both report variants share. Each explanation is ONE
@@ -53,7 +53,7 @@ export const ImportBlockedReport = ({
           )}
         </div>
       </Alert>
-      <div className={modalActionClass}>
+      <div className="modal-action">
         <Button variant="ghost" onClick={onCancel}>
           {t("common.cancel")}
         </Button>

--- a/web/src/pages/students/ImportProblemsReport.tsx
+++ b/web/src/pages/students/ImportProblemsReport.tsx
@@ -1,5 +1,5 @@
 import { Trans, useTranslation } from "react-i18next"
-import { Alert, Button, MonoLtr } from "@/components/ui"
+import { Alert, Button, modalActionClass, MonoLtr } from "@/components/ui"
 import type { ImportProblem } from "@/pages/students/importProblems"
 
 // The per-line list both report variants share. Each explanation is ONE
@@ -53,7 +53,7 @@ export const ImportBlockedReport = ({
           )}
         </div>
       </Alert>
-      <div className="modal-action">
+      <div className={modalActionClass}>
         <Button variant="ghost" onClick={onCancel}>
           {t("common.cancel")}
         </Button>

--- a/web/src/pages/students/InviteLinksModal.tsx
+++ b/web/src/pages/students/InviteLinksModal.tsx
@@ -1,9 +1,8 @@
-import { useId } from "react"
 import { useTranslation } from "react-i18next"
 import { CheckIcon, CopyIcon } from "@/components/ui/icons"
 
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
-import { Button, Input, Modal, Heading } from "@/components/ui"
+import { Button, Input, Modal } from "@/components/ui"
 
 // A single copyable link row (read-only input + copy button).
 const CopyLinkField = ({
@@ -75,24 +74,23 @@ const InviteLinksModal = ({
   onClose: () => void
 }) => {
   const { t } = useTranslation()
-  const titleId = useId()
 
   const onboardUrl = `${window.location.origin}/${org}/${classroom}/onboard`
   const inviteUrl = `https://github.com/orgs/${org}/invitation`
 
   return (
-    <Modal open={open} onClose={onClose} size="lg" aria-labelledby={titleId}>
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <Heading as="h3" id={titleId}>
-            {t("students.inviteStudents")}
-          </Heading>
-          <p className="mt-1 text-sm text-base-content/70">
-            {t("students.inviteLinksHint")}
-          </p>
-        </div>
-      </div>
-
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="lg"
+      title={t("students.inviteStudents")}
+      subtitle={t("students.inviteLinksHint")}
+      footer={
+        <Button variant="ghost" onClick={onClose}>
+          {t("common.close")}
+        </Button>
+      }
+    >
       <div className="mt-5 flex flex-col gap-5">
         <CopyLinkField
           label={t("students.onboardingLinkLabel")}
@@ -108,12 +106,6 @@ const InviteLinksModal = ({
           ariaLabel={t("students.studentInviteLinkAria")}
           copyAriaLabel={t("students.copyInviteLinkAria")}
         />
-      </div>
-
-      <div className="modal-action">
-        <Button variant="ghost" onClick={onClose}>
-          {t("common.close")}
-        </Button>
       </div>
     </Modal>
   )

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -168,20 +168,22 @@ const RosterBulkActionsBar = ({
   // the writer silently report the pending ones as "already removed".
   const unenrollableSelected = selectedRows.filter(canTargetForUnenroll)
 
-  const isOpen = phase !== "idle"
+  // The progress dialog's visibility is its own flag, decoupled from `phase`:
+  // closing must not reset phase/result/action, or the fading dialog would
+  // collapse to just its title mid-animation. Each run resets them anyway.
+  const [modalOpen, setModalOpen] = useState(false)
+  const isOpen = modalOpen
 
   const closeModal = () => {
     if (phase === "working") return
-    setPhase("idle")
-    setResult(null)
-    setError(null)
-    setAction(null)
+    setModalOpen(false)
   }
 
   const runUnenroll = async () => {
     if (unenrollableSelected.length === 0) return
     setAction("unenroll")
     setPhase("working")
+    setModalOpen(true)
     setError(null)
     setResult(null)
     setProgress({
@@ -222,6 +224,7 @@ const RosterBulkActionsBar = ({
     if (invitableSelected === 0) return
     setAction("invite")
     setPhase("working")
+    setModalOpen(true)
     setError(null)
     setResult(null)
     setProgress({
@@ -320,6 +323,7 @@ const RosterBulkActionsBar = ({
     if (cancellableSelected.length === 0) return
     setAction("cancel")
     setPhase("working")
+    setModalOpen(true)
     setError(null)
     setResult(null)
     const total = cancellableSelected.length

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -168,9 +168,8 @@ const RosterBulkActionsBar = ({
   // the writer silently report the pending ones as "already removed".
   const unenrollableSelected = selectedRows.filter(canTargetForUnenroll)
 
-  // The progress dialog's visibility is its own flag, decoupled from `phase`:
-  // closing must not reset phase/result/action, or the fading dialog would
-  // collapse to just its title mid-animation. Each run resets them anyway.
+  // Visibility is its own flag: closing must not reset phase/result/action
+  // (close-animation note in ui/Modal); each run resets them anyway.
   const [modalOpen, setModalOpen] = useState(false)
   const isOpen = modalOpen
 

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -170,8 +170,7 @@ const RosterBulkActionsBar = ({
 
   // Visibility is its own flag: closing must not reset phase/result/action
   // (close-animation note in ui/Modal); each run resets them anyway.
-  const [modalOpen, setModalOpen] = useState(false)
-  const isOpen = modalOpen
+  const [isOpen, setModalOpen] = useState(false)
 
   const closeModal = () => {
     if (phase === "working") return

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   PaperAirplaneIcon,
@@ -9,7 +9,7 @@ import {
 
 import type { GitHubClient } from "@/github-core/client"
 import { ConfirmModal } from "@/components/modals"
-import { Alert, Button, Modal, Toolbar, Heading } from "@/components/ui"
+import { Alert, Button, Modal, Toolbar } from "@/components/ui"
 import { GitHubAPIError } from "@/github-core/errors"
 import { cancelOrgInvitation } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
@@ -137,7 +137,6 @@ const RosterBulkActionsBar = ({
   canGroupBySection?: boolean
 }) => {
   const { t } = useTranslation()
-  const titleId = useId()
 
   const [action, setAction] = useState<"unenroll" | "invite" | "cancel" | null>(
     null,
@@ -582,18 +581,25 @@ const RosterBulkActionsBar = ({
         onClose={closeModal}
         closeDisabled={phase === "working"}
         size="2xl"
-        aria-labelledby={titleId}
+        title={
+          action === "invite"
+            ? t("students.bulk.inviteTitle")
+            : action === "cancel"
+              ? t("students.bulk.cancelTitle")
+              : t("students.bulk.unenrollTitle")
+        }
+        footer={
+          phase === "complete" ? (
+            <Button variant="primary" onClick={closeModal}>
+              {t("students.bulk.done")}
+            </Button>
+          ) : phase === "error" ? (
+            <Button variant="primary" onClick={closeModal}>
+              {t("common.done")}
+            </Button>
+          ) : undefined
+        }
       >
-        <div className="flex items-start justify-between gap-4">
-          <Heading as="h3" id={titleId}>
-            {action === "invite"
-              ? t("students.bulk.inviteTitle")
-              : action === "cancel"
-                ? t("students.bulk.cancelTitle")
-                : t("students.bulk.unenrollTitle")}
-          </Heading>
-        </div>
-
         {phase === "working" && (
           <div className="mt-6">
             <p className="mb-2 font-medium">{progress.message}</p>
@@ -629,11 +635,6 @@ const RosterBulkActionsBar = ({
                 rows={section.rows}
               />
             ))}
-            <div className="modal-action">
-              <Button variant="primary" onClick={closeModal}>
-                {t("students.bulk.done")}
-              </Button>
-            </div>
           </div>
         )}
 
@@ -642,11 +643,6 @@ const RosterBulkActionsBar = ({
             <Alert tone="error">
               <span>{error ?? t("students.somethingWentWrong")}</span>
             </Alert>
-            <div className="modal-action">
-              <Button variant="ghost" onClick={closeModal}>
-                {t("common.close")}
-              </Button>
-            </div>
           </div>
         )}
       </Modal>

--- a/web/src/pages/students/RosterImportResult.tsx
+++ b/web/src/pages/students/RosterImportResult.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { Alert, Button } from "@/components/ui"
+import { Alert, Button, modalActionClass } from "@/components/ui"
 import { ROLE_LABEL_KEY } from "@/util/classroomRoleUI"
 import type {
   BulkImportResult,
@@ -252,7 +252,7 @@ export const RosterImportResult = ({
           ))
         : null}
 
-      <div className="modal-action">
+      <div className={modalActionClass}>
         <Button variant="primary" onClick={onDone}>
           {t("students.done")}
         </Button>

--- a/web/src/pages/students/RosterImportResult.tsx
+++ b/web/src/pages/students/RosterImportResult.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { Alert, Button, modalActionClass } from "@/components/ui"
+import { Alert, Button } from "@/components/ui"
 import { ROLE_LABEL_KEY } from "@/util/classroomRoleUI"
 import type {
   BulkImportResult,
@@ -252,7 +252,7 @@ export const RosterImportResult = ({
           ))
         : null}
 
-      <div className={modalActionClass}>
+      <div className="modal-action">
         <Button variant="primary" onClick={onDone}>
           {t("students.done")}
         </Button>

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useId, useState } from "react"
+import { useEffect, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import {
   LinkExternalIcon,
   MarkGithubIcon,
   PaperAirplaneIcon,
   PersonAddIcon,
-  XIcon,
 } from "@/components/ui/icons"
 
 import Avatar from "@/components/avatar"
@@ -42,14 +41,7 @@ import {
   STATE_BADGE_TONE,
   STATE_LABEL_KEY,
 } from "@/util/classroomRoleUI"
-import {
-  Badge,
-  Button,
-  EmphasisLtr,
-  Modal,
-  Select,
-  Heading,
-} from "@/components/ui"
+import { Badge, Button, EmphasisLtr, Modal, Select } from "@/components/ui"
 
 // Roster-owned detail modal (single native <dialog>), opened by clicking a
 // roster row. Shares the identity header with the Org Members modal; everything
@@ -115,7 +107,6 @@ const RosterMemberModal = ({
 }) => {
   const { t } = useTranslation()
   const client = useGitHubClient()
-  const titleId = useId()
   const [confirmingUnenroll, setConfirmingUnenroll] = useState(false)
   const [confirmingResend, setConfirmingResend] = useState(false)
   const [confirmingCancel, setConfirmingCancel] = useState(false)
@@ -190,7 +181,13 @@ const RosterMemberModal = ({
 
   if (!row) {
     // Never had a row (initial mount, closed): nothing to show.
-    return <Modal open={open} onClose={handleClose} aria-labelledby={titleId} />
+    return (
+      <Modal
+        open={open}
+        onClose={handleClose}
+        title={t("students.detailTitle")}
+      />
+    )
   }
 
   const student = rowToStudent(row)
@@ -518,28 +515,10 @@ const RosterMemberModal = ({
       open={open}
       onClose={handleClose}
       closeDisabled={busy}
-      hideCloseButton
       size="lg"
-      boxClassName="p-0"
-      aria-labelledby={titleId}
+      title={t("students.detailTitle")}
     >
-      <div className="flex items-start justify-between gap-4 border-b border-base-300 px-6 py-4">
-        <Heading as="h2" id={titleId}>
-          {t("students.detailTitle")}
-        </Heading>
-        <Button
-          variant="ghost"
-          size="sm"
-          shape="square"
-          onClick={handleClose}
-          disabled={busy}
-          aria-label={t("common.close")}
-        >
-          <XIcon aria-hidden="true" className="size-4" />
-        </Button>
-      </div>
-
-      <div className="flex flex-col gap-5 px-6 py-5">
+      <div className="mt-4 flex flex-col gap-5">
         {/* Identity with the enrollment actions as icons on the right — the
               GitHub username itself links to the profile. */}
         <div className="flex items-start justify-between gap-4">

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -139,14 +139,21 @@ const RosterMemberModal = ({
 
   const handleClose = () => {
     if (busy) return
+    onClose()
+  }
+
+  // Reset transient confirm/edit state when OPENING — a close-time reset would
+  // collapse an open confirm panel under the dialog's fade-out; the reopened
+  // modal still never shows a stale panel.
+  useEffect(() => {
+    if (!open) return
     setConfirmingUnenroll(false)
     setConfirmingResend(false)
     setConfirmingCancel(false)
     setPendingRole(null)
     setRoleOwnerConfirmed(false)
     setEditingProfile(false)
-    onClose()
-  }
+  }, [open])
 
   // Retain the last non-null row so the modal keeps rendering its real content
   // through the close animation. Without this, clearing the selection swaps in a

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -142,9 +142,7 @@ const RosterMemberModal = ({
     onClose()
   }
 
-  // Reset transient confirm/edit state when OPENING — a close-time reset would
-  // collapse an open confirm panel under the dialog's fade-out; the reopened
-  // modal still never shows a stale panel.
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (!open) return
     setConfirmingUnenroll(false)
@@ -155,11 +153,8 @@ const RosterMemberModal = ({
     setEditingProfile(false)
   }, [open])
 
-  // Retain the last non-null row so the modal keeps rendering its real content
-  // through the close animation. Without this, clearing the selection swaps in a
-  // structurally-empty <Modal> for the frames the dialog is still fading out,
-  // flashing a tiny empty box. `open` (from the parent's Boolean(selected)) still
-  // drives the actual close.
+  // Retain the last non-null row so the fading dialog keeps its content after
+  // the parent clears the selection (close-animation note in ui/Modal).
   const [lastRow, setLastRow] = useState<TeamRosterRow | null>(null)
   useEffect(() => {
     if (rowProp) setLastRow(rowProp)

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -522,7 +522,7 @@ const RosterMemberModal = ({
       open={open}
       onClose={handleClose}
       closeDisabled={busy}
-      size="lg"
+      size="2xl"
       title={t("students.detailTitle")}
     >
       <div className="mt-4 flex flex-col gap-5">

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -204,14 +204,12 @@ const UploadRoster = ({
     }
   }
 
-  // Clear internal state after the modal has actually closed (open -> false),
-  // so a programmatic close doesn't flash the idle drop-zone mid-close.
-  const wasOpenRef = useRef(false)
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
+  // `open !== true` keeps the uncontrolled mode (open undefined) untouched,
+  // which never reset here either.
   useEffect(() => {
-    if (wasOpenRef.current && open === false) {
-      resetToDropZone()
-    }
-    wasOpenRef.current = Boolean(open)
+    if (open !== true) return
+    resetToDropZone()
   }, [open])
 
   const handleClose = () => {

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { UploadIcon } from "@/components/ui/icons"
 
@@ -10,7 +10,7 @@ import type {
   RosterUploadContext,
 } from "@/domain/students"
 import type { GitHubClient } from "@/github-core/client"
-import { Alert, Button, Modal, Heading } from "@/components/ui"
+import { Alert, Button, Modal } from "@/components/ui"
 import {
   classifyRosterUpload,
   hasTeacherPromotion,
@@ -97,7 +97,6 @@ const UploadRoster = ({
   onOpenChange,
 }: UploadRosterProps) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
-  const titleId = useId()
   const { t } = useTranslation()
 
   const [phase, setPhase] = useState<ImportPhase>("idle")
@@ -693,21 +692,37 @@ const UploadRoster = ({
         onClose={handleClose}
         closeDisabled={phase === "importing"}
         size="5xl"
-        aria-labelledby={titleId}
+        title={t("students.uploadTitle")}
+        subtitle={fileName ? t("students.fileLabel", { fileName }) : undefined}
+        footer={
+          phase === "preview" && !blocked ? (
+            <>
+              <Button variant="ghost" onClick={resetToDropZone}>
+                {t("common.cancel")}
+              </Button>
+              <Button
+                variant="primary"
+                disabled={!canProcess}
+                onClick={startImport}
+              >
+                {rosterPrimaryLabel}
+              </Button>
+            </>
+          ) : phase === "error" ? (
+            <>
+              <Button variant="ghost" onClick={handleClose}>
+                {t("common.close")}
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {t("students.chooseAnotherFile")}
+              </Button>
+            </>
+          ) : undefined
+        }
       >
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <Heading as="h3" id={titleId}>
-              {t("students.uploadTitle")}
-            </Heading>
-            {fileName && (
-              <p className="text-sm opacity-70 mt-1">
-                {t("students.fileLabel", { fileName })}
-              </p>
-            )}
-          </div>
-        </div>
-
         {phase === "idle" && (
           <div className="mt-6">
             {/* Drop zone + click-to-pick. One entry for all three formats; the
@@ -909,20 +924,6 @@ const UploadRoster = ({
                 )}
               </Alert>
             )}
-
-            <div className="modal-action">
-              <Button variant="ghost" onClick={resetToDropZone}>
-                {t("common.cancel")}
-              </Button>
-
-              <Button
-                variant="primary"
-                disabled={!canProcess}
-                onClick={startImport}
-              >
-                {rosterPrimaryLabel}
-              </Button>
-            </div>
           </div>
         )}
 
@@ -974,19 +975,6 @@ const UploadRoster = ({
             <Alert tone="error">
               <span>{error ?? t("students.somethingWentWrong")}</span>
             </Alert>
-
-            <div className="modal-action">
-              <Button variant="ghost" onClick={handleClose}>
-                {t("common.close")}
-              </Button>
-
-              <Button
-                variant="primary"
-                onClick={() => fileInputRef.current?.click()}
-              >
-                {t("students.chooseAnotherFile")}
-              </Button>
-            </div>
           </div>
         )}
       </Modal>

--- a/web/src/pages/submissions/AcceptLinkModal.tsx
+++ b/web/src/pages/submissions/AcceptLinkModal.tsx
@@ -142,6 +142,10 @@ function AcceptShareSummaryNotice({
     return (
       <Alert
         tone="warning"
+        // The default tone icon is opted out: this alert stacks its text and
+        // action responsively, so the icon is laid out inline with the text
+        // (the EmptyRosterNotice pattern).
+        icon={null}
         className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between"
       >
         <div className="flex items-start gap-2">

--- a/web/src/pages/submissions/AcceptLinkModal.tsx
+++ b/web/src/pages/submissions/AcceptLinkModal.tsx
@@ -12,9 +12,9 @@ import {
   CopyableCode,
   EmphasisLtr,
   Modal,
+  ModalIcon,
   RouterButton,
   rtlFlip,
-  Heading,
 } from "@/components/ui"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { OrgRepoCreationNotice } from "@/components/OrgRepoCreationNotice"
@@ -56,19 +56,18 @@ export function AcceptLinkModal({
   const { copied: copiedCli, copy: copyCli } = useCopyToClipboard(cli, 1500)
 
   return (
-    <Modal open={open} onClose={onClose} size="2xl">
-      <div className="flex items-start gap-3">
-        <div className="rounded-box bg-primary/10 p-2.5 text-primary">
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="2xl"
+      title={t("submissions.accept.heading")}
+      subtitle={t("submissions.accept.subheading")}
+      headerVisual={
+        <ModalIcon>
           <LinkIcon aria-hidden="true" className="size-4" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3">{t("submissions.accept.heading")}</Heading>
-          <p className="text-sm text-base-content/70">
-            {t("submissions.accept.subheading")}
-          </p>
-        </div>
-      </div>
-
+        </ModalIcon>
+      }
+    >
       <div className="mt-4 flex flex-col gap-4">
         <AcceptShareSummaryNotice
           summary={summary}

--- a/web/src/pages/submissions/AcceptLinkModal.tsx
+++ b/web/src/pages/submissions/AcceptLinkModal.tsx
@@ -142,9 +142,8 @@ function AcceptShareSummaryNotice({
     return (
       <Alert
         tone="warning"
-        // The default tone icon is opted out: this alert stacks its text and
-        // action responsively, so the icon is laid out inline with the text
-        // (the EmptyRosterNotice pattern).
+        // icon={null} + inline icon: the stacked responsive layout lays the
+        // icon out with the text (the EmptyRosterNotice pattern).
         icon={null}
         className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between"
       >

--- a/web/src/pages/submissions/CloneSubmissionsModal.tsx
+++ b/web/src/pages/submissions/CloneSubmissionsModal.tsx
@@ -1,7 +1,7 @@
 import { ChevronRightIcon, TerminalIcon } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
 
-import { CopyableCode, Heading, Modal, rtlFlip } from "@/components/ui"
+import { CopyableCode, Modal, ModalIcon, rtlFlip } from "@/components/ui"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 
 // Published extension repo (see CONTRIBUTING.md "Distribution"), where
@@ -29,19 +29,18 @@ export function CloneSubmissionsModal({
   )
 
   return (
-    <Modal open={open} onClose={onClose} size="2xl">
-      <div className="flex items-start gap-3">
-        <div className="rounded-box bg-primary/10 p-2.5 text-primary">
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="2xl"
+      title={t("submissions.cloneAll.heading")}
+      subtitle={t("submissions.cloneAll.subheading")}
+      headerVisual={
+        <ModalIcon>
           <TerminalIcon aria-hidden="true" className="size-4" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <Heading as="h3">{t("submissions.cloneAll.heading")}</Heading>
-          <p className="text-sm text-base-content/70">
-            {t("submissions.cloneAll.subheading")}
-          </p>
-        </div>
-      </div>
-
+        </ModalIcon>
+      }
+    >
       <div className="mt-4 flex flex-col gap-4">
         <CopyableCode
           value={cli}

--- a/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
+++ b/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { FileZipIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Spinner } from "@/components/ui"
+import { Alert, Button, Modal, ModalIcon, Spinner } from "@/components/ui"
 import useDownloadAllSubmissions from "@/hooks/mutations/useDownloadAllSubmissions"
 import {
   BULK_DOWNLOAD_WARN_THRESHOLD,
@@ -109,11 +109,11 @@ export function DownloadAllSubmissionsModal({
       open={open}
       onClose={handleClose}
       size="md"
-      title={
-        <span className="flex items-center gap-2">
+      title={t("submissions.downloadAll.title")}
+      headerVisual={
+        <ModalIcon>
           <FileZipIcon aria-hidden="true" className="size-4" />
-          {t("submissions.downloadAll.title")}
-        </span>
+        </ModalIcon>
       }
       footer={
         summary || error ? (

--- a/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
+++ b/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
@@ -81,6 +81,12 @@ export function DownloadAllSubmissionsModal({
   // anything else is an unexpected batch error.
   const assemblyError = error instanceof ZipAssemblyError
 
+  // Clear the prior run when OPENING (not on close, which would swap the
+  // summary back to the confirm view under the fade-out).
+  useEffect(() => {
+    if (open) reset()
+  }, [open, reset])
+
   // Picker dismissed before anything ran — close quietly, no empty summary.
   useEffect(() => {
     if (outcome?.status === "cancelled") {
@@ -93,7 +99,6 @@ export function DownloadAllSubmissionsModal({
     // Closing mid-run cancels the in-flight batch rather than trapping the user.
     if (running) cancel()
     onClose()
-    reset()
   }
 
   const handleRun = () => {

--- a/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
+++ b/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useId } from "react"
+import { useEffect } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { FileZipIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Spinner, Heading } from "@/components/ui"
+import { Alert, Button, Modal, Spinner } from "@/components/ui"
 import useDownloadAllSubmissions from "@/hooks/mutations/useDownloadAllSubmissions"
 import {
   BULK_DOWNLOAD_WARN_THRESHOLD,
@@ -62,7 +62,6 @@ export function DownloadAllSubmissionsModal({
   owners: string[]
 }) {
   const { t } = useTranslation()
-  const titleId = useId()
   const {
     mutate,
     isPending,
@@ -106,13 +105,38 @@ export function DownloadAllSubmissionsModal({
       open={open}
       onClose={handleClose}
       size="md"
-      aria-labelledby={titleId}
+      title={
+        <span className="flex items-center gap-2">
+          <FileZipIcon aria-hidden="true" className="size-4" />
+          {t("submissions.downloadAll.title")}
+        </span>
+      }
+      footer={
+        summary || error ? (
+          <Button variant="primary" size="sm" onClick={handleClose}>
+            {t("common.done")}
+          </Button>
+        ) : running ? (
+          <Button variant="ghost" size="sm" onClick={handleClose}>
+            {t("common.cancel")}
+          </Button>
+        ) : (
+          <>
+            <Button variant="ghost" size="sm" onClick={handleClose}>
+              {t("common.cancel")}
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              disabled={count === 0}
+              onClick={handleRun}
+            >
+              {t("submissions.downloadAll.confirmLabel", { count })}
+            </Button>
+          </>
+        )
+      }
     >
-      <Heading as="h3" className="flex items-center gap-2" id={titleId}>
-        <FileZipIcon aria-hidden="true" className="size-4" />
-        {t("submissions.downloadAll.title")}
-      </Heading>
-
       {error ? (
         <div className="mt-3 space-y-3">
           <Alert tone="error">
@@ -209,32 +233,6 @@ export function DownloadAllSubmissionsModal({
           )}
         </div>
       )}
-
-      <div className="modal-action">
-        {summary || error ? (
-          <Button size="sm" onClick={handleClose}>
-            {t("common.close")}
-          </Button>
-        ) : running ? (
-          <Button variant="ghost" size="sm" onClick={handleClose}>
-            {t("common.cancel")}
-          </Button>
-        ) : (
-          <>
-            <Button variant="ghost" size="sm" onClick={handleClose}>
-              {t("common.cancel")}
-            </Button>
-            <Button
-              variant="primary"
-              size="sm"
-              disabled={count === 0}
-              onClick={handleRun}
-            >
-              {t("submissions.downloadAll.confirmLabel", { count })}
-            </Button>
-          </>
-        )}
-      </div>
     </Modal>
   )
 }

--- a/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
+++ b/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
@@ -81,8 +81,7 @@ export function DownloadAllSubmissionsModal({
   // anything else is an unexpected batch error.
   const assemblyError = error instanceof ZipAssemblyError
 
-  // Clear the prior run when OPENING (not on close, which would swap the
-  // summary back to the confirm view under the fade-out).
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (open) reset()
   }, [open, reset])

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useId, useMemo, useRef } from "react"
+import { useEffect, useMemo, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { PeopleIcon, RepoIcon } from "@/components/ui/icons"
 
-import { Badge, Modal, MonoLtr, Heading } from "@/components/ui"
+import { Badge, Modal, MonoLtr } from "@/components/ui"
 import useGetRepo from "@/hooks/useGetRepo"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
 import useGetAutogradeState from "@/hooks/useGetAutogradeState"
@@ -271,7 +271,6 @@ export const ManageSubmissionModal = ({
   }
 }) => {
   const dialogRef = useRef<HTMLDialogElement | null>(null)
-  const titleId = useId()
   const { t } = useTranslation()
 
   // Lifted here (not in SubmissionDetails) so the repo's default-branch tip can
@@ -313,16 +312,15 @@ export const ManageSubmissionModal = ({
       // the two modal boxes don't visibly layer. The editor renders its own
       // backdrop on top; dismissing it un-hides this box.
       boxClassName={subModalOpen ? "invisible" : undefined}
-      aria-labelledby={titleId}
+      title={<span className="block truncate">{title}</span>}
+      subtitle={
+        subtitle ? (
+          <span className="block truncate text-base-content/60">
+            {subtitle}
+          </span>
+        ) : undefined
+      }
     >
-      <Heading as="h3" className="truncate pe-8" id={titleId}>
-        {title}
-      </Heading>
-      {subtitle ? (
-        <p className="mt-0.5 truncate text-sm text-base-content/60">
-          {subtitle}
-        </p>
-      ) : null}
       {repoHref ? (
         <a
           className="link link-hover mt-2 inline-flex w-fit max-w-full items-center gap-1.5"

--- a/web/src/pages/submissions/MetricsModal.tsx
+++ b/web/src/pages/submissions/MetricsModal.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next"
 
-import { Modal, StatCard, Heading } from "@/components/ui"
+import { Modal, StatCard } from "@/components/ui"
 
 // The submission metrics, consolidated behind a single toolbar button so they
 // no longer push the roster down. Pure presentation: the page computes the
@@ -54,8 +54,12 @@ export function MetricsModal({
   }
 
   return (
-    <Modal open={open} onClose={onClose} size="2xl">
-      <Heading as="h3">{t("submissions.metrics.title")}</Heading>
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="2xl"
+      title={t("submissions.metrics.title")}
+    >
       <div className="mt-4 grid grid-cols-2 gap-4">
         <StatCard
           label={

--- a/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
+++ b/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { GitPullRequestIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Spinner } from "@/components/ui"
+import { Alert, Button, Modal, ModalIcon, Spinner } from "@/components/ui"
 import useOpenAllFeedbackPrs from "@/hooks/mutations/useOpenAllFeedbackPrs"
 import type { OpenAllRepoResult } from "@/domain/assignments"
 import type { AssignmentMode } from "@/types/classroom"
@@ -92,11 +92,11 @@ export function OpenAllFeedbackPrsModal({
       onClose={handleClose}
       size="md"
       closeDisabled={running}
-      title={
-        <span className="flex items-center gap-2">
+      title={t("submissions.openAllPrs.title")}
+      headerVisual={
+        <ModalIcon>
           <GitPullRequestIcon aria-hidden="true" className="size-4" />
-          {t("submissions.openAllPrs.title")}
-        </span>
+        </ModalIcon>
       }
       footer={
         summary ? (

--- a/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
+++ b/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { GitPullRequestIcon } from "@/components/ui/icons"
 
@@ -71,11 +72,16 @@ export function OpenAllFeedbackPrsModal({
   const count = repos.length
   const running = isPending
 
+  // Clear the prior run when OPENING so the dialog starts at the confirm state
+  // — resetting on close would swap the summary back to the confirm view under
+  // the fade-out.
+  useEffect(() => {
+    if (open) reset()
+  }, [open, reset])
+
   const handleClose = () => {
     if (running) return
     onClose()
-    // Clear the prior run so reopening starts at the confirm state.
-    reset()
   }
 
   const handleRun = () => {

--- a/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
+++ b/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
@@ -72,9 +72,7 @@ export function OpenAllFeedbackPrsModal({
   const count = repos.length
   const running = isPending
 
-  // Clear the prior run when OPENING so the dialog starts at the confirm state
-  // — resetting on close would swap the summary back to the confirm view under
-  // the fade-out.
+  // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
     if (open) reset()
   }, [open, reset])

--- a/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
+++ b/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
@@ -1,8 +1,7 @@
-import { useId } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { GitPullRequestIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, Spinner, Heading } from "@/components/ui"
+import { Alert, Button, Modal, Spinner } from "@/components/ui"
 import useOpenAllFeedbackPrs from "@/hooks/mutations/useOpenAllFeedbackPrs"
 import type { OpenAllRepoResult } from "@/domain/assignments"
 import type { AssignmentMode } from "@/types/classroom"
@@ -61,7 +60,6 @@ export function OpenAllFeedbackPrsModal({
   repos: string[]
 }) {
   const { t } = useTranslation()
-  const titleId = useId()
   const {
     mutate,
     isPending,
@@ -90,13 +88,44 @@ export function OpenAllFeedbackPrsModal({
       onClose={handleClose}
       size="md"
       closeDisabled={running}
-      aria-labelledby={titleId}
+      title={
+        <span className="flex items-center gap-2">
+          <GitPullRequestIcon aria-hidden="true" className="size-4" />
+          {t("submissions.openAllPrs.title")}
+        </span>
+      }
+      footer={
+        summary ? (
+          <Button variant="primary" size="sm" onClick={handleClose}>
+            {t("common.done")}
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={running}
+              onClick={handleClose}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              loading={running}
+              loadingLabel={t("submissions.openAllPrs.running", {
+                done: progress?.done ?? 0,
+                total: progress?.total ?? count,
+              })}
+              disabled={running || count === 0}
+              onClick={handleRun}
+            >
+              {t("submissions.openAllPrs.confirmLabel", { count })}
+            </Button>
+          </>
+        )
+      }
     >
-      <Heading as="h3" className="flex items-center gap-2" id={titleId}>
-        <GitPullRequestIcon aria-hidden="true" className="size-4" />
-        {t("submissions.openAllPrs.title")}
-      </Heading>
-
       {/* Summary — the run finished. */}
       {summary ? (
         <div className="mt-3 space-y-3">
@@ -187,38 +216,6 @@ export function OpenAllFeedbackPrsModal({
           <p>{t("submissions.openAllPrs.confirmHint")}</p>
         </div>
       )}
-
-      <div className="modal-action">
-        {summary ? (
-          <Button size="sm" onClick={handleClose}>
-            {t("common.close")}
-          </Button>
-        ) : (
-          <>
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={running}
-              onClick={handleClose}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button
-              variant="primary"
-              size="sm"
-              loading={running}
-              loadingLabel={t("submissions.openAllPrs.running", {
-                done: progress?.done ?? 0,
-                total: progress?.total ?? count,
-              })}
-              disabled={running || count === 0}
-              onClick={handleRun}
-            >
-              {t("submissions.openAllPrs.confirmLabel", { count })}
-            </Button>
-          </>
-        )}
-      </div>
     </Modal>
   )
 }

--- a/web/src/pages/submissions/ReviewButton.tsx
+++ b/web/src/pages/submissions/ReviewButton.tsx
@@ -1,8 +1,8 @@
 import { CodeReviewIcon } from "@/components/ui/icons"
-import { useId, useState } from "react"
+import { useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 
-import { Button, Modal, MonoLtr, Heading } from "@/components/ui"
+import { Button, Modal, MonoLtr } from "@/components/ui"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import useGetFeedbackPr from "@/hooks/useGetFeedbackPr"
 import useRepairFeedbackPr from "@/hooks/mutations/useRepairFeedbackPr"
@@ -39,7 +39,6 @@ export const FeedbackPrAction = ({
 }) => {
   const { t } = useTranslation()
   const { notify } = useToast()
-  const titleId = useId()
   const [resolving, setResolving] = useState(false)
   // The empty/error modal is mounted on demand (controlled `open`), not per
   // trigger: the table renders one action per row, and a hidden <dialog> per
@@ -129,23 +128,51 @@ export const FeedbackPrAction = ({
           open
           onClose={() => setModalOpen(false)}
           size="md"
-          hideCloseButton
-          aria-labelledby={titleId}
+          title={
+            errorMsg
+              ? t("submissions.reviewModal.errorTitle")
+              : t("submissions.reviewModal.emptyTitle")
+          }
+          footer={
+            <>
+              <Button
+                as="a"
+                variant="ghost"
+                size="sm"
+                href={`https://github.com/${org}/${repo}/pulls`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {t("submissions.reviewModal.openRepoPrs")}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={repair.isPending}
+                onClick={() => setModalOpen(false)}
+              >
+                {t("common.close")}
+              </Button>
+              {!errorMsg && (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  loading={repair.isPending}
+                  loadingLabel={t("submissions.repairPr.repairing")}
+                  onClick={handleRepair}
+                >
+                  {t("submissions.repairPr.repair")}
+                </Button>
+              )}
+            </>
+          }
         >
           {errorMsg ? (
-            <>
-              <Heading as="h3" id={titleId}>
-                {t("submissions.reviewModal.errorTitle")}
-              </Heading>
-              <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-base-content/70">
-                {errorMsg}
-              </p>
-            </>
+            <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-base-content/70">
+              {errorMsg}
+            </p>
           ) : (
             <>
-              <Heading as="h3" id={titleId}>
-                {t("submissions.reviewModal.emptyTitle")}
-              </Heading>
               <p className="mt-2 text-sm leading-6 text-base-content/70">
                 <Trans
                   i18nKey="submissions.reviewModal.emptyBody"
@@ -158,34 +185,6 @@ export const FeedbackPrAction = ({
               </p>
             </>
           )}
-          <div className="modal-action">
-            <a
-              className="btn btn-ghost btn-sm"
-              href={`https://github.com/${org}/${repo}/pulls`}
-              target="_blank"
-              rel="noreferrer"
-            >
-              {t("submissions.reviewModal.openRepoPrs")}
-            </a>
-            {!errorMsg && (
-              <Button
-                size="sm"
-                loading={repair.isPending}
-                loadingLabel={t("submissions.repairPr.repairing")}
-                onClick={handleRepair}
-              >
-                {t("submissions.repairPr.repair")}
-              </Button>
-            )}
-            <Button
-              variant={errorMsg ? undefined : "ghost"}
-              size="sm"
-              disabled={repair.isPending}
-              onClick={() => setModalOpen(false)}
-            >
-              {t("common.close")}
-            </Button>
-          </div>
         </Modal>
       )}
     </>

--- a/web/src/pages/submissions/ScoreOverrideModal.tsx
+++ b/web/src/pages/submissions/ScoreOverrideModal.tsx
@@ -8,7 +8,6 @@ import {
   Input,
   Modal,
   Spinner,
-  Heading,
 } from "@/components/ui"
 import { ScoreBadge } from "@/pages/submissions/ScoreBadge"
 import { useSetScoreOverride } from "@/hooks/mutations/useSetScoreOverride"
@@ -180,7 +179,6 @@ export function ScoreOverrideModal({
     )
   }
 
-  const titleId = `score-override-title-${owner}`
   const title = overridden
     ? t("submissions.scoreOverride.titleOverride")
     : hasGrade
@@ -207,16 +205,49 @@ export function ScoreOverrideModal({
       onClose={onClose}
       closeDisabled={saving}
       size="md"
-      aria-labelledby={titleId}
+      title={title}
+      subtitle={description}
+      footer={
+        <>
+          {/* Destructive Clear sits apart on the start side; Cancel/Save keep
+              the standard end-aligned order. */}
+          <div className="me-auto">
+            {overridden ? (
+              <Button
+                type="button"
+                variant="error"
+                size="sm"
+                disabled={saving}
+                aria-label={t("submissions.scoreOverride.clearLabel", { name })}
+                onClick={clear}
+              >
+                {t("submissions.scoreOverride.clear")}
+              </Button>
+            ) : null}
+          </div>
+          {saving ? <Spinner size="xs" className="self-center" /> : null}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={saving}
+            onClick={onClose}
+          >
+            {t("common.cancel")}
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            disabled={saving || saveBlocked}
+            onClick={save}
+          >
+            {t("submissions.scoreOverride.save")}
+          </Button>
+        </>
+      }
     >
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <Heading as="h3" id={titleId}>
-            {title}
-          </Heading>
-          <p className="text-sm text-base-content/70">{description}</p>
-        </div>
-
+      <div className="mt-4 flex flex-col gap-4">
         {showAutograded ? (
           <div className="flex items-center gap-2 text-sm">
             <span className="text-base-content/60">
@@ -304,44 +335,6 @@ export function ScoreOverrideModal({
               : t("submissions.scoreOverride.saveError")}
           </Alert>
         ) : null}
-
-        <div className="flex items-center justify-between gap-2">
-          <div>
-            {overridden ? (
-              <Button
-                type="button"
-                variant="error"
-                size="sm"
-                disabled={saving}
-                aria-label={t("submissions.scoreOverride.clearLabel", { name })}
-                onClick={clear}
-              >
-                {t("submissions.scoreOverride.clear")}
-              </Button>
-            ) : null}
-          </div>
-          <div className="flex items-center gap-2">
-            {saving ? <Spinner size="xs" /> : null}
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={saving}
-              onClick={onClose}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button
-              type="button"
-              variant="primary"
-              size="sm"
-              disabled={saving || saveBlocked}
-              onClick={save}
-            >
-              {t("submissions.scoreOverride.save")}
-            </Button>
-          </div>
-        </div>
       </div>
     </Modal>
   )

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
 
-import { Button } from "@/components/ui"
+import { Button, DropdownMenu } from "@/components/ui"
 
 // Consolidates the workflow actions (Collect now / Regrade all / View workflow)
 // plus the CSV export and Metrics into one dropdown so the toolbar stays
@@ -154,11 +154,7 @@ export function SubmissionsActionsMenu({
           : t("submissions.menu.actions")}
         {!busy && <ChevronDownIcon aria-hidden="true" className="size-4" />}
       </Button>
-      <ul
-        tabIndex={0}
-        role="menu"
-        className="dropdown-content menu z-10 mt-1 w-64 rounded-box border border-base-300 bg-base-100 p-1 shadow"
-      >
+      <DropdownMenu className="w-64">
         {/* Metrics — graded-snapshot stats; hidden in live view (onMetrics
             omitted there). */}
         {onMetrics && (
@@ -501,7 +497,7 @@ export function SubmissionsActionsMenu({
             {t("submissions.downloadAll.menuLabel")}
           </button>
         </li>
-      </ul>
+      </DropdownMenu>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Extends the shared `Modal` primitive with Primer Dialog anatomy — `title`/`subtitle`/`headerVisual`/`footer` slots with automatic `aria-labelledby`/`aria-describedby` wiring, a header divider, a `role` passthrough, and a single-sourced `ModalIcon` chip — and rebuilds `ConfirmModal` on top of it as a proper `alertdialog`. All ~60 modal call sites migrate off hand-rolled headers and `modal-action` footers, fixing four unlabeled dialogs, `aria-label`-vs-`labelledby` and heading-level drift, and normalizing footer conventions (ghost Cancel/Close left, primary rightmost, primary "Done" after finished bulk runs). The duplicated dropdown recipe converges on a new `DropdownMenu` primitive, and duplicate alert tone icons are removed.
- Fixes modal dismissal so content stays intact through the ~200ms close fade: transient state now resets on open instead of at close across ~14 modals, detail modals retain their last row while fading, bulk action bars own a dedicated open flag decoupled from their run phase, and `NewOrgModal` keeps its body mounted via a new `useLingeringOpen` hook. Also stabilizes the `reset` identity returned by `useOpenAllFeedbackPrs`/`useDownloadAllSubmissions`, whose reset-on-open effects could otherwise wipe an in-flight bulk run.
- Reworks the member surfaces for consistency: the add-member and member-detail forms share labels and width (2xl), the add form's Name splits into first/last fields feeding `useEnrollOrInviteStudent` directly (removing the lossy `splitName` round trip), the member detail modal moves its manage link and destructive action into the dialog footer, and decorative input icons are dropped. New tests cover the Modal slots/aria wiring, `useLingeringOpen`, and reset stability.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 356 files / 4494 tests, includes the i18n key audit)
- [x] Manual pass over the high-traffic modals in the dev server: delete assignment/classroom confirms, roster member detail + edit, add member, bulk modals, accept-link and upload modals
- [ ] Reviewer spot-check: dismissal animations (no content collapse mid-fade), bulk-run progress persisting through a run, both themes