### PR TITLE
feat: add autograder failure-details and show-output options

### DIFF
--- a/cli/gh-teacher/autograders_tests/test_declarative_grader.py
+++ b/cli/gh-teacher/autograders_tests/test_declarative_grader.py
@@ -125,15 +125,16 @@ class TestExecuteIO:
                 "expected": "one\ntwo", "comparison": "exact", "points": 1}
         o = ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
         assert not o["passed"]
-        assert "--- expected" in o["detail"]
-        assert "+++ actual stdout" in o["detail"]
-        assert "-two" in o["detail"] and "+nope" in o["detail"]
+        detail = ag.compose_detail(o)
+        assert "--- expected" in detail
+        assert "+++ actual stdout" in detail
+        assert "-two" in detail and "+nope" in detail
         # The matching line is context, not a change.
-        assert "-one" not in o["detail"] and "+one" not in o["detail"]
+        assert "-one" not in detail and "+one" not in detail
         # A non-empty diff replaces the verbatim blocks — never both (a
         # both-emitted regression would otherwise pass).
-        assert "--- expected (exact) ---" not in o["detail"]
-        assert "--- actual stdout ---" not in o["detail"]
+        assert "--- expected (exact) ---" not in detail
+        assert "--- actual stdout ---" not in detail
 
     def test_included_fail_keeps_expected_and_actual_blocks(self, tmp_path):
         # A line diff against a substring expectation is noise; included and
@@ -142,9 +143,10 @@ class TestExecuteIO:
                 "expected": "yes", "comparison": "included", "points": 1}
         o = ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
         assert not o["passed"]
-        assert "--- expected (included) ---" in o["detail"]
-        assert "--- actual stdout ---" in o["detail"]
-        assert "+++" not in o["detail"]
+        detail = ag.compose_detail(o)
+        assert "--- expected (included) ---" in detail
+        assert "--- actual stdout ---" in detail
+        assert "+++" not in detail
 
     def test_exact_fail_with_empty_diff_falls_back_to_blocks(self, tmp_path):
         # Separator characters splitlines() folds away (here \x0c) fail the
@@ -154,15 +156,17 @@ class TestExecuteIO:
                 "expected": "one\ntwo", "comparison": "exact", "points": 1}
         o = ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
         assert not o["passed"]
-        assert "--- expected (exact) ---" in o["detail"]
-        assert "--- actual stdout ---" in o["detail"]
+        detail = ag.compose_detail(o)
+        assert "--- expected (exact) ---" in detail
+        assert "--- actual stdout ---" in detail
 
     def test_fail_includes_stderr_block(self, tmp_path):
         spec = {"name": "t", "type": "io", "run": "echo warn >&2; echo nope",
                 "expected": "yes", "comparison": "exact", "points": 1}
         o = ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
         assert not o["passed"]
-        assert "--- stderr ---" in o["detail"] and "warn" in o["detail"]
+        detail = ag.compose_detail(o)
+        assert "--- stderr ---" in detail and "warn" in detail
 
     def test_invalid_regex_fails_with_message(self, tmp_path):
         spec = {"name": "t", "type": "io", "run": "echo x",
@@ -346,6 +350,9 @@ class TestLoadTests:
         {"name": "a", "type": "io", "run": "cat", "comparison": "exact", "expected": "x", "input": 5},
         {"name": "a", "type": "io", "run": "cat", "comparison": "exact", "expected": "x", "input-file": 123},
         {"name": "a", "type": "run", "run": "true", "points": 1, "setup": 123},
+        {"name": "a", "type": "run", "run": "true", "points": 1, "failure-details": "loud"},
+        {"name": "a", "type": "run", "run": "true", "points": 1, "failure-details": 3},
+        {"name": "a", "type": "run", "run": "true", "points": 1, "show-output": "yes"},
     ])
     def test_rejects_wrongly_typed_optional_fields(self, tmp_path, bad_field):
         # These fields aren't checked by the schema sentinel but are
@@ -354,6 +361,137 @@ class TestLoadTests:
         p = self._write(tmp_path, {"schema": "classroom50/tests/v1", "tests": [bad_field]})
         with pytest.raises(ag.TestsConfigError):
             ag.load_tests(p)
+
+    def test_defaults_fold_into_specs(self, tmp_path):
+        # The envelope's `defaults` supply assignment-level failure-details /
+        # show-output; a spec's own value (including an explicit false) wins.
+        p = self._write(tmp_path, {
+            "schema": "classroom50/tests/v1",
+            "defaults": {"failure-details": "none", "show-output": True},
+            "tests": [
+                {"name": "inherits", "type": "run", "run": "true", "points": 1},
+                {"name": "overrides", "type": "run", "run": "true", "points": 1,
+                 "failure-details": "full", "show-output": False},
+            ],
+        })
+        tests = ag.load_tests(p)
+        assert tests[0]["failure-details"] == "none"
+        assert tests[0]["show-output"] is True
+        assert tests[1]["failure-details"] == "full"
+        assert tests[1]["show-output"] is False
+
+    @pytest.mark.parametrize("bad_defaults", [
+        "none", ["none"], {"failure-details": "loud"}, {"show-output": "yes"},
+    ])
+    def test_bad_defaults_rejected(self, tmp_path, bad_defaults):
+        p = self._write(tmp_path, {
+            "schema": "classroom50/tests/v1",
+            "defaults": bad_defaults,
+            "tests": [{"name": "a", "type": "run", "run": "true", "points": 1}],
+        })
+        with pytest.raises(ag.TestsConfigError, match="defaults"):
+            ag.load_tests(p)
+
+
+# ---------------------------------------------------------------------------
+# compose_detail / compose_output (failure-details policy + per-surface limits)
+# ---------------------------------------------------------------------------
+
+
+class TestComposeDetail:
+    def _io_fail(self, tmp_path, level, comparison="exact"):
+        spec = {"name": "t", "type": "io", "run": "echo warn >&2; echo nope",
+                "expected": "one\ntwo", "comparison": comparison, "points": 1,
+                "failure-details": level}
+        return ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
+
+    def test_full_shows_expected_side(self, tmp_path):
+        detail = ag.compose_detail(self._io_fail(tmp_path, "full"))
+        assert "-two" in detail and "+nope" in detail  # the diff
+
+    def test_actual_only_hides_expected_and_diff(self, tmp_path):
+        # #765: neither the diff nor the expected block may reveal the answer,
+        # but the student's own stdout/stderr stay visible.
+        detail = ag.compose_detail(self._io_fail(tmp_path, "actual-only"))
+        assert "two" not in detail
+        assert "+++" not in detail and "--- expected" not in detail
+        assert "--- actual stdout ---" in detail and "nope" in detail
+        assert "--- stderr ---" in detail and "warn" in detail
+
+    def test_actual_only_included_comparison(self, tmp_path):
+        detail = ag.compose_detail(
+            self._io_fail(tmp_path, "actual-only", comparison="included"))
+        assert "--- expected" not in detail
+        assert "nope" in detail
+
+    def test_none_keeps_only_the_failure_kind(self, tmp_path):
+        detail = ag.compose_detail(self._io_fail(tmp_path, "none"))
+        assert detail == "exit 0; comparison=exact"
+
+    def test_none_hides_run_output(self, tmp_path):
+        spec = {"name": "t", "type": "run", "run": "echo secret >&2; false",
+                "points": 1, "failure-details": "none"}
+        o = ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
+        detail = ag.compose_detail(o)
+        assert detail == "exit 1 (wanted 0)" and "secret" not in detail
+
+    def test_none_hides_setup_output(self, tmp_path):
+        spec = {"name": "t", "type": "run", "setup": "echo secret >&2; false",
+                "run": "true", "points": 1, "failure-details": "none"}
+        o = ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
+        detail = ag.compose_detail(o)
+        assert detail == "setup exited 1" and "secret" not in detail
+
+    def test_actual_only_keeps_run_output(self, tmp_path):
+        # actual-only only redacts the expected side; a run test has none, so
+        # it matches full.
+        spec = {"name": "t", "type": "run", "run": "echo oops >&2; false",
+                "points": 1, "failure-details": "actual-only"}
+        o = ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
+        assert "oops" in ag.compose_detail(o)
+
+    def test_surface_limits_clip_independently(self, tmp_path):
+        # #612: the same outcome renders clipped for the release body but far
+        # roomier for the Actions log — clipping happens at render, not capture.
+        spec = {"name": "t", "type": "run",
+                "run": "python3 -c \"print('x' * 10000)\"; false",
+                "timeout": 60, "points": 1}
+        o = ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
+        body_detail = ag.compose_detail(o)
+        log_detail = ag.compose_detail(o, limit=ag.MAX_LOG_CAPTURED_CHARS)
+        assert "... (truncated)" in body_detail
+        assert len(body_detail) < 3000
+        assert "... (truncated)" not in log_detail
+        assert "x" * 10000 in log_detail
+
+
+class TestComposeOutput:
+    def test_labels_each_captured_stream(self, tmp_path):
+        spec = {"name": "t", "type": "run", "setup": "echo setup-out; echo setup-err >&2",
+                "run": "echo run-out; echo run-err >&2", "points": 1,
+                "show-output": True}
+        o = ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
+        assert o["passed"]
+        output = ag.compose_output(o)
+        assert "--- setup stdout ---\nsetup-out" in output
+        assert "--- setup stderr ---\nsetup-err" in output
+        assert "--- stdout ---\nrun-out" in output
+        assert "--- stderr ---\nrun-err" in output
+
+    def test_silent_pass_notes_no_output(self, tmp_path):
+        spec = {"name": "t", "type": "run", "run": "true", "points": 1,
+                "show-output": True}
+        o = ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
+        assert ag.compose_output(o) == "(no output captured)"
+
+    def test_passing_io_stdout_is_captured(self, tmp_path):
+        # #764's capture half: a passing test's output used to be discarded.
+        spec = {"name": "t", "type": "io", "run": "echo hello",
+                "expected": "hello", "comparison": "included", "points": 1,
+                "show-output": True}
+        o = ag.execute_test(spec, cwd=tmp_path, fixtures_dir=tmp_path)
+        assert o["passed"]
+        assert "hello" in ag.compose_output(o)
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +518,52 @@ class TestRenderDeclarativeBody:
         outcomes = [{"test-name": "a", "passed": True, "score": 1, "max-score": 1, "detail": ""}]
         body = ag.render_declarative_body(result, outcomes, "all good")
         assert "Failure details" not in body
+        assert "Test output" not in body
+
+    def test_show_output_adds_collapsed_output_section(self):
+        # #764: a passing show-output test gets its captured streams in a
+        # collapsed section; an ordinary passing test stays silent.
+        result = {"score": 2, "max-score": 2}
+        outcomes = [
+            {"test-name": "loud", "passed": True, "score": 1, "max-score": 1,
+             "detail": "", "show-output": True,
+             "capture": {"stdout": "dotnet 8.0.100\n"}},
+            {"test-name": "quiet", "passed": True, "score": 1, "max-score": 1,
+             "detail": "", "capture": {"stdout": "hidden\n"}},
+        ]
+        body = ag.render_declarative_body(result, outcomes, "all good")
+        assert "<details><summary>Test output</summary>" in body
+        assert "**loud**" in body and "dotnet 8.0.100" in body
+        assert "**quiet**" not in body and "hidden" not in body
+
+    def test_failure_details_policy_applies_to_body(self):
+        # #765: the release body must honor actual-only — no expected block.
+        result = {"score": 0, "max-score": 1}
+        outcomes = [
+            {"test-name": "t", "passed": False, "score": 0, "max-score": 1,
+             "detail": "exit 0; comparison=included", "type": "io",
+             "comparison": "included", "failure-kind": "output",
+             "failure-details": "actual-only",
+             "capture": {"stdout": "mine\n", "expected": "answer"}},
+        ]
+        body = ag.render_declarative_body(result, outcomes, "s")
+        assert "mine" in body
+        assert "answer" not in body and "--- expected" not in body
+
+    def test_show_output_with_backtick_fence_cannot_break_out(self):
+        # Same injection defense as the failure details: passing output flows
+        # into the new section, so a ``` line must stay inside the fence.
+        evil = "```\n# PWNED markdown heading\n```python"
+        result = {"score": 1, "max-score": 1}
+        outcomes = [{"test-name": "t", "passed": True, "score": 1, "max-score": 1,
+                     "detail": "", "show-output": True,
+                     "capture": {"stdout": evil}}]
+        body = ag.render_declarative_body(result, outcomes, "s")
+        lines = body.splitlines()
+        start = lines.index("````")
+        end = len(lines) - 1 - lines[::-1].index("````")
+        assert start < end
+        assert "# PWNED markdown heading" in lines[start:end]
 
     def test_detail_with_backtick_fence_cannot_break_out(self):
         # Student output flows into the failure detail; a ``` line must
@@ -464,6 +648,55 @@ class TestRenderLogReport:
         outcomes = [{"test-name": "t", "passed": False, "score": 0, "max-score": 1}]
         report = ag.render_log_report(outcomes, color=False)
         assert "::group::FAIL: t\n::endgroup::" in report
+
+    def test_passing_show_output_gets_a_group(self):
+        # #764 on the log surface: passing show-output tests fold their
+        # captured streams into an OUTPUT group; ordinary passes stay bare.
+        outcomes = [
+            {"test-name": "loud", "passed": True, "score": 1, "max-score": 1,
+             "detail": "", "show-output": True,
+             "capture": {"stdout": "dotnet 8.0.100\n"}},
+            {"test-name": "quiet", "passed": True, "score": 1, "max-score": 1,
+             "detail": "", "capture": {"stdout": "hidden\n"}},
+        ]
+        report = ag.render_log_report(outcomes, color=False)
+        assert "::group::OUTPUT: loud" in report
+        assert "\n  --- stdout ---\n  dotnet 8.0.100" in report
+        assert "OUTPUT: quiet" not in report and "hidden" not in report
+
+    def test_show_output_cannot_inject_workflow_commands(self):
+        # The OUTPUT group carries student-controlled output too; the same
+        # two-space indent must defend it.
+        outcomes = [{"test-name": "t", "passed": True, "score": 1, "max-score": 1,
+                     "detail": "", "show-output": True,
+                     "capture": {"stdout": "::endgroup::\n::error::pwned"}}]
+        report = ag.render_log_report(outcomes, color=False)
+        for line in report.splitlines():
+            if line.startswith("::"):
+                assert line in ("::group::OUTPUT: t", "::endgroup::")
+
+    def test_log_surface_uses_the_larger_clip(self):
+        # #612: output that the release body truncates renders in full in the
+        # log group (up to MAX_LOG_CAPTURED_CHARS).
+        long_out = "y" * (ag.MAX_CAPTURED_CHARS * 3)
+        outcomes = [{"test-name": "t", "passed": False, "score": 0, "max-score": 1,
+                     "detail": "exit 1 (wanted 0)", "type": "run",
+                     "failure-kind": "exit", "capture": {"stderr": long_out}}]
+        report = ag.render_log_report(outcomes, color=False)
+        assert long_out in report
+        assert "... (truncated)" not in report
+
+    def test_failure_details_policy_applies_to_log(self):
+        # #765: students can read their own repo's workflow logs, so the log
+        # groups honor the policy too.
+        outcomes = [{"test-name": "t", "passed": False, "score": 0, "max-score": 1,
+                     "detail": "exit 0; comparison=exact", "type": "io",
+                     "comparison": "exact", "failure-kind": "output",
+                     "failure-details": "none",
+                     "capture": {"stdout": "mine", "expected": "answer"}}]
+        report = ag.render_log_report(outcomes, color=False)
+        assert "answer" not in report and "mine" not in report
+        assert "::group::FAIL: t\n  exit 0; comparison=exact\n::endgroup::" in report
 
 
 # ---------------------------------------------------------------------------

--- a/cli/gh-teacher/autograders_tests/test_inline_validator.py
+++ b/cli/gh-teacher/autograders_tests/test_inline_validator.py
@@ -182,7 +182,8 @@ def _manifest(*, slug: str = "hello", runtime: dict | None = None,
               tests: list | None = None,
               release_assets: object = _MISSING,
               submission_mode: object = _MISSING,
-              submission_tags: object = _MISSING) -> dict:
+              submission_tags: object = _MISSING,
+              test_defaults: object = _MISSING) -> dict:
     """Minimum assignments.json with one entry, optional runtime/tests."""
     entry = {
         "slug": slug,
@@ -201,6 +202,8 @@ def _manifest(*, slug: str = "hello", runtime: dict | None = None,
         entry["submission_mode"] = submission_mode
     if submission_tags is not _MISSING:
         entry["submission_tags"] = submission_tags
+    if test_defaults is not _MISSING:
+        entry["test_defaults"] = test_defaults
     return {
         "schema": "classroom50/assignments/v1",
         "assignments": [entry],
@@ -527,6 +530,65 @@ class TestDeclarativeTestsValidation:
         )
         assert rc != 0
         assert "tests must be an array" in stderr
+
+    def test_reporting_options_accepted(self, inline_script, tmp_path):
+        # failure-details / show-output per test plus the assignment-level
+        # test_defaults block (issues #612/#764/#765) validate cleanly; an
+        # explicit show-output false is legal (overrides a true default).
+        rc, _stdout, stderr, _outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=_classroom_yaml(),
+            manifest=_manifest(
+                test_defaults={"failure-details": "none", "show-output": True},
+                tests=[
+                    {"name": "a", "type": "run", "run": "true", "points": 1,
+                     "failure-details": "actual-only", "show-output": False},
+                ],
+            ),
+        )
+        assert rc == 0, stderr
+
+    def test_bad_failure_details_rejected(self, inline_script, tmp_path):
+        rc, _stdout, stderr, _outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=_classroom_yaml(),
+            manifest=_manifest(tests=[
+                {"name": "a", "type": "run", "run": "true", "points": 1,
+                 "failure-details": "loud"},
+            ]),
+        )
+        assert rc != 0
+        assert "failure-details" in stderr
+
+    def test_non_boolean_show_output_rejected(self, inline_script, tmp_path):
+        rc, _stdout, stderr, _outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=_classroom_yaml(),
+            manifest=_manifest(tests=[
+                {"name": "a", "type": "run", "run": "true", "points": 1,
+                 "show-output": "yes"},
+            ]),
+        )
+        assert rc != 0
+        assert "show-output" in stderr
+
+    @pytest.mark.parametrize("bad_defaults", [
+        "none",
+        {"failure-details": "loud"},
+        {"show-output": "yes"},
+        {"unknown-key": True},
+    ])
+    def test_bad_test_defaults_rejected(self, inline_script, tmp_path, bad_defaults):
+        rc, _stdout, stderr, _outputs = _run_validator(
+            inline_script, tmp_path,
+            classroom50_yaml=_classroom_yaml(),
+            manifest=_manifest(
+                test_defaults=bad_defaults,
+                tests=[{"name": "a", "type": "run", "run": "true", "points": 1}],
+            ),
+        )
+        assert rc != 0
+        assert "test_defaults" in stderr
 
     def test_unknown_test_key_rejected(self, inline_script, tmp_path):
         # Mirrors Go's DisallowUnknownFields: a typo'd `compare` (it's

--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -165,6 +165,7 @@ type AssignmentEntry struct {
 	MaxGroupSize       int              `json:"max_group_size,omitempty"`
 	Runtime            *RuntimeRef      `json:"runtime,omitempty"`
 	Tests              []TestSpec       `json:"tests,omitempty"`
+	TestDefaults       *TestDefaults    `json:"test_defaults,omitempty"`
 	FeedbackPR         bool             `json:"feedback_pr,omitempty"`
 	EmptyRepo          bool             `json:"empty_repo,omitempty"`
 	NoAutograder       bool             `json:"no_autograder,omitempty"`
@@ -204,7 +205,8 @@ var knownEntryKeys = map[string]struct{}{
 	"slug": {}, "name": {}, "description": {}, "template": {}, "due": {},
 	"due_meta": {}, "mode": {}, "autograder": {}, "max_group_size": {},
 	"runtime": {}, "tests": {}, "feedback_pr": {}, "empty_repo": {},
-	"locked": {}, "closed": {}, "allowed_files": {}, "release_assets": {}, "pass_threshold": {},
+	"test_defaults": {},
+	"locked":        {}, "closed": {}, "allowed_files": {}, "release_assets": {}, "pass_threshold": {},
 	"migrated_from": {}, "available_from": {}, "available_from_meta": {},
 	"renamed_from":       {},
 	"student_permission": {}, "submission_mode": {}, "submission_tags": {},
@@ -980,6 +982,11 @@ func ValidateAssignmentEntry(entry AssignmentEntry) error {
 			return err
 		}
 	}
+	if entry.TestDefaults != nil {
+		if err := ValidateTestDefaults(*entry.TestDefaults); err != nil {
+			return err
+		}
+	}
 	if err := ValidateAllowedFiles(entry.AllowedFiles); err != nil {
 		return err
 	}
@@ -1220,6 +1227,11 @@ func ValidateExistingEntry(entry AssignmentEntry) error {
 	}
 	if len(entry.Tests) > 0 {
 		if err := ValidateTests(entry.Tests); err != nil {
+			return fmt.Errorf("entry %q: %w", entry.Slug, err)
+		}
+	}
+	if entry.TestDefaults != nil {
+		if err := ValidateTestDefaults(*entry.TestDefaults); err != nil {
 			return fmt.Errorf("entry %q: %w", entry.Slug, err)
 		}
 	}

--- a/cli/gh-teacher/internal/assignment/assignments_json_test.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json_test.go
@@ -636,6 +636,80 @@ func TestParseAssignments_TestsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseAssignments_TestDefaultsRoundTrip(t *testing.T) {
+	// The assignment-level test_defaults block parses (including an explicit
+	// per-test show-output:false override), validates its enum, and survives
+	// a re-encode/re-parse.
+	in := []byte(`{
+  "schema": "classroom50/assignments/v1",
+  "assignments": [
+    {
+      "slug": "hello",
+      "name": "Hello",
+      "mode": "individual",
+      "autograder": "default",
+      "test_defaults": { "failure-details": "none", "show-output": true },
+      "tests": [
+        { "name": "a", "type": "run", "run": "true", "points": 1 },
+        { "name": "b", "type": "run", "run": "true", "points": 1, "failure-details": "full", "show-output": false }
+      ]
+    }
+  ]
+}`)
+	file, err := ParseAssignments(in)
+	if err != nil {
+		t.Fatalf("ParseAssignments: %v", err)
+	}
+	entry := file.Assignments[0]
+	if entry.TestDefaults == nil || entry.TestDefaults.FailureDetails != "none" {
+		t.Fatalf("test_defaults not parsed: %#v", entry.TestDefaults)
+	}
+	if entry.TestDefaults.ShowOutput == nil || !*entry.TestDefaults.ShowOutput {
+		t.Errorf("test_defaults.show-output not parsed: %#v", entry.TestDefaults.ShowOutput)
+	}
+	if entry.Tests[1].FailureDetails != "full" {
+		t.Errorf("per-test failure-details not parsed: %#v", entry.Tests[1])
+	}
+	if entry.Tests[1].ShowOutput == nil || *entry.Tests[1].ShowOutput {
+		t.Errorf("explicit per-test show-output:false lost: %#v", entry.Tests[1].ShowOutput)
+	}
+
+	encoded, err := EncodeAssignments(file)
+	if err != nil {
+		t.Fatalf("EncodeAssignments: %v", err)
+	}
+	again, err := ParseAssignments(encoded)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if !reflect.DeepEqual(again.Assignments[0].TestDefaults, entry.TestDefaults) {
+		t.Errorf("test_defaults not stable across round-trip: %#v", again.Assignments[0].TestDefaults)
+	}
+	if !reflect.DeepEqual(again.Assignments[0].Tests, entry.Tests) {
+		t.Errorf("tests not stable across round-trip: %#v", again.Assignments[0].Tests)
+	}
+}
+
+func TestParseAssignments_RejectsBadTestDefaults(t *testing.T) {
+	// An invalid enum value and an unknown sub-key (the closed-sub-object
+	// rule, mirroring runtime) must both be hard errors.
+	for name, block := range map[string]string{
+		"bad enum":        `{ "failure-details": "loud" }`,
+		"unknown sub-key": `{ "verbosity": "high" }`,
+	} {
+		in := []byte(`{
+  "schema": "classroom50/assignments/v1",
+  "assignments": [
+    { "slug": "hello", "name": "Hello", "mode": "individual", "autograder": "default",
+      "test_defaults": ` + block + ` }
+  ]
+}`)
+		if _, err := ParseAssignments(in); err == nil {
+			t.Errorf("%s: expected error, got nil", name)
+		}
+	}
+}
+
 func TestParseAssignments_FeedbackPRRoundTrip(t *testing.T) {
 	// feedback_pr=true parses, survives a re-encode/re-parse, and an
 	// entry without the field defaults to false.

--- a/cli/gh-teacher/internal/assignment/tests.go
+++ b/cli/gh-teacher/internal/assignment/tests.go
@@ -28,18 +28,31 @@ import (
 //
 // Points has no omitempty so a 0-point informational test reads explicitly.
 type TestSpec struct {
-	Name         string `json:"name"`
-	Type         string `json:"type"`
-	Setup        string `json:"setup,omitempty"`
-	Run          string `json:"run"`
-	Input        string `json:"input,omitempty"`
-	InputFile    string `json:"input-file,omitempty"`
-	Expected     string `json:"expected,omitempty"`
-	ExpectedFile string `json:"expected-file,omitempty"`
-	Comparison   string `json:"comparison,omitempty"`
-	Timeout      int    `json:"timeout,omitempty"`
-	ExitCode     *int   `json:"exit-code,omitempty"`
-	Points       int    `json:"points"`
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	Setup          string `json:"setup,omitempty"`
+	Run            string `json:"run"`
+	Input          string `json:"input,omitempty"`
+	InputFile      string `json:"input-file,omitempty"`
+	Expected       string `json:"expected,omitempty"`
+	ExpectedFile   string `json:"expected-file,omitempty"`
+	Comparison     string `json:"comparison,omitempty"`
+	Timeout        int    `json:"timeout,omitempty"`
+	ExitCode       *int   `json:"exit-code,omitempty"`
+	Points         int    `json:"points"`
+	FailureDetails string `json:"failure-details,omitempty"`
+	// *bool, not bool: an explicit false must survive the wire so a single
+	// test can opt out of a test_defaults show-output=true.
+	ShowOutput *bool `json:"show-output,omitempty"`
+}
+
+// TestDefaults is an assignment's `test_defaults` block: assignment-level
+// values for the per-test reporting options, applied by the grader to any
+// test that doesn't set its own. A CLOSED sub-object like RuntimeRef — a new
+// key must ship in lockstep across the schema, this struct, and the web type.
+type TestDefaults struct {
+	FailureDetails string `json:"failure-details,omitempty"`
+	ShowOutput     *bool  `json:"show-output,omitempty"`
 }
 
 const (
@@ -62,6 +75,19 @@ const (
 
 // comparisonModes is the allow-list, sorted.
 var comparisonModes = []string{comparisonExact, comparisonIncluded, comparisonRegex}
+
+// Failure-detail levels: how much of a failing test's captured output the
+// grader shows students (full = diff/expected+actual, actual-only = the
+// student's own output, none = just the failure kind). Empty means the
+// grader default (full).
+const (
+	failureDetailsFull       = "full"
+	failureDetailsActualOnly = "actual-only"
+	failureDetailsNone       = "none"
+)
+
+// failureDetailsLevels is the allow-list, sorted.
+var failureDetailsLevels = []string{failureDetailsActualOnly, failureDetailsFull, failureDetailsNone}
 
 // Bounds: generous for real assignments, tight enough that a hand-edited
 // assignments.json can't wedge the gradebook or blow the contents-API ceiling.
@@ -91,6 +117,23 @@ func isValidComparison(s string) bool {
 		}
 	}
 	return false
+}
+
+func isValidFailureDetails(s string) bool {
+	for _, l := range failureDetailsLevels {
+		if s == l {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateTestDefaults checks an assignment's test_defaults block.
+func ValidateTestDefaults(d TestDefaults) error {
+	if d.FailureDetails != "" && !isValidFailureDetails(d.FailureDetails) {
+		return fmt.Errorf("invalid failure-details %q: must be one of %v", d.FailureDetails, failureDetailsLevels)
+	}
+	return nil
 }
 
 // ValidateTests checks an assignment's test list on both paths: count cap,
@@ -137,6 +180,9 @@ func ValidateTestSpec(t TestSpec) error {
 	}
 	if t.Points < 0 || t.Points > maxTestPoints {
 		return fmt.Errorf("points %d must be between 0 and %d", t.Points, maxTestPoints)
+	}
+	if t.FailureDetails != "" && !isValidFailureDetails(t.FailureDetails) {
+		return fmt.Errorf("invalid failure-details %q: must be one of %v", t.FailureDetails, failureDetailsLevels)
 	}
 
 	if t.Type == testTypeIO {

--- a/cli/gh-teacher/internal/assignment/tests_test.go
+++ b/cli/gh-teacher/internal/assignment/tests_test.go
@@ -1,14 +1,19 @@
 package assignment
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
 )
 
 func intPtr(n int) *int { return &n }
+
+func boolPtr(b bool) *bool { return &b }
 
 func TestValidateTestSpec(t *testing.T) {
 	cases := []struct {
@@ -156,6 +161,20 @@ func TestValidateTestSpec(t *testing.T) {
 			name:    "run test exit-code out of range",
 			spec:    TestSpec{Name: "t", Type: "run", Run: "x", ExitCode: intPtr(256), Points: 1},
 			wantErr: "exit-code",
+		},
+		{
+			name: "valid failure-details and show-output",
+			spec: TestSpec{Name: "t", Type: "run", Run: "x", Points: 1,
+				FailureDetails: "actual-only", ShowOutput: boolPtr(true)},
+		},
+		{
+			name: "explicit show-output false accepted",
+			spec: TestSpec{Name: "t", Type: "run", Run: "x", Points: 1, ShowOutput: boolPtr(false)},
+		},
+		{
+			name:    "invalid failure-details",
+			spec:    TestSpec{Name: "t", Type: "run", Run: "x", Points: 1, FailureDetails: "loud"},
+			wantErr: "failure-details",
 		},
 	}
 	for _, tc := range cases {
@@ -373,5 +392,115 @@ func TestRemoveTest(t *testing.T) {
 func TestPerAssignmentAutograderPath(t *testing.T) {
 	if got := PerAssignmentAutograderPath("cs-principles", "hello"); got != "cs-principles/autograders/hello/autograder.py" {
 		t.Errorf("unexpected path %q", got)
+	}
+}
+
+func TestValidateTestDefaults(t *testing.T) {
+	cases := []struct {
+		name     string
+		defaults TestDefaults
+		wantErr  string
+	}{
+		{name: "empty is valid", defaults: TestDefaults{}},
+		{name: "valid values", defaults: TestDefaults{FailureDetails: "none", ShowOutput: boolPtr(true)}},
+		{name: "explicit full", defaults: TestDefaults{FailureDetails: "full"}},
+		{
+			name:     "invalid failure-details",
+			defaults: TestDefaults{FailureDetails: "loud"},
+			wantErr:  "failure-details",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTestDefaults(tc.defaults)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestParseTestsFile_ShowOutputFalseRoundTrips pins the *bool contract: an
+// explicit show-output:false must survive a parse (it overrides a
+// test_defaults show-output:true), while an absent field stays nil.
+func TestParseTestsFile_ShowOutputFalseRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tests.json")
+	body := `[
+  {"name":"opts-out","type":"run","run":"x","points":1,"show-output":false,"failure-details":"actual-only"},
+  {"name":"inherits","type":"run","run":"x","points":1}
+]`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := ParseTestsFile(path)
+	if err != nil {
+		t.Fatalf("ParseTestsFile: %v", err)
+	}
+	if got[0].ShowOutput == nil || *got[0].ShowOutput {
+		t.Errorf("explicit show-output:false lost: %#v", got[0].ShowOutput)
+	}
+	if got[0].FailureDetails != "actual-only" {
+		t.Errorf("failure-details lost: %q", got[0].FailureDetails)
+	}
+	if got[1].ShowOutput != nil {
+		t.Errorf("absent show-output must stay nil, got %#v", got[1].ShowOutput)
+	}
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"show-output":false`) {
+		t.Errorf("explicit false must re-emit on the wire, got %s", raw)
+	}
+	if strings.Count(string(raw), `"show-output"`) != 1 {
+		t.Errorf("absent show-output must stay omitted on the wire, got %s", raw)
+	}
+}
+
+// TestFailureDetailsEnumParity pins the failure-details allow-list against the
+// JSON schema enum (the declared source of truth); the web mirror
+// (TEST_FAILURE_DETAILS_LEVELS) is pinned against the same enum by a vitest.
+// Compared as sorted sets: the schema lists the default (`full`) first, while
+// the Go slice is sorted for stable error messages.
+func TestFailureDetailsEnumParity(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "schemas", "assignments-v1.schema.json"))
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schema struct {
+		Defs struct {
+			Test struct {
+				Properties struct {
+					FailureDetails struct {
+						Enum []string `json:"enum"`
+					} `json:"failure-details"`
+				} `json:"properties"`
+			} `json:"test"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+	schemaEnum := append([]string(nil), schema.Defs.Test.Properties.FailureDetails.Enum...)
+	if len(schemaEnum) == 0 {
+		t.Fatalf("schema failure-details enum not found; did the $defs shape change?")
+	}
+	sort.Strings(schemaEnum)
+	goLevels := append([]string(nil), failureDetailsLevels...)
+	sort.Strings(goLevels)
+	if !reflect.DeepEqual(schemaEnum, goLevels) {
+		t.Errorf("failure-details drift: schema enum %v != failureDetailsLevels %v — update every mirror in lockstep (schema, tests.go, runner.py, web TEST_FAILURE_DETAILS_LEVELS)",
+			schemaEnum, goLevels)
 	}
 }

--- a/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
+++ b/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
@@ -45,18 +45,20 @@ func assignmentTestCmd() *cobra.Command {
 
 func assignmentTestAddCmd() *cobra.Command {
 	var (
-		name         string
-		ttype        string
-		setup        string
-		run          string
-		input        string
-		inputFile    string
-		expected     string
-		expectedFile string
-		comparison   string
-		timeout      int
-		exitCode     int
-		points       int
+		name           string
+		ttype          string
+		setup          string
+		run            string
+		input          string
+		inputFile      string
+		expected       string
+		expectedFile   string
+		comparison     string
+		timeout        int
+		exitCode       int
+		points         int
+		failureDetails string
+		showOutput     bool
 	)
 
 	cmd := &cobra.Command{
@@ -100,23 +102,30 @@ func assignmentTestAddCmd() *cobra.Command {
 			}
 
 			spec := assignment.TestSpec{
-				Name:         strings.TrimSpace(name),
-				Type:         strings.TrimSpace(ttype),
-				Setup:        setup,
-				Run:          run,
-				Input:        input,
-				InputFile:    strings.TrimSpace(inputFile),
-				Expected:     expected,
-				ExpectedFile: strings.TrimSpace(expectedFile),
-				Comparison:   strings.TrimSpace(comparison),
-				Timeout:      timeout,
-				Points:       points,
+				Name:           strings.TrimSpace(name),
+				Type:           strings.TrimSpace(ttype),
+				Setup:          setup,
+				Run:            run,
+				Input:          input,
+				InputFile:      strings.TrimSpace(inputFile),
+				Expected:       expected,
+				ExpectedFile:   strings.TrimSpace(expectedFile),
+				Comparison:     strings.TrimSpace(comparison),
+				Timeout:        timeout,
+				Points:         points,
+				FailureDetails: strings.TrimSpace(failureDetails),
 			}
 			// ExitCode is a pointer so "unset" stays distinct from
 			// "explicitly require 0"; set it only when the flag was passed.
 			if cmd.Flags().Changed("exit-code") {
 				ec := exitCode
 				spec.ExitCode = &ec
+			}
+			// ShowOutput is a pointer too: an explicit --show-output=false
+			// must survive to override a test_defaults show-output=true.
+			if cmd.Flags().Changed("show-output") {
+				so := showOutput
+				spec.ShowOutput = &so
 			}
 			if err := assignment.ValidateTestSpec(spec); err != nil {
 				return err
@@ -142,6 +151,8 @@ func assignmentTestAddCmd() *cobra.Command {
 	cmd.Flags().IntVar(&timeout, "timeout", 0, "Seconds before the test fails (0 = default of 10s)")
 	cmd.Flags().IntVar(&exitCode, "exit-code", 0, "run only: required exit code (default 0); pass to require a specific code")
 	cmd.Flags().IntVar(&points, "points", 0, "Points the test is worth")
+	cmd.Flags().StringVar(&failureDetails, "failure-details", "", "How much failure detail students see: full | actual-only | none (empty = the assignment default)")
+	cmd.Flags().BoolVar(&showOutput, "show-output", false, "Include captured setup/run output in the report even when the test passes")
 	return cmd
 }
 

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py
@@ -71,6 +71,12 @@ def materialize(root: pathlib.Path) -> int:
             outdir = root / classroom / "autograders" / slug
             outdir.mkdir(parents=True, exist_ok=True)
             payload = {"schema": TESTS_SCHEMA_V1, "tests": tests}
+            # Assignment-level defaults for the per-test reporting options
+            # (failure-details / show-output) ride the envelope; runner.py's
+            # load_tests folds them into each spec at grade time.
+            defaults = entry.get("test_defaults")
+            if isinstance(defaults, dict) and defaults:
+                payload["defaults"] = defaults
             (outdir / TESTS_FILENAME).write_text(
                 json.dumps(payload, indent=2) + "\n", encoding="utf-8")
             print(f"materialized {outdir / TESTS_FILENAME} ({len(tests)} test(s))")

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
@@ -92,6 +92,22 @@ DEFAULT_TEST_TIMEOUT = 10
 # bloat the published release.
 MAX_CAPTURED_CHARS = 2000
 
+# Far roomier cap for the Actions log, where long failure output (a LaTeX
+# build log, a compiler spew) is the whole point (#612) — the log viewer
+# handles megabytes, the release body must stay skimmable.
+MAX_LOG_CAPTURED_CHARS = 100_000
+
+# Per-test failure-detail levels -- mirror tests.go / tests-v1.schema.json.
+# full: diff (exact) or expected+actual blocks, plus stderr (the default).
+# actual-only: the student's own output, never the expected side or a diff.
+# none: just the failure-kind summary line.
+FAILURE_DETAILS_FULL = "full"
+FAILURE_DETAILS_ACTUAL_ONLY = "actual-only"
+FAILURE_DETAILS_NONE = "none"
+FAILURE_DETAILS_LEVELS = (
+    FAILURE_DETAILS_FULL, FAILURE_DETAILS_ACTUAL_ONLY, FAILURE_DETAILS_NONE,
+)
+
 # ANSI codes for the log report -- the Actions log viewer renders these, the
 # release body (Markdown) must never see them, so color is applied only at
 # render time in render_log_report.
@@ -1520,11 +1536,12 @@ def compare_output(actual: str, expected: str, mode: str) -> bool:
     raise ValueError(f"unknown comparison mode {mode!r}")
 
 
-def _clip(text: str | None) -> str:
-    """Truncate captured output for the release body."""
+def _clip(text: str | None, limit: int = MAX_CAPTURED_CHARS) -> str:
+    """Truncate captured output for a rendering surface (release body by
+    default; the log report passes its own, larger limit)."""
     text = text or ""
-    if len(text) > MAX_CAPTURED_CHARS:
-        return text[:MAX_CAPTURED_CHARS] + "\n... (truncated)"
+    if len(text) > limit:
+        return text[:limit] + "\n... (truncated)"
     return text
 
 
@@ -1533,12 +1550,13 @@ def _unified_diff(expected: str, actual: str) -> str:
     io test. A diff pinpoints the divergent line; the raw side-by-side blocks
     it replaces made students eyeball-compare up to 2000 chars each. Inputs
     are stripped to mirror compare_output's exact semantics, so the diff never
-    flags leading/trailing whitespace the comparison ignores."""
+    flags leading/trailing whitespace the comparison ignores. Returned raw --
+    each renderer clips it to its own surface limit."""
     lines = difflib.unified_diff(
         expected.strip().splitlines(), actual.strip().splitlines(),
         fromfile="expected", tofile="actual stdout", lineterm="",
     )
-    return _clip("\n".join(lines))
+    return "\n".join(lines)
 
 
 def _fence(text: str) -> str:
@@ -1550,9 +1568,13 @@ def _fence(text: str) -> str:
 
 
 def _make_outcome(name: str, points: int, passed: bool, detail: str,
-                  *, score: int | None = None) -> dict[str, Any]:
-    """One test's outcome. Carries the v1 result-row fields plus a `detail`
-    string used only for the release body (stripped before result.json)."""
+                  *, score: int | None = None,
+                  capture: dict[str, str] | None = None) -> dict[str, Any]:
+    """One test's outcome. Carries the v1 result-row fields plus rendering-only
+    fields stripped before result.json: a `detail` summary line (the failure
+    kind -- safe under every failure-details level) and a `capture` dict of raw
+    streams (stdout/stderr/setup-stdout/setup-stderr/expected) that the
+    renderers clip and policy-filter per surface."""
     if score is None:
         score = points if passed else 0
     return {
@@ -1561,6 +1583,7 @@ def _make_outcome(name: str, points: int, passed: bool, detail: str,
         "score": score,
         "max-score": points,
         "detail": detail,
+        "capture": {k: v for k, v in (capture or {}).items() if v},
     }
 
 
@@ -1609,18 +1632,21 @@ def _run_command(command: str, cwd: pathlib.Path, timeout: int,
     )
 
 
-def _run_setup(setup: str, cwd: pathlib.Path, timeout: int) -> str | None:
-    """Run a test's setup command. Returns an error string if it times out or
-    exits non-zero, else None."""
+def _run_setup(setup: str, cwd: pathlib.Path,
+               timeout: int) -> tuple[str | None, subprocess.CompletedProcess[str] | None]:
+    """Run a test's setup command. Returns (error-summary, process): the
+    summary is None on success; the process is None when the command never
+    produced one (timeout / failed start). Captured streams travel back raw so
+    the renderers can clip and policy-filter them per surface."""
     try:
         sp = _run_command(setup, cwd, timeout)
     except subprocess.TimeoutExpired:
-        return f"setup timed out after {timeout}s"
+        return f"setup timed out after {timeout}s", None
     except OSError as exc:
-        return f"setup failed to start: {exc}"
+        return f"setup failed to start: {exc}", None
     if sp.returncode != 0:
-        return f"setup exited {sp.returncode}\n{_clip(sp.stderr or sp.stdout)}"
-    return None
+        return f"setup exited {sp.returncode}", sp
+    return None, sp
 
 
 # import name -> pip package for the pytest deps bare setup-python omits (#212).
@@ -1690,38 +1716,65 @@ def _grade_python(spec: dict[str, Any], cwd: pathlib.Path, timeout: int,
         if not passed:
             score = min(score, max(0, points - 1))
         detail = f"pytest: {passed_n}/{total_n} cases passed"
-        if not passed:
-            detail += "\n" + _clip(rp.stdout or rp.stderr)
-        return _make_outcome(name, points, passed, detail, score=score)
+        return _make_outcome(name, points, passed, detail, score=score,
+                             capture={"stdout": rp.stdout, "stderr": rp.stderr})
 
     # Fallback: no parseable report -> all-or-nothing on the exit code
     # (e.g., an offline runner couldn't load pytest-json-report).
     passed = rp.returncode == 0
     detail = (f"pytest exit {rp.returncode} "
               f"(no JSON report from pytest-json-report; scored on exit code)")
-    if not passed:
-        detail += "\n" + _clip(rp.stdout or rp.stderr)
-    return _make_outcome(name, points, passed, detail)
+    return _make_outcome(name, points, passed, detail,
+                         capture={"stdout": rp.stdout, "stderr": rp.stderr})
 
 
 def execute_test(spec: dict[str, Any], *, cwd: pathlib.Path,
                  fixtures_dir: pathlib.Path) -> dict[str, Any]:
     """Run one declarative test and return its outcome dict. Never raises for a
     test failure -- a timeout, crash, bad fixture, or bad regex all map to a
-    failing outcome with a diagnostic `detail`."""
+    failing outcome with a diagnostic `detail`. The outcome carries raw
+    captured streams plus the test's effective reporting options; the
+    renderers apply clipping and the failure-details policy per surface."""
     name = spec["name"]
     points = int(spec.get("points") or 0)
-    ttype = spec["type"]
     timeout = int(spec.get("timeout") or 0) or DEFAULT_TEST_TIMEOUT
 
+    outcome = None
+    setup_capture: dict[str, str] = {}
     setup = spec.get("setup") or ""
     if setup:
-        err = _run_setup(setup, cwd, timeout)
+        err, sp = _run_setup(setup, cwd, timeout)
+        if sp is not None:
+            setup_capture = {k: v for k, v in
+                             (("setup-stdout", sp.stdout), ("setup-stderr", sp.stderr)) if v}
         if err:
-            return _make_outcome(name, points, False, err)
+            outcome = _make_outcome(name, points, False, err)
+            outcome["failure-kind"] = "setup"
+    if outcome is None:
+        outcome = _execute_spec(spec, cwd=cwd, fixtures_dir=fixtures_dir,
+                                name=name, points=points, timeout=timeout)
 
+    # Setup streams ride every outcome: a setup failure's details show them,
+    # and show-output includes them even on a pass (#764).
+    outcome["capture"] = {**setup_capture, **outcome.get("capture", {})}
+    outcome["type"] = spec["type"]
+    if spec["type"] == TEST_TYPE_IO:
+        outcome["comparison"] = spec.get("comparison")
+    outcome["failure-details"] = spec.get("failure-details") or FAILURE_DETAILS_FULL
+    outcome["show-output"] = bool(spec.get("show-output"))
+    return outcome
+
+
+def _execute_spec(spec: dict[str, Any], *, cwd: pathlib.Path,
+                  fixtures_dir: pathlib.Path, name: str, points: int,
+                  timeout: int) -> dict[str, Any]:
+    """Run the spec's `run` phase (setup already done) and grade it."""
+    ttype = spec["type"]
     if ttype == TEST_TYPE_PYTHON:
-        return _grade_python(spec, cwd, timeout, points, name)
+        outcome = _grade_python(spec, cwd, timeout, points, name)
+        if not outcome["passed"]:
+            outcome.setdefault("failure-kind", "cases")
+        return outcome
 
     try:
         stdin = _resolve_stdin(spec, fixtures_dir)
@@ -1735,14 +1788,18 @@ def execute_test(spec: dict[str, Any], *, cwd: pathlib.Path,
     except OSError as exc:
         return _make_outcome(name, points, False, f"failed to start: {exc}")
 
+    capture = {"stdout": rp.stdout, "stderr": rp.stderr}
+
     if ttype == TEST_TYPE_RUN:
         want = spec.get("exit-code")
         want = 0 if want is None else int(want)
         passed = rp.returncode == want
-        detail = f"exit {rp.returncode} (wanted {want})"
+        outcome = _make_outcome(name, points, passed,
+                                f"exit {rp.returncode} (wanted {want})",
+                                capture=capture)
         if not passed:
-            detail += "\n" + _clip(rp.stderr or rp.stdout)
-        return _make_outcome(name, points, passed, detail)
+            outcome["failure-kind"] = "exit"
+        return outcome
 
     # io test.
     try:
@@ -1754,24 +1811,14 @@ def execute_test(spec: dict[str, Any], *, cwd: pathlib.Path,
         passed = compare_output(rp.stdout, expected, comparison)
     except re.error as exc:
         return _make_outcome(name, points, False, f"invalid regex in expected: {exc}")
-    detail = f"exit {rp.returncode}; comparison={comparison}"
     if not passed:
-        # A line diff only makes sense against a full expected output, and only
-        # for exact: for included/regex the expectation is a fragment or
-        # pattern, so those keep the verbatim expected/actual blocks. The exact
-        # comparison also sees separator characters splitlines() folds away
-        # (\x0c, \x85, \u2028, a literal \r in an inline expected), so a failing
-        # exact test can yield an empty diff — fall back to the same verbatim
-        # blocks rather than show FAIL with no explanation.
-        diff = _unified_diff(expected, rp.stdout) if comparison == COMPARISON_EXACT else ""
-        if diff:
-            detail += f"\n{diff}"
-        else:
-            detail += (f"\n--- expected ({comparison}) ---\n{_clip(expected)}"
-                       f"\n--- actual stdout ---\n{_clip(rp.stdout)}")
-        if rp.stderr.strip():
-            detail += f"\n--- stderr ---\n{_clip(rp.stderr)}"
-    return _make_outcome(name, points, passed, detail)
+        capture["expected"] = expected
+    outcome = _make_outcome(name, points, passed,
+                            f"exit {rp.returncode}; comparison={comparison}",
+                            capture=capture)
+    if not passed:
+        outcome["failure-kind"] = "output"
+    return outcome
 
 
 def _validate_test_spec(t: Any) -> str | None:
@@ -1809,12 +1856,34 @@ def _validate_test_spec(t: Any) -> str | None:
     exit_code = t.get("exit-code")
     if exit_code is not None and (isinstance(exit_code, bool) or not isinstance(exit_code, int)):
         return "exit-code must be an integer"
+    fd = t.get("failure-details")
+    if fd is not None and fd not in FAILURE_DETAILS_LEVELS:
+        return f"failure-details must be one of {list(FAILURE_DETAILS_LEVELS)}"
+    so = t.get("show-output")
+    if so is not None and not isinstance(so, bool):
+        return "show-output must be a boolean"
+    return None
+
+
+def _validate_test_defaults(d: Any) -> str | None:
+    """Validate the envelope's `defaults` block (assignment-level values for
+    the per-test reporting options)."""
+    if not isinstance(d, dict):
+        return "not an object"
+    fd = d.get("failure-details")
+    if fd is not None and fd not in FAILURE_DETAILS_LEVELS:
+        return f"failure-details must be one of {list(FAILURE_DETAILS_LEVELS)}"
+    so = d.get("show-output")
+    if so is not None and not isinstance(so, bool):
+        return "show-output must be a boolean"
     return None
 
 
 def load_tests(path: pathlib.Path) -> list[dict[str, Any]]:
-    """Parse + re-validate a materialized tests.json. Raises TestsConfigError
-    on any structural problem."""
+    """Parse + re-validate a materialized tests.json, folding the envelope's
+    `defaults` (assignment-level failure-details / show-output) into each spec
+    that doesn't set its own. Raises TestsConfigError on any structural
+    problem."""
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise TestsConfigError(f"{TESTS_FILENAME} is not a JSON object")
@@ -1824,6 +1893,13 @@ def load_tests(path: pathlib.Path) -> list[dict[str, Any]]:
     tests = data.get("tests")
     if not isinstance(tests, list) or not tests:
         raise TestsConfigError(f"{TESTS_FILENAME} 'tests' must be a non-empty list")
+    defaults = data.get("defaults")
+    if defaults is not None:
+        err = _validate_test_defaults(defaults)
+        if err:
+            raise TestsConfigError(f"{TESTS_FILENAME} defaults: {err}")
+    else:
+        defaults = {}
     seen = set()
     for i, t in enumerate(tests):
         err = _validate_test_spec(t)
@@ -1834,14 +1910,87 @@ def load_tests(path: pathlib.Path) -> list[dict[str, Any]]:
         if t["name"] in seen:
             raise TestsConfigError(f"{TESTS_FILENAME} tests[{i}]: duplicate test name {t['name']!r}")
         seen.add(t["name"])
+        for key in ("failure-details", "show-output"):
+            if key not in t and key in defaults:
+                t[key] = defaults[key]
     return tests
+
+
+def compose_detail(outcome: dict[str, Any], *, limit: int = MAX_CAPTURED_CHARS) -> str:
+    """Failure text for one failing outcome, clipped to the surface's limit
+    and honoring the test's failure-details level: `none` stops at the
+    failure-kind summary line, `actual-only` adds only the student's own
+    streams, and `full` (the default) also shows the expected side."""
+    level = outcome.get("failure-details") or FAILURE_DETAILS_FULL
+    detail = (outcome.get("detail") or "").rstrip()
+    if level == FAILURE_DETAILS_NONE:
+        return detail
+    cap = outcome.get("capture") or {}
+    kind = outcome.get("failure-kind")
+    if kind == "setup":
+        out = cap.get("setup-stderr") or cap.get("setup-stdout") or ""
+        return detail + (f"\n{_clip(out, limit)}" if out else "")
+    if kind == "cases":
+        out = cap.get("stdout") or cap.get("stderr") or ""
+        return detail + (f"\n{_clip(out, limit)}" if out else "")
+    if kind == "exit":
+        out = cap.get("stderr") or cap.get("stdout") or ""
+        return detail + (f"\n{_clip(out, limit)}" if out else "")
+    if kind == "output":
+        comparison = outcome.get("comparison") or ""
+        stdout = cap.get("stdout") or ""
+        if level == FAILURE_DETAILS_FULL:
+            # A line diff only makes sense against a full expected output, and
+            # only for exact: for included/regex the expectation is a fragment
+            # or pattern, so those keep the verbatim expected/actual blocks.
+            # The exact comparison also sees separator characters splitlines()
+            # folds away (\x0c, \x85, \u2028, a literal \r in an inline
+            # expected), so a failing exact test can yield an empty diff —
+            # fall back to the same verbatim blocks rather than show FAIL with
+            # no explanation.
+            diff = (_unified_diff(cap.get("expected") or "", stdout)
+                    if comparison == COMPARISON_EXACT else "")
+            if diff:
+                detail += f"\n{_clip(diff, limit)}"
+            else:
+                detail += (f"\n--- expected ({comparison}) ---"
+                           f"\n{_clip(cap.get('expected'), limit)}"
+                           f"\n--- actual stdout ---\n{_clip(stdout, limit)}")
+        else:
+            # actual-only: the diff and the expected block would both reveal
+            # the answer, so only the student's own stdout is shown.
+            detail += f"\n--- actual stdout ---\n{_clip(stdout, limit)}"
+        stderr = cap.get("stderr") or ""
+        if stderr.strip():
+            detail += f"\n--- stderr ---\n{_clip(stderr, limit)}"
+        return detail
+    # timeout / failed start / bad fixture / bad regex: the summary is all
+    # there is (no process output was captured).
+    return detail
+
+
+def compose_output(outcome: dict[str, Any], *, limit: int = MAX_CAPTURED_CHARS) -> str:
+    """Captured setup/run streams of one outcome for the opt-in show-output
+    section (#764) -- rendered for passing tests, since failing ones already
+    surface their output through the failure details."""
+    cap = outcome.get("capture") or {}
+    parts = []
+    for key, label in (("setup-stdout", "setup stdout"),
+                       ("setup-stderr", "setup stderr"),
+                       ("stdout", "stdout"),
+                       ("stderr", "stderr")):
+        text = cap.get(key) or ""
+        if text.strip():
+            parts.append(f"--- {label} ---\n{_clip(text, limit)}")
+    return "\n".join(parts) or "(no output captured)"
 
 
 def render_declarative_body(result: dict[str, Any], outcomes: list[dict[str, Any]],
                             summary: str) -> str:
     """Release-body Markdown for a declaratively-graded submission: the score
-    line, a per-test table, and a collapsible failure-detail section with
-    captured output for any failing test."""
+    line, a per-test table, a collapsible failure-detail section with captured
+    output for any failing test, and a collapsible output section for passing
+    tests that opted in via show-output."""
     lines = [f"### classroom50 autograde: {result['score']}/{result['max-score']}", ""]
     lines.append("| Test | Result | Score |")
     lines.append("|---|---|---|")
@@ -1856,12 +2005,28 @@ def render_declarative_body(result: dict[str, Any], outcomes: list[dict[str, Any
         lines.append("<details><summary>Failure details</summary>")
         lines.append("")
         for o in failed:
-            detail = (o.get("detail") or "").rstrip()
+            detail = compose_detail(o).rstrip()
             fence = _fence(detail)
             lines.append(f"**{o['test-name']}**")
             lines.append("")
             lines.append(fence)
             lines.append(detail)
+            lines.append(fence)
+            lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    showing = [o for o in outcomes if o["passed"] and o.get("show-output")]
+    if showing:
+        lines.append("<details><summary>Test output</summary>")
+        lines.append("")
+        for o in showing:
+            output = compose_output(o).rstrip()
+            fence = _fence(output)
+            lines.append(f"**{o['test-name']}**")
+            lines.append("")
+            lines.append(fence)
+            lines.append(output)
             lines.append(fence)
             lines.append("")
         lines.append("</details>")
@@ -1887,10 +2052,13 @@ def _strip_control_chars(text: str) -> str:
 
 def render_log_report(outcomes: list[dict[str, Any]], *, color: bool) -> str:
     """Per-test report for the workflow log: a PASS/FAIL line per test, then
-    one collapsible ::group:: per failing test with its captured detail.
-    Failures only get groups — folding every passing test would bury the red
-    ones. The release body carries the same data as Markdown; this is the
-    log-surface rendering (ANSI is fine here, Markdown tables are not).
+    one collapsible ::group:: per failing test with its captured detail, then
+    one per passing show-output test. Only those get groups — folding every
+    passing test would bury the red ones. The release body carries the same
+    data as Markdown; this is the log-surface rendering (ANSI is fine here,
+    Markdown tables are not). The log clips at MAX_LOG_CAPTURED_CHARS, far
+    above the release body's cap, so long failure output is debuggable here
+    (#612) without bloating the published release.
 
     Detail lines are indented two spaces: detail carries student-controlled
     program output, and GitHub only interprets workflow commands (::error::,
@@ -1915,13 +2083,23 @@ def render_log_report(outcomes: list[dict[str, Any]], *, color: bool) -> str:
         # inject a workflow command even if it reached this renderer some other
         # way (mirrors the two-space indent that defends the detail lines).
         lines.append(f"::group::FAIL: {_strip_control_chars(o['test-name'])}")
-        for dl in (o.get("detail") or "").rstrip().splitlines():
+        detail = compose_detail(o, limit=MAX_LOG_CAPTURED_CHARS)
+        for dl in detail.rstrip().splitlines():
             if dl.startswith("+"):
                 dl = _colorize(dl, ANSI_GREEN, color=color)
             elif dl.startswith("-"):
                 dl = _colorize(dl, ANSI_RED, color=color)
             elif dl.startswith("@@"):
                 dl = _colorize(dl, ANSI_CYAN, color=color)
+            lines.append(f"  {dl}")
+        lines.append("::endgroup::")
+
+    for o in outcomes:
+        if not (o["passed"] and o.get("show-output")):
+            continue
+        lines.append(f"::group::OUTPUT: {_strip_control_chars(o['test-name'])}")
+        output = compose_output(o, limit=MAX_LOG_CAPTURED_CHARS)
+        for dl in output.rstrip().splitlines():
             lines.append(f"  {dl}")
         lines.append("::endgroup::")
     return "\n".join(lines) + "\n"

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
@@ -291,9 +291,10 @@ jobs:
           if tests is not None:
               _TEST_TYPES = {"io", "run", "python"}
               _COMPARISONS = {"exact", "included", "regex"}
+              _FAILURE_DETAILS = {"full", "actual-only", "none"}
               _TEST_KEYS = {"name", "type", "setup", "run", "input", "input-file",
                             "expected", "expected-file", "comparison", "timeout",
-                            "exit-code", "points"}
+                            "exit-code", "points", "failure-details", "show-output"}
               _IO_ONLY_KEYS = ("input", "input-file", "expected", "expected-file", "comparison")
               if not isinstance(tests, list):
                   fail(f"entry {assignment!r}: tests must be an array")
@@ -333,6 +334,12 @@ jobs:
                   points = t.get("points", 0)
                   if isinstance(points, bool) or not isinstance(points, int) or not (0 <= points <= 1000):
                       fail(f"{where}.points must be an integer between 0 and 1000")
+                  fd = t.get("failure-details")
+                  if fd is not None and fd not in _FAILURE_DETAILS:
+                      fail(f"{where}.failure-details {fd!r} must be one of {sorted(_FAILURE_DETAILS)}")
+                  so = t.get("show-output")
+                  if so is not None and not isinstance(so, bool):
+                      fail(f"{where}.show-output must be a boolean")
                   exit_code = t.get("exit-code")
                   if ttype == "io":
                       comparison = t.get("comparison")
@@ -355,6 +362,23 @@ jobs:
                               fail(f"{where}: exit-code is only valid for a run test, not a {ttype} test")
                           if isinstance(exit_code, bool) or not isinstance(exit_code, int) or not (0 <= exit_code <= 255):
                               fail(f"{where}.exit-code must be an integer between 0 and 255")
+
+          # === Re-validate the assignment-level test_defaults block ===
+          # Mirrors tests.go's TestDefaults validator: a closed sub-object
+          # carrying defaults for the per-test reporting options.
+          test_defaults = entry.get("test_defaults")
+          if test_defaults is not None:
+              if not isinstance(test_defaults, dict):
+                  fail(f"entry {assignment!r}: test_defaults must be an object")
+              extras = sorted(set(test_defaults) - {"failure-details", "show-output"})
+              if extras:
+                  fail(f"entry {assignment!r}: test_defaults has unsupported keys: {extras}")
+              fd = test_defaults.get("failure-details")
+              if fd is not None and fd not in {"full", "actual-only", "none"}:
+                  fail(f"entry {assignment!r}: test_defaults.failure-details {fd!r} must be one of ['actual-only', 'full', 'none']")
+              so = test_defaults.get("show-output")
+              if so is not None and not isinstance(so, bool):
+                  fail(f"entry {assignment!r}: test_defaults.show-output must be a boolean")
 
           runtime = entry.get("runtime") or {}
           if not isinstance(runtime, dict):

--- a/cli/gh-teacher/skeleton_tests/test_assignments_schema.py
+++ b/cli/gh-teacher/skeleton_tests/test_assignments_schema.py
@@ -76,6 +76,35 @@ class TestSchemaAccepts:
         tests = [{"name": "t", "type": "run", "run": "x", "exit-code": 42, "points": 1}]
         assert _errors(_manifest(_entry(tests=tests))) == []
 
+    def test_reporting_options_accepted(self):
+        # Per-test failure-details / show-output plus the assignment-level
+        # test_defaults block (issues #612/#764/#765). An explicit
+        # show-output: false is legal — it overrides a true default.
+        tests = [
+            {"name": "a", "type": "run", "run": "x", "points": 1,
+             "failure-details": "actual-only", "show-output": True},
+            {"name": "b", "type": "run", "run": "x", "points": 1,
+             "failure-details": "none", "show-output": False},
+            {"name": "c", "type": "run", "run": "x", "points": 1,
+             "failure-details": "full"},
+        ]
+        entry = _entry(tests=tests)
+        entry["test_defaults"] = {"failure-details": "none", "show-output": True}
+        assert _errors(_manifest(entry)) == []
+
+    def test_bad_reporting_options_rejected(self):
+        tests = [{"name": "a", "type": "run", "run": "x", "points": 1,
+                  "failure-details": "loud"}]
+        assert _errors(_manifest(_entry(tests=tests))) != []
+        tests = [{"name": "a", "type": "run", "run": "x", "points": 1,
+                  "show-output": "yes"}]
+        assert _errors(_manifest(_entry(tests=tests))) != []
+        entry = _entry()
+        entry["test_defaults"] = {"failure-details": "loud"}
+        assert _errors(_manifest(entry)) != []
+        entry["test_defaults"] = {"unknown-key": True}
+        assert _errors(_manifest(entry)) != []
+
     def test_feedback_pr_flag_accepted(self):
         # feedback_pr is a CLI-written boolean (gh teacher assignment add
         # --feedback-pr); the schema must accept it given the assignment

--- a/cli/gh-teacher/skeleton_tests/test_materialize_tests.py
+++ b/cli/gh-teacher/skeleton_tests/test_materialize_tests.py
@@ -136,3 +136,40 @@ class TestMaterialize:
         out = tmp_path / "cs" / "autograders" / "hello" / "tests.json"
         loaded = runner.load_tests(out)
         assert [t["name"] for t in loaded] == ["compiles", "prints"]
+
+    def test_copies_test_defaults_into_envelope(self, tmp_path):
+        # An assignment-level test_defaults block rides the tests.json
+        # envelope as `defaults`; runner.load_tests folds it into each spec.
+        _write_classroom(tmp_path, "cs", _manifest([
+            {"slug": "hello",
+             "test_defaults": {"failure-details": "none", "show-output": True},
+             "tests": [
+                 {"name": "compiles", "type": "run", "run": "true", "points": 1},
+                 {"name": "loud", "type": "run", "run": "true", "points": 1,
+                  "failure-details": "full", "show-output": False},
+             ]},
+        ]))
+        mt.materialize(tmp_path)
+        out = tmp_path / "cs" / "autograders" / "hello" / "tests.json"
+        payload = json.loads(out.read_text())
+        assert payload["defaults"] == {"failure-details": "none", "show-output": True}
+        loaded = runner.load_tests(out)
+        assert loaded[0]["failure-details"] == "none"
+        assert loaded[0]["show-output"] is True
+        assert loaded[1]["failure-details"] == "full"
+        assert loaded[1]["show-output"] is False
+
+    def test_omits_absent_or_empty_test_defaults(self, tmp_path):
+        # No test_defaults (or an empty/malformed one) keeps the envelope at
+        # its historical two-key shape.
+        _write_classroom(tmp_path, "cs-a", _manifest([
+            {"slug": "hello", "tests": [_io_test()]}]))
+        _write_classroom(tmp_path, "cs-b", _manifest([
+            {"slug": "world", "test_defaults": {}, "tests": [_io_test()]}]))
+        _write_classroom(tmp_path, "cs-c", _manifest([
+            {"slug": "bad", "test_defaults": "nope", "tests": [_io_test()]}]))
+        mt.materialize(tmp_path)
+        for classroom, slug in (("cs-a", "hello"), ("cs-b", "world"), ("cs-c", "bad")):
+            payload = json.loads(
+                (tmp_path / classroom / "autograders" / slug / "tests.json").read_text())
+            assert "defaults" not in payload

--- a/schemas/assignments-v1.schema.json
+++ b/schemas/assignments-v1.schema.json
@@ -118,6 +118,15 @@
           "items": { "$ref": "#/$defs/test" },
           "description": "Declarative tests. Mutually exclusive with a per-assignment autograder.py at <classroom>/autograders/<slug>/ — probe before writing."
         },
+        "test_defaults": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "failure-details": { "enum": ["full", "actual-only", "none"] },
+            "show-output": { "type": "boolean" }
+          },
+          "description": "Assignment-level defaults for the per-test reporting options `failure-details` and `show-output` (see #/$defs/test for their semantics); a test's own value overrides. Only meaningful alongside `tests` — the materializer copies it into tests.json's `defaults` and it is otherwise ignored. Omit entirely for the built-in defaults (failure-details `full`, show-output `false`); like `runtime` it is a CLOSED sub-object, so a new sub-key must ship in lockstep across this schema, the Go TestDefaults struct, and the web Assignment['test_defaults'] type in the same release."
+        },
         "feedback_pr": {
           "type": "boolean",
           "description": "Opt the assignment into the Feedback Pull Request: one long-lived PR per student repo (base = a frozen branch at the baseline commit, head = the default branch) for inline teacher review of the full starter→submission diff. Both accept clients open it at accept time (best-effort, so it exists even with GitHub Actions disabled); the autograde runner adopts that PR by base+head and maintains it, and remains the fallback creator when accept could not. Product default is ON (both `gh teacher assignment add` and the GUI create it enabled). On the wire it is collapsed: the CLI omits the field when false (omitempty), so readers must treat an absent field as `false`; the GUI may also write `false` explicitly, so accept both. Absent or false means the PR never opens."
@@ -417,6 +426,14 @@
           "minimum": 0,
           "maximum": 1000,
           "description": "Defaults to 0 (informational test) when omitted; the CLI always writes it."
+        },
+        "failure-details": {
+          "enum": ["full", "actual-only", "none"],
+          "description": "How much failure detail students see for this test (release body, Actions log, run summary). `full` (the default when absent) = unified diff for exact comparisons, otherwise expected+actual blocks, plus stderr. `actual-only` = the student's own stdout/stderr only — no expected output and no diff (a diff would reveal it). `none` = only the failure kind (wrong output, wrong exit code, timeout, setup failed). Overrides the assignment's `test_defaults`."
+        },
+        "show-output": {
+          "type": "boolean",
+          "description": "Include the captured stdout/stderr of this test's setup/run commands in the submission report and Actions log even when the test PASSES, inside a collapsed details block. Overrides the assignment's `test_defaults`. On the wire it is collapsed: writers omit the field when false, so readers must treat an absent field as `false` (passing output discarded)."
         }
       },
       "allOf": [

--- a/schemas/tests-v1.schema.json
+++ b/schemas/tests-v1.schema.json
@@ -12,6 +12,15 @@
       "type": "array",
       "maxItems": 100,
       "items": { "$ref": "#/$defs/test" }
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "failure-details": { "enum": ["full", "actual-only", "none"] },
+        "show-output": { "type": "boolean" }
+      },
+      "description": "Assignment-level defaults for the per-test reporting options, copied verbatim from the assignment's `test_defaults` by materialize_tests.py. A test's own `failure-details` / `show-output` value overrides the default. Absent means the built-in defaults (failure-details `full`, show-output `false`)."
     }
   },
   "$defs": {
@@ -47,6 +56,14 @@
           "minimum": 0,
           "maximum": 1000,
           "description": "Defaults to 0 (informational test) when omitted; the CLI always writes it."
+        },
+        "failure-details": {
+          "enum": ["full", "actual-only", "none"],
+          "description": "How much failure detail students see for this test (release body, Actions log, run summary). `full` (the default when absent) = unified diff for exact comparisons, otherwise expected+actual blocks, plus stderr. `actual-only` = the student's own stdout/stderr only — no expected output and no diff (a diff would reveal it). `none` = only the failure kind (wrong output, wrong exit code, timeout, setup failed). Overrides the assignment's `test_defaults`."
+        },
+        "show-output": {
+          "type": "boolean",
+          "description": "Include the captured stdout/stderr of this test's setup/run commands in the submission report and Actions log even when the test PASSES, inside a collapsed details block. Overrides the assignment's `test_defaults`. On the wire it is collapsed: writers omit the field when false, so readers must treat an absent field as `false` (passing output discarded)."
         }
       },
       "allOf": [

--- a/web/src/domain/assignments.test.ts
+++ b/web/src/domain/assignments.test.ts
@@ -34,6 +34,7 @@ import type { GitHubClient } from "@/github-core/client"
 import { GitHubAPIError } from "@/github-core/errors"
 import type { Assignment } from "@/types/classroom"
 import { REPO_PERMISSIONS, SUBMISSION_MODES } from "@/types/classroom"
+import { TEST_FAILURE_DETAILS_LEVELS } from "@/types/classroom"
 import type { SubmissionMode } from "@/types/classroom"
 
 const fullSource: Assignment = {
@@ -3304,6 +3305,40 @@ describe("SUBMISSION_MODES parity with assignments-v1 schema", () => {
   it("matches the schema submission_mode enum exactly and in order", () => {
     const schemaEnum = schema.$defs.assignment.properties.submission_mode.enum
     expect(schemaEnum).toEqual([...SUBMISSION_MODES])
+  })
+})
+
+describe("TEST_FAILURE_DETAILS_LEVELS parity with assignments-v1 schema", () => {
+  const schemaPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../schemas/assignments-v1.schema.json",
+  )
+  const schema = JSON.parse(readFileSync(schemaPath, "utf-8")) as {
+    $defs: {
+      test: {
+        properties: { "failure-details": { enum: string[] } }
+      }
+      assignment: {
+        properties: {
+          test_defaults: {
+            properties: { "failure-details": { enum: string[] } }
+          }
+        }
+      }
+    }
+  }
+
+  it("matches the schema failure-details enum exactly and in order", () => {
+    const schemaEnum = schema.$defs.test.properties["failure-details"].enum
+    expect(schemaEnum).toEqual([...TEST_FAILURE_DETAILS_LEVELS])
+  })
+
+  it("matches the test_defaults failure-details enum too", () => {
+    const schemaEnum =
+      schema.$defs.assignment.properties.test_defaults.properties[
+        "failure-details"
+      ].enum
+    expect(schemaEnum).toEqual([...TEST_FAILURE_DETAILS_LEVELS])
   })
 })
 

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -9,6 +9,7 @@ import {
   SUBMISSION_MODES,
   GRADING_MODES,
   GRADING_MAX_POINTS_MIN,
+  TEST_FAILURE_DETAILS_LEVELS,
   assertAssignmentMode,
   defaultStudentPermission,
 } from "@/types/classroom"
@@ -135,6 +136,9 @@ const ASSIGNMENT_KEY_OWNERSHIP: Record<
   grading: "classroom50-owned",
   repo_features: "classroom50-owned",
   tests: "classroom50-owned",
+  // Rebuilt from input alongside tests; a clearing edit (back to the grader
+  // defaults) must win over the stale stored block.
+  test_defaults: "classroom50-owned",
   // Written only by the CLI's `migrate`; the form never rebuilds it, so it must
   // ride through a GUI edit untouched.
   migrated_from: "preserved",
@@ -760,6 +764,27 @@ async function buildAssignmentEntry(
 
   if (tests.length > 0) {
     entry.tests = tests
+  }
+
+  // test_defaults: assignment-level defaults for the per-test reporting
+  // options. Only meaningful with tests (the materializer folds it into
+  // tests.json), so omit it otherwise; also omit when every value is the
+  // grader default (the caller already collapses those away).
+  if (
+    tests.length > 0 &&
+    input.test_defaults &&
+    Object.keys(input.test_defaults).length > 0
+  ) {
+    const failureDetails = input.test_defaults["failure-details"]
+    if (
+      failureDetails !== undefined &&
+      !TEST_FAILURE_DETAILS_LEVELS.includes(failureDetails)
+    ) {
+      throw new Error(
+        `test_defaults.failure-details: must be one of ${TEST_FAILURE_DETAILS_LEVELS.join(", ")} (got "${String(failureDetails)}").`,
+      )
+    }
+    entry.test_defaults = { ...input.test_defaults }
   }
 
   // pass_threshold: opt-in integer percentage [0,100]. Absent means the teacher

--- a/web/src/domain/assignments/repoCreation.ts
+++ b/web/src/domain/assignments/repoCreation.ts
@@ -1,6 +1,7 @@
 import type { GitHubClient } from "@/github-core/client"
 import type { GitHubRepo } from "@/github-core/types"
 import type {
+  AssignmentTestDefaults,
   RepoPermission,
   RepoFeatures,
   SubmissionMode,
@@ -419,6 +420,11 @@ export type CreateAssignmentInput = {
   // the block when no key is set; accept resolves + applies it at fresh create.
   repo_features?: RepoFeatures
   tests: AssignmentTestDraft[]
+  // Assignment-level defaults for the per-test reporting options
+  // (failure-details / show-output); per-test values override.
+  // buildAssignmentEntry omits the block when undefined or when the
+  // assignment carries no tests. Mirrors the CLI's test_defaults object.
+  test_defaults?: AssignmentTestDefaults
   // Whether the write path may attempt the owner-only template read-grant
   // (addRepositoryToTeam). Set from useCanAttemptTemplateGrant at the call site
   // (true unless the org role is a confirmed non-owner). When false the save

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1457,6 +1457,8 @@
       "showOutputOn": "Include output",
       "showOutputOff": "Discard output",
       "defaultOption": "{{label}} (default)",
+      "reportOptions": "Report options",
+      "reportOptionsHint": "What the submission report shows for this test. Both options start at the assignment's report defaults; pick another value to override it for this test only.",
       "defaults": {
         "heading": "Report defaults",
         "hint": "Defaults for every test; a test's own report options override them.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1447,6 +1447,24 @@
       "timeout": "Timeout (seconds)",
       "timeoutHint": "0 = default (10s)",
       "points": "Points",
+      "failureDetails": "Failure details shown to students",
+      "failureDetailsHint": "How much of a failing run students see in the submission report and workflow log.",
+      "failureDetailsFull": "Full: diff or expected and actual output",
+      "failureDetailsActualOnly": "Student output only (never the expected output)",
+      "failureDetailsNone": "Failure type only (no output)",
+      "showOutput": "Output when passing",
+      "showOutputHint": "Include the captured setup/run output in the report even when the test passes, inside a collapsed section.",
+      "showOutputOn": "Include output",
+      "showOutputOff": "Discard output",
+      "defaultOption": "{{label}} (default)",
+      "defaults": {
+        "heading": "Report defaults",
+        "hint": "Defaults for every test; a test's own report options override them.",
+        "failureDetails": "Default failure details",
+        "failureDetailsFull": "Full: diff or expected and actual output",
+        "showOutput": "Include passing test output",
+        "showOutputHelp": "Adds each passing test's captured setup/run output to the submission report and workflow log, collapsed by default. Useful when authoring or debugging an autograder."
+      },
       "type": {
         "io": {
           "label": "Input/Output",

--- a/web/src/pages/CreateAssignmentPage.test.tsx
+++ b/web/src/pages/CreateAssignmentPage.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@/lib/githubHealth/githubStatusApi", () => ({
 // payload — the page's onError/onSuccess wiring is what's under test.
 vi.mock("@/pages/assignments/CreateAssignmentForm", () => ({
   formValuesToRepoFeatures: () => undefined,
+  formValuesToTestDefaults: () => undefined,
   default: ({
     onSubmit,
   }: {

--- a/web/src/pages/CreateAssignmentPage.tsx
+++ b/web/src/pages/CreateAssignmentPage.tsx
@@ -10,6 +10,7 @@ import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
 import { OrgRepoCreationNotice } from "@/components/OrgRepoCreationNotice"
 import CreateAssignmentForm, {
   formValuesToRepoFeatures,
+  formValuesToTestDefaults,
 } from "@/pages/assignments/CreateAssignmentForm"
 import { deriveFormShape } from "@/pages/assignments/formShape"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -169,6 +170,7 @@ const CreateAssignmentPage = () => {
                 repo_features: formValuesToRepoFeatures(values),
                 classroom,
                 tests: values.tests,
+                test_defaults: formValuesToTestDefaults(values),
               },
               {
                 onError: (err) => {

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -8,6 +8,7 @@ import type { AssignmentForm } from "./assignmentFormModel"
 
 import {
   FormField,
+  HelpTooltip,
   Badge,
   Button,
   Collapse,
@@ -403,75 +404,89 @@ const AutogradingTestModal = ({
           </FormField>
         </div>
 
-        <div className="flex flex-wrap gap-8">
-          <FormField
-            htmlFor={field("failureDetails")}
-            label={t("assignments.autograder.failureDetails")}
-            hint={t("assignments.autograder.failureDetailsHint")}
-          >
-            {({ id }) => (
-              <Select
-                id={id}
-                value={draft.failureDetails || defaults.failureDetails}
-                onChange={(e) => {
-                  // Picking the assignment default stores "" (inherit), so a
-                  // later change to the default still cascades to this test;
-                  // any other pick is an explicit per-test override.
-                  const level = e.target.value as AssignmentTestFailureDetails
-                  set(
-                    "failureDetails",
-                    level === defaults.failureDetails ? "" : level,
-                  )
-                }}
-              >
-                {FAILURE_DETAILS_OPTIONS.map(({ value, labelKey }) => (
-                  <option key={value} value={value}>
-                    {value === defaults.failureDetails
-                      ? t("assignments.autograder.defaultOption", {
-                          label: t(labelKey),
-                        })
-                      : t(labelKey)}
-                  </option>
-                ))}
-              </Select>
-            )}
-          </FormField>
+        <fieldset className="border-t border-base-300 pt-4">
+          <legend className="sr-only">
+            {t("assignments.autograder.reportOptions")}
+          </legend>
+          <div className="flex items-center gap-1.5">
+            <span className="label font-bold" aria-hidden="true">
+              {t("assignments.autograder.reportOptions")}
+            </span>
+            <HelpTooltip
+              help={t("assignments.autograder.reportOptionsHint")}
+              position="right"
+            />
+          </div>
+          <div className="mt-3 grid grid-cols-1 gap-x-8 gap-y-5 sm:grid-cols-2">
+            <FormField
+              htmlFor={field("failureDetails")}
+              label={t("assignments.autograder.failureDetails")}
+              hint={t("assignments.autograder.failureDetailsHint")}
+            >
+              {({ id }) => (
+                <Select
+                  id={id}
+                  value={draft.failureDetails || defaults.failureDetails}
+                  onChange={(e) => {
+                    // Picking the assignment default stores "" (inherit), so a
+                    // later change to the default still cascades to this test;
+                    // any other pick is an explicit per-test override.
+                    const level = e.target.value as AssignmentTestFailureDetails
+                    set(
+                      "failureDetails",
+                      level === defaults.failureDetails ? "" : level,
+                    )
+                  }}
+                >
+                  {FAILURE_DETAILS_OPTIONS.map(({ value, labelKey }) => (
+                    <option key={value} value={value}>
+                      {value === defaults.failureDetails
+                        ? t("assignments.autograder.defaultOption", {
+                            label: t(labelKey),
+                          })
+                        : t(labelKey)}
+                    </option>
+                  ))}
+                </Select>
+              )}
+            </FormField>
 
-          <FormField
-            htmlFor={field("showOutput")}
-            label={t("assignments.autograder.showOutput")}
-            hint={t("assignments.autograder.showOutputHint")}
-          >
-            {({ id }) => (
-              <Select
-                id={id}
-                value={
-                  (
-                    draft.showOutput === ""
-                      ? defaults.showOutput
-                      : draft.showOutput
-                  )
-                    ? "on"
-                    : "off"
-                }
-                onChange={(e) => {
-                  const on = e.target.value === "on"
-                  set("showOutput", on === defaults.showOutput ? "" : on)
-                }}
-              >
-                {SHOW_OUTPUT_OPTIONS.map(({ on, labelKey }) => (
-                  <option key={labelKey} value={on ? "on" : "off"}>
-                    {on === defaults.showOutput
-                      ? t("assignments.autograder.defaultOption", {
-                          label: t(labelKey),
-                        })
-                      : t(labelKey)}
-                  </option>
-                ))}
-              </Select>
-            )}
-          </FormField>
-        </div>
+            <FormField
+              htmlFor={field("showOutput")}
+              label={t("assignments.autograder.showOutput")}
+              hint={t("assignments.autograder.showOutputHint")}
+            >
+              {({ id }) => (
+                <Select
+                  id={id}
+                  value={
+                    (
+                      draft.showOutput === ""
+                        ? defaults.showOutput
+                        : draft.showOutput
+                    )
+                      ? "on"
+                      : "off"
+                  }
+                  onChange={(e) => {
+                    const on = e.target.value === "on"
+                    set("showOutput", on === defaults.showOutput ? "" : on)
+                  }}
+                >
+                  {SHOW_OUTPUT_OPTIONS.map(({ on, labelKey }) => (
+                    <option key={labelKey} value={on ? "on" : "off"}>
+                      {on === defaults.showOutput
+                        ? t("assignments.autograder.defaultOption", {
+                            label: t(labelKey),
+                          })
+                        : t(labelKey)}
+                    </option>
+                  ))}
+                </Select>
+              )}
+            </FormField>
+          </div>
+        </fieldset>
       </div>
     </Modal>
   )
@@ -720,15 +735,16 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
 
               {/* Assignment-level defaults for the per-test report options;
                   a test's own report options override them (folded into the
-                  materialized tests.json as `defaults`). */}
-              <fieldset className="mt-4">
-                <legend className="label font-bold">
+                  materialized tests.json as `defaults`). Framed like the
+                  table above so the two read as one tests unit. */}
+              <div className="mt-4 rounded-box border border-base-300 p-4">
+                <span className="label font-bold">
                   {t("assignments.autograder.defaults.heading")}
-                </legend>
-                <p className="text-sm pb-2 text-base-content/70">
+                </span>
+                <p className="mt-0.5 text-sm text-base-content/70">
                   {t("assignments.autograder.defaults.hint")}
                 </p>
-                <div className="flex flex-wrap items-center gap-x-8 gap-y-3">
+                <div className="mt-4 flex flex-col gap-4">
                   <form.Field name="test_failure_details">
                     {(defaultsField) => (
                       <FormField
@@ -736,10 +752,12 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                         label={t(
                           "assignments.autograder.defaults.failureDetails",
                         )}
+                        help={t("assignments.autograder.failureDetailsHint")}
                       >
                         {({ id }) => (
                           <Select
                             id={id}
+                            className="w-full max-w-sm"
                             value={defaultsField.state.value}
                             onChange={(e) =>
                               defaultsField.handleChange(
@@ -781,7 +799,7 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                     )}
                   </form.Field>
                 </div>
-              </fieldset>
+              </div>
             </Collapse>
 
             {editor && (

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -17,6 +17,7 @@ import {
   Select,
   TableShell,
   Textarea,
+  ToggleField,
 } from "@/components/ui"
 import type { AssignmentTestDraft } from "@/util/assignmentTests"
 import {
@@ -24,7 +25,10 @@ import {
   TEST_TIMEOUT_MAX_SECONDS,
   validateTestDraft,
 } from "@/util/assignmentTests"
-import type { AssignmentTestComparison } from "@/types/classroom"
+import type {
+  AssignmentTestComparison,
+  AssignmentTestFailureDetails,
+} from "@/types/classroom"
 
 const TYPE_OPTIONS = [
   {
@@ -44,6 +48,37 @@ const TYPE_OPTIONS = [
   },
 ] as const
 
+const FAILURE_DETAILS_OPTIONS = [
+  {
+    value: "full",
+    labelKey: "assignments.autograder.failureDetailsFull",
+  },
+  {
+    value: "actual-only",
+    labelKey: "assignments.autograder.failureDetailsActualOnly",
+  },
+  {
+    value: "none",
+    labelKey: "assignments.autograder.failureDetailsNone",
+  },
+] as const satisfies readonly {
+  value: AssignmentTestFailureDetails
+  labelKey: string
+}[]
+
+const SHOW_OUTPUT_OPTIONS = [
+  { on: true, labelKey: "assignments.autograder.showOutputOn" },
+  { on: false, labelKey: "assignments.autograder.showOutputOff" },
+] as const
+
+// The assignment's resolved report defaults, threaded into the test editor so
+// its selects can mark the current default option instead of offering an
+// opaque "assignment default" entry.
+type TestReportDefaults = {
+  failureDetails: AssignmentTestFailureDetails
+  showOutput: boolean
+}
+
 type TestErrors = Partial<Record<keyof AssignmentTestDraft, string>>
 
 // Editor works on a local copy; nothing reaches the form's `tests` until commit.
@@ -59,6 +94,7 @@ type AutogradingTestModalProps = {
   editor: EditorState
   dialogRef: React.RefObject<HTMLDialogElement | null>
   otherNames: string[]
+  defaults: TestReportDefaults
   onCancel: () => void
   onCommit: (draft: AssignmentTestDraft) => void
 }
@@ -67,6 +103,7 @@ const AutogradingTestModal = ({
   editor,
   dialogRef,
   otherNames,
+  defaults,
   onCancel,
   onCommit,
 }: AutogradingTestModalProps) => {
@@ -365,6 +402,76 @@ const AutogradingTestModal = ({
             )}
           </FormField>
         </div>
+
+        <div className="flex flex-wrap gap-8">
+          <FormField
+            htmlFor={field("failureDetails")}
+            label={t("assignments.autograder.failureDetails")}
+            hint={t("assignments.autograder.failureDetailsHint")}
+          >
+            {({ id }) => (
+              <Select
+                id={id}
+                value={draft.failureDetails || defaults.failureDetails}
+                onChange={(e) => {
+                  // Picking the assignment default stores "" (inherit), so a
+                  // later change to the default still cascades to this test;
+                  // any other pick is an explicit per-test override.
+                  const level = e.target.value as AssignmentTestFailureDetails
+                  set(
+                    "failureDetails",
+                    level === defaults.failureDetails ? "" : level,
+                  )
+                }}
+              >
+                {FAILURE_DETAILS_OPTIONS.map(({ value, labelKey }) => (
+                  <option key={value} value={value}>
+                    {value === defaults.failureDetails
+                      ? t("assignments.autograder.defaultOption", {
+                          label: t(labelKey),
+                        })
+                      : t(labelKey)}
+                  </option>
+                ))}
+              </Select>
+            )}
+          </FormField>
+
+          <FormField
+            htmlFor={field("showOutput")}
+            label={t("assignments.autograder.showOutput")}
+            hint={t("assignments.autograder.showOutputHint")}
+          >
+            {({ id }) => (
+              <Select
+                id={id}
+                value={
+                  (
+                    draft.showOutput === ""
+                      ? defaults.showOutput
+                      : draft.showOutput
+                  )
+                    ? "on"
+                    : "off"
+                }
+                onChange={(e) => {
+                  const on = e.target.value === "on"
+                  set("showOutput", on === defaults.showOutput ? "" : on)
+                }}
+              >
+                {SHOW_OUTPUT_OPTIONS.map(({ on, labelKey }) => (
+                  <option key={labelKey} value={on ? "on" : "off"}>
+                    {on === defaults.showOutput
+                      ? t("assignments.autograder.defaultOption", {
+                          label: t(labelKey),
+                        })
+                      : t(labelKey)}
+                  </option>
+                ))}
+              </Select>
+            )}
+          </FormField>
+        </div>
       </div>
     </Modal>
   )
@@ -387,6 +494,7 @@ const typeBadge = (type: AssignmentTestDraft["type"], t: TFunction) => {
 
 const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
   const { t } = useTranslation()
+  const paneFieldId = useId()
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const [editor, setEditor] = useState<EditorState | null>(null)
   // The test list collapses so a long table doesn't bury the Advanced settings
@@ -609,19 +717,97 @@ const AutogradingTestsPane = ({ form }: { form: AssignmentForm }) => {
                   )}
                 </tbody>
               </TableShell>
+
+              {/* Assignment-level defaults for the per-test report options;
+                  a test's own report options override them (folded into the
+                  materialized tests.json as `defaults`). */}
+              <fieldset className="mt-4">
+                <legend className="label font-bold">
+                  {t("assignments.autograder.defaults.heading")}
+                </legend>
+                <p className="text-sm pb-2 text-base-content/70">
+                  {t("assignments.autograder.defaults.hint")}
+                </p>
+                <div className="flex flex-wrap items-center gap-x-8 gap-y-3">
+                  <form.Field name="test_failure_details">
+                    {(defaultsField) => (
+                      <FormField
+                        htmlFor={`${paneFieldId}-failure-details`}
+                        label={t(
+                          "assignments.autograder.defaults.failureDetails",
+                        )}
+                      >
+                        {({ id }) => (
+                          <Select
+                            id={id}
+                            value={defaultsField.state.value}
+                            onChange={(e) =>
+                              defaultsField.handleChange(
+                                e.target
+                                  .value as (typeof defaultsField.state)["value"],
+                              )
+                            }
+                          >
+                            <option value="">
+                              {t(
+                                "assignments.autograder.defaults.failureDetailsFull",
+                              )}
+                            </option>
+                            <option value="actual-only">
+                              {t(
+                                "assignments.autograder.failureDetailsActualOnly",
+                              )}
+                            </option>
+                            <option value="none">
+                              {t("assignments.autograder.failureDetailsNone")}
+                            </option>
+                          </Select>
+                        )}
+                      </FormField>
+                    )}
+                  </form.Field>
+
+                  <form.Field name="test_show_output">
+                    {(defaultsField) => (
+                      <ToggleField
+                        id={`${paneFieldId}-show-output`}
+                        checked={defaultsField.state.value}
+                        onChange={defaultsField.handleChange}
+                        label={t("assignments.autograder.defaults.showOutput")}
+                        help={t(
+                          "assignments.autograder.defaults.showOutputHelp",
+                        )}
+                      />
+                    )}
+                  </form.Field>
+                </div>
+              </fieldset>
             </Collapse>
 
             {editor && (
-              <AutogradingTestModal
-                // Remount per open so the local draft re-initializes from the
-                // freshly opened baseline.
-                key={`${editor.mode}-${editor.index}`}
-                editor={editor}
-                dialogRef={dialogRef}
-                otherNames={otherNames(field.state.value, editor)}
-                onCancel={closeEditor}
-                onCommit={commitEditor}
-              />
+              <form.Subscribe
+                selector={(state) => ({
+                  // Resolve "" (grader default) to the concrete level so the
+                  // modal can mark the effective default option.
+                  failureDetails:
+                    state.values.test_failure_details || ("full" as const),
+                  showOutput: state.values.test_show_output,
+                })}
+              >
+                {(defaults) => (
+                  <AutogradingTestModal
+                    // Remount per open so the local draft re-initializes from the
+                    // freshly opened baseline.
+                    key={`${editor.mode}-${editor.index}`}
+                    editor={editor}
+                    dialogRef={dialogRef}
+                    otherNames={otherNames(field.state.value, editor)}
+                    defaults={defaults}
+                    onCancel={closeEditor}
+                    onCommit={commitEditor}
+                  />
+                )}
+              </form.Subscribe>
             )}
           </>
         )}

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -23,6 +23,7 @@ import {
 // assignmentFormModel directly.
 export { assignmentToFormValues } from "./assignmentFormModel"
 export { formValuesToRepoFeatures } from "./assignmentFormModel"
+export { formValuesToTestDefaults } from "./assignmentFormModel"
 
 // The whole-form error list (submit-time validation errors that aren't bound to
 // a single field). Rendered once below the sections, as an error Alert so the

--- a/web/src/pages/assignments/EditAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.test.tsx
@@ -38,6 +38,7 @@ vi.mock("react-i18next", async (importOriginal) => {
 vi.mock("./CreateAssignmentForm", () => ({
   assignmentToFormValues: (value: unknown) => value,
   formValuesToRepoFeatures: () => undefined,
+  formValuesToTestDefaults: () => undefined,
   default: ({
     onSubmit,
   }: {

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import CreateAssignmentForm, {
   assignmentToFormValues,
   formValuesToRepoFeatures,
+  formValuesToTestDefaults,
 } from "./CreateAssignmentForm"
 import { deriveFormShape } from "./formShape"
 import {
@@ -179,6 +180,7 @@ const EditAssignmentForm = ({
                 repo_features: formValuesToRepoFeatures(values),
                 classroom,
                 tests: values.tests,
+                test_defaults: formValuesToTestDefaults(values),
                 slug: assignment,
               }
 

--- a/web/src/pages/assignments/assignmentFormModel.test.ts
+++ b/web/src/pages/assignments/assignmentFormModel.test.ts
@@ -6,6 +6,8 @@ import {
   validateAssignmentForm,
   toSubmitValues,
   formValuesToRepoFeatures,
+  formValuesToTestDefaults,
+  testFailureDetailsChoice,
   shouldSeedBuiltInAutograder,
   type CreateAssignmentFormValues,
 } from "./assignmentFormModel"
@@ -31,6 +33,8 @@ const draft = (
   timeout: 30,
   exitCode: "",
   points: 10,
+  failureDetails: "",
+  showOutput: "",
   ...over,
 })
 
@@ -78,6 +82,8 @@ const base: CreateAssignmentFormValues = {
   repo_feature_projects: "inherit",
   repo_feature_pull_requests: "inherit",
   tests: [],
+  test_failure_details: "",
+  test_show_output: false,
 }
 
 describe("validateAssignmentForm — happy paths", () => {
@@ -1178,5 +1184,80 @@ describe("shouldSeedBuiltInAutograder", () => {
         autogradingState: "built-in",
       }),
     ).toBe(false)
+  })
+})
+
+describe("test_defaults form mapping (failure-details / show-output)", () => {
+  it("collapses the grader defaults to an omitted block", () => {
+    expect(
+      formValuesToTestDefaults({
+        test_failure_details: "",
+        test_show_output: false,
+      }),
+    ).toBeUndefined()
+  })
+
+  it("writes only the non-default values", () => {
+    expect(
+      formValuesToTestDefaults({
+        test_failure_details: "none",
+        test_show_output: false,
+      }),
+    ).toEqual({ "failure-details": "none" })
+    expect(
+      formValuesToTestDefaults({
+        test_failure_details: "",
+        test_show_output: true,
+      }),
+    ).toEqual({ "show-output": true })
+    expect(
+      formValuesToTestDefaults({
+        test_failure_details: "actual-only",
+        test_show_output: true,
+      }),
+    ).toEqual({ "failure-details": "actual-only", "show-output": true })
+  })
+
+  it("reads a stored explicit 'full' as the default choice", () => {
+    // Round-trip normalization: an explicit assignment-level "full" equals
+    // the grader default, so re-saving drops the redundant key.
+    expect(testFailureDetailsChoice("full")).toBe("")
+    expect(testFailureDetailsChoice(undefined)).toBe("")
+    expect(testFailureDetailsChoice("none")).toBe("none")
+    expect(testFailureDetailsChoice("actual-only")).toBe("actual-only")
+  })
+
+  it("assignmentToFormValues seeds the defaults controls from the entry", () => {
+    const values = assignmentToFormValues({
+      slug: "hw1",
+      name: "HW1",
+      mode: "individual",
+      autograder: "default",
+      tests: [{ name: "t", type: "run", run: "true", points: 1 }],
+      test_defaults: { "failure-details": "none", "show-output": true },
+    })
+    expect(values.test_failure_details).toBe("none")
+    expect(values.test_show_output).toBe(true)
+  })
+
+  it("toSubmitValues clears the defaults without the built-in autograder", () => {
+    const submitted = toSubmitValues({
+      ...base,
+      autograding_state: "none",
+      test_failure_details: "none",
+      test_show_output: true,
+    })
+    expect(submitted.test_failure_details).toBe("")
+    expect(submitted.test_show_output).toBe(false)
+  })
+
+  it("toSubmitValues keeps the defaults with the built-in autograder", () => {
+    const submitted = toSubmitValues({
+      ...base,
+      test_failure_details: "actual-only",
+      test_show_output: true,
+    })
+    expect(submitted.test_failure_details).toBe("actual-only")
+    expect(submitted.test_show_output).toBe(true)
   })
 })

--- a/web/src/pages/assignments/assignmentFormModel.ts
+++ b/web/src/pages/assignments/assignmentFormModel.ts
@@ -51,6 +51,8 @@ import { deriveFormShape } from "./formShape"
 import { resolveSubmissionMode } from "@/domain/assignments/submissionDetection"
 import type {
   Assignment,
+  AssignmentTestDefaults,
+  AssignmentTestFailureDetails,
   RepoPermission,
   RepoFeatures,
   SubmissionMode,
@@ -200,6 +202,13 @@ export type CreateAssignmentFormValues = {
   repo_feature_projects: RepoFeatureChoice
   repo_feature_pull_requests: RepoFeatureChoice
   tests: AssignmentTestDraft[]
+  // Assignment-level defaults for the per-test reporting options; a test's own
+  // value overrides. "" = the grader default (full failure details). Maps to
+  // the wire test_defaults["failure-details"], omitted when "".
+  test_failure_details: AssignmentTestFailureDetails | ""
+  // Assignment-level default for including passing-test output in the report.
+  // Maps to test_defaults["show-output"], omitted when false.
+  test_show_output: boolean
 }
 
 // A single repo-feature control's value. "inherit" is the default and omits the
@@ -242,6 +251,35 @@ export function formValuesToRepoFeatures(
   apply(value.repo_feature_projects, "projects")
   apply(value.repo_feature_pull_requests, "pull_requests")
   return Object.keys(result).length > 0 ? result : undefined
+}
+
+// Write mapping: the two defaults controls -> the wire test_defaults object,
+// omitting the grader-default values ("" failure details, show-output off).
+// Returns undefined when both are default so the caller omits the block
+// entirely (matching buildAssignmentEntry's omit-when-empty rule).
+export function formValuesToTestDefaults(
+  value: Pick<
+    CreateAssignmentFormValues,
+    "test_failure_details" | "test_show_output"
+  >,
+): AssignmentTestDefaults | undefined {
+  const result: AssignmentTestDefaults = {}
+  if (value.test_failure_details !== "") {
+    result["failure-details"] = value.test_failure_details
+  }
+  if (value.test_show_output) {
+    result["show-output"] = true
+  }
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+// Read mapping: a stored failure-details default -> the form choice. An
+// explicit "full" reads as "" (the grader default), so a round-trip normalizes
+// it away rather than persisting a redundant key.
+export function testFailureDetailsChoice(
+  value: AssignmentTestFailureDetails | undefined,
+): AssignmentTestFailureDetails | "" {
+  return value === undefined || value === "full" ? "" : value
 }
 
 // Create-only: slug uniqueness is not validated in edit mode (no rename).
@@ -641,6 +679,10 @@ export function toSubmitValues(
     repo_feature_projects: value.repo_feature_projects,
     repo_feature_pull_requests: value.repo_feature_pull_requests,
     tests: isEmptyRepo ? [] : value.tests,
+    // Grading-adjacent like the built-in-only fields: without the built-in
+    // autograder no report is rendered, so clear stale defaults on submit.
+    test_failure_details: noBuiltIn ? "" : value.test_failure_details,
+    test_show_output: noBuiltIn ? false : value.test_show_output,
   }
 }
 
@@ -714,6 +756,8 @@ export const useAssignmentForm = (
       repo_feature_pull_requests:
         defaultValues?.repo_feature_pull_requests ?? "inherit",
       tests: defaultValues?.tests || [],
+      test_failure_details: defaultValues?.test_failure_details ?? "",
+      test_show_output: defaultValues?.test_show_output ?? false,
     } satisfies CreateAssignmentFormValues,
     validators: {
       onSubmit: ({ value }) => {
@@ -837,5 +881,9 @@ export const assignmentToFormValues = (
     allowed_files: allowedFilesToText(assignment.allowed_files),
     release_assets: releaseAssetsToText(assignment.release_assets),
     tests,
+    test_failure_details: testFailureDetailsChoice(
+      assignment.test_defaults?.["failure-details"],
+    ),
+    test_show_output: assignment.test_defaults?.["show-output"] ?? false,
   }
 }

--- a/web/src/pages/assignments/formShape.test.ts
+++ b/web/src/pages/assignments/formShape.test.ts
@@ -47,6 +47,8 @@ const base: CreateAssignmentFormValues = {
   repo_feature_projects: "inherit",
   repo_feature_pull_requests: "inherit",
   tests: [],
+  test_failure_details: "",
+  test_show_output: false,
 }
 
 describe("deriveFormShape — repository source", () => {

--- a/web/src/pages/assignments/sections/sectionFields.test.ts
+++ b/web/src/pages/assignments/sections/sectionFields.test.ts
@@ -51,6 +51,8 @@ const defaults: CreateAssignmentFormValues = {
   repo_feature_projects: "inherit",
   repo_feature_pull_requests: "inherit",
   tests: [],
+  test_failure_details: "",
+  test_show_output: false,
 }
 
 describe("sectionIsConfigured", () => {

--- a/web/src/pages/assignments/sections/sectionFields.test.ts
+++ b/web/src/pages/assignments/sections/sectionFields.test.ts
@@ -109,6 +109,16 @@ describe("sectionIsConfigured", () => {
     const maxChanged = { ...defaults, grading_max_points: 42 }
     expect(sectionIsConfigured("submission", maxChanged, defaults)).toBe(true)
   })
+
+  it("attributes the report defaults to the submission section", () => {
+    // The test_defaults controls live in the autograder pane, so changing only
+    // them must surface the submission section's Reset (and reset with it).
+    const details = { ...defaults, test_failure_details: "none" as const }
+    expect(sectionIsConfigured("submission", details, defaults)).toBe(true)
+    const output = { ...defaults, test_show_output: true }
+    expect(sectionIsConfigured("submission", output, defaults)).toBe(true)
+    expect(sectionIsConfigured("details", output, defaults)).toBe(false)
+  })
 })
 
 describe("errorKeyMatchesField", () => {

--- a/web/src/pages/assignments/sections/sectionFields.ts
+++ b/web/src/pages/assignments/sections/sectionFields.ts
@@ -54,6 +54,8 @@ export const SECTION_FIELDS: Record<
     "pass_threshold_enabled",
     "pass_threshold",
     "tests",
+    "test_failure_details",
+    "test_show_output",
   ],
   schedule: ["available_from_date", "due_date"],
 }

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -326,6 +326,11 @@ export type Assignment = {
   // RepoFeatures struct (`repo_features`, closed object).
   repo_features?: RepoFeatures
   tests?: AssignmentTest[]
+  // Assignment-level defaults for the per-test reporting options
+  // (failure-details / show-output); per-test values override. Only
+  // meaningful alongside `tests`. In lockstep with the CLI's assignments-v1
+  // schema (`test_defaults`) and the Go TestDefaults struct.
+  test_defaults?: AssignmentTestDefaults
   // CLI migrate provenance. The GUI doesn't write it but must round-trip it.
   migrated_from?: MigratedFrom
   // The assignment's PREVIOUS slug, from the one-shot slug rename (a single
@@ -386,6 +391,18 @@ export type DueMeta = {
 export type AssignmentTestType = "io" | "run" | "python"
 export type AssignmentTestComparison = "included" | "exact" | "regex"
 
+// How much of a failing test's captured output students see. Absent = the
+// assignment default, then the grader default "full". In lockstep with the
+// CLI's assignments-v1/tests-v1 schema enum and tests.go's
+// failureDetailsLevels (parity-tested by a vitest).
+export const TEST_FAILURE_DETAILS_LEVELS = [
+  "full",
+  "actual-only",
+  "none",
+] as const
+export type AssignmentTestFailureDetails =
+  (typeof TEST_FAILURE_DETAILS_LEVELS)[number]
+
 // One declarative autograding test (v1 testSpec, kebab-case wire keys).
 // `io` compares stdout, `run` checks the exit code, `python` runs pytest.
 export type AssignmentTest = {
@@ -401,6 +418,23 @@ export type AssignmentTest = {
   timeout?: number
   "exit-code"?: number
   points: number
+  // How much failure detail students see (absent = the assignment default,
+  // then the grader default `full`). In lockstep with the assignments-v1
+  // schema and the Go TestSpec.
+  "failure-details"?: AssignmentTestFailureDetails
+  // Include captured setup/run output in the report even on a pass. An
+  // explicit false overrides a test_defaults show-output=true, so absent and
+  // false are distinct on the wire.
+  "show-output"?: boolean
+}
+
+// Assignment-level defaults for the per-test reporting options; a test's own
+// value overrides. A CLOSED sub-object like `runtime`: a new key must ship in
+// lockstep across the assignments-v1 schema, the Go TestDefaults struct, and
+// this type in the same release.
+export type AssignmentTestDefaults = {
+  "failure-details"?: AssignmentTestFailureDetails
+  "show-output"?: boolean
 }
 
 // The roster's identity/metadata columns — the classroom GitHub team is the

--- a/web/src/util/assignmentTests.test.ts
+++ b/web/src/util/assignmentTests.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import { draftToTest, emptyTestDraft, testToDraft } from "./assignmentTests"
+import type { AssignmentTest } from "@/types/classroom"
+
+// The reporting options (failure-details / show-output, issues #612/#764/#765)
+// must survive the web draft round-trip — testToDraft/draftToTest rebuild
+// every field, so an unmapped key would be silently stripped on any web edit.
+describe("test draft round-trip of the reporting options", () => {
+  it("defaults to inherit ('') on the empty draft and omits the keys on the wire", () => {
+    const draft = emptyTestDraft()
+    expect(draft.failureDetails).toBe("")
+    expect(draft.showOutput).toBe("")
+    const test = draftToTest({ ...draft, name: "t", run: "true" })
+    expect("failure-details" in test).toBe(false)
+    expect("show-output" in test).toBe(false)
+  })
+
+  it("round-trips explicit values, including show-output false", () => {
+    // An explicit false overrides an assignment-level show-output default of
+    // true, so it must reach the wire — absent and false are distinct.
+    const test: AssignmentTest = {
+      name: "t",
+      type: "run",
+      run: "true",
+      points: 1,
+      "failure-details": "actual-only",
+      "show-output": false,
+    }
+    const draft = testToDraft(test)
+    expect(draft.failureDetails).toBe("actual-only")
+    expect(draft.showOutput).toBe(false)
+    const again = draftToTest(draft)
+    expect(again["failure-details"]).toBe("actual-only")
+    expect(again["show-output"]).toBe(false)
+  })
+
+  it("round-trips show-output true on every test type", () => {
+    for (const test of [
+      { name: "r", type: "run", run: "true", points: 1 },
+      {
+        name: "i",
+        type: "io",
+        run: "echo hi",
+        expected: "hi",
+        comparison: "included",
+        points: 1,
+      },
+      { name: "p", type: "python", run: "pytest", points: 1 },
+    ] satisfies AssignmentTest[]) {
+      const withOptions: AssignmentTest = {
+        ...test,
+        "failure-details": "none",
+        "show-output": true,
+      }
+      const again = draftToTest(testToDraft(withOptions))
+      expect(again["failure-details"]).toBe("none")
+      expect(again["show-output"]).toBe(true)
+    }
+  })
+
+  it("keeps absent reporting options absent through a round-trip", () => {
+    const test: AssignmentTest = {
+      name: "t",
+      type: "run",
+      run: "true",
+      points: 1,
+    }
+    const again = draftToTest(testToDraft(test))
+    expect("failure-details" in again).toBe(false)
+    expect("show-output" in again).toBe(false)
+  })
+})

--- a/web/src/util/assignmentTests.ts
+++ b/web/src/util/assignmentTests.ts
@@ -1,12 +1,16 @@
 import type {
   AssignmentTest,
   AssignmentTestComparison,
+  AssignmentTestFailureDetails,
   AssignmentTestType,
 } from "@/types/classroom"
 
 // Form-side draft for one declarative test. Camel-cased and all-fields-present
 // so it plugs into @tanstack/react-form cleanly; `draftToTest` converts to the
 // kebab-case v1 wire shape and drops fields that don't apply to the type.
+// failureDetails/showOutput use "" for "inherit the assignment default" —
+// an explicit showOutput false still reaches the wire, where it overrides a
+// test_defaults show-output=true.
 export type AssignmentTestDraft = {
   name: string
   type: AssignmentTestType
@@ -20,6 +24,8 @@ export type AssignmentTestDraft = {
   timeout: number
   exitCode: number | ""
   points: number
+  failureDetails: AssignmentTestFailureDetails | ""
+  showOutput: boolean | ""
 }
 
 // A setup command is encoded as a leading 0-point `run` test with this reserved
@@ -75,6 +81,8 @@ export const emptyTestDraft = (): AssignmentTestDraft => ({
   timeout: 0,
   exitCode: "",
   points: 10,
+  failureDetails: "",
+  showOutput: "",
 })
 
 export const testToDraft = (test: AssignmentTest): AssignmentTestDraft => ({
@@ -90,6 +98,8 @@ export const testToDraft = (test: AssignmentTest): AssignmentTestDraft => ({
   timeout: test.timeout ?? 0,
   exitCode: test["exit-code"] ?? "",
   points: test.points,
+  failureDetails: test["failure-details"] ?? "",
+  showOutput: test["show-output"] ?? "",
 })
 
 // draftToTest serializes a draft into the exact v1 wire shape: kebab-case keys,
@@ -123,6 +133,12 @@ export function draftToTest(draft: AssignmentTestDraft): AssignmentTest {
   if (draft.type === "run" && draft.exitCode !== "") {
     test["exit-code"] = draft.exitCode
   }
+
+  if (draft.failureDetails !== "")
+    test["failure-details"] = draft.failureDetails
+  // An explicit false is written (not collapsed): it overrides a
+  // test_defaults show-output=true for this one test.
+  if (draft.showOutput !== "") test["show-output"] = draft.showOutput
 
   return test
 }


### PR DESCRIPTION
## Summary

Fixes the three autograder reporting issues with one refactor: the declarative grader now captures each test's raw setup/run output and applies truncation plus a visibility policy at render time, per surface.

- **Full output in the Actions log** (#612): failing tests' `::group::` blocks in the workflow log now clip at 100,000 chars per stream instead of 2,000; the release body and run summary keep the 2,000-char clip so published reports stay skimmable.
- **Opt-in passing-test output** (#764): `show-output: true` (per test, or assignment-wide) keeps a passing test's captured setup/run stdout/stderr and renders it in a collapsed `Test output` section of the release body and an `OUTPUT` group in the log. Default off; no more `; false` workaround.
- **Failure-detail levels** (#765): `failure-details: full | actual-only | none` controls what students see on every surface — `actual-only` shows only the student's own output (the unified diff is suppressed too, since it reveals the expected side), `none` reports just the failure kind.

Contract changes are additive and land in lockstep across all mirrors: `assignments-v1`/`tests-v1` schemas (per-test fields + a `test_defaults` entry block carried to the runner via a new optional `defaults` envelope key), Go `TestSpec`/`TestDefaults` + validators + `gh teacher assignment test add --failure-details/--show-output`, the workflow's inline validator, `materialize_tests.py`, and the web app (full editor UI: per-test selects that mark the effective assignment default "(default)", a framed Report defaults panel under the tests table, draft round-trip so web edits preserve the fields, and section-reset ownership). `show-output` is a tri-state on the wire so an explicit `false` can override a `true` assignment default.

Closes #612, closes #764, closes #765.

## Test plan

- [x] `python3 -m pytest cli/gh-teacher/skeleton_tests cli/gh-teacher/autograders_tests` (1294 tests: policy matrix per level x comparison, per-surface clip limits, defaults folding, passing-output capture/render, injection defenses, schema + materializer + inline-validator parity)
- [x] `go build ./... && go test ./...` and `golangci-lint run` in `cli/gh-teacher` (new validator cases, `test_defaults` round-trip, explicit `show-output: false` wire round-trip, failure-details schema parity)
- [x] `npm run check` in `web/` (tsc, eslint, prettier, arch:validate, 4520 vitest tests incl. enum parity and draft round-trip)
- [ ] Manual: publish an assignment with `failure-details: none` + `show-output: true` and verify the release body, Actions log, and run summary on a real submission