### PR TITLE
refactor(web): single-source the bulk-modal phase shell and finish the footer migration

### DIFF
--- a/web/src/components/bulk/resultView.test.tsx
+++ b/web/src/components/bulk/resultView.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { BulkPhaseFooter } from "./resultView"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) }
+})
+
+afterEach(cleanup)
+
+const base = {
+  busy: false,
+  showApply: true,
+  applyLabel: "Apply",
+  onApply: () => {},
+  onClose: () => {},
+}
+
+describe("BulkPhaseFooter", () => {
+  it("renders ghost Cancel plus primary Apply while idle", () => {
+    render(<BulkPhaseFooter {...base} phase="idle" />)
+    expect(screen.getByRole("button", { name: "common.cancel" })).toBeDefined()
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDefined()
+  })
+
+  it("hides Apply when there is nothing to run on", () => {
+    render(<BulkPhaseFooter {...base} phase="idle" showApply={false} />)
+    expect(screen.queryByRole("button", { name: "Apply" })).toBeNull()
+  })
+
+  it("disables Apply via applyDisabled without hiding it", () => {
+    render(<BulkPhaseFooter {...base} phase="idle" applyDisabled />)
+    const apply = screen.getByRole("button", {
+      name: "Apply",
+    }) as HTMLButtonElement
+    expect(apply.disabled).toBe(true)
+  })
+
+  it("shows only a disabled Cancel while working", () => {
+    render(<BulkPhaseFooter {...base} phase="working" busy />)
+    const cancel = screen.getByRole("button", {
+      name: "common.cancel",
+    }) as HTMLButtonElement
+    expect(cancel.disabled).toBe(true)
+    expect(screen.queryByRole("button", { name: "Apply" })).toBeNull()
+  })
+
+  it.each(["complete", "error"] as const)(
+    "dismisses a finished %s run with a single primary Done",
+    (phase) => {
+      const onClose = vi.fn()
+      render(<BulkPhaseFooter {...base} phase={phase} onClose={onClose} />)
+      const done = screen.getByRole("button", { name: "common.done" })
+      expect(screen.getAllByRole("button")).toHaveLength(1)
+      done.click()
+      expect(onClose).toHaveBeenCalledTimes(1)
+    },
+  )
+})

--- a/web/src/components/bulk/resultView.tsx
+++ b/web/src/components/bulk/resultView.tsx
@@ -1,8 +1,13 @@
-// Presentational scaffolding shared by the bulk-action bars (org-members and
-// roster). Each bar owns its own action orchestration and result mappers; only
-// this generic "run phase + labeled sections of {label, detail} rows in a
-// modal" shell is shared, so a change to result presentation lands in one place
-// rather than drifting across the copies.
+// Presentational scaffolding shared by the bulk fan-out modals and action bars
+// (org-members and roster). Each caller owns its own action orchestration and
+// result mappers; only the generic "run phase + progress + labeled sections of
+// {label, detail} rows in a modal" shell is shared, so a change to the
+// presentation lands in one place rather than drifting across the copies.
+
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@/components/ui"
+import { Spinner } from "@/components/Spinner"
 
 // The lifecycle of a bulk run's modal: idle (closed) -> working (progress) ->
 // complete/error (results).
@@ -46,3 +51,80 @@ export const BulkResultSection = ({
     </div>
   </div>
 )
+
+// The canonical bulk-modal footer: a finished run (complete/error) dismisses
+// with primary Done; before that, ghost Cancel plus the idle-only primary
+// Apply. CloseSubmissionModal keeps its own footer — its finish-closing branch
+// is intentional divergence, not drift.
+export const BulkPhaseFooter = ({
+  phase,
+  busy,
+  showApply,
+  applyDisabled = false,
+  applyLabel,
+  onApply,
+  onClose,
+}: {
+  phase: BulkPhase
+  busy: boolean
+  // Render the Apply action while idle; false when there is nothing to run on.
+  showApply: boolean
+  applyDisabled?: boolean
+  applyLabel: string
+  onApply: () => void
+  onClose: () => void
+}) => {
+  const { t } = useTranslation()
+  if (phase === "complete" || phase === "error") {
+    return (
+      <Button variant="primary" onClick={onClose}>
+        {t("common.done")}
+      </Button>
+    )
+  }
+  return (
+    <>
+      <Button variant="ghost" disabled={busy} onClick={onClose}>
+        {t("common.cancel")}
+      </Button>
+      {phase === "idle" && showApply && (
+        <Button variant="primary" disabled={applyDisabled} onClick={onApply}>
+          {applyLabel}
+        </Button>
+      )}
+    </>
+  )
+}
+
+// The working-phase block: spinner, percent bar, caption. With
+// `indeterminateUntilFirst`, the bar omits `value` until the first item lands
+// so a slow first write animates instead of sitting at 0%.
+export const BulkProgressBlock = ({
+  workingLabel,
+  caption,
+  progress,
+  indeterminateUntilFirst = false,
+}: {
+  workingLabel: string
+  caption: React.ReactNode
+  progress: BulkProgress
+  indeterminateUntilFirst?: boolean
+}) => {
+  const pct =
+    progress.total > 0
+      ? Math.round((progress.processed / progress.total) * 100)
+      : 0
+  return (
+    <div className="mt-6 flex flex-col items-center gap-3 py-6">
+      <Spinner label={workingLabel} />
+      <progress
+        className="progress progress-primary w-full"
+        {...(indeterminateUntilFirst && progress.processed === 0
+          ? {}
+          : { value: pct })}
+        max={100}
+      />
+      <p className="text-sm text-base-content/70">{caption}</p>
+    </div>
+  )
+}

--- a/web/src/components/modals/BulkAutogradeStateModal.tsx
+++ b/web/src/components/modals/BulkAutogradeStateModal.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { PauseIcon, PlayIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
-import { Spinner } from "@/components/Spinner"
+import { Alert, Modal, ModalIcon } from "@/components/ui"
 import {
+  BulkPhaseFooter,
+  BulkProgressBlock,
   BulkResultSection,
   type BulkPhase,
   type BulkProgress,
@@ -200,13 +201,6 @@ export function BulkAutogradeStateModal({
   }
 
   const busy = phase === "working"
-  const pct = useMemo(
-    () =>
-      progress.total > 0
-        ? Math.round((progress.processed / progress.total) * 100)
-        : 0,
-    [progress],
-  )
 
   return (
     <Modal
@@ -235,26 +229,18 @@ export function BulkAutogradeStateModal({
         </ModalIcon>
       }
       footer={
-        phase === "complete" || phase === "error" ? (
-          <Button variant="primary" onClick={() => onClose()}>
-            {t("common.done")}
-          </Button>
-        ) : (
-          <>
-            <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
-              {t("common.cancel")}
-            </Button>
-            {phase === "idle" && total > 0 && (
-              <Button variant="primary" onClick={() => void run()}>
-                {t(
-                  isPause
-                    ? "submissions.bulkAutograde.pauseApply"
-                    : "submissions.bulkAutograde.resumeApply",
-                )}
-              </Button>
-            )}
-          </>
-        )
+        <BulkPhaseFooter
+          phase={phase}
+          busy={busy}
+          showApply={total > 0}
+          applyLabel={t(
+            isPause
+              ? "submissions.bulkAutograde.pauseApply"
+              : "submissions.bulkAutograde.resumeApply",
+          )}
+          onApply={() => void run()}
+          onClose={onClose}
+        />
       }
     >
       {phase === "idle" && (
@@ -277,20 +263,14 @@ export function BulkAutogradeStateModal({
       )}
 
       {busy && (
-        <div className="mt-6 flex flex-col items-center gap-3 py-6">
-          <Spinner label={t("submissions.bulkAutograde.working")} />
-          <progress
-            className="progress progress-primary w-full"
-            value={pct}
-            max={100}
-          />
-          <p className="text-sm text-base-content/70">
-            {t("submissions.bulkAutograde.progress", {
-              processed: progress.processed,
-              total: progress.total,
-            })}
-          </p>
-        </div>
+        <BulkProgressBlock
+          workingLabel={t("submissions.bulkAutograde.working")}
+          progress={progress}
+          caption={t("submissions.bulkAutograde.progress", {
+            processed: progress.processed,
+            total: progress.total,
+          })}
+        />
       )}
 
       {(phase === "complete" || phase === "error") && result && (

--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ShieldCheckIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, ModalIcon, Select } from "@/components/ui"
-import { Spinner } from "@/components/Spinner"
+import { Alert, Modal, ModalIcon, Select } from "@/components/ui"
 import {
+  BulkPhaseFooter,
+  BulkProgressBlock,
   BulkResultSection,
   type BulkPhase,
   type BulkProgress,
@@ -166,13 +167,6 @@ export function BulkRepoAccessModal({
   }
 
   const busy = phase === "working"
-  const pct = useMemo(
-    () =>
-      progress.total > 0
-        ? Math.round((progress.processed / progress.total) * 100)
-        : 0,
-    [progress],
-  )
 
   return (
     <Modal
@@ -188,22 +182,14 @@ export function BulkRepoAccessModal({
         </ModalIcon>
       }
       footer={
-        phase === "complete" || phase === "error" ? (
-          <Button variant="primary" onClick={() => onClose()}>
-            {t("common.done")}
-          </Button>
-        ) : (
-          <>
-            <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
-              {t("common.cancel")}
-            </Button>
-            {phase === "idle" && total > 0 && (
-              <Button variant="primary" onClick={() => void run()}>
-                {t("submissions.bulkAccess.apply")}
-              </Button>
-            )}
-          </>
-        )
+        <BulkPhaseFooter
+          phase={phase}
+          busy={busy}
+          showApply={total > 0}
+          applyLabel={t("submissions.bulkAccess.apply")}
+          onApply={() => void run()}
+          onClose={onClose}
+        />
       }
     >
       {phase === "idle" && (
@@ -244,24 +230,19 @@ export function BulkRepoAccessModal({
       )}
 
       {busy && (
-        <div className="mt-6 flex flex-col items-center gap-3 py-6">
-          <Spinner label={t("submissions.bulkAccess.working")} />
-          <progress
-            className="progress progress-primary w-full"
-            // Indeterminate until the first repo completes, so a slow write
-            // animates instead of sitting at 0%.
-            {...(progress.processed > 0 ? { value: pct } : {})}
-            max={100}
-          />
-          <p className="text-sm text-base-content/70">
-            {progress.processed > 0
+        <BulkProgressBlock
+          workingLabel={t("submissions.bulkAccess.working")}
+          indeterminateUntilFirst
+          progress={progress}
+          caption={
+            progress.processed > 0
               ? t("submissions.bulkAccess.progress", {
                   processed: progress.processed,
                   total: progress.total,
                 })
-              : t("submissions.bulkAccess.working")}
-          </p>
-        </div>
+              : t("submissions.bulkAccess.working")
+          }
+        />
       )}
 
       {(phase === "complete" || phase === "error") && result && (

--- a/web/src/components/modals/BulkRepoFeaturesModal.tsx
+++ b/web/src/components/modals/BulkRepoFeaturesModal.tsx
@@ -3,9 +3,10 @@ import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { SlidersIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, ModalIcon, Select } from "@/components/ui"
-import { Spinner } from "@/components/Spinner"
+import { Alert, Modal, ModalIcon, Select } from "@/components/ui"
 import {
+  BulkPhaseFooter,
+  BulkProgressBlock,
   BulkResultSection,
   type BulkPhase,
   type BulkProgress,
@@ -228,13 +229,6 @@ export function BulkRepoFeaturesModal({
   }
 
   const busy = phase === "working"
-  const pct = useMemo(
-    () =>
-      progress.total > 0
-        ? Math.round((progress.processed / progress.total) * 100)
-        : 0,
-    [progress],
-  )
 
   return (
     <Modal
@@ -250,26 +244,15 @@ export function BulkRepoFeaturesModal({
         </ModalIcon>
       }
       footer={
-        phase === "complete" || phase === "error" ? (
-          <Button variant="primary" onClick={() => onClose()}>
-            {t("common.done")}
-          </Button>
-        ) : (
-          <>
-            <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
-              {t("common.cancel")}
-            </Button>
-            {phase === "idle" && total > 0 && (
-              <Button
-                variant="primary"
-                disabled={nothingSelected}
-                onClick={() => void run()}
-              >
-                {t("submissions.bulkFeatures.apply")}
-              </Button>
-            )}
-          </>
-        )
+        <BulkPhaseFooter
+          phase={phase}
+          busy={busy}
+          showApply={total > 0}
+          applyDisabled={nothingSelected}
+          applyLabel={t("submissions.bulkFeatures.apply")}
+          onApply={() => void run()}
+          onClose={onClose}
+        />
       }
     >
       {phase === "idle" && (
@@ -318,20 +301,14 @@ export function BulkRepoFeaturesModal({
       )}
 
       {busy && (
-        <div className="mt-6 flex flex-col items-center gap-3 py-6">
-          <Spinner label={t("submissions.bulkFeatures.working")} />
-          <progress
-            className="progress progress-primary w-full"
-            value={pct}
-            max={100}
-          />
-          <p className="text-sm text-base-content/70">
-            {t("submissions.bulkFeatures.progress", {
-              processed: progress.processed,
-              total: progress.total,
-            })}
-          </p>
-        </div>
+        <BulkProgressBlock
+          workingLabel={t("submissions.bulkFeatures.working")}
+          progress={progress}
+          caption={t("submissions.bulkFeatures.progress", {
+            processed: progress.processed,
+            total: progress.total,
+          })}
+        />
       )}
 
       {(phase === "complete" || phase === "error") && result && (

--- a/web/src/components/modals/BulkSubmissionTriggerModal.tsx
+++ b/web/src/components/modals/BulkSubmissionTriggerModal.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { GitBranchIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
-import { Spinner } from "@/components/Spinner"
+import { Alert, Modal, ModalIcon } from "@/components/ui"
 import {
+  BulkPhaseFooter,
+  BulkProgressBlock,
   BulkResultSection,
   type BulkPhase,
   type BulkProgress,
@@ -236,13 +237,6 @@ export function BulkSubmissionTriggerModal({
   }
 
   const busy = phase === "working"
-  const pct = useMemo(
-    () =>
-      progress.total > 0
-        ? Math.round((progress.processed / progress.total) * 100)
-        : 0,
-    [progress],
-  )
 
   return (
     <Modal
@@ -261,22 +255,14 @@ export function BulkSubmissionTriggerModal({
         </ModalIcon>
       }
       footer={
-        phase === "complete" || phase === "error" ? (
-          <Button variant="primary" onClick={() => onClose()}>
-            {t("common.done")}
-          </Button>
-        ) : (
-          <>
-            <Button variant="ghost" disabled={busy} onClick={() => onClose()}>
-              {t("common.cancel")}
-            </Button>
-            {phase === "idle" && total > 0 && (
-              <Button variant="primary" onClick={() => void run()}>
-                {t("submissions.bulkTrigger.apply")}
-              </Button>
-            )}
-          </>
-        )
+        <BulkPhaseFooter
+          phase={phase}
+          busy={busy}
+          showApply={total > 0}
+          applyLabel={t("submissions.bulkTrigger.apply")}
+          onApply={() => void run()}
+          onClose={onClose}
+        />
       }
     >
       {phase === "idle" && (
@@ -294,20 +280,14 @@ export function BulkSubmissionTriggerModal({
       )}
 
       {busy && (
-        <div className="mt-6 flex flex-col items-center gap-3 py-6">
-          <Spinner label={t("submissions.bulkTrigger.working")} />
-          <progress
-            className="progress progress-primary w-full"
-            value={pct}
-            max={100}
-          />
-          <p className="text-sm text-base-content/70">
-            {t("submissions.bulkTrigger.progress", {
-              processed: progress.processed,
-              total: progress.total,
-            })}
-          </p>
-        </div>
+        <BulkProgressBlock
+          workingLabel={t("submissions.bulkTrigger.working")}
+          progress={progress}
+          caption={t("submissions.bulkTrigger.progress", {
+            processed: progress.processed,
+            total: progress.total,
+          })}
+        />
       )}
 
       {(phase === "complete" || phase === "error") && result && (

--- a/web/src/components/modals/CloseSubmissionModal.tsx
+++ b/web/src/components/modals/CloseSubmissionModal.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { CalendarIcon } from "@/components/ui/icons"
 
 import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
-import { Spinner } from "@/components/Spinner"
 import {
+  BulkProgressBlock,
   BulkResultSection,
   type BulkPhase,
   type BulkProgress,
@@ -204,13 +204,6 @@ export function CloseSubmissionModal({
   }
 
   const busy = phase === "working"
-  const pct = useMemo(
-    () =>
-      progress.total > 0
-        ? Math.round((progress.processed / progress.total) * 100)
-        : 0,
-    [progress],
-  )
 
   return (
     <Modal
@@ -292,25 +285,19 @@ export function CloseSubmissionModal({
       )}
 
       {busy && (
-        <div className="mt-6 flex flex-col items-center gap-3 py-6">
-          <Spinner label={t("submissions.closeSubmission.working")} />
-          <progress
-            className="progress progress-primary w-full"
-            // Omit `value` until the first repo completes so the bar animates
-            // as an indeterminate track instead of sitting at 0% while a slow
-            // write is in flight; once something lands it reflects real pct.
-            {...(progress.processed > 0 ? { value: pct } : {})}
-            max={100}
-          />
-          <p className="text-sm text-base-content/70">
-            {progress.processed > 0
+        <BulkProgressBlock
+          workingLabel={t("submissions.closeSubmission.working")}
+          indeterminateUntilFirst
+          progress={progress}
+          caption={
+            progress.processed > 0
               ? t("submissions.closeSubmission.progress", {
                   processed: progress.processed,
                   total: progress.total,
                 })
-              : t("submissions.closeSubmission.working")}
-          </p>
-        </div>
+              : t("submissions.closeSubmission.working")
+          }
+        />
       )}
 
       {phase === "error" && flagError && (

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -358,19 +358,6 @@ export function GroupCollaboratorsModal({
       closeDisabled={isSaving}
       size="xl"
       title={assignmentName || t("components.modals.groupCollaborators.title")}
-      subtitle={
-        repoName ? (
-          <a
-            className="link inline-flex items-center gap-1.5"
-            href={repoUrl || `https://github.com/${org}/${repoName}`}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <MarkGithubIcon aria-hidden="true" className="size-4" />
-            {t("components.modals.groupCollaborators.viewRepository")}
-          </a>
-        ) : undefined
-      }
       headerVisual={
         <ModalIcon>
           <PeopleIcon className="size-4" aria-hidden="true" />
@@ -412,6 +399,19 @@ export function GroupCollaboratorsModal({
         </>
       }
     >
+      {/* In the body, not the `subtitle` slot: an interactive link as the
+          dialog's aria-describedby reads poorly for AT users. */}
+      {repoName && (
+        <a
+          className="link mt-3 inline-flex w-fit items-center gap-1.5 text-sm"
+          href={repoUrl || `https://github.com/${org}/${repoName}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <MarkGithubIcon aria-hidden="true" className="size-4" />
+          {t("components.modals.groupCollaborators.viewRepository")}
+        </a>
+      )}
       {loadingCollaborators ? (
         <div className="flex py-10">
           <Spinner

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/icons"
 
 import { Spinner } from "@/components/Spinner"
+import { ViewRepositoryLink } from "@/components/modals/ViewRepositoryLink"
 import {
   Alert,
   AnimatedAlert,
@@ -399,18 +400,12 @@ export function GroupCollaboratorsModal({
         </>
       }
     >
-      {/* In the body, not the `subtitle` slot: an interactive link as the
-          dialog's aria-describedby reads poorly for AT users. */}
       {repoName && (
-        <a
-          className="link mt-3 inline-flex w-fit items-center gap-1.5 text-sm"
+        <ViewRepositoryLink
           href={repoUrl || `https://github.com/${org}/${repoName}`}
-          target="_blank"
-          rel="noreferrer"
         >
-          <MarkGithubIcon aria-hidden="true" className="size-4" />
           {t("components.modals.groupCollaborators.viewRepository")}
-        </a>
+        </ViewRepositoryLink>
       )}
       {loadingCollaborators ? (
         <div className="flex py-10">

--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/icons"
 
 import { Spinner } from "@/components/Spinner"
+import { ViewRepositoryLink } from "@/components/modals/ViewRepositoryLink"
 import {
   Alert,
   AnimatedAlert,
@@ -427,22 +428,16 @@ export function RepoAccessModal({
         </>
       }
     >
-      {/* In the body, not the `subtitle` slot: an interactive link as the
-          dialog's aria-describedby reads poorly for AT users. */}
       {repoName && (
-        <a
-          className="link mt-3 inline-flex w-fit items-center gap-1.5 text-sm"
+        <ViewRepositoryLink
           href={repoUrl || `https://github.com/${org}/${repoName}`}
-          target="_blank"
-          rel="noreferrer"
         >
-          <MarkGithubIcon aria-hidden="true" className="size-4" />
           {assignmentName
             ? t("components.modals.repoAccess.viewRepoNamed", {
                 name: assignmentName,
               })
             : t("components.modals.groupCollaborators.viewRepository")}
-        </a>
+        </ViewRepositoryLink>
       )}
       {loadingCollaborators ? (
         <div className="flex py-10">

--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -394,23 +394,6 @@ export function RepoAccessModal({
       closeDisabled={isSaving}
       size="xl"
       title={t("components.modals.repoAccess.title")}
-      subtitle={
-        repoName ? (
-          <a
-            className="link inline-flex items-center gap-1.5"
-            href={repoUrl || `https://github.com/${org}/${repoName}`}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <MarkGithubIcon aria-hidden="true" className="size-4" />
-            {assignmentName
-              ? t("components.modals.repoAccess.viewRepoNamed", {
-                  name: assignmentName,
-                })
-              : t("components.modals.groupCollaborators.viewRepository")}
-          </a>
-        ) : undefined
-      }
       headerVisual={
         <ModalIcon>
           <ShieldCheckIcon className="size-4" aria-hidden="true" />
@@ -444,6 +427,23 @@ export function RepoAccessModal({
         </>
       }
     >
+      {/* In the body, not the `subtitle` slot: an interactive link as the
+          dialog's aria-describedby reads poorly for AT users. */}
+      {repoName && (
+        <a
+          className="link mt-3 inline-flex w-fit items-center gap-1.5 text-sm"
+          href={repoUrl || `https://github.com/${org}/${repoName}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <MarkGithubIcon aria-hidden="true" className="size-4" />
+          {assignmentName
+            ? t("components.modals.repoAccess.viewRepoNamed", {
+                name: assignmentName,
+              })
+            : t("components.modals.groupCollaborators.viewRepository")}
+        </a>
+      )}
       {loadingCollaborators ? (
         <div className="flex py-10">
           <Spinner

--- a/web/src/components/modals/ViewRepositoryLink.tsx
+++ b/web/src/components/modals/ViewRepositoryLink.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react"
+
+import { MarkGithubIcon } from "@/components/ui/icons"
+
+/**
+ * The "view repository" link modals render at the top of the body — not in the
+ * Modal `subtitle` slot, because an interactive link as the dialog's
+ * aria-describedby reads poorly for AT users.
+ */
+export function ViewRepositoryLink({
+  href,
+  children,
+}: {
+  href: string
+  children: ReactNode
+}) {
+  return (
+    <a
+      className="link mt-3 inline-flex w-fit items-center gap-1.5 text-sm"
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+    >
+      <MarkGithubIcon aria-hidden="true" className="size-4" />
+      {children}
+    </a>
+  )
+}

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -29,6 +29,8 @@ type ConfirmModalProps = {
 // Primer-style ConfirmationDialog built on the shared Modal primitive
 // (role="alertdialog", exactly two footer buttons: ghost Cancel left,
 // error/warning/primary confirm right).
+// `onClose` must be idempotent: a successful confirm and the dialog's native
+// close event both fire it.
 export function ConfirmModal({
   open,
   title,

--- a/web/src/components/ui/Modal.test.tsx
+++ b/web/src/components/ui/Modal.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, afterEach, vi, beforeAll } from "vitest"
 import { render, screen, cleanup } from "@testing-library/react"
 import { createRef } from "react"
 
-import { Modal } from "./Modal"
+import { Modal, ModalFooterPortal } from "./Modal"
 
 // happy-dom doesn't implement <dialog> showModal/close; stub them so the
 // open-sync effect can run without throwing.
@@ -233,6 +233,47 @@ describe("Modal", () => {
     const action = container.querySelector(".modal-action")
     expect(action).not.toBeNull()
     expect(action?.textContent).toContain("Save")
+  })
+
+  it("portals body-owned buttons into the same footer row", () => {
+    const { container } = render(
+      <Modal open title="t">
+        <p>step body</p>
+        <ModalFooterPortal>
+          <button type="button">Apply</button>
+        </ModalFooterPortal>
+      </Modal>,
+    )
+    const action = container.querySelector(".modal-action")
+    expect(action?.textContent).toContain("Apply")
+    // The portal moved the button out of the body flow into the footer row.
+    expect(screen.getByText("Apply").parentElement).toBe(action)
+  })
+
+  it("composes the footer prop with portal content in one row", () => {
+    const { container } = render(
+      <Modal open title="t" footer={<button type="button">Close</button>}>
+        <ModalFooterPortal>
+          <button type="button">Apply</button>
+        </ModalFooterPortal>
+      </Modal>,
+    )
+    const actions = container.querySelectorAll(".modal-action")
+    expect(actions).toHaveLength(1)
+    expect(actions[0].textContent).toContain("Close")
+    expect(actions[0].textContent).toContain("Apply")
+  })
+
+  it("keeps the empty footer row hidden when neither prop nor portal fills it", () => {
+    const { container } = render(
+      <Modal open title="t">
+        body
+      </Modal>,
+    )
+    const action = container.querySelector(".modal-action") as HTMLElement
+    expect(action.childNodes).toHaveLength(0)
+    // empty:hidden removes the row (and its top margin) from layout.
+    expect(action.className).toContain("empty:hidden")
   })
 
   it("passes role through for confirmation dialogs", () => {

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -1,12 +1,16 @@
 import { XIcon } from "./icons"
 import {
+  createContext,
+  useContext,
   useEffect,
   useId,
   useRef,
+  useState,
   type ReactNode,
   type Ref,
   type RefObject,
 } from "react"
+import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "./Button"
@@ -28,11 +32,18 @@ import { Heading } from "./Heading"
 // modal-box itself scrolls), and a right-aligned `footer` action row. Passing
 // `title` wires aria-labelledby automatically; `subtitle` wires
 // aria-describedby. Prefer these slots over hand-rolling a header/footer.
+// Body content whose buttons are wired to state the `footer` prop can't reach
+// (a form instance, a phase-local handler) renders them through
+// <ModalFooterPortal> into the same canonical row instead.
 //
 // Close-animation invariant: the dialog keeps painting through its ~200ms
 // fade-out, so callers must not mutate content at close — reset transient
 // state when OPENING, retain cleared row data through the fade, and gate
 // open-only content with useLingeringOpen.
+
+// The footer container element, provided per Modal instance so
+// ModalFooterPortal can target the canonical action row.
+const ModalFooterContext = createContext<HTMLDivElement | null>(null)
 
 export type ModalSize =
   "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "5xl"
@@ -110,6 +121,9 @@ export function Modal({
   const closeId = useId()
   const titleId = useId()
   const subtitleId = useId()
+  // The footer container as state (not a ref) so ModalFooterPortal consumers
+  // re-render once the element exists.
+  const [footerEl, setFooterEl] = useState<HTMLDivElement | null>(null)
 
   const labelledBy =
     aria["aria-labelledby"] ?? (title !== undefined ? titleId : undefined)
@@ -197,8 +211,15 @@ export function Modal({
             </div>
           </div>
         )}
-        {children}
-        {footer !== undefined && <div className="modal-action">{footer}</div>}
+        <ModalFooterContext.Provider value={footerEl}>
+          {children}
+        </ModalFooterContext.Provider>
+        {/* Always mounted so ModalFooterPortal can target it; empty:hidden
+            keeps the row (and its top margin) from painting when neither the
+            prop nor a portal fills it. */}
+        <div ref={setFooterEl} className="modal-action empty:hidden">
+          {footer}
+        </div>
       </div>
 
       {/* DaisyUI's click-outside-to-close backdrop. The button is a mouse
@@ -215,6 +236,15 @@ export function Modal({
 }
 
 export default Modal
+
+// Renders body-owned action buttons into the Modal's canonical footer row.
+// For content whose buttons need state the `footer` prop can't reach (a form
+// instance, a phase-local handler); renders nothing outside a Modal.
+export function ModalFooterPortal({ children }: { children: ReactNode }) {
+  const container = useContext(ModalFooterContext)
+  if (!container) return null
+  return createPortal(children, container)
+}
 
 // Single source for the header icon chip used as `headerVisual` — callers must
 // not hand-roll the size/tone recipe.

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -38,7 +38,7 @@ export type { HelpTooltipPosition } from "./FormField"
 export { Heading, headingVariantClass } from "./Heading"
 export type { HeadingProps, HeadingVariant } from "./Heading"
 
-export { Modal, ModalIcon } from "./Modal"
+export { Modal, ModalIcon, ModalFooterPortal } from "./Modal"
 export type { ModalProps, ModalSize, ModalIconTone } from "./Modal"
 
 export { DropdownMenu } from "./DropdownMenu"

--- a/web/src/hooks/useDeferredRun.test.ts
+++ b/web/src/hooks/useDeferredRun.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest"
+import { renderHook, act, cleanup } from "@testing-library/react"
+
+import { useDeferredRun } from "./useDeferredRun"
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe("useDeferredRun", () => {
+  it("runs the callback on the next macrotask, not synchronously", () => {
+    const { result } = renderHook(() => useDeferredRun())
+    const fn = vi.fn()
+
+    act(() => result.current(fn))
+    expect(fn).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("replaces a still-pending handoff instead of firing both", () => {
+    const { result } = renderHook(() => useDeferredRun())
+    const first = vi.fn()
+    const second = vi.fn()
+
+    act(() => {
+      result.current(first)
+      result.current(second)
+    })
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
+  it("cancels the pending handoff on unmount", () => {
+    const { result, unmount } = renderHook(() => useDeferredRun())
+    const fn = vi.fn()
+
+    act(() => result.current(fn))
+    unmount()
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(fn).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("allows a second handoff after the first has fired", () => {
+    const { result } = renderHook(() => useDeferredRun())
+    const fn = vi.fn()
+
+    act(() => result.current(fn))
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+    act(() => result.current(fn))
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/web/src/hooks/useDeferredRun.ts
+++ b/web/src/hooks/useDeferredRun.ts
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useRef } from "react"
+
+/**
+ * Defers a callback by one macrotask — the confirm-close -> run handoff, so
+ * the next dialog doesn't stack over the still-closing confirm. At most one
+ * handoff is pending: scheduling again cancels the previous timer, and an
+ * unmount cancels whatever is pending so a stray fan-out can't fire.
+ */
+export function useDeferredRun(): (fn: () => void | Promise<void>) => void {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    },
+    [],
+  )
+
+  return useCallback((fn: () => void | Promise<void>) => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      void fn()
+    }, 0)
+  }, [])
+}

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react"
+import { useEffect, useId, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { PlusIcon, XIcon } from "@/components/ui/icons"
 
@@ -207,6 +207,20 @@ const BulkActionsBar = ({
   // (close-animation note in ui/Modal); each run resets them anyway.
   const [isOpen, setModalOpen] = useState(false)
 
+  // The confirm-close -> run handoff defers one macrotask so the progress
+  // dialog doesn't stack over the still-closing confirm; tracked so an unmount
+  // can't fire a stray fan-out.
+  const runTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(
+    () => () => {
+      if (runTimerRef.current) clearTimeout(runTimerRef.current)
+    },
+    [],
+  )
+  const deferRun = (which: "add" | "remove") => {
+    runTimerRef.current = setTimeout(() => void run(which), 0)
+  }
+
   const closeModal = () => {
     if (phase === "working") return
     setModalOpen(false)
@@ -386,7 +400,7 @@ const BulkActionsBar = ({
           // the progress dialog doesn't stack its box and backdrop over the
           // still-closing confirm. Not awaited — run() drives its own dialog.
           setConfirmingRemove(false)
-          setTimeout(() => void run("remove"), 0)
+          deferRun("remove")
         }}
         onClose={() => setConfirmingRemove(false)}
       />
@@ -406,7 +420,7 @@ const BulkActionsBar = ({
         confirmLabel={t("orgMembers.bulk.add")}
         onConfirm={async () => {
           setConfirmingAdd(false)
-          setTimeout(() => void run("add"), 0)
+          deferRun("add")
         }}
         onClose={() => setConfirmingAdd(false)}
       />

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from "react"
+import { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { PlusIcon, XIcon } from "@/components/ui/icons"
 
@@ -16,6 +16,7 @@ import {
   type BulkRemoveFromClassroomResult,
 } from "@/domain/orgMembers/bulkRemoveFromClassroom"
 import { ConfirmModal } from "@/components/modals"
+import { useDeferredRun } from "@/hooks/useDeferredRun"
 import { logger } from "@/lib/logger"
 import {
   BulkResultSection,
@@ -207,19 +208,7 @@ const BulkActionsBar = ({
   // (close-animation note in ui/Modal); each run resets them anyway.
   const [isOpen, setModalOpen] = useState(false)
 
-  // The confirm-close -> run handoff defers one macrotask so the progress
-  // dialog doesn't stack over the still-closing confirm; tracked so an unmount
-  // can't fire a stray fan-out.
-  const runTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(
-    () => () => {
-      if (runTimerRef.current) clearTimeout(runTimerRef.current)
-    },
-    [],
-  )
-  const deferRun = (which: "add" | "remove") => {
-    runTimerRef.current = setTimeout(() => void run(which), 0)
-  }
+  const deferRun = useDeferredRun()
 
   const closeModal = () => {
     if (phase === "working") return
@@ -400,7 +389,7 @@ const BulkActionsBar = ({
           // the progress dialog doesn't stack its box and backdrop over the
           // still-closing confirm. Not awaited — run() drives its own dialog.
           setConfirmingRemove(false)
-          deferRun("remove")
+          deferRun(() => run("remove"))
         }}
         onClose={() => setConfirmingRemove(false)}
       />
@@ -420,7 +409,7 @@ const BulkActionsBar = ({
         confirmLabel={t("orgMembers.bulk.add")}
         onConfirm={async () => {
           setConfirmingAdd(false)
-          deferRun("add")
+          deferRun(() => run("add"))
         }}
         onClose={() => setConfirmingAdd(false)}
       />

--- a/web/src/pages/students/EditStudentForm.test.tsx
+++ b/web/src/pages/students/EditStudentForm.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest"
 import {
   render,
   screen,
@@ -10,6 +10,18 @@ import {
 import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { ReactElement } from "react"
+
+// happy-dom doesn't implement <dialog> showModal/close; stub them so the host
+// Modal can open (a closed dialog hides its content from role queries).
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function () {
+    this.open = true
+  }
+  HTMLDialogElement.prototype.close = function () {
+    this.open = false
+    this.dispatchEvent(new Event("close"))
+  }
+})
 
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
@@ -30,6 +42,7 @@ vi.mock("@/domain/students", () => ({
 }))
 
 import EditStudentForm from "./EditStudentForm"
+import { Modal } from "@/components/ui"
 import type { Student } from "@/types/classroom"
 
 afterEach(() => {
@@ -47,9 +60,15 @@ const student: Student = {
   role: "student",
 }
 
+// Host the form inside an OPEN Modal so its ModalFooterPortal buttons mount
+// into the footer row and stay visible to role queries, like in the app.
 const renderForm = (ui: ReactElement) =>
   render(
-    <QueryClientProvider client={new QueryClient()}>{ui}</QueryClientProvider>,
+    <QueryClientProvider client={new QueryClient()}>
+      <Modal open aria-label="host">
+        {ui}
+      </Modal>
+    </QueryClientProvider>,
   )
 
 // #: a successful save unmounts the form (parent leaves edit mode) while
@@ -172,7 +191,9 @@ describe("EditStudentForm in-flight Save button", () => {
     const client = new QueryClient()
     const { rerender } = render(
       <QueryClientProvider client={client}>
-        <EditStudentForm {...props} student={{ ...student }} />
+        <Modal open aria-label="host">
+          <EditStudentForm {...props} student={{ ...student }} />
+        </Modal>
       </QueryClientProvider>,
     )
 
@@ -187,7 +208,9 @@ describe("EditStudentForm in-flight Save button", () => {
     // modal does on every render. The button must stay disabled.
     rerender(
       <QueryClientProvider client={client}>
-        <EditStudentForm {...props} student={{ ...student }} />
+        <Modal open aria-label="host">
+          <EditStudentForm {...props} student={{ ...student }} />
+        </Modal>
       </QueryClientProvider>,
     )
     expect(button.disabled).toBe(true)

--- a/web/src/pages/students/EditStudentForm.tsx
+++ b/web/src/pages/students/EditStudentForm.tsx
@@ -1,6 +1,6 @@
 import { MarkGithubIcon } from "@/components/ui/icons"
 import { revalidateLogic, useForm } from "@tanstack/react-form"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useId, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { useUpdateStudent } from "@/hooks/mutations/useUpdateStudent"
 import { getErrorMessage } from "@/github-core/errorMessage"
@@ -14,6 +14,7 @@ import {
   AnimatedAlert,
   Button,
   Input,
+  ModalFooterPortal,
   MonoLtr,
 } from "@/components/ui"
 
@@ -60,6 +61,8 @@ const EditStudentForm = ({
   lockEmail?: boolean
 }) => {
   const runSave = useSafeSubmit()
+  // Ties the portaled footer submit button to this form element.
+  const formId = useId()
   const { t } = useTranslation()
   const [error, setError] = useState<string | null>(null)
 
@@ -151,6 +154,7 @@ const EditStudentForm = ({
 
   return (
     <form
+      id={formId}
       onSubmit={(e) => {
         e.preventDefault()
         e.stopPropagation()
@@ -274,7 +278,9 @@ const EditStudentForm = ({
         {error}
       </AnimatedAlert>
 
-      <div className="modal-action">
+      {/* The buttons render in the host modal's footer row; `form={formId}`
+          keeps the portaled submit wired to this form element. */}
+      <ModalFooterPortal>
         <Button
           type="button"
           variant="ghost"
@@ -289,6 +295,7 @@ const EditStudentForm = ({
           {([canSubmit, isSubmitting]) => (
             <Button
               type="submit"
+              form={formId}
               variant="primary"
               loading={isSubmitting}
               loadingLabel={t("students.saving")}
@@ -298,7 +305,7 @@ const EditStudentForm = ({
             </Button>
           )}
         </form.Subscribe>
-      </div>
+      </ModalFooterPortal>
     </form>
   )
 }

--- a/web/src/pages/students/ImportProblemsReport.test.tsx
+++ b/web/src/pages/students/ImportProblemsReport.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, afterEach, vi } from "vitest"
+import { describe, expect, it, afterEach } from "vitest"
 import { render, screen, cleanup } from "@testing-library/react"
 import { I18nextProvider } from "react-i18next"
 import i18n from "i18next"
@@ -8,6 +8,7 @@ import en from "@/locales/en.json"
 import {
   ImportBlockedReport,
   ImportSkippedReport,
+  onlyTransientBlockers,
 } from "./ImportProblemsReport"
 import { classifyImportProblems } from "./importProblems"
 
@@ -26,11 +27,7 @@ await i18n.use(initReactI18next).init({
 const renderReport = (problems: ReturnType<typeof classifyImportProblems>) =>
   render(
     <I18nextProvider i18n={i18n}>
-      <ImportBlockedReport
-        problems={problems}
-        onRetry={() => {}}
-        onCancel={() => {}}
-      />
+      <ImportBlockedReport problems={problems} />
     </I18nextProvider>,
   )
 
@@ -102,35 +99,27 @@ describe("ImportBlockedReport", () => {
     expect(item.querySelector("strong")).toBeNull()
   })
 
-  it("offers a retry, not a file edit, when every blocker is transient", () => {
+  it("signals the transient-only case and drops the fix-the-file hint", () => {
     // The file is fine — GitHub could not be reached — so "fix these lines and
-    // upload again" would send the teacher to edit nothing.
-    const onRetry = vi.fn()
-    render(
-      <I18nextProvider i18n={i18n}>
-        <ImportBlockedReport
-          problems={classifyImportProblems(
-            [],
-            [{ line: 2, reason: "id-lookup-failed", githubId: "999" }],
-          )}
-          onRetry={onRetry}
-          onCancel={() => {}}
-        />
-      </I18nextProvider>,
+    // upload again" would send the teacher to edit nothing. The host modal's
+    // footer keys the retry action off onlyTransientBlockers.
+    const problems = classifyImportProblems(
+      [],
+      [{ line: 2, reason: "id-lookup-failed", githubId: "999" }],
     )
-    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy()
+    renderReport(problems)
+    expect(onlyTransientBlockers(problems)).toBe(true)
     expect(screen.queryByText(en.students.importBlockedHint)).toBeNull()
   })
 
   it("keeps the fix-the-file hint when a blocker is file content", () => {
-    renderReport(
-      classifyImportProblems(
-        [{ line: 2, reason: "bad-email", value: "n/a" }],
-        [{ line: 3, reason: "id-lookup-failed", githubId: "999" }],
-      ),
+    const problems = classifyImportProblems(
+      [{ line: 2, reason: "bad-email", value: "n/a" }],
+      [{ line: 3, reason: "id-lookup-failed", githubId: "999" }],
     )
+    renderReport(problems)
+    expect(onlyTransientBlockers(problems)).toBe(false)
     expect(screen.getByText(en.students.importBlockedHint)).toBeTruthy()
-    expect(screen.queryByRole("button", { name: "Check again" })).toBeNull()
   })
 })
 

--- a/web/src/pages/students/ImportProblemsReport.tsx
+++ b/web/src/pages/students/ImportProblemsReport.tsx
@@ -1,5 +1,5 @@
 import { Trans, useTranslation } from "react-i18next"
-import { Alert, Button, MonoLtr } from "@/components/ui"
+import { Alert, MonoLtr } from "@/components/ui"
 import type { ImportProblem } from "@/pages/students/importProblems"
 
 // The per-line list both report variants share. Each explanation is ONE
@@ -20,50 +20,43 @@ const ProblemList = ({ problems }: { problems: readonly ImportProblem[] }) => (
   </ul>
 )
 
+// A transient GitHub lookup failure blocks a file that is perfectly correct, so
+// "fix these lines and re-upload" would send the teacher to edit nothing. When
+// every blocker is that kind, the caller offers the retry that actually
+// resolves it instead. Shared with UploadRoster's footer.
+export const onlyTransientBlockers = (
+  problems: readonly ImportProblem[],
+): boolean => {
+  const blocking = problems.filter((p) => p.blocking)
+  return (
+    blocking.length > 0 &&
+    blocking.every((p) => p.key === "students.dropIdLookupFailed")
+  )
+}
+
 // The blocking report: shown INSTEAD of the preview when any row carries content we
 // couldn't use, so there is no table and no import button to press. Every problem is
 // listed, including the non-blocking ones, so one pass over the file fixes all.
+// The Cancel/retry actions live in the host modal's footer.
 export const ImportBlockedReport = ({
   problems,
-  onRetry,
-  onCancel,
 }: {
   problems: readonly ImportProblem[]
-  onRetry: () => void
-  onCancel: () => void
 }) => {
   const { t } = useTranslation()
   const blocking = problems.filter((p) => p.blocking)
-  // A transient GitHub lookup failure blocks a file that is perfectly correct, so
-  // "fix these lines and re-upload" would send the teacher to edit nothing. When
-  // every blocker is that kind, offer the retry that actually resolves it instead.
-  const onlyTransient =
-    blocking.length > 0 &&
-    blocking.every((p) => p.key === "students.dropIdLookupFailed")
   return (
-    <>
-      <Alert tone="error" className="mb-4">
-        <div className="flex flex-col gap-1">
-          <span className="font-medium">
-            {t("students.importBlocked", { count: blocking.length })}
-          </span>
-          <ProblemList problems={problems} />
-          {onlyTransient ? null : (
-            <span className="text-sm">{t("students.importBlockedHint")}</span>
-          )}
-        </div>
-      </Alert>
-      <div className="modal-action">
-        <Button variant="ghost" onClick={onCancel}>
-          {t("common.cancel")}
-        </Button>
-        {onlyTransient ? (
-          <Button variant="primary" onClick={onRetry}>
-            {t("students.importRetryLookup")}
-          </Button>
-        ) : null}
+    <Alert tone="error" className="mb-4">
+      <div className="flex flex-col gap-1">
+        <span className="font-medium">
+          {t("students.importBlocked", { count: blocking.length })}
+        </span>
+        <ProblemList problems={problems} />
+        {onlyTransientBlockers(problems) ? null : (
+          <span className="text-sm">{t("students.importBlockedHint")}</span>
+        )}
       </div>
-    </>
+    </Alert>
   )
 }
 

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   PaperAirplaneIcon,
@@ -171,6 +171,20 @@ const RosterBulkActionsBar = ({
   // Visibility is its own flag: closing must not reset phase/result/action
   // (close-animation note in ui/Modal); each run resets them anyway.
   const [isOpen, setModalOpen] = useState(false)
+
+  // The confirm-close -> run handoff defers one macrotask so the progress
+  // dialog doesn't stack over the still-closing confirm; tracked so an unmount
+  // can't fire a stray fan-out.
+  const runTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(
+    () => () => {
+      if (runTimerRef.current) clearTimeout(runTimerRef.current)
+    },
+    [],
+  )
+  const deferRun = (fn: () => Promise<void>) => {
+    runTimerRef.current = setTimeout(() => void fn(), 0)
+  }
 
   const closeModal = () => {
     if (phase === "working") return
@@ -537,7 +551,7 @@ const RosterBulkActionsBar = ({
         confirmLabel={t("students.bulk.unenroll")}
         onConfirm={async () => {
           setConfirmingUnenroll(false)
-          setTimeout(() => void runUnenroll(), 0)
+          deferRun(runUnenroll)
         }}
         onClose={() => setConfirmingUnenroll(false)}
       />
@@ -555,7 +569,7 @@ const RosterBulkActionsBar = ({
         confirmLabel={t("students.bulk.invite")}
         onConfirm={async () => {
           setConfirmingInvite(false)
-          setTimeout(() => void runInvite(), 0)
+          deferRun(runInvite)
         }}
         onClose={() => setConfirmingInvite(false)}
       />
@@ -573,7 +587,7 @@ const RosterBulkActionsBar = ({
         confirmLabel={t("students.bulk.cancelInvite")}
         onConfirm={async () => {
           setConfirmingCancel(false)
-          setTimeout(() => void runCancel(), 0)
+          deferRun(runCancel)
         }}
         onClose={() => setConfirmingCancel(false)}
       />

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   PaperAirplaneIcon,
@@ -9,6 +9,7 @@ import {
 
 import type { GitHubClient } from "@/github-core/client"
 import { ConfirmModal } from "@/components/modals"
+import { useDeferredRun } from "@/hooks/useDeferredRun"
 import { Alert, Button, Modal, Toolbar } from "@/components/ui"
 import { GitHubAPIError } from "@/github-core/errors"
 import { cancelOrgInvitation } from "@/github-core/mutations"
@@ -172,19 +173,7 @@ const RosterBulkActionsBar = ({
   // (close-animation note in ui/Modal); each run resets them anyway.
   const [isOpen, setModalOpen] = useState(false)
 
-  // The confirm-close -> run handoff defers one macrotask so the progress
-  // dialog doesn't stack over the still-closing confirm; tracked so an unmount
-  // can't fire a stray fan-out.
-  const runTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(
-    () => () => {
-      if (runTimerRef.current) clearTimeout(runTimerRef.current)
-    },
-    [],
-  )
-  const deferRun = (fn: () => Promise<void>) => {
-    runTimerRef.current = setTimeout(() => void fn(), 0)
-  }
+  const deferRun = useDeferredRun()
 
   const closeModal = () => {
     if (phase === "working") return

--- a/web/src/pages/students/RosterImportResult.tsx
+++ b/web/src/pages/students/RosterImportResult.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { Alert, Button } from "@/components/ui"
+import { Alert } from "@/components/ui"
 import { ROLE_LABEL_KEY } from "@/util/classroomRoleUI"
 import type {
   BulkImportResult,
@@ -104,7 +104,6 @@ export const RosterImportResult = ({
   roleChangeOutcome,
   emailResult = null,
   emailError = null,
-  onDone,
 }: {
   result: BulkImportResult
   inviteError: string | null
@@ -112,7 +111,6 @@ export const RosterImportResult = ({
   roleChangeOutcome: RoleChangeOutcome | null
   emailResult?: BulkInviteByEmailResult | null
   emailError?: string | null
-  onDone: () => void
 }) => {
   const { t } = useTranslation()
   const emailInvitedCount = emailResult?.invited.length ?? 0
@@ -251,12 +249,6 @@ export const RosterImportResult = ({
             <ImportResultSection key={section.title} {...section} />
           ))
         : null}
-
-      <div className="modal-action">
-        <Button variant="primary" onClick={onDone}>
-          {t("students.done")}
-        </Button>
-      </div>
     </div>
   )
 }

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -57,6 +57,7 @@ import { classifyImportProblems } from "./importProblems"
 import {
   ImportBlockedReport,
   ImportSkippedReport,
+  onlyTransientBlockers,
 } from "./ImportProblemsReport"
 
 // Preserve the module's original public surface: the pure parse helpers live in
@@ -693,7 +694,21 @@ const UploadRoster = ({
         title={t("students.uploadTitle")}
         subtitle={fileName ? t("students.fileLabel", { fileName }) : undefined}
         footer={
-          phase === "preview" && !blocked ? (
+          phase === "preview" && blocked ? (
+            <>
+              <Button variant="ghost" onClick={resetToDropZone}>
+                {t("common.cancel")}
+              </Button>
+              {onlyTransientBlockers(problems) && (
+                <Button
+                  variant="primary"
+                  onClick={() => applyKind(fileText, uploadKind)}
+                >
+                  {t("students.importRetryLookup")}
+                </Button>
+              )}
+            </>
+          ) : phase === "preview" ? (
             <>
               <Button variant="ghost" onClick={resetToDropZone}>
                 {t("common.cancel")}
@@ -706,6 +721,10 @@ const UploadRoster = ({
                 {rosterPrimaryLabel}
               </Button>
             </>
+          ) : phase === "complete" ? (
+            <Button variant="primary" onClick={handleClose}>
+              {t("students.done")}
+            </Button>
           ) : phase === "error" ? (
             <>
               <Button variant="ghost" onClick={handleClose}>
@@ -787,11 +806,7 @@ const UploadRoster = ({
         {/* Resolution still runs underneath a blocked file, so an unusable
             github_id joins the list rather than waiting for the next upload. */}
         {phase === "preview" && blocked && (
-          <ImportBlockedReport
-            problems={problems}
-            onRetry={() => applyKind(fileText, uploadKind)}
-            onCancel={resetToDropZone}
-          />
+          <ImportBlockedReport problems={problems} />
         )}
 
         {phase === "preview" && !blocked && (
@@ -964,7 +979,6 @@ const UploadRoster = ({
             roleChangeOutcome={roleChangeOutcome}
             emailResult={emailResult}
             emailError={emailError}
-            onDone={handleClose}
           />
         )}
 


### PR DESCRIPTION
## Summary

Follow-up to #752, finishing the modal work it started.

- Multi-step modal bodies can now put their action buttons in the canonical footer without lifting state: the shared `Modal` always renders its footer container (hidden when empty) and exposes it through a new `ModalFooterPortal`. `EditStudentForm`'s Cancel/Save render into `RosterMemberModal`'s footer with a form-id-wired submit, and `UploadRoster`'s blocked/complete phases move their actions into the host footer (`onlyTransientBlockers` exported to gate the retry) — clearing the last three in-body `modal-action` rows.
- The bulk-modal phase recipe has one source now: `BulkPhaseFooter` (complete/error -> primary Done, otherwise ghost Cancel plus idle Apply) and `BulkProgressBlock` (spinner + progress + caption, with indeterminate-until-first-item) replace the copies hand-synced across the five bulk modals. `CloseSubmissionModal` keeps its bespoke finish-closing footer by design but adopts the shared progress block.
- Modal hygiene: the confirm->run `setTimeout` handoffs in both bulk action bars live in a shared `useDeferredRun` hook that cancels a pending timer on re-schedule and on unmount (previously a stray fan-out could fire after unmount); the interactive "view repository" links move out of the `subtitle` slot into a shared `ViewRepositoryLink` in the body, so the dialogs' `aria-describedby` is plain text again; `ConfirmModal` documents its idempotent `onClose` contract.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 358 files / 4507 tests)
- [x] New unit tests: `ModalFooterPortal` (portaling, prop+portal composition, hidden-when-empty), `BulkPhaseFooter` phase -> button matrix, `useDeferredRun` (defer, replace-on-reschedule, unmount-cancel)
- [ ] Reviewer spot-check: one bulk modal end-to-end (idle -> working -> complete -> Done), roster member edit Save/Cancel from the footer, roster upload blocked/complete views, both themes
