### PR TITLE
fix(cli): use the student's git identity for submit commits

### DIFF
--- a/cli/gh-student/internal/identity/identity.go
+++ b/cli/gh-student/internal/identity/identity.go
@@ -1,9 +1,11 @@
-// Package identity derives the authenticated user's git author/committer
-// identity (login + GitHub noreply email) for stamping submit commits.
+// Package identity resolves the git author/committer identity stamped on
+// submit commits.
 package identity
 
 import (
 	"fmt"
+	"os/exec"
+	"strings"
 
 	"github.com/foundation50/gh-student/internal/githubapi"
 )
@@ -14,16 +16,40 @@ type GitIdentity struct {
 	Email string
 }
 
-// Fetch returns the authenticated user's GitHub login and
-// `<id>+<login>@users.noreply.github.com` noreply email.
-func Fetch(client githubapi.Client) (GitIdentity, error) {
+// Resolve returns the user's git identity as configured for the repo at dir
+// (the submit commit is created in a temp clone, where that config wouldn't
+// apply — and a mismatched email makes signed commits show as unverified).
+// Unset fields fall back to the GitHub login + noreply email, so a shell
+// without git identity still submits.
+func Resolve(client githubapi.Client, dir string) (GitIdentity, error) {
+	identity := GitIdentity{
+		Name:  gitConfig(dir, "user.name"),
+		Email: gitConfig(dir, "user.email"),
+	}
+	if identity.Name != "" && identity.Email != "" {
+		return identity, nil
+	}
+
 	login, id, err := githubapi.CurrentUser(client)
 	if err != nil {
 		return GitIdentity{}, err
 	}
+	if identity.Name == "" {
+		identity.Name = login
+	}
+	if identity.Email == "" {
+		identity.Email = fmt.Sprintf("%d+%s@users.noreply.github.com", id, login)
+	}
+	return identity, nil
+}
 
-	return GitIdentity{
-		Name:  login,
-		Email: fmt.Sprintf("%d+%s@users.noreply.github.com", id, login),
-	}, nil
+// gitConfig returns key as git resolves it from dir, or "" when unset or
+// unreadable (best-effort — the noreply fallback covers it).
+func gitConfig(dir, key string) string {
+	cmd := exec.Command("git", "-C", dir, "config", "--get", key)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/cli/gh-student/internal/identity/identity_test.go
+++ b/cli/gh-student/internal/identity/identity_test.go
@@ -1,0 +1,93 @@
+package identity
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"github.com/foundation50/gh-student/internal/githubapi"
+	"github.com/foundation50/gh-student/internal/githubtest"
+)
+
+// initRepo creates a temp git repo hidden from the host's global/system git
+// config, so only config set by the test is visible.
+func initRepo(t *testing.T) string {
+	t.Helper()
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func userClient(t *testing.T, login string, id int64) githubapi.Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/user", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"login":"` + login + `","id":` + strconv.FormatInt(id, 10) + `}`))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return githubtest.NewTestClient(t, server)
+}
+
+func TestResolve_PrefersGitConfig(t *testing.T) {
+	dir := initRepo(t)
+	runGit(t, dir, "config", "user.name", "Ada Lovelace")
+	runGit(t, dir, "config", "user.email", "ada@example.edu")
+
+	// Any API call fails the resolve, proving config alone suffices.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unexpected API call", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	got, err := Resolve(client, dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	want := GitIdentity{Name: "Ada Lovelace", Email: "ada@example.edu"}
+	if got != want {
+		t.Fatalf("Resolve = %+v, want %+v", got, want)
+	}
+}
+
+func TestResolve_FallsBackToNoreply(t *testing.T) {
+	dir := initRepo(t)
+
+	got, err := Resolve(userClient(t, "octocat", 7), dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	want := GitIdentity{Name: "octocat", Email: "7+octocat@users.noreply.github.com"}
+	if got != want {
+		t.Fatalf("Resolve = %+v, want %+v", got, want)
+	}
+}
+
+func TestResolve_FillsOnlyMissingFields(t *testing.T) {
+	dir := initRepo(t)
+	runGit(t, dir, "config", "user.email", "ada@example.edu")
+
+	got, err := Resolve(userClient(t, "octocat", 7), dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	want := GitIdentity{Name: "octocat", Email: "ada@example.edu"}
+	if got != want {
+		t.Fatalf("Resolve = %+v, want %+v", got, want)
+	}
+}

--- a/cli/gh-student/internal/submitcmd/submit.go
+++ b/cli/gh-student/internal/submitcmd/submit.go
@@ -113,8 +113,9 @@ func submitAssignment(ctx context.Context, client githubapi.Client, verbose bool
 
 	message := contract.PrefixCommit(fmt.Sprintf("Submit %s", config.Assignment))
 
-	// Stamp the commit so a shell without git identity still submits.
-	identity, err := identitypkg.Fetch(client)
+	// The user's git identity, with a noreply fallback so a shell without
+	// git identity still submits.
+	identity, err := identitypkg.Resolve(client, root)
 	if err != nil {
 		return fmt.Errorf("resolve git identity: %w", err)
 	}

--- a/cli/shared/ghutil/ghutil.go
+++ b/cli/shared/ghutil/ghutil.go
@@ -216,7 +216,7 @@ func ResolveSettledDefaultBranch(client *api.RESTClient, owner, repo, fallback s
 
 // CurrentUser returns the authenticated user's login and immutable numeric ID
 // via GET /user. Callers needing only the login can ignore the id (e.g.
-// whoami); gh-student's identity.Fetch uses both to build the noreply email.
+// whoami); gh-student's identity.Resolve uses both to build the noreply email.
 func CurrentUser(client *api.RESTClient) (login string, id int64, err error) {
 	var user struct {
 		Login string `json:"login"`


### PR DESCRIPTION
## Summary

Fixes #772.

`gh student submit` builds the submission commit in a temporary bare clone and unconditionally stamped it with the API-derived `<id>+<login>@users.noreply.github.com` email — overriding the student's configured git identity, so their GPG/SSH-signed submissions showed as **unverified** while a plain `git commit` worked fine.

- `identity.Fetch` is now `identity.Resolve(client, dir)`: it reads `user.name` / `user.email` as git resolves them from the student's clone (repo-local config wins over global), and only falls back to the GitHub login + noreply email for fields left unset — preserving the original intent that a shell without any git identity can still submit.
- New tests cover config-wins (no API call needed), full noreply fallback, and per-field fill, isolated from the host's git config via `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`.

The teacher CLI is unaffected: it never makes local git commits (all writes go through the git-data API, where GitHub stamps the authenticated user's verified identity server-side).

## Test plan

- [x] `go test ./cli/gh-student/...`
- [x] `golangci-lint run` and `golangci-lint fmt --diff` in `cli/gh-student`