### PR TITLE
fix: stop concurrent invite acceptance from corrupting roster.csv

### DIFF
--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -645,8 +645,7 @@ func RemoveTeamMembership(client githubapi.Client, org, slug, username string) e
 // GetTeamMembershipState reads one user's membership on one team ("active" or
 // "pending"). found=false on 404 — GitHub's authoritative "not on this team" (a
 // missing team 404s the same way). Any other error propagates so a transient
-// blip is never read as "not a member" — the roster sync uses this as
-// decision-time proof before deleting an invite metadata team.
+// blip is never read as "not a member".
 func GetTeamMembershipState(client githubapi.Client, org, slug, username string) (state string, found bool, err error) {
 	path := fmt.Sprintf("orgs/%s/teams/%s/memberships/%s",
 		url.PathEscape(org), url.PathEscape(slug), url.PathEscape(username))

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -642,6 +642,26 @@ func RemoveTeamMembership(client githubapi.Client, org, slug, username string) e
 	return nil
 }
 
+// GetTeamMembershipState reads one user's membership on one team ("active" or
+// "pending"). found=false on 404 — GitHub's authoritative "not on this team" (a
+// missing team 404s the same way). Any other error propagates so a transient
+// blip is never read as "not a member" — the roster sync uses this as
+// decision-time proof before deleting an invite metadata team.
+func GetTeamMembershipState(client githubapi.Client, org, slug, username string) (state string, found bool, err error) {
+	path := fmt.Sprintf("orgs/%s/teams/%s/memberships/%s",
+		url.PathEscape(org), url.PathEscape(slug), url.PathEscape(username))
+	var resp struct {
+		State string `json:"state"`
+	}
+	if err := client.Get(path, &resp); err != nil {
+		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("GET %s: %w", path, err)
+	}
+	return resp.State, true, nil
+}
+
 // teamHasRepoAccess reports whether the team addressed by `slug` already has
 // any access to <org>/<repo> (204 = yes, 404 = no). Keeps GrantTeamRepoRead
 // idempotent.

--- a/cli/gh-teacher/internal/roster/sync.go
+++ b/cli/gh-teacher/internal/roster/sync.go
@@ -148,6 +148,10 @@ type classroomIndex struct {
 	// idByLogin omits any login held by more than one member: two accounts
 	// answering to one login is not something to guess at.
 	idByLogin map[string]int64
+	// teamSlugs are the classroom teams `enrolled` was built from (student
+	// first), kept so the scan can re-prove an apparent unenrollment with
+	// decision-time point reads before the one irreversible action of the pass.
+	teamSlugs []string
 	// archived is classroom.json `active: false`: the roster is frozen, so
 	// --write is refused (the web's assertClassroomNotArchived).
 	archived bool
@@ -197,6 +201,7 @@ func loadClassroomIndex(client githubapi.Client, org, classroom, branch string) 
 
 	counts := map[string]int{}
 	for _, team := range teams {
+		idx.teamSlugs = append(idx.teamSlugs, team.slug)
 		// Strict read: a classroom or staff team is RECORDED, so its absence is a
 		// broken classroom (renamed, deleted, mistyped), not an empty roster.
 		// Reading it as no members would make every accepted invitee look
@@ -335,10 +340,27 @@ func scanInviteTeams(client githubapi.Client, errOut io.Writer, org, classroom s
 				continue
 			}
 			if !idx.enrolled[invitee.ID] {
-				// Accepted, then removed from the classroom: the lifecycle is
-				// over, and the record must not resurrect the row later.
-				scan.staleSlugs = append(scan.staleSlugs, team.Slug)
-				continue
+				// Absent from idx.enrolled is NOT proof of unenrollment: the
+				// index was built once, before this loop, so a student who
+				// accepted mid-pass sits on their invite team while missing
+				// from the snapshot. Deleting on that stale evidence would
+				// destroy the only record of their email <-> account mapping
+				// (issue #756), so re-prove absence with decision-time point
+				// reads first; any membership means the snapshot was stale —
+				// they enrolled since it was taken, so recover them.
+				enrolled, confErr := confirmEnrollment(client, org, idx.teamSlugs, invitee.Login)
+				if confErr != nil {
+					scan.trusted = false
+					_, _ = fmt.Fprintf(errOut, "Warning: %s: re-checking %s's classroom membership failed (%v); leaving %s alone.\n", org, invitee.Login, confErr, team.Slug)
+					continue
+				}
+				if !enrolled {
+					// Accepted, then removed from the classroom: the lifecycle
+					// is over, and the record must not resurrect the row later.
+					scan.staleSlugs = append(scan.staleSlugs, team.Slug)
+					continue
+				}
+				idx.enrolled[invitee.ID] = true
 			}
 			scan.recovered = append(scan.recovered, inviteRecovery{
 				Email: email, Login: invitee.Login, ID: invitee.ID, Slug: team.Slug,
@@ -355,6 +377,25 @@ func pastGCAge(createdAt time.Time) bool {
 		return false
 	}
 	return time.Since(createdAt) > contract.InviteTeamGCMinAge
+}
+
+// confirmEnrollment re-reads whether login is on any classroom team RIGHT NOW,
+// via per-team point reads (GET .../memberships/{login}) — the decision-time
+// proof required before deleting an invite metadata team as "unenrolled". Any
+// membership record (active or pending) counts: neither state proves the
+// invite lifecycle is over. Strict: a failed read propagates so the caller
+// keeps the team.
+func confirmEnrollment(client githubapi.Client, org string, teamSlugs []string, login string) (bool, error) {
+	for _, slug := range teamSlugs {
+		_, found, err := configrepo.GetTeamMembershipState(client, org, slug, login)
+		if err != nil {
+			return false, err
+		}
+		if found {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // rosterPlan is the roster-side work phase 2 derives from the scan and the

--- a/cli/gh-teacher/internal/roster/sync.go
+++ b/cli/gh-teacher/internal/roster/sync.go
@@ -149,8 +149,7 @@ type classroomIndex struct {
 	// answering to one login is not something to guess at.
 	idByLogin map[string]int64
 	// teamSlugs are the classroom teams `enrolled` was built from (student
-	// first), kept so the scan can re-prove an apparent unenrollment with
-	// decision-time point reads before the one irreversible action of the pass.
+	// first), kept for the scan's decision-time enrollment re-check.
 	teamSlugs []string
 	// archived is classroom.json `active: false`: the roster is frozen, so
 	// --write is refused (the web's assertClassroomNotArchived).
@@ -263,6 +262,7 @@ func scanInviteTeams(client githubapi.Client, errOut io.Writer, org, classroom s
 		return scan
 	}
 
+scanLoop:
 	for _, team := range teams {
 		state, ok, err := configrepo.ReadInviteTeam(client, org, team.Slug)
 		if err != nil {
@@ -345,12 +345,16 @@ func scanInviteTeams(client githubapi.Client, errOut io.Writer, org, classroom s
 				// accepted mid-pass sits on their invite team while missing
 				// from the snapshot. Deleting on that stale evidence would
 				// destroy the only record of their email <-> account mapping
-				// (issue #756), so re-prove absence with decision-time point
-				// reads first; any membership means the snapshot was stale —
-				// they enrolled since it was taken, so recover them.
+				// (issue #756), so re-prove absence at decision time first;
+				// any membership means the snapshot was stale — they enrolled
+				// since it was taken, so recover them.
 				enrolled, confErr := confirmEnrollment(client, org, idx.teamSlugs, invitee.Login)
 				if confErr != nil {
 					scan.trusted = false
+					if cliutil.IsRateLimited(confErr) {
+						_, _ = fmt.Fprintf(errOut, "Warning: %s: rate-limited while re-checking %s's classroom membership; stopping the invite pass early — re-run later.\n", org, invitee.Login)
+						break scanLoop
+					}
 					_, _ = fmt.Fprintf(errOut, "Warning: %s: re-checking %s's classroom membership failed (%v); leaving %s alone.\n", org, invitee.Login, confErr, team.Slug)
 					continue
 				}
@@ -379,12 +383,9 @@ func pastGCAge(createdAt time.Time) bool {
 	return time.Since(createdAt) > contract.InviteTeamGCMinAge
 }
 
-// confirmEnrollment re-reads whether login is on any classroom team RIGHT NOW,
-// via per-team point reads (GET .../memberships/{login}) — the decision-time
-// proof required before deleting an invite metadata team as "unenrolled". Any
-// membership record (active or pending) counts: neither state proves the
-// invite lifecycle is over. Strict: a failed read propagates so the caller
-// keeps the team.
+// confirmEnrollment reports whether login is on any classroom team RIGHT NOW,
+// via per-team point reads. Any membership record (active or pending) counts.
+// Strict: a failed read propagates so the caller keeps the team.
 func confirmEnrollment(client githubapi.Client, org string, teamSlugs []string, login string) (bool, error) {
 	for _, slug := range teamSlugs {
 		_, found, err := configrepo.GetTeamMembershipState(client, org, slug, login)

--- a/cli/gh-teacher/internal/roster/sync_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/sync_cmd_test.go
@@ -107,6 +107,10 @@ func (m *syncMock) handler(t *testing.T) http.Handler {
 		rest := strings.TrimPrefix(r.URL.Path, "/orgs/o/teams/")
 		if _, login, ok := strings.Cut(rest, "/memberships/"); ok {
 			if m.membershipStatus != 0 {
+				if m.membershipStatus == http.StatusTooManyRequests {
+					// A real secondary limit carries the header IsRateLimited keys on.
+					w.Header().Set("Retry-After", "30")
+				}
 				w.WriteHeader(m.membershipStatus)
 				return
 			}
@@ -469,6 +473,63 @@ func TestRunRosterSync_EnrollmentRecheckFailureKeepsTeam(t *testing.T) {
 	}
 	if !strings.Contains(errOut, "Warning") {
 		t.Errorf("stderr must warn about the failed re-check:\n%s", errOut)
+	}
+}
+
+// A PENDING membership record still means the invite lifecycle is not provably
+// over: the re-check must recover, not delete. A refactor to `state == "active"`
+// fails this test.
+func TestRunRosterSync_PendingMembershipRecheckRecovers(t *testing.T) {
+	mock := newSyncMock(t, storedRosterHeader+",Ada,Lovelace,"+inviteTestEmail+",,,student\n")
+	mock.teams = []syncTeam{acceptedInviteTeam(t)}
+	mock.classroomMembers = []map[string]any{{"login": "someone-else", "id": 999}}
+	mock.membershipStates = map[string]string{syncTestAcceptedLogin: "pending"}
+
+	if _, _, err := runSync(t, mock, true); err != nil {
+		t.Fatalf("runRosterSync: %v", err)
+	}
+	rows := committedRosterRows(t, mock)
+	if len(rows) != 1 || rows[0].Username != syncTestAcceptedLogin {
+		t.Fatalf("expected the fold onto the pending row, got %#v", rows)
+	}
+	want := configrepo.InviteTeamName(inviteTestClassroom, inviteTestEmail)
+	if len(mock.deletedTeams) != 1 || mock.deletedTeams[0] != want {
+		t.Errorf("deleted teams = %v, want only the post-commit retire of %s", mock.deletedTeams, want)
+	}
+}
+
+// A rate-limited re-check must stop the whole invite pass early (like every
+// other rate-limited read), not burn one doomed request per remaining team.
+func TestRunRosterSync_RateLimitedRecheckStopsPassEarly(t *testing.T) {
+	second := syncTeam{
+		slug:      configrepo.InviteTeamName(inviteTestClassroom, "second@uni.edu"),
+		desc:      syncInviteRecord(t, "second@uni.edu"),
+		createdAt: time.Now().Add(-time.Hour),
+		members:   []map[string]any{{"login": "bea", "id": 202}},
+	}
+	mock := newSyncMock(t, storedRosterHeader+",Ada,Lovelace,"+inviteTestEmail+",,,student\n")
+	mock.teams = []syncTeam{acceptedInviteTeam(t), second}
+	mock.classroomMembers = []map[string]any{{"login": "someone-else", "id": 999}}
+	mock.membershipStatus = http.StatusTooManyRequests
+
+	_, errOut, err := runSync(t, mock, true)
+	if got := exitCode(err); got != 1 {
+		t.Fatalf("exit code = %d (err %v), want 1 for a rate-limited pass", got, err)
+	}
+	if len(mock.deletedTeams) != 0 || len(mock.blobs) != 0 {
+		t.Errorf("deleted %v / committed %d blob(s) on a rate-limited pass", mock.deletedTeams, len(mock.blobs))
+	}
+	if !strings.Contains(errOut, "rate-limited") {
+		t.Errorf("stderr must name the rate limit:\n%s", errOut)
+	}
+	pointReads := 0
+	for _, c := range mock.calls {
+		if strings.Contains(c.Path, "/memberships/") {
+			pointReads++
+		}
+	}
+	if pointReads != 1 {
+		t.Errorf("membership point reads = %d, want 1 — the first rate limit must stop the pass", pointReads)
 	}
 }
 

--- a/cli/gh-teacher/internal/roster/sync_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/sync_cmd_test.go
@@ -69,6 +69,12 @@ type syncMock struct {
 	// staffMembers is each recorded staff team's membership, keyed by slug —
 	// the source of an appended row's team-derived role.
 	staffMembers map[string][]map[string]any
+	// membershipStates answers the decision-time enrollment point reads
+	// (GET .../teams/{slug}/memberships/{login}) by login; a login absent here
+	// 404s, GitHub's "not on this team". membershipStatus overrides every such
+	// read with an error status (a degraded re-check).
+	membershipStates map[string]string
+	membershipStatus int
 	// classroomJSONStatus fails the classroom.json read, the degraded case that
 	// must make the whole pass read-mostly.
 	classroomJSONStatus int
@@ -99,6 +105,18 @@ func (m *syncMock) handler(t *testing.T) http.Handler {
 
 	base.HandleFunc("/orgs/o/teams/", func(w http.ResponseWriter, r *http.Request) {
 		rest := strings.TrimPrefix(r.URL.Path, "/orgs/o/teams/")
+		if _, login, ok := strings.Cut(rest, "/memberships/"); ok {
+			if m.membershipStatus != 0 {
+				w.WriteHeader(m.membershipStatus)
+				return
+			}
+			if state, ok := m.membershipStates[login]; ok {
+				_ = json.NewEncoder(w).Encode(map[string]any{"state": state})
+				return
+			}
+			http.NotFound(w, r)
+			return
+		}
 		slug, members := rest, false
 		if trimmed, ok := strings.CutSuffix(rest, "/members"); ok {
 			slug, members = trimmed, true
@@ -395,6 +413,62 @@ func TestRunRosterSync_SoleMemberOnNoClassroomTeamDeletesWithoutFolding(t *testi
 	want := configrepo.InviteTeamName(inviteTestClassroom, inviteTestEmail)
 	if len(mock.deletedTeams) != 1 || mock.deletedTeams[0] != want {
 		t.Errorf("deleted teams = %v, want just %s", mock.deletedTeams, want)
+	}
+}
+
+// The #756 race: a student accepts WHILE the pass runs, so they sit on their
+// invite team while absent from the enrollment snapshot taken earlier. The
+// stale snapshot must never authorize the irreversible team delete — the
+// decision-time membership re-check proves they enrolled mid-pass, so the pass
+// folds them like any other recovery and only RETIRES the team post-commit.
+func TestRunRosterSync_MidPassAcceptorIsRecoveredNotDeleted(t *testing.T) {
+	mock := newSyncMock(t, storedRosterHeader+",Ada,Lovelace,"+inviteTestEmail+",section-1,,student\n")
+	mock.teams = []syncTeam{acceptedInviteTeam(t)}
+	// The snapshot predates the acceptance: the invitee is not in the list...
+	mock.classroomMembers = []map[string]any{{"login": "someone-else", "id": 999}}
+	// ...but the point read shows them on the classroom team NOW.
+	mock.membershipStates = map[string]string{syncTestAcceptedLogin: "active"}
+
+	if _, _, err := runSync(t, mock, true); err != nil {
+		t.Fatalf("runRosterSync: %v", err)
+	}
+	rows := committedRosterRows(t, mock)
+	if len(rows) != 1 {
+		t.Fatalf("committed %d row(s), want the one folded row: %#v", len(rows), rows)
+	}
+	row := rows[0]
+	if row.Username != syncTestAcceptedLogin || row.GitHubID != syncTestAcceptedID {
+		t.Errorf("row did not gain the recovered identity: %#v", row)
+	}
+	if row.FirstName != "Ada" || row.LastName != "Lovelace" || row.Section != "section-1" {
+		t.Errorf("fold lost teacher-owned metadata: %#v", row)
+	}
+	want := configrepo.InviteTeamName(inviteTestClassroom, inviteTestEmail)
+	if len(mock.deletedTeams) != 1 || mock.deletedTeams[0] != want {
+		t.Errorf("deleted teams = %v, want the retired %s (post-commit), never a stale delete", mock.deletedTeams, want)
+	}
+}
+
+// A failed enrollment re-check proves nothing about the one team it guards, so
+// the pass keeps it, warns, and degrades (exit 1) rather than guessing.
+func TestRunRosterSync_EnrollmentRecheckFailureKeepsTeam(t *testing.T) {
+	mock := newSyncMock(t, storedRosterHeader+",Ada,Lovelace,"+inviteTestEmail+",,,student\n")
+	mock.teams = []syncTeam{acceptedInviteTeam(t)}
+	mock.classroomMembers = []map[string]any{{"login": "someone-else", "id": 999}}
+	mock.membershipStatus = http.StatusInternalServerError
+
+	_, errOut, err := runSync(t, mock, true)
+	if got := exitCode(err); got != 1 {
+		t.Fatalf("exit code = %d (err %v), want 1 for a degraded re-check", got, err)
+	}
+	if len(mock.deletedTeams) != 0 {
+		t.Errorf("deleted %v; an unproven unenrollment must keep the team", mock.deletedTeams)
+	}
+	if len(mock.blobs) != 0 {
+		t.Errorf("committed %d blob(s); an unproven identity must not be folded", len(mock.blobs))
+	}
+	if !strings.Contains(errOut, "Warning") {
+		t.Errorf("stderr must warn about the failed re-check:\n%s", errOut)
 	}
 }
 

--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -30,6 +30,7 @@ import {
   StudentAlreadyEnrolledError,
 } from "./students"
 import { removeEmailInviteRow } from "./students/rosterPrimitives"
+import { inviteTeamName, marshalInviteDescription } from "@/util/inviteTeam"
 import { GitHubAPIError } from "@/github-core/errors"
 import type { GitHubClient } from "@/github-core/client"
 
@@ -2497,6 +2498,17 @@ const makeTeamClient = (opts: {
   orgInviteEmails?: string[]
   // When set, the org-invitations read rejects, so removal fails closed.
   orgInvitesReject?: boolean
+  // Invite metadata teams served through the REAL collect seam (the sync's
+  // decision-time re-collect): listed on the org team list, point-read with
+  // description/created_at, members listed by exact slug.
+  inviteTeams?: {
+    slug: string
+    description: string
+    members: TeamMemberSeed[]
+  }[]
+  // How many ref updates fail 409 first (drives withGitConflictRetry); the
+  // retried closure then re-reads the CSV the losing attempt staged.
+  refConflicts?: number
   // When set, a members read for the teacher/ta team rejects with this
   // non-404 status (to exercise the best-effort staff-read degradation).
   staffReadRejects?: { role: "teacher" | "ta"; status: number }
@@ -2504,6 +2516,7 @@ const makeTeamClient = (opts: {
   const committed: { content: string | null } = { content: null }
   const memberSet = new Set((opts.members ?? []).map((m) => m.toLowerCase()))
   const teamAdds: string[] = []
+  const refConflictsSeen = { count: 0 }
 
   const requestRaw = vi.fn().mockImplementation((path: string) => {
     if (path.includes("/contents/") && path.includes("classroom.json")) {
@@ -2533,9 +2546,14 @@ const makeTeamClient = (opts: {
       }
       // Org team list (GET /orgs/{org}/teams?page=..) — enumerated by the
       // sync's decision-time invite re-collect when a team member has no
-      // roster row. No invite teams exist in these harnesses.
+      // roster row.
       if (/\/orgs\/[^/]+\/teams\?/.test(path)) {
-        return Promise.resolve([])
+        return Promise.resolve(
+          (opts.inviteTeams ?? []).map((t, i) => ({
+            id: 700 + i,
+            slug: t.slug,
+          })),
+        )
       }
       // Team-add: PUT .../teams/{slug}/memberships/{login}
       if (path.includes("/teams/") && path.includes("/memberships/")) {
@@ -2584,6 +2602,13 @@ const makeTeamClient = (opts: {
         const slug = decodeURIComponent(
           path.split("/teams/")[1].split("/members")[0],
         )
+        // An invite metadata team's members, by exact slug.
+        const invite = (opts.inviteTeams ?? []).find((t) => t.slug === slug)
+        if (invite) {
+          return Promise.resolve(
+            invite.members.map((m) => ({ login: m.login, id: m.id })),
+          )
+        }
         const rejects = opts.staffReadRejects
         const rejectsTeacher =
           rejects &&
@@ -2621,6 +2646,21 @@ const makeTeamClient = (opts: {
           name: m.name ?? null,
         }))
         return Promise.resolve(members)
+      }
+      // Invite metadata team point read (readInviteTeam): GET
+      // /orgs/{org}/teams/{slug} — description + created_at.
+      {
+        const m = path.match(/\/orgs\/[^/]+\/teams\/([^/?]+)$/)
+        const slug = m ? decodeURIComponent(m[1]) : null
+        const invite = (opts.inviteTeams ?? []).find((t) => t.slug === slug)
+        if (invite) {
+          return Promise.resolve({
+            id: 700,
+            slug: invite.slug,
+            description: invite.description,
+            created_at: new Date().toISOString(),
+          })
+        }
       }
       // Org membership state: GET /orgs/{org}/memberships/{login}
       if (path.includes("/memberships/") && !path.includes("/teams/")) {
@@ -2666,6 +2706,27 @@ const makeTeamClient = (opts: {
         return Promise.resolve({ sha: "new-commit-sha" })
       }
       if (path.endsWith("/git/refs/heads/main")) {
+        if ((opts.refConflicts ?? 0) > refConflictsSeen.count) {
+          refConflictsSeen.count++
+          // The losing attempt's staged CSV stands in for the concurrent
+          // writer's commit: the retry re-reads it as the current file.
+          return Promise.reject(
+            new GitHubAPIError({
+              status: 409,
+              url: path,
+              message: "conflict",
+              body: null,
+              rateLimit: {
+                limit: null,
+                remaining: null,
+                used: null,
+                reset: null,
+                resource: null,
+                retryAfter: null,
+              },
+            }),
+          )
+        }
         return Promise.resolve({})
       }
       return Promise.reject(new Error(`unexpected request: ${path}`))
@@ -2678,6 +2739,94 @@ const makeTeamClient = (opts: {
     request,
   }
 }
+
+describe("syncRosterFromTeam — real invite-team seam (#756)", () => {
+  const email = "ada@uni.edu"
+  const inviteTeamFor = async () => ({
+    slug: await inviteTeamName("cs101", email),
+    description: marshalInviteDescription({ email, classroom: "cs101" }),
+    members: [{ login: "ada", id: 42 }],
+  })
+
+  it("folds a mid-pass acceptor via the UN-mocked re-collect; mapping reported recorded", async () => {
+    // Ada accepted between the caller's collect (nothing recovered, her email
+    // live) and this sync's team read. The re-collect runs the REAL
+    // collectInviteRecoveries against a real invite team served over the wire:
+    // slug hashed from (classroom, email), v1 description, one member.
+    const team = await inviteTeamFor()
+    const { client, committed, request } = makeTeamClient({
+      startingCsv: HEADER + `,Ada,Lovelace,${email},,,student\n`,
+      users: {},
+      teamHas: [{ login: "ada", id: 42 }],
+      inviteTeams: [team],
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: {
+        recovered: [],
+        liveInviteEmails: new Set([email]),
+        trusted: true,
+        deletedStale: 0,
+      },
+    })
+
+    // Identity folded onto the invite-time row — no appended duplicate.
+    const rows = rowsFromCsv(committed.content!)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      username: "ada",
+      github_id: "42",
+      email,
+      first_name: "Ada",
+      last_name: "Lovelace",
+    })
+    // The landed fold makes the mapping finalizable.
+    expect(result.recordedRecoveries).toEqual([
+      { email, invitee: { id: 42, login: "ada" }, slug: team.slug },
+    ])
+    // The in-closure re-collect is read-only: nothing was deleted.
+    const deletes = request.mock.calls.filter(
+      ([, options]) => (options as { method?: string })?.method === "DELETE",
+    )
+    expect(deletes).toEqual([])
+  })
+
+  it("re-derives the fold on a 409 retry: no duplicate row, teardown deferred safely", async () => {
+    const team = await inviteTeamFor()
+    const { client, committed } = makeTeamClient({
+      startingCsv: HEADER + `,Ada,Lovelace,${email},,,student\n`,
+      users: {},
+      teamHas: [{ login: "ada", id: 42 }],
+      inviteTeams: [team],
+      refConflicts: 1,
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      org: "acme",
+      classroom: "cs101",
+      invites: {
+        recovered: [],
+        liveInviteEmails: new Set([email]),
+        trusted: true,
+        deletedStale: 0,
+      },
+    })
+
+    // Attempt 1 folded and lost the ref race; attempt 2 re-read the folded
+    // file and recognized the work as done — ONE row, never a duplicate.
+    const rows = rowsFromCsv(committed.content!)
+    expect(
+      rows.filter((r) => r.username === "ada" || r.email === email),
+    ).toHaveLength(1)
+    expect(result.noop).toBe(true)
+    // The retry attempt never re-collected (the folded row leaves no unknown
+    // member), so the caller's empty state proves no mapping recorded THIS
+    // pass: teardown fails closed and defers to the next pass's re-recovery.
+    expect(result.recordedRecoveries).toEqual([])
+  })
+})
 
 describe("bulkEnrollStudentsInClassroom — verify org membership, flag non-members", () => {
   it("adds active org members to the team and skips non-members", async () => {

--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -2531,6 +2531,12 @@ const makeTeamClient = (opts: {
         if (!u) return Promise.reject(new Error(`404 no such user: ${login}`))
         return Promise.resolve({ login, name: null, email: null, ...u })
       }
+      // Org team list (GET /orgs/{org}/teams?page=..) — enumerated by the
+      // sync's decision-time invite re-collect when a team member has no
+      // roster row. No invite teams exist in these harnesses.
+      if (/\/orgs\/[^/]+\/teams\?/.test(path)) {
+        return Promise.resolve([])
+      }
       // Team-add: PUT .../teams/{slug}/memberships/{login}
       if (path.includes("/teams/") && path.includes("/memberships/")) {
         const login = decodeURIComponent(path.split("/memberships/")[1])

--- a/web/src/domain/students/inviteRecoveries.test.ts
+++ b/web/src/domain/students/inviteRecoveries.test.ts
@@ -318,6 +318,81 @@ describe("collectInviteRecoveries", () => {
     expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
+  it("counts a PENDING team membership as enrolled in the re-check", async () => {
+    // Any membership record means the invite lifecycle is not provably over —
+    // a refactor to `state === "active"` must fail this test, or a mid-window
+    // acceptor would lose their mapping.
+    const team = await inviteState("cs101", "mid@example.com", [
+      { id: 99, login: "mid" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
+    listTeamMembers.mockResolvedValue([{ id: 2, login: "someone-else" }])
+    getTeamMembershipState.mockResolvedValue("pending")
+
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered.map((r) => r.email)).toEqual(["mid@example.com"])
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("a rate-limited re-check stops the pass early (never one team's 'unknown')", async () => {
+    const first = await inviteState("cs101", "one@example.com", [
+      { id: 98, login: "one" },
+    ])
+    const second = await inviteState("cs101", "two@example.com", [
+      { id: 99, login: "two" },
+    ])
+    listInviteTeams.mockResolvedValue([
+      { slug: first.slug },
+      { slug: second.slug },
+    ])
+    readInviteTeam.mockImplementation(
+      async (_c: unknown, _o: unknown, slug: string) =>
+        slug === first.slug ? first : second,
+    )
+    listTeamMembers.mockResolvedValue([{ id: 2, login: "someone-else" }])
+    getTeamMembershipState.mockRejectedValue(rateLimitError())
+
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.trusted).toBe(false)
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+    // The pass stopped at the first rate limit instead of burning a request
+    // per remaining team.
+    expect(readInviteTeam).toHaveBeenCalledTimes(1)
+  })
+
+  it("readOnly classifies identically but never deletes (the sync's re-collect mode)", async () => {
+    // One confirmed-unenrolled team and one aged member-less team: a normal
+    // pass deletes both; readOnly must classify the same (neither counted
+    // live) while touching nothing.
+    const gone = await inviteState("cs101", "left@example.com", [
+      { id: 99, login: "left" },
+    ])
+    const aged = await inviteState("cs101", "stale@example.com", [], {
+      createdAt: OLD_ENOUGH,
+    })
+    listInviteTeams.mockResolvedValue([
+      { slug: gone.slug },
+      { slug: aged.slug },
+    ])
+    readInviteTeam.mockImplementation(
+      async (_c: unknown, _o: unknown, slug: string) =>
+        slug === gone.slug ? gone : aged,
+    )
+    listTeamMembers.mockResolvedValue([{ id: 2, login: "someone-else" }])
+
+    const state = await collectInviteRecoveries(client, {
+      ...INPUT,
+      readOnly: true,
+    })
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+    expect(state.deletedStale).toBe(0)
+    expect(state.recovered).toEqual([])
+    // Neither email reads as live: the classification matched a mutating pass.
+    expect(state.liveInviteEmails.size).toBe(0)
+    expect(state.trusted).toBe(true)
+  })
+
   it("keeps the team (untrusted) when the enrollment re-check fails", async () => {
     const team = await inviteState("cs101", "blip@example.com", [
       { id: 99, login: "blip" },

--- a/web/src/domain/students/inviteRecoveries.test.ts
+++ b/web/src/domain/students/inviteRecoveries.test.ts
@@ -6,6 +6,7 @@ const readInviteTeam = vi.fn()
 const deleteInviteTeam = vi.fn()
 const listTeamMembers = vi.fn()
 const listOrgInvitations = vi.fn()
+const getTeamMembershipState = vi.fn()
 const resolveClassroomTeamSlugs = vi.fn()
 
 vi.mock("@/github-core/mutations", () => ({
@@ -16,6 +17,7 @@ vi.mock("@/github-core/mutations", () => ({
 vi.mock("@/github-core/queries", () => ({
   listTeamMembers: (...a: unknown[]) => listTeamMembers(...a),
   listOrgInvitations: (...a: unknown[]) => listOrgInvitations(...a),
+  getTeamMembershipState: (...a: unknown[]) => getTeamMembershipState(...a),
 }))
 vi.mock("./rosterPrimitives", () => ({
   resolveClassroomTeamSlugs: (...a: unknown[]) =>
@@ -96,6 +98,9 @@ beforeEach(() => {
     { id: 2, login: "member2" },
     { id: 3, login: "member3" },
   ])
+  // Default: the decision-time enrollment re-check agrees with the snapshot —
+  // a login absent from listTeamMembers is genuinely on no classroom team.
+  getTeamMembershipState.mockResolvedValue(null)
 })
 
 describe("INVITE_TEAM_GC_MIN_AGE_MS — cross-tool contract", () => {
@@ -281,7 +286,53 @@ describe("collectInviteRecoveries", () => {
     const state = await collectInviteRecoveries(client, INPUT)
     expect(state.recovered).toEqual([])
     expect(state.deletedStale).toBe(1)
+    // The delete was authorized by decision-time point reads, not the snapshot.
+    expect(getTeamMembershipState).toHaveBeenCalled()
     expect(deleteInviteTeam).toHaveBeenCalledWith(client, "org", team.slug)
+  })
+
+  // The #756 race: a student accepts WHILE the pass iterates, so they sit on
+  // their invite team but are absent from the enrollment snapshot taken
+  // earlier. The stale snapshot must never authorize the irreversible team
+  // delete — the decision-time re-check proves they enrolled mid-pass.
+  it("recovers (never deletes) a mid-pass acceptor the snapshot missed", async () => {
+    const team = await inviteState("cs101", "fresh@example.com", [
+      { id: 99, login: "fresh" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
+    // Snapshot predates their acceptance...
+    listTeamMembers.mockResolvedValue([{ id: 2, login: "someone-else" }])
+    // ...but the point read shows them on the classroom team NOW.
+    getTeamMembershipState.mockResolvedValue("active")
+
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered).toEqual([
+      {
+        email: "fresh@example.com",
+        invitee: { id: 99, login: "fresh" },
+        slug: team.slug,
+      },
+    ])
+    expect(state.deletedStale).toBe(0)
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
+  })
+
+  it("keeps the team (untrusted) when the enrollment re-check fails", async () => {
+    const team = await inviteState("cs101", "blip@example.com", [
+      { id: 99, login: "blip" },
+    ])
+    listInviteTeams.mockResolvedValue([{ slug: team.slug }])
+    readInviteTeam.mockResolvedValue(team)
+    listTeamMembers.mockResolvedValue([{ id: 2, login: "someone-else" }])
+    // Absence can't be proven: a failed re-check must keep the team.
+    getTeamMembershipState.mockRejectedValue(new Error("boom"))
+
+    const state = await collectInviteRecoveries(client, INPUT)
+    expect(state.recovered).toEqual([])
+    expect(state.deletedStale).toBe(0)
+    expect(state.trusted).toBe(false)
+    expect(deleteInviteTeam).not.toHaveBeenCalled()
   })
 
   it("keeps the team (untrusted) when NO classroom member is visible at all", async () => {

--- a/web/src/domain/students/inviteRecoveries.ts
+++ b/web/src/domain/students/inviteRecoveries.ts
@@ -4,7 +4,11 @@ import {
   listInviteTeams,
   readInviteTeam,
 } from "@/github-core/mutations"
-import { listOrgInvitations, listTeamMembers } from "@/github-core/queries"
+import {
+  getTeamMembershipState,
+  listOrgInvitations,
+  listTeamMembers,
+} from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
 import { inviteTeamName, normalizeInviteEmail } from "@/util/inviteTeam"
 import { log, resolveClassroomTeamSlugs } from "./rosterPrimitives"
@@ -64,7 +68,10 @@ export const INVITE_TEAM_GC_MIN_AGE_MS = 24 * 60 * 60 * 1000
 //     team is left in place for the caller to delete after the roster commit
 //     lands;
 //   - one member on NO classroom team -> unenrolled after accepting; delete the
-//     team now so the mapping can't resurrect a removed student;
+//     team now so the mapping can't resurrect a removed student. Absence is
+//     re-proven with decision-time point reads first — the enrollment snapshot
+//     is cached for the whole pass, so a student accepting mid-pass would
+//     otherwise be misread as unenrolled and their mapping destroyed (#756);
 //   - zero members -> the invite is live (row kept), unless the team aged past
 //     the GC guard AND no pending org invitation still maps to it (cancelled/
 //     expired) -> delete;
@@ -98,10 +105,17 @@ export async function collectInviteRecoveries(
   // derived slug would 404 -> [] and make an enrolled invitee look unenrolled).
   // A read failure propagates to the per-team catch, never silently reads as
   // "member of nothing".
+  let classroomSlugs: Awaited<
+    ReturnType<typeof resolveClassroomTeamSlugs>
+  > | null = null
+  const loadClassroomSlugs = async () => {
+    classroomSlugs ??= await resolveClassroomTeamSlugs(client, org, classroom)
+    return classroomSlugs
+  }
   let enrolledIds: Set<number> | null = null
   const loadEnrolledIds = async (): Promise<Set<number>> => {
     if (enrolledIds) return enrolledIds
-    const slugs = await resolveClassroomTeamSlugs(client, org, classroom)
+    const slugs = await loadClassroomSlugs()
     const rosters = await Promise.all(
       [slugs.student, ...Object.values(slugs.staff)].map((slug) =>
         listTeamMembers(client, org, slug),
@@ -109,6 +123,29 @@ export async function collectInviteRecoveries(
     )
     enrolledIds = new Set(rosters.flat().map((m) => m.id))
     return enrolledIds
+  }
+
+  // Decision-time proof for the ONE irreversible action in this pass: is this
+  // login on any classroom team RIGHT NOW? The cached snapshot above predates
+  // most of the loop, so a student who accepts while it iterates is absent
+  // from it while already sitting on their invite team — deleting on that
+  // stale evidence destroys the only record of their email <-> account mapping
+  // (issue #756). Point reads, not a re-list: the snapshot lists are exactly
+  // what went stale. "unknown" (a failed read) must keep the team.
+  const confirmEnrollment = async (
+    login: string,
+  ): Promise<"enrolled" | "unenrolled" | "unknown"> => {
+    try {
+      const slugs = await loadClassroomSlugs()
+      for (const slug of [slugs.student, ...Object.values(slugs.staff)]) {
+        const state = await getTeamMembershipState(client, org, slug, login)
+        if (state !== null) return "enrolled"
+      }
+      return "unenrolled"
+    } catch (err) {
+      log.error("invite reconcile: enrollment re-check failed", { login, err })
+      return "unknown"
+    }
   }
 
   // Live invite-team slugs, fetched lazily only when a member-less team is old
@@ -182,11 +219,23 @@ export async function collectInviteRecoveries(
         continue
       }
       if (!enrolled.has(invitee.id)) {
-        // Accepted, then removed from the classroom: the invite lifecycle is
-        // over. Delete the team so its record can't resurrect the row later.
-        await deleteInviteTeam(client, org, slug)
-        deletedStale += 1
-        continue
+        // Absent from the snapshot is NOT proof of unenrollment — a student
+        // who accepted mid-pass looks exactly like this. Only a decision-time
+        // re-check may authorize the irreversible delete; a confirmed stale
+        // snapshot means they enrolled since it was taken, so recover them.
+        const confirmed = await confirmEnrollment(invitee.login)
+        if (confirmed === "unknown") {
+          trusted = false
+          continue
+        }
+        if (confirmed === "unenrolled") {
+          // Accepted, then removed from the classroom: the invite lifecycle is
+          // over. Delete the team so its record can't resurrect the row later.
+          await deleteInviteTeam(client, org, slug)
+          deletedStale += 1
+          continue
+        }
+        enrolled.add(invitee.id)
       }
 
       recovered.push({

--- a/web/src/domain/students/inviteRecoveries.ts
+++ b/web/src/domain/students/inviteRecoveries.ts
@@ -69,23 +69,27 @@ export const INVITE_TEAM_GC_MIN_AGE_MS = 24 * 60 * 60 * 1000
 //     lands;
 //   - one member on NO classroom team -> unenrolled after accepting; delete the
 //     team now so the mapping can't resurrect a removed student. Absence is
-//     re-proven with decision-time point reads first — the enrollment snapshot
-//     is cached for the whole pass, so a student accepting mid-pass would
-//     otherwise be misread as unenrolled and their mapping destroyed (#756);
+//     re-proven at decision time first (see confirmEnrollment);
 //   - zero members -> the invite is live (row kept), unless the team aged past
 //     the GC guard AND no pending org invitation still maps to it (cancelled/
 //     expired) -> delete;
 //   - anomalies (tampered hash, >1 member) -> keep the team, count its email
 //     as live, and warn — never guess.
 //
+// `readOnly` classifies WITHOUT the deletes (stale/unenrolled teams are simply
+// not counted live): the roster sync's in-closure re-collect runs on every
+// conflict-retry attempt and from plain team syncs, and an irreversible
+// destructive action does not belong inside either. Deletion stays exclusive
+// to the top-level reconcile's own collect pass.
+//
 // Never throws. Fail-safe: any read failure (enumeration, a team, the org
 // invitation list) flips `trusted` off so the sync skips row removals; a rate
 // limit stops the pass early the same way.
 export async function collectInviteRecoveries(
   client: GitHubClient,
-  input: { org: string; classroom: string },
+  input: { org: string; classroom: string; readOnly?: boolean },
 ): Promise<InviteReconcileState> {
-  const { org, classroom } = input
+  const { org, classroom, readOnly = false } = input
   const recovered: RecoveredInvite[] = []
   const liveInviteEmails = new Set<string>()
   let trusted = true
@@ -143,6 +147,9 @@ export async function collectInviteRecoveries(
       }
       return "unenrolled"
     } catch (err) {
+      // A rate limit must stop the whole pass (the per-team catch below
+      // breaks on it), not read as one team's "unknown".
+      if (err instanceof GitHubAPIError && err.isRateLimited) throw err
       log.error("invite reconcile: enrollment re-check failed", { login, err })
       return "unknown"
     }
@@ -190,8 +197,10 @@ export async function collectInviteRecoveries(
           isPastGcAge(state.createdAt) &&
           !(await loadLiveInviteSlugs()).has(slug)
         ) {
-          await deleteInviteTeam(client, org, slug)
-          deletedStale += 1
+          if (!readOnly) {
+            await deleteInviteTeam(client, org, slug)
+            deletedStale += 1
+          }
         } else {
           liveInviteEmails.add(record.email)
         }
@@ -219,10 +228,9 @@ export async function collectInviteRecoveries(
         continue
       }
       if (!enrolled.has(invitee.id)) {
-        // Absent from the snapshot is NOT proof of unenrollment — a student
-        // who accepted mid-pass looks exactly like this. Only a decision-time
-        // re-check may authorize the irreversible delete; a confirmed stale
-        // snapshot means they enrolled since it was taken, so recover them.
+        // Absent from the snapshot is NOT proof of unenrollment (see
+        // confirmEnrollment); a confirmed stale snapshot means they enrolled
+        // mid-pass, so recover them.
         const confirmed = await confirmEnrollment(invitee.login)
         if (confirmed === "unknown") {
           trusted = false
@@ -231,8 +239,10 @@ export async function collectInviteRecoveries(
         if (confirmed === "unenrolled") {
           // Accepted, then removed from the classroom: the invite lifecycle is
           // over. Delete the team so its record can't resurrect the row later.
-          await deleteInviteTeam(client, org, slug)
-          deletedStale += 1
+          if (!readOnly) {
+            await deleteInviteTeam(client, org, slug)
+            deletedStale += 1
+          }
           continue
         }
         enrolled.add(invitee.id)

--- a/web/src/domain/students/reconcileRoster.test.ts
+++ b/web/src/domain/students/reconcileRoster.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
     addedUsernames: [],
     recoveredEmails: ["alice@example.com"],
     removedEmails: [],
-    lateRecovered: [],
+    recordedRecoveries: [RECOVERED],
     noop: false,
   })
   finalizeInviteRecoveries.mockResolvedValue(undefined)
@@ -69,7 +69,7 @@ describe("reconcileRoster", () => {
         addedUsernames: ["alice"],
         recoveredEmails: ["alice@example.com"],
         removedEmails: ["dead@x"],
-        lateRecovered: [],
+        recordedRecoveries: [RECOVERED],
         noop: false,
       }
     })
@@ -88,7 +88,7 @@ describe("reconcileRoster", () => {
         invites: expect.objectContaining({ trusted: true }),
       }),
     )
-    // ...and the recovered teams are deleted only after it.
+    // ...and only the mappings the sync reports RECORDED are deleted, after it.
     expect(finalizeInviteRecoveries).toHaveBeenCalledWith(
       client,
       { org: "org", classroom: "cs101" },
@@ -98,13 +98,16 @@ describe("reconcileRoster", () => {
       addedUsernames: ["alice"],
       recoveredEmails: ["alice@example.com"],
       removedEmails: ["dead@x"],
-      lateRecovered: [],
+      recordedRecoveries: [RECOVERED],
       noop: false,
       deletedStaleTeams: 1,
     })
   })
 
-  it("finalizes late recoveries the sync collected itself (mid-pass acceptance)", async () => {
+  it("finalizes exactly what the sync recorded — an unrecorded mapping keeps its team", async () => {
+    // The sync recorded only bob's mapping (alice's fold never landed): alice's
+    // team must survive as the sole record of her address, re-recovered next
+    // pass; bob's is torn down now that the commit carrying it landed.
     const LATE = {
       email: "bob@example.com",
       invitee: { id: 3, login: "bob" },
@@ -114,17 +117,15 @@ describe("reconcileRoster", () => {
       addedUsernames: [],
       recoveredEmails: ["bob@example.com"],
       removedEmails: [],
-      lateRecovered: [LATE],
+      recordedRecoveries: [LATE],
       noop: false,
     })
 
     await reconcileRoster(client, INPUT)
-    // The late mapping's team is torn down with the rest — its fold landed in
-    // the same commit, so leaving it would only defer to the next pass.
     expect(finalizeInviteRecoveries).toHaveBeenCalledWith(
       client,
       { org: "org", classroom: "cs101" },
-      [RECOVERED, LATE],
+      [LATE],
     )
   })
 

--- a/web/src/domain/students/reconcileRoster.test.ts
+++ b/web/src/domain/students/reconcileRoster.test.ts
@@ -44,6 +44,7 @@ beforeEach(() => {
     addedUsernames: [],
     recoveredEmails: ["alice@example.com"],
     removedEmails: [],
+    lateRecovered: [],
     noop: false,
   })
   finalizeInviteRecoveries.mockResolvedValue(undefined)
@@ -68,6 +69,7 @@ describe("reconcileRoster", () => {
         addedUsernames: ["alice"],
         recoveredEmails: ["alice@example.com"],
         removedEmails: ["dead@x"],
+        lateRecovered: [],
         noop: false,
       }
     })
@@ -96,9 +98,34 @@ describe("reconcileRoster", () => {
       addedUsernames: ["alice"],
       recoveredEmails: ["alice@example.com"],
       removedEmails: ["dead@x"],
+      lateRecovered: [],
       noop: false,
       deletedStaleTeams: 1,
     })
+  })
+
+  it("finalizes late recoveries the sync collected itself (mid-pass acceptance)", async () => {
+    const LATE = {
+      email: "bob@example.com",
+      invitee: { id: 3, login: "bob" },
+      slug: "invite-bbbbbbbbbbbbbbbb",
+    }
+    syncRosterFromTeam.mockResolvedValue({
+      addedUsernames: [],
+      recoveredEmails: ["bob@example.com"],
+      removedEmails: [],
+      lateRecovered: [LATE],
+      noop: false,
+    })
+
+    await reconcileRoster(client, INPUT)
+    // The late mapping's team is torn down with the rest — its fold landed in
+    // the same commit, so leaving it would only defer to the next pass.
+    expect(finalizeInviteRecoveries).toHaveBeenCalledWith(
+      client,
+      { org: "org", classroom: "cs101" },
+      [RECOVERED, LATE],
+    )
   })
 
   it("does NOT delete recovered teams when the sync throws (re-recovered next pass)", async () => {

--- a/web/src/domain/students/reconcileRoster.ts
+++ b/web/src/domain/students/reconcileRoster.ts
@@ -24,11 +24,14 @@ export type ReconcileRosterResult = SyncRosterFromTeamResult & {
 //   2. sync: one conflict-retried commit that folds the recovered mappings
 //      onto their rows, removes email-only rows no live invite team backs,
 //      appends missing team members, and reconciles roles/ids.
-//   3. finalize: delete the recovered mappings' teams only AFTER that commit
-//      landed — including any the sync recovered itself via its decision-time
-//      re-collect (a student who accepted after step 1's snapshot) — skipping
-//      any slug a fresh pending invitation now maps to (a same-email re-invite
-//      adopts the same deterministic slug).
+//   3. finalize: delete ONLY the mappings the roster provably records after
+//      the sync (sync.recordedRecoveries — the caller's recoveries plus any
+//      the sync's decision-time re-collect folded, gated on the landed rows;
+//      the web mirror of the CLI's recordsRecovery). An unrecorded mapping
+//      keeps its team as the sole record of the address and is re-recovered
+//      next pass. finalize itself still skips any slug a fresh pending
+//      invitation now maps to (a same-email re-invite adopts the same
+//      deterministic slug).
 // Throws what syncRosterFromTeam throws (archived classroom, malformed CSV,
 // transient write failures); the collect half is never-throw by contract.
 export async function reconcileRoster(
@@ -38,10 +41,11 @@ export async function reconcileRoster(
   const { org, classroom } = input
   const invites = await collectInviteRecoveries(client, { org, classroom })
   const sync = await syncRosterFromTeam(client, { org, classroom, invites })
-  await finalizeInviteRecoveries(client, { org, classroom }, [
-    ...invites.recovered,
-    ...sync.lateRecovered,
-  ])
+  await finalizeInviteRecoveries(
+    client,
+    { org, classroom },
+    sync.recordedRecoveries,
+  )
   return { ...sync, deletedStaleTeams: invites.deletedStale }
 }
 

--- a/web/src/domain/students/reconcileRoster.ts
+++ b/web/src/domain/students/reconcileRoster.ts
@@ -25,8 +25,10 @@ export type ReconcileRosterResult = SyncRosterFromTeamResult & {
 //      onto their rows, removes email-only rows no live invite team backs,
 //      appends missing team members, and reconciles roles/ids.
 //   3. finalize: delete the recovered mappings' teams only AFTER that commit
-//      landed, skipping any slug a fresh pending invitation now maps to (a
-//      same-email re-invite adopts the same deterministic slug).
+//      landed — including any the sync recovered itself via its decision-time
+//      re-collect (a student who accepted after step 1's snapshot) — skipping
+//      any slug a fresh pending invitation now maps to (a same-email re-invite
+//      adopts the same deterministic slug).
 // Throws what syncRosterFromTeam throws (archived classroom, malformed CSV,
 // transient write failures); the collect half is never-throw by contract.
 export async function reconcileRoster(
@@ -36,7 +38,10 @@ export async function reconcileRoster(
   const { org, classroom } = input
   const invites = await collectInviteRecoveries(client, { org, classroom })
   const sync = await syncRosterFromTeam(client, { org, classroom, invites })
-  await finalizeInviteRecoveries(client, { org, classroom }, invites.recovered)
+  await finalizeInviteRecoveries(client, { org, classroom }, [
+    ...invites.recovered,
+    ...sync.lateRecovered,
+  ])
   return { ...sync, deletedStaleTeams: invites.deletedStale }
 }
 

--- a/web/src/domain/students/rosterSync.test.ts
+++ b/web/src/domain/students/rosterSync.test.ts
@@ -1,0 +1,241 @@
+// @vitest-environment node
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+const createGitCommit = vi.fn()
+const createGitTree = vi.fn()
+const updateRef = vi.fn()
+const getRawFile = vi.fn()
+const getBranchRef = vi.fn()
+const getCommit = vi.fn()
+const getConfigRepoBranch = vi.fn()
+const resolveClassroomTeamSlugs = vi.fn()
+const listClassroomMembersWithRoles = vi.fn()
+const collectInviteRecoveries = vi.fn()
+const pendingInviteEmails = vi.fn()
+
+vi.mock("@/github-core/mutations", () => ({
+  createGitCommit: (...a: unknown[]) => createGitCommit(...a),
+  createGitTree: (...a: unknown[]) => createGitTree(...a),
+  updateRef: (...a: unknown[]) => updateRef(...a),
+}))
+vi.mock("@/github-core/queries", () => ({
+  getRawFile: (...a: unknown[]) => getRawFile(...a),
+}))
+vi.mock("@/github-core/configRepoReads", () => ({
+  getBranchRef: (...a: unknown[]) => getBranchRef(...a),
+  getCommit: (...a: unknown[]) => getCommit(...a),
+  getConfigRepoBranch: (...a: unknown[]) => getConfigRepoBranch(...a),
+}))
+vi.mock("../classrooms", () => ({
+  withGitConflictRetry: (fn: () => unknown) => fn(),
+  assertClassroomNotArchived: () => Promise.resolve(),
+}))
+vi.mock("./rosterPrimitives", () => ({
+  log: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+  // Mirrors the real helper (one blob at the roster path); hand-rolled because
+  // importing the actual module would drag in the unmocked github-core surface.
+  rosterWriteTree: (classroom: string, csv: string) => [
+    {
+      path: `${classroom}/roster.csv`,
+      mode: "100644",
+      type: "blob",
+      content: csv,
+    },
+  ],
+  resolveClassroomTeamSlugs: (...a: unknown[]) =>
+    resolveClassroomTeamSlugs(...a),
+  listClassroomMembersWithRoles: (...a: unknown[]) =>
+    listClassroomMembersWithRoles(...a),
+}))
+vi.mock("./inviteRecoveries", () => ({
+  collectInviteRecoveries: (...a: unknown[]) => collectInviteRecoveries(...a),
+  pendingInviteEmails: (...a: unknown[]) => pendingInviteEmails(...a),
+}))
+
+import { syncRosterFromTeam } from "./rosterSync"
+import type { InviteReconcileState } from "./inviteRecoveries"
+
+const client = {} as never
+const INPUT = { org: "org", classroom: "cs101" }
+
+const HEADER = "username,first_name,last_name,email,section,github_id,role\n"
+
+const emptyInvites = (
+  over: Partial<InviteReconcileState> = {},
+): InviteReconcileState => ({
+  recovered: [],
+  liveInviteEmails: new Set(),
+  trusted: true,
+  deletedStale: 0,
+  ...over,
+})
+
+// The CSV the closure committed, parsed back into row objects (or null when no
+// commit was made).
+const committed = { csv: null as string | null }
+const rowsFromCommit = () => {
+  if (committed.csv === null) return null
+  const [header, ...lines] = committed.csv.trim().split("\n")
+  const fields = header.split(",")
+  return lines.map((line) =>
+    Object.fromEntries(line.split(",").map((v, i) => [fields[i], v])),
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  committed.csv = null
+  getConfigRepoBranch.mockResolvedValue("main")
+  getBranchRef.mockResolvedValue({ object: { sha: "base-sha" } })
+  getCommit.mockResolvedValue({ tree: { sha: "base-tree" } })
+  resolveClassroomTeamSlugs.mockResolvedValue({
+    student: "classroom50-cs101",
+    staff: {
+      teacher: "classroom50-cs101-teacher",
+      hta: "classroom50-cs101-hta",
+      ta: "classroom50-cs101-ta",
+    },
+  })
+  listClassroomMembersWithRoles.mockResolvedValue({
+    members: [],
+    fullyRead: true,
+    pendingRoleKeys: new Set(),
+  })
+  pendingInviteEmails.mockResolvedValue(new Set())
+  collectInviteRecoveries.mockResolvedValue(emptyInvites())
+  createGitTree.mockImplementation(
+    (_c: unknown, input: { tree: { content?: string }[] }) => {
+      committed.csv = input.tree[0]?.content ?? null
+      return Promise.resolve({ sha: "tree-sha" })
+    },
+  )
+  createGitCommit.mockResolvedValue({ sha: "commit-sha" })
+  updateRef.mockResolvedValue(undefined)
+})
+
+describe("syncRosterFromTeam — late-acceptance re-collect (#756)", () => {
+  it("folds a mid-pass acceptor onto their email row instead of appending a duplicate", async () => {
+    // Ada accepted BETWEEN the caller's collect (which saw her invite team
+    // member-less: her email is "live", nothing recovered) and this closure's
+    // team read (which sees her enrolled).
+    getRawFile.mockResolvedValue(HEADER + ",Ada,Lovelace,ada@uni.edu,,,student")
+    listClassroomMembersWithRoles.mockResolvedValue({
+      members: [{ id: 42, login: "ada", role: "student" }],
+      fullyRead: true,
+      pendingRoleKeys: new Set(),
+    })
+    collectInviteRecoveries.mockResolvedValue(
+      emptyInvites({
+        recovered: [
+          {
+            email: "ada@uni.edu",
+            invitee: { id: 42, login: "ada" },
+            slug: "invite-aaaaaaaaaaaaaaaa",
+          },
+        ],
+      }),
+    )
+
+    const result = await syncRosterFromTeam(client, {
+      ...INPUT,
+      invites: emptyInvites({ liveInviteEmails: new Set(["ada@uni.edu"]) }),
+    })
+
+    // The stale caller state forced ONE decision-time re-collect...
+    expect(collectInviteRecoveries).toHaveBeenCalledTimes(1)
+    // ...whose mapping upgraded the invite-time row in place: identity filled,
+    // teacher metadata kept, NO appended duplicate, NO removal.
+    expect(rowsFromCommit()).toEqual([
+      {
+        username: "ada",
+        first_name: "Ada",
+        last_name: "Lovelace",
+        email: "ada@uni.edu",
+        section: "",
+        github_id: "42",
+        role: "student",
+      },
+    ])
+    expect(result.addedUsernames).toEqual([])
+    expect(result.removedEmails).toEqual([])
+    expect(result.recoveredEmails).toEqual(["ada@uni.edu"])
+    // The late mapping is surfaced so reconcileRoster can retire its team.
+    expect(result.lateRecovered).toEqual([
+      {
+        email: "ada@uni.edu",
+        invitee: { id: 42, login: "ada" },
+        slug: "invite-aaaaaaaaaaaaaaaa",
+      },
+    ])
+  })
+
+  it("still appends a genuinely new member after the re-collect proves no mapping", async () => {
+    getRawFile.mockResolvedValue(HEADER)
+    listClassroomMembersWithRoles.mockResolvedValue({
+      members: [{ id: 7, login: "zed", role: "student" }],
+      fullyRead: true,
+      pendingRoleKeys: new Set(),
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      ...INPUT,
+      invites: emptyInvites(),
+    })
+
+    expect(collectInviteRecoveries).toHaveBeenCalledTimes(1)
+    expect(result.addedUsernames).toEqual(["zed"])
+    expect(result.lateRecovered).toEqual([])
+    expect(rowsFromCommit()).toEqual([
+      {
+        username: "zed",
+        first_name: "",
+        last_name: "",
+        email: "",
+        section: "",
+        github_id: "7",
+        role: "student",
+      },
+    ])
+  })
+
+  it("does not re-collect when every member is already claimed or recovered", async () => {
+    getRawFile.mockResolvedValue(
+      HEADER + "ada,Ada,Lovelace,ada@uni.edu,,42,student",
+    )
+    listClassroomMembersWithRoles.mockResolvedValue({
+      members: [{ id: 42, login: "ada", role: "student" }],
+      fullyRead: true,
+      pendingRoleKeys: new Set(),
+    })
+
+    const result = await syncRosterFromTeam(client, {
+      ...INPUT,
+      invites: emptyInvites(),
+    })
+
+    expect(collectInviteRecoveries).not.toHaveBeenCalled()
+    expect(result.noop).toBe(true)
+  })
+
+  it("keeps removals off in plain mode even when a re-collect ran", async () => {
+    // Plain team sync (no invites passed): the caller proved nothing about the
+    // invite lifecycle, so even a trusted re-collect must not authorize reaping
+    // the email-only row — only the fold and the append may act.
+    getRawFile.mockResolvedValue(HEADER + ",Bea,Ng,bea@uni.edu,,,student")
+    listClassroomMembersWithRoles.mockResolvedValue({
+      members: [{ id: 9, login: "zoe", role: "student" }],
+      fullyRead: true,
+      pendingRoleKeys: new Set(),
+    })
+
+    const result = await syncRosterFromTeam(client, INPUT)
+
+    expect(collectInviteRecoveries).toHaveBeenCalledTimes(1)
+    // No liveness confirmation was even attempted: removals never arm.
+    expect(pendingInviteEmails).not.toHaveBeenCalled()
+    expect(result.removedEmails).toEqual([])
+    const rows = rowsFromCommit()
+    expect(rows?.map((r) => r.email)).toContain("bea@uni.edu")
+    expect(result.addedUsernames).toEqual(["zoe"])
+  })
+})

--- a/web/src/domain/students/rosterSync.test.ts
+++ b/web/src/domain/students/rosterSync.test.ts
@@ -141,8 +141,13 @@ describe("syncRosterFromTeam — late-acceptance re-collect (#756)", () => {
       invites: emptyInvites({ liveInviteEmails: new Set(["ada@uni.edu"]) }),
     })
 
-    // The stale caller state forced ONE decision-time re-collect...
+    // The stale caller state forced ONE decision-time re-collect — READ-ONLY:
+    // deletes stay with the top-level reconcile.
     expect(collectInviteRecoveries).toHaveBeenCalledTimes(1)
+    expect(collectInviteRecoveries).toHaveBeenCalledWith(client, {
+      ...INPUT,
+      readOnly: true,
+    })
     // ...whose mapping upgraded the invite-time row in place: identity filled,
     // teacher metadata kept, NO appended duplicate, NO removal.
     expect(rowsFromCommit()).toEqual([
@@ -159,8 +164,8 @@ describe("syncRosterFromTeam — late-acceptance re-collect (#756)", () => {
     expect(result.addedUsernames).toEqual([])
     expect(result.removedEmails).toEqual([])
     expect(result.recoveredEmails).toEqual(["ada@uni.edu"])
-    // The late mapping is surfaced so reconcileRoster can retire its team.
-    expect(result.lateRecovered).toEqual([
+    // The landed fold records the mapping, so its team is safe to retire.
+    expect(result.recordedRecoveries).toEqual([
       {
         email: "ada@uni.edu",
         invitee: { id: 42, login: "ada" },
@@ -184,7 +189,7 @@ describe("syncRosterFromTeam — late-acceptance re-collect (#756)", () => {
 
     expect(collectInviteRecoveries).toHaveBeenCalledTimes(1)
     expect(result.addedUsernames).toEqual(["zed"])
-    expect(result.lateRecovered).toEqual([])
+    expect(result.recordedRecoveries).toEqual([])
     expect(rowsFromCommit()).toEqual([
       {
         username: "zed",
@@ -231,11 +236,123 @@ describe("syncRosterFromTeam — late-acceptance re-collect (#756)", () => {
     const result = await syncRosterFromTeam(client, INPUT)
 
     expect(collectInviteRecoveries).toHaveBeenCalledTimes(1)
+    // Plain mode may only ever run a READ-ONLY collect — no team deletions
+    // from a mutation hook's sync.
+    expect(collectInviteRecoveries).toHaveBeenCalledWith(client, {
+      ...INPUT,
+      readOnly: true,
+    })
     // No liveness confirmation was even attempted: removals never arm.
     expect(pendingInviteEmails).not.toHaveBeenCalled()
     expect(result.removedEmails).toEqual([])
     const rows = rowsFromCommit()
     expect(rows?.map((r) => r.email)).toContain("bea@uni.edu")
     expect(result.addedUsernames).toEqual(["zoe"])
+  })
+
+  it("a DEGRADED re-collect merges, never replaces: caller folds land, removals disarm", async () => {
+    // The caller collected a trusted recovery for Ada, then the in-closure
+    // re-collect (triggered by unknown member Zed) degrades to the never-throw
+    // empty state. Replacing the caller's state would skip Ada's fold while
+    // her team is finalized — the #756-class loss the merge rule prevents.
+    getRawFile.mockResolvedValue(
+      HEADER +
+        ",Ada,Lovelace,ada@uni.edu,,,student\n" +
+        ",Dead,Row,dead@uni.edu,,,student",
+    )
+    listClassroomMembersWithRoles.mockResolvedValue({
+      members: [
+        { id: 42, login: "ada", role: "student" },
+        { id: 7, login: "zed", role: "student" },
+      ],
+      fullyRead: true,
+      pendingRoleKeys: new Set(),
+    })
+    collectInviteRecoveries.mockResolvedValue(emptyInvites({ trusted: false }))
+    // The caller's (trusted) state says dead@uni.edu has no live backing.
+    const ADA = {
+      email: "ada@uni.edu",
+      invitee: { id: 42, login: "ada" },
+      slug: "invite-aaaaaaaaaaaaaaaa",
+    }
+
+    const result = await syncRosterFromTeam(client, {
+      ...INPUT,
+      invites: emptyInvites({ recovered: [ADA] }),
+    })
+
+    // Ada's fold still landed from the caller's recovery...
+    const rows = rowsFromCommit()
+    expect(rows?.find((r) => r.username === "ada")).toMatchObject({
+      github_id: "42",
+      email: "ada@uni.edu",
+      first_name: "Ada",
+    })
+    // ...her recorded mapping is finalizable...
+    expect(result.recordedRecoveries).toEqual([ADA])
+    // ...and the untrusted re-collect disarmed removals (dead row survives).
+    expect(result.removedEmails).toEqual([])
+    expect(rows?.map((r) => r.email)).toContain("dead@uni.edu")
+    expect(pendingInviteEmails).not.toHaveBeenCalled()
+  })
+
+  it("only RECORDED mappings are finalizable: an unlanded recovery keeps its team", async () => {
+    // The caller recovered Eve, but her invitee is invisible to this closure's
+    // members read (degraded staff read) and no row names her — nothing lands.
+    // Her mapping must NOT be reported recorded, or finalize would delete the
+    // only record of her address.
+    getRawFile.mockResolvedValue(HEADER + ",Ada,Lovelace,ada@uni.edu,,,student")
+    listClassroomMembersWithRoles.mockResolvedValue({
+      members: [{ id: 42, login: "ada", role: "student" }],
+      fullyRead: false,
+      pendingRoleKeys: new Set(),
+    })
+    const ADA = {
+      email: "ada@uni.edu",
+      invitee: { id: 42, login: "ada" },
+      slug: "invite-aaaaaaaaaaaaaaaa",
+    }
+    const EVE = {
+      email: "eve@uni.edu",
+      invitee: { id: 99, login: "eve" },
+      slug: "invite-eeeeeeeeeeeeeeee",
+    }
+
+    const result = await syncRosterFromTeam(client, {
+      ...INPUT,
+      invites: emptyInvites({ recovered: [ADA, EVE] }),
+    })
+
+    // Ada folded (row records her mapping); Eve landed nowhere.
+    expect(result.recordedRecoveries).toEqual([ADA])
+    expect(rowsFromCommit()?.some((r) => r.username === "eve")).toBe(false)
+  })
+
+  it("a noop pass still reports mappings the file already records", async () => {
+    // Ada's row already carries identity + email (a prior pass folded it, but
+    // finalize failed). Nothing to commit — yet her team is provably redundant
+    // and must be retirable, or it would leak until some other change lands.
+    getRawFile.mockResolvedValue(
+      HEADER + "ada,Ada,Lovelace,ada@uni.edu,,42,student",
+    )
+    listClassroomMembersWithRoles.mockResolvedValue({
+      members: [{ id: 42, login: "ada", role: "student" }],
+      fullyRead: true,
+      pendingRoleKeys: new Set(),
+    })
+    const ADA = {
+      email: "ada@uni.edu",
+      invitee: { id: 42, login: "ada" },
+      slug: "invite-aaaaaaaaaaaaaaaa",
+    }
+
+    const result = await syncRosterFromTeam(client, {
+      ...INPUT,
+      invites: emptyInvites({ recovered: [ADA] }),
+    })
+
+    expect(result.noop).toBe(true)
+    expect(committed.csv).toBeNull()
+    expect(result.recordedRecoveries).toEqual([ADA])
   })
 })

--- a/web/src/domain/students/rosterSync.ts
+++ b/web/src/domain/students/rosterSync.ts
@@ -41,12 +41,11 @@ export type SyncRosterFromTeamResult = {
   recoveredEmails: string[]
   // Email-only rows removed because no live invite team backs them.
   removedEmails: string[]
-  // Mappings recovered by the in-closure re-collect (a student who accepted
-  // AFTER the caller's collect pass), unknown to the caller's invite state.
-  // Returned so reconcileRoster can finalize (delete) their teams too once
-  // this commit has landed; a caller that ignores them just leaves the teams
-  // for the next pass to re-recover idempotently.
-  lateRecovered: RecoveredInvite[]
+  // The recovered mappings (the caller's and the in-closure re-collect's) that
+  // the roster provably records after this pass — the only teams safe for
+  // reconcileRoster to finalize (delete). An unrecorded mapping keeps its team
+  // as the sole record of the address and is re-recovered next pass.
+  recordedRecoveries: RecoveredInvite[]
   // No missing members, no role changes, no invite fold — nothing committed.
   noop: boolean
 }
@@ -176,9 +175,16 @@ export async function syncRosterFromTeam(
     // closure's team read (their invite team read as member-less then). Acting
     // on the stale state would append an identity-only duplicate of their
     // pending email row and strand that row for the reaper — the corruption of
-    // issue #756 — so re-collect once at decision time and fold with the fresh
-    // state. Genuinely new members (added to the team out of band) still fall
-    // through to the append below, at the cost of this one extra collect.
+    // issue #756 — so re-collect once at decision time (READ-ONLY: deletes stay
+    // with the top-level reconcile) and fold with the freshened state.
+    // Genuinely new members (added to the team out of band) still fall through
+    // to the append below.
+    //
+    // The re-collect only ever ADDS knowledge — merge, never replace. A
+    // degraded re-collect (empty, untrusted) must not discard the caller's
+    // trusted recoveries: dropping them would skip their folds while the
+    // caller still finalizes their teams, losing the mappings. Removals demand
+    // BOTH states trusted; live emails union (keeping a row is always safe).
     const hasUnknownMember = (f: ReturnType<typeof foldInvites>) => {
       const { ids, logins } = rosterClaimSet(f.foldedStudents)
       const recIds = new Set(f.recovered.map((r) => String(r.invitee.id)))
@@ -189,13 +195,24 @@ export async function syncRosterFromTeam(
           !recIds.has(String(m.id)),
       )
     }
-    let lateRecovered: RecoveredInvite[] = []
     if (hasUnknownMember(fold)) {
-      const fresh = await collectInviteRecoveries(client, { org, classroom })
+      const fresh = await collectInviteRecoveries(client, {
+        org,
+        classroom,
+        readOnly: true,
+      })
       const known = new Set((invites?.recovered ?? []).map((r) => r.slug))
-      lateRecovered = fresh.recovered.filter((r) => !known.has(r.slug))
-      inviteState = fresh
-      fold = foldInvites(fresh.recovered)
+      const lateRecovered = fresh.recovered.filter((r) => !known.has(r.slug))
+      inviteState = {
+        recovered: [...(invites?.recovered ?? []), ...lateRecovered],
+        liveInviteEmails: new Set([
+          ...(invites?.liveInviteEmails ?? []),
+          ...fresh.liveInviteEmails,
+        ]),
+        trusted: (invites?.trusted ?? false) && fresh.trusted,
+        deletedStale: invites?.deletedStale ?? 0,
+      }
+      fold = foldInvites(inviteState.recovered)
     }
     const { foldedStudents, recByEmail, recoveredEmails, unclaimed } = fold
     const inviteFolds = fold.inviteFolds
@@ -334,6 +351,25 @@ export async function syncRosterFromTeam(
       return next
     })
 
+    // A mapping is RECORDED when a row with an identity (username or usable
+    // github_id) carries the invited email AND names the account (id or login)
+    // — the web mirror of the CLI's recordsRecovery. Only recorded mappings
+    // may be finalized: until then the invite team is the sole record of the
+    // address, and deleting it on a fold that never landed loses the mapping.
+    const recordedRecoveries = (rows: StudentCsvRow[]) =>
+      (inviteState?.recovered ?? []).filter((r) => {
+        const emailKey = normalizeInviteEmail(r.email)
+        const loginKey = r.invitee.login.trim().toLowerCase()
+        return rows.some(
+          (s) =>
+            (s.username.trim() !== "" ||
+              resolveGitHubId(s.github_id) !== null) &&
+            normalizeInviteEmail(s.email ?? "") === emailKey &&
+            (parseGitHubId(s.github_id) === r.invitee.id ||
+              s.username.trim().toLowerCase() === loginKey),
+        )
+      })
+
     if (
       missing.length === 0 &&
       roleChanges === 0 &&
@@ -349,7 +385,9 @@ export async function syncRosterFromTeam(
         addedUsernames: [],
         recoveredEmails: [],
         removedEmails: [],
-        lateRecovered,
+        // No commit, but the file on disk already records these (that is what
+        // made the fold a no-op), so their teams are safe to retire.
+        recordedRecoveries: recordedRecoveries(reconciledStudents),
         noop: true,
       }
     }
@@ -406,7 +444,10 @@ export async function syncRosterFromTeam(
       addedUsernames: addedRows.map((r) => r.username),
       recoveredEmails,
       removedEmails,
-      lateRecovered,
+      recordedRecoveries: recordedRecoveries([
+        ...reconciledStudents,
+        ...addedRows,
+      ]),
       noop: false,
     }
   })

--- a/web/src/domain/students/rosterSync.ts
+++ b/web/src/domain/students/rosterSync.ts
@@ -28,8 +28,11 @@ import {
   resolveClassroomTeamSlugs,
   listClassroomMembersWithRoles,
 } from "./rosterPrimitives"
-import type { InviteReconcileState } from "./inviteRecoveries"
-import { pendingInviteEmails } from "./inviteRecoveries"
+import type { InviteReconcileState, RecoveredInvite } from "./inviteRecoveries"
+import {
+  collectInviteRecoveries,
+  pendingInviteEmails,
+} from "./inviteRecoveries"
 
 export type SyncRosterFromTeamResult = {
   // Team members newly appended to roster.csv as metadata rows.
@@ -38,6 +41,12 @@ export type SyncRosterFromTeamResult = {
   recoveredEmails: string[]
   // Email-only rows removed because no live invite team backs them.
   removedEmails: string[]
+  // Mappings recovered by the in-closure re-collect (a student who accepted
+  // AFTER the caller's collect pass), unknown to the caller's invite state.
+  // Returned so reconcileRoster can finalize (delete) their teams too once
+  // this commit has landed; a caller that ignores them just leaves the teams
+  // for the next pass to re-recover idempotently.
+  lateRecovered: RecoveredInvite[]
   // No missing members, no role changes, no invite fold — nothing committed.
   noop: boolean
 }
@@ -66,16 +75,21 @@ export type SyncRosterFromTeamResult = {
 //
 // The diff is recomputed INSIDE the retried closure (re-reading both teams and
 // CSV each attempt) so a 409 retry or concurrent edit can't reintroduce or
-// duplicate rows. Uses the same github_id -> username -> email fallback join as
-// the roster view when deciding "missing", so a pre-resolution row with an
-// empty github_id isn't treated as missing (which would append a duplicate).
+// duplicate rows. A member unknown to both the CSV and the caller's invite
+// state triggers one decision-time re-collect of the invite teams before any
+// append — a student who accepted AFTER the caller's collect must be folded
+// onto their invite-time row, never appended as a duplicate (#756). Uses the
+// same github_id -> username -> email fallback join as the roster view when
+// deciding "missing", so a pre-resolution row with an empty github_id isn't
+// treated as missing (which would append a duplicate).
 export async function syncRosterFromTeam(
   client: GitHubClient,
   input: {
     org: string
     classroom: string
     // Invite-reconcile state from collectInviteRecoveries. Omitted = plain
-    // team sync (no fold, no removals).
+    // team sync: no removals, and folds only what a decision-time re-collect
+    // (triggered by an unknown member) proves.
     invites?: InviteReconcileState
   },
 ): Promise<SyncRosterFromTeamResult> {
@@ -108,62 +122,105 @@ export async function syncRosterFromTeam(
     // mapping claims at most one row; borrow-only writes (blank fields filled,
     // teacher values win). A mapping with no row at all is appended below with
     // its email attached.
-    const recovered = invites?.recovered ?? []
-    const recByEmail = new Map(recovered.map((r) => [r.email, r]))
-    const recById = new Map(recovered.map((r) => [String(r.invitee.id), r]))
-    const recByLogin = new Map(
-      recovered.map((r) => [r.invitee.login.toLowerCase(), r]),
-    )
-    const claimed = new Set<(typeof recovered)[number]>()
-    const recoveredEmails: string[] = []
-    let inviteFolds = 0
-    const foldedStudents = currentStudents.map((s) => {
-      const emailKey = normalizeInviteEmail(s.email ?? "")
-      const idKey = parseGitHubId(s.github_id)
-      const match =
-        (emailKey ? recByEmail.get(emailKey) : undefined) ??
-        (idKey !== null ? recById.get(String(idKey)) : undefined) ??
-        recByLogin.get(s.username.trim().toLowerCase())
-      if (!match || claimed.has(match)) return s
-      claimed.add(match)
-      const next = normalizeStudentRow({
-        ...s,
-        username: s.username || match.invitee.login,
-        github_id: s.github_id || String(match.invitee.id),
-        email: s.email?.trim() || match.email,
+    const foldInvites = (recovered: RecoveredInvite[]) => {
+      const recByEmail = new Map(recovered.map((r) => [r.email, r]))
+      const recById = new Map(recovered.map((r) => [String(r.invitee.id), r]))
+      const recByLogin = new Map(
+        recovered.map((r) => [r.invitee.login.toLowerCase(), r]),
+      )
+      const claimed = new Set<RecoveredInvite>()
+      const recoveredEmails: string[] = []
+      let inviteFolds = 0
+      const foldedStudents = currentStudents.map((s) => {
+        const emailKey = normalizeInviteEmail(s.email ?? "")
+        const idKey = parseGitHubId(s.github_id)
+        const match =
+          (emailKey ? recByEmail.get(emailKey) : undefined) ??
+          (idKey !== null ? recById.get(String(idKey)) : undefined) ??
+          recByLogin.get(s.username.trim().toLowerCase())
+        if (!match || claimed.has(match)) return s
+        claimed.add(match)
+        const next = normalizeStudentRow({
+          ...s,
+          username: s.username || match.invitee.login,
+          github_id: s.github_id || String(match.invitee.id),
+          email: s.email?.trim() || match.email,
+        })
+        if (
+          next.username !== s.username ||
+          next.github_id !== s.github_id ||
+          next.email !== s.email
+        ) {
+          inviteFolds++
+          recoveredEmails.push(match.email)
+          return next
+        }
+        return s
       })
-      if (
-        next.username !== s.username ||
-        next.github_id !== s.github_id ||
-        next.email !== s.email
-      ) {
-        inviteFolds++
-        recoveredEmails.push(match.email)
-        return next
+      return {
+        recovered,
+        recByEmail,
+        foldedStudents,
+        recoveredEmails,
+        inviteFolds,
+        unclaimed: recovered.filter((r) => !claimed.has(r)),
       }
-      return s
-    })
-    const unclaimed = recovered.filter((r) => !claimed.has(r))
+    }
+
+    let inviteState = invites
+    let fold = foldInvites(inviteState?.recovered ?? [])
+
+    // --- Late-acceptance re-collect ------------------------------------------
+    // A member no roster row identifies and no recovered mapping covers is
+    // usually a student who accepted BETWEEN the caller's collect pass and this
+    // closure's team read (their invite team read as member-less then). Acting
+    // on the stale state would append an identity-only duplicate of their
+    // pending email row and strand that row for the reaper — the corruption of
+    // issue #756 — so re-collect once at decision time and fold with the fresh
+    // state. Genuinely new members (added to the team out of band) still fall
+    // through to the append below, at the cost of this one extra collect.
+    const hasUnknownMember = (f: ReturnType<typeof foldInvites>) => {
+      const { ids, logins } = rosterClaimSet(f.foldedStudents)
+      const recIds = new Set(f.recovered.map((r) => String(r.invitee.id)))
+      return members.some(
+        (m) =>
+          !ids.has(String(m.id)) &&
+          !logins.has(m.login.toLowerCase()) &&
+          !recIds.has(String(m.id)),
+      )
+    }
+    let lateRecovered: RecoveredInvite[] = []
+    if (hasUnknownMember(fold)) {
+      const fresh = await collectInviteRecoveries(client, { org, classroom })
+      const known = new Set((invites?.recovered ?? []).map((r) => r.slug))
+      lateRecovered = fresh.recovered.filter((r) => !known.has(r.slug))
+      inviteState = fresh
+      fold = foldInvites(fresh.recovered)
+    }
+    const { foldedStudents, recByEmail, recoveredEmails, unclaimed } = fold
+    const inviteFolds = fold.inviteFolds
 
     // --- Dead email-row removal ---------------------------------------------
     // An email-ONLY row (no username, no valid github_id) exists on the roster
     // only while a live invite backs it; once the invite is cancelled, expired,
-    // or GC'd, the row goes too — in this same commit. Two gates keep that from
-    // eating a legitimate row: the invite-reconcile state must be trustworthy
-    // (a degraded invite-team read must never masquerade as "no live invites"),
-    // and every candidate is confirmed against GitHub's CURRENT pending
-    // invitations. That confirmation is read HERE, inside the retried closure,
-    // because the collect pass snapshotted teams BEFORE this CSV read — an
-    // invite sent in between has its fresh row in `currentStudents` but no
+    // or GC'd, the row goes too — in this same commit. Removals are exclusive
+    // to the full reconcile (the caller passed its invite state): a plain team
+    // sync proves nothing about the invite lifecycle. Two further gates keep
+    // one from eating a legitimate row: the invite-reconcile state must be
+    // trustworthy (a degraded invite-team read must never masquerade as "no
+    // live invites"), and every candidate is confirmed against GitHub's CURRENT
+    // pending invitations. That confirmation is read HERE, inside the retried
+    // closure, because the collect pass snapshotted teams BEFORE this CSV read
+    // — an invite sent in between has its fresh row in `currentStudents` but no
     // entry in the snapshot, and must not be reaped for it.
     const deadRows = new Set<StudentCsvRow>()
-    if (invites?.trusted) {
+    if (invites && inviteState?.trusted) {
       for (const s of foldedStudents) {
         if (s.username.trim()) continue
         if (resolveGitHubId(s.github_id) !== null) continue
         const emailKey = normalizeInviteEmail(s.email ?? "")
         if (!emailKey) continue // a blank junk row is not this pass's call
-        if (invites.liveInviteEmails.has(emailKey)) continue
+        if (inviteState.liveInviteEmails.has(emailKey)) continue
         if (recByEmail.has(emailKey)) continue
         deadRows.add(s)
       }
@@ -292,6 +349,7 @@ export async function syncRosterFromTeam(
         addedUsernames: [],
         recoveredEmails: [],
         removedEmails: [],
+        lateRecovered,
         noop: true,
       }
     }
@@ -348,6 +406,7 @@ export async function syncRosterFromTeam(
       addedUsernames: addedRows.map((r) => r.username),
       recoveredEmails,
       removedEmails,
+      lateRecovered,
       noop: false,
     }
   })

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -80,6 +80,7 @@ export {
   ensureTeam,
   listTeamMembers,
   teamMembersQuery,
+  getTeamMembershipState,
   listOrgTeams,
   orgTeamsQuery,
   listRepoTeams,

--- a/web/src/github-core/queries/teamReads.test.ts
+++ b/web/src/github-core/queries/teamReads.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest"
+
+import { getTeamMembershipState } from "./teamReads"
+import { GitHubAPIError } from "../errors"
+import type { GitHubClient } from "../client"
+
+const rateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+
+const apiError = (status: number) =>
+  new GitHubAPIError({
+    status,
+    url: "/orgs/acme/teams/classroom50-cs101/memberships/ada",
+    message: `http ${status}`,
+    body: {},
+    rateLimit,
+  })
+
+const clientWith = (impl: (path: string) => Promise<unknown>): GitHubClient =>
+  ({ request: impl }) as unknown as GitHubClient
+
+// The invite reconcile's irreversible team delete rests on this exact
+// contract: 404 is the only "not a member" — every other failure must
+// propagate so a transient blip is never read as unenrollment.
+describe("getTeamMembershipState", () => {
+  it("resolves the membership state for active and pending records", async () => {
+    await expect(
+      getTeamMembershipState(
+        clientWith(async () => ({ state: "active" })),
+        "acme",
+        "classroom50-cs101",
+        "ada",
+      ),
+    ).resolves.toBe("active")
+    await expect(
+      getTeamMembershipState(
+        clientWith(async () => ({ state: "pending" })),
+        "acme",
+        "classroom50-cs101",
+        "ada",
+      ),
+    ).resolves.toBe("pending")
+  })
+
+  it("treats a record with no state field as a membership (active)", async () => {
+    await expect(
+      getTeamMembershipState(
+        clientWith(async () => ({})),
+        "acme",
+        "classroom50-cs101",
+        "ada",
+      ),
+    ).resolves.toBe("active")
+  })
+
+  it("resolves null on 404 — the one authoritative 'not on this team'", async () => {
+    await expect(
+      getTeamMembershipState(
+        clientWith(async () => {
+          throw apiError(404)
+        }),
+        "acme",
+        "classroom50-cs101",
+        "ada",
+      ),
+    ).resolves.toBeNull()
+  })
+
+  it("propagates every non-404 error instead of reading it as absence", async () => {
+    for (const status of [500, 502, 403, 429]) {
+      await expect(
+        getTeamMembershipState(
+          clientWith(async () => {
+            throw apiError(status)
+          }),
+          "acme",
+          "classroom50-cs101",
+          "ada",
+        ),
+      ).rejects.toMatchObject({ status })
+    }
+  })
+
+  it("escapes org, slug, and username in the request path", async () => {
+    let requested = ""
+    await getTeamMembershipState(
+      clientWith(async (path) => {
+        requested = path
+        return { state: "active" }
+      }),
+      "acme",
+      "classroom50-cs101",
+      "ada lovelace",
+    )
+    expect(requested).toBe(
+      "/orgs/acme/teams/classroom50-cs101/memberships/ada%20lovelace",
+    )
+  })
+})

--- a/web/src/github-core/queries/teamReads.ts
+++ b/web/src/github-core/queries/teamReads.ts
@@ -102,8 +102,7 @@ export function teamMembersQuery(
 // /orgs/{org}/teams/{slug}/memberships/{username}): "active", "pending", or
 // null on 404 — GitHub's authoritative "not on this team" (a missing team 404s
 // the same way). Any other error propagates so a transient blip is never read
-// as "not a member" — the invite reconcile uses this as decision-time proof
-// before its one irreversible action (deleting a metadata team).
+// as "not a member".
 export async function getTeamMembershipState(
   client: GitHubClient,
   org: string,

--- a/web/src/github-core/queries/teamReads.ts
+++ b/web/src/github-core/queries/teamReads.ts
@@ -98,6 +98,28 @@ export function teamMembersQuery(
   })
 }
 
+// One user's membership on one team (GET
+// /orgs/{org}/teams/{slug}/memberships/{username}): "active", "pending", or
+// null on 404 — GitHub's authoritative "not on this team" (a missing team 404s
+// the same way). Any other error propagates so a transient blip is never read
+// as "not a member" — the invite reconcile uses this as decision-time proof
+// before its one irreversible action (deleting a metadata team).
+export async function getTeamMembershipState(
+  client: GitHubClient,
+  org: string,
+  teamSlug: string,
+  username: string,
+): Promise<"active" | "pending" | null> {
+  return tolerateGitHubError(async () => {
+    const membership = await client.request<{ state?: string }>(
+      `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
+        teamSlug,
+      )}/memberships/${encodeURIComponent(username)}`,
+    )
+    return membership.state === "pending" ? "pending" : "active"
+  }, null)
+}
+
 // Every team in the org across all pages (GET /orgs/{org}/teams). Owner/member
 // visibility applies (secret teams only listed for members who can see them).
 // Used to cross-reference each `classroom50-<classroom>` team's live membership


### PR DESCRIPTION
## Summary

Fixes #756.

- **Root cause:** a reconcile pass classified a student as "accepted, then unenrolled" from a pass-long cached enrollment snapshot. A student accepting mid-pass matched that signature, so their invite metadata team — the only durable record of the email-to-account mapping — was irreversibly deleted. The sync then appended an identity-only duplicate row (`Uname,,,,,id,student`) and the dead-row reaper deleted the teacher's original row, losing names and emails across the staggered "cleanup" commits seen in the issue.
- **Fix (web + CLI):** absence is now re-proven at decision time with per-team membership point reads (`GET /orgs/{org}/teams/{slug}/memberships/{login}`) before any invite-team delete; any membership record (active or pending) recovers the student instead. Failed or rate-limited re-checks fail closed (team kept, pass degraded).
- **Fix (web sync):** when a team member is unknown to both the CSV and the caller's invite state, the sync runs one decision-time re-collect inside its conflict-retried closure and folds the late acceptor onto their invite-time row instead of appending a duplicate. The re-collect is read-only (deletes stay with the top-level reconcile) and merge-only (a degraded re-collect can never discard the caller's trusted recoveries; removals require both states trusted).
- **Teardown hardening:** `reconcileRoster` now finalizes (deletes) only mappings the landed roster provably records (`recordedRecoveries`, the web mirror of the CLI's `recordsRecovery`); an unrecorded mapping keeps its team and is re-recovered idempotently next pass.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, 4553 tests) green
- [x] `go test ./...` + `golangci-lint run` green across gh-teacher, gh-student, shared
- [x] New regression tests: mid-pass acceptor recovered not deleted (web + CLI); degraded re-collect merges and disarms removals; unrecorded mapping keeps its team (incl. noop path); real un-mocked invite-team seam over the wire; 409 conflict retry folds once with fail-closed teardown deferral; `getTeamMembershipState` 404-vs-error contract; pending-membership counts as enrolled (web + CLI); rate-limited re-check stops the pass early (web + CLI); plain-mode sync stays read-only and removal-free