### PR TITLE
fix(web): stop showing stale classroom names to students after rename

### DIFF
--- a/web/src/domain/reconcileClassroom.test.ts
+++ b/web/src/domain/reconcileClassroom.test.ts
@@ -5,6 +5,7 @@ const ensureClassroomTeam = vi.fn()
 const ensureStaffTeams = vi.fn()
 const grantStaffTeamsConfigRepoAccess = vi.fn()
 const reconcileDescription = vi.fn()
+const projectDescription = vi.fn()
 const removeUserFromTeam = vi.fn()
 
 vi.mock("@/github-core/configRepoReads", () => ({
@@ -17,6 +18,8 @@ vi.mock("@/github-core/mutations", () => ({
     grantStaffTeamsConfigRepoAccess(...a),
   reconcileStudentTeamDescription: (...a: unknown[]) =>
     reconcileDescription(...a),
+  projectTeamDescriptionFromRecord: (...a: unknown[]) =>
+    projectDescription(...a),
   removeUserFromTeam: (...a: unknown[]) => removeUserFromTeam(...a),
 }))
 // The roster reconciliation is exercised in reconcileRoster.test.ts; here it's
@@ -61,6 +64,7 @@ beforeEach(() => {
   ensureStaffTeams.mockReset()
   grantStaffTeamsConfigRepoAccess.mockReset()
   reconcileDescription.mockReset()
+  projectDescription.mockReset()
   removeUserFromTeam.mockReset()
   // Healthy defaults: active classroom, everything already converged.
   getClassroomJson.mockResolvedValue({ name: "CS101", active: true })
@@ -78,6 +82,7 @@ beforeEach(() => {
     created: [],
   })
   reconcileDescription.mockResolvedValue({ changed: false })
+  projectDescription.mockResolvedValue({ changed: false })
   removeUserFromTeam.mockResolvedValue(undefined)
   grantStaffTeamsConfigRepoAccess.mockResolvedValue(undefined)
 })
@@ -149,19 +154,53 @@ describe("reconcileClassroom", () => {
     expect(reconcileDescription).toHaveBeenCalledTimes(1)
   })
 
-  it("skips all writes on an archived classroom", async () => {
-    getClassroomJson.mockResolvedValue({ name: "CS101", active: false })
+  it("skips team/roster writes on an archived classroom but still heals the description", async () => {
+    // The archived short-circuit must not extend to the team-description
+    // projection: an archived classroom's classroom50/team/v1 record has to
+    // advertise active: false, and this pass is the only heal when the
+    // best-effort projection inside editClassroom failed during the archive.
+    const archived = { name: "CS101", active: false }
+    getClassroomJson.mockResolvedValue(archived)
+    projectDescription.mockResolvedValue({
+      changed: true,
+      slug: "classroom50-cs101",
+    })
     const result = await reconcileClassroom(client, "org", "cs101")
     expect(result).toEqual({
       skipped: true,
-      description: { changed: false },
+      description: { changed: true, slug: "classroom50-cs101" },
       staffCreated: [],
       invitesBackfilled: [],
       rosterChanged: false,
     })
     expect(ensureClassroomTeam).not.toHaveBeenCalled()
     expect(ensureStaffTeams).not.toHaveBeenCalled()
+    // Projected from the record the archived gate already read, never a
+    // config-repo re-fetch.
     expect(reconcileDescription).not.toHaveBeenCalled()
+    expect(projectDescription).toHaveBeenCalledWith(
+      client,
+      "org",
+      "cs101",
+      archived,
+    )
+    expect(getClassroomJson).toHaveBeenCalledTimes(1)
+  })
+
+  it("rewraps an archived-path description 404 as permanent (no just-created team to excuse it)", async () => {
+    getClassroomJson.mockResolvedValue({ name: "CS101", active: false })
+    projectDescription.mockRejectedValue(githubAPIError(404))
+    await expect(
+      reconcileClassroom(client, "org", "cs101"),
+    ).rejects.toBeInstanceOf(ClassroomReconcilePermanentError)
+  })
+
+  it("leaves a non-404 archived-path description failure transient", async () => {
+    getClassroomJson.mockResolvedValue({ name: "CS101", active: false })
+    projectDescription.mockRejectedValue(githubAPIError(500))
+    const err = await reconcileClassroom(client, "org", "cs101").catch((e) => e)
+    expect(err).toBeInstanceOf(GitHubAPIError)
+    expect(err).not.toBeInstanceOf(ClassroomReconcilePermanentError)
   })
 
   it("treats a missing/legacy classroom.json (404) as active and reconciles", async () => {

--- a/web/src/domain/reconcileClassroom.ts
+++ b/web/src/domain/reconcileClassroom.ts
@@ -1,11 +1,16 @@
 import type { GitHubClient } from "@/github-core/client"
 import { getClassroomJson } from "@/github-core/configRepoReads"
 import { GitHubAPIError } from "@/github-core/errors"
-import { isClassroomArchived, type StaffRole } from "@/types/classroom"
+import {
+  isClassroomArchived,
+  type Classroom,
+  type StaffRole,
+} from "@/types/classroom"
 import {
   ensureClassroomTeam,
   ensureStaffTeams,
   grantStaffTeamsConfigRepoAccess,
+  projectTeamDescriptionFromRecord,
   reconcileStudentTeamDescription,
   removeUserFromTeam,
   type TeamDescriptionReconcileResult,
@@ -52,12 +57,43 @@ const NOOP_RESULT: ClassroomReconcileResult = {
   rosterChanged: false,
 }
 
-// Verify (and self-heal) every classroom-scoped GitHub resource a teacher/owner
+// An archived classroom skips the team/roster writes, but its team-description
+// projection must still converge: the classroom50/team/v1 record has to
+// advertise active: false (and the final name/term), and this is the only heal
+// when the best-effort projection inside editClassroom failed during the
+// archive/edit itself. Projected from the record the archived gate already
+// read — never a re-fetch.
+async function reconcileArchivedClassroom(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+  record: Classroom,
+): Promise<ClassroomReconcileResult> {
+  let description: TeamDescriptionReconcileResult
+  try {
+    description = await projectTeamDescriptionFromRecord(
+      client,
+      org,
+      classroom,
+      record,
+    )
+  } catch (err) {
+    // This path never creates the student team, so a team-read 404 is a wrong
+    // or deleted slug that never converges — latch it (mirrors the active
+    // path); everything else stays transient for a later retry.
+    if (err instanceof GitHubAPIError && err.isNotFound) {
+      throw new ClassroomReconcilePermanentError(err)
+    }
+    throw err
+  }
+  return { ...NOOP_RESULT, description }
+} // Verify (and self-heal) every classroom-scoped GitHub resource a teacher/owner
 // depends on, in one idempotent pass, composing the existing primitives.
 //
 // Every call is an org-owner op; the caller MUST gate on the teacher role. An
-// archived classroom short-circuits with no writes (returns skipped); a
-// missing/legacy classroom.json reads as active.
+// archived classroom skips the team/roster writes (returns skipped) but still
+// converges its team-description projection; a missing/legacy classroom.json
+// reads as active.
 //
 // `creator` (the acting owner) is dropped from the student/hta/ta teams this
 // pass touches, never teacher: the create POST silently adds the owner as a
@@ -72,7 +108,10 @@ export async function reconcileClassroom(
   classroom: string,
   creator?: string,
 ): Promise<ClassroomReconcileResult> {
-  if (await isArchived(client, org, classroom)) return NOOP_RESULT
+  const archivedRecord = await readArchivedRecord(client, org, classroom)
+  if (archivedRecord) {
+    return reconcileArchivedClassroom(client, org, classroom, archivedRecord)
+  }
 
   const { slug: studentTeamSlug, created: studentTeamCreated } =
     await ensureClassroomTeam(client, org, classroom)
@@ -190,20 +229,20 @@ async function dropCreatorFromNonTeacherTeams(
   }
 }
 
-// True only when classroom.json positively records active: false. A missing
-// classroom.json (404, legacy) reads as active; a transient read failure
-// rethrows so the caller's latch retries rather than reconciling blind.
-async function isArchived(
+// The classroom.json record when the classroom positively records
+// active: false, else null. A missing classroom.json (404, legacy) reads as
+// active; a transient read failure rethrows so the caller's latch retries
+// rather than reconciling blind.
+async function readArchivedRecord(
   client: GitHubClient,
   org: string,
   classroom: string,
-): Promise<boolean> {
+): Promise<Classroom | null> {
   try {
-    return isClassroomArchived(
-      await getClassroomJson(client, { org, classroom }),
-    )
+    const record = await getClassroomJson(client, { org, classroom })
+    return isClassroomArchived(record) ? record : null
   } catch (err) {
-    if (err instanceof GitHubAPIError && err.isNotFound) return false
+    if (err instanceof GitHubAPIError && err.isNotFound) return null
     throw err
   }
 }

--- a/web/src/github-core/mutations.test.ts
+++ b/web/src/github-core/mutations.test.ts
@@ -207,6 +207,139 @@ describe("editClassroom archived read-only guard", () => {
   })
 })
 
+// Students never read classroom.json — they render the classroom50/team/v1
+// record projected onto the student team's description (GET /user/teams). An
+// edit must re-project that record, or existing students keep seeing the old
+// name forever (the classroom-rename stale-title bug). The projection derives
+// from the record the edit just committed, NOT a contents re-read (the
+// Contents API is read-after-write eventual and could echo the pre-write body).
+describe("editClassroom team-description re-projection", () => {
+  const makeClient = (opts?: {
+    teamPrivacy?: string
+    patchFails?: boolean
+  }) => {
+    const patched: { body: unknown }[] = []
+    const requestRaw = vi.fn().mockImplementation((path: string) => {
+      if (path.includes("/contents/")) {
+        return Promise.resolve(
+          JSON.stringify({
+            schema: "classroom50/classroom/v1",
+            short_name: "cs101",
+            name: "CS 101",
+            term: "Fall",
+            org: "acme",
+            team: { id: 7, slug: "classroom50-cs101" },
+          }),
+        )
+      }
+      return Promise.reject(new Error(`unexpected requestRaw: ${path}`))
+    })
+    const request = vi
+      .fn()
+      .mockImplementation(
+        (path: string, init?: { method?: string; body?: unknown }) => {
+          const method = init?.method ?? "GET"
+          if (/\/repos\/[^/]+\/classroom50$/.test(path)) {
+            return Promise.resolve({ default_branch: "main" })
+          }
+          if (path.endsWith("/git/ref/heads/main")) {
+            return Promise.resolve({ object: { sha: "base-sha" } })
+          }
+          if (path.includes("/git/commits/")) {
+            return Promise.resolve({ tree: { sha: "base-tree-sha" } })
+          }
+          if (path.endsWith("/git/blobs")) {
+            return Promise.resolve({ sha: "blob-sha" })
+          }
+          if (path.endsWith("/git/trees")) {
+            return Promise.resolve({ sha: "tree-sha" })
+          }
+          if (path.endsWith("/git/commits")) {
+            return Promise.resolve({ sha: "new-commit-sha" })
+          }
+          if (path.endsWith("/git/refs/heads/main")) {
+            return Promise.resolve({})
+          }
+          if (method === "GET" && /\/orgs\/[^/]+\/teams\/[^/]+$/.test(path)) {
+            return Promise.resolve({
+              id: 7,
+              slug: "classroom50-cs101",
+              privacy: opts?.teamPrivacy ?? "secret",
+              description: JSON.stringify({
+                schema: "classroom50/team/v1",
+                name: "CS 101",
+                term: "Fall",
+              }),
+            })
+          }
+          if (method === "PATCH" && /\/orgs\/[^/]+\/teams\/[^/]+$/.test(path)) {
+            if (opts?.patchFails) {
+              return Promise.reject(new Error("PATCH forbidden"))
+            }
+            patched.push({ body: init?.body })
+            return Promise.resolve({})
+          }
+          return Promise.reject(new Error(`unexpected request: ${path}`))
+        },
+      )
+    const client = { request, requestRaw } as unknown as GitHubClient
+    return { client, patched, requestRaw }
+  }
+
+  it("PATCHes the student team description with the just-committed record", async () => {
+    const { client, patched, requestRaw } = makeClient()
+
+    const result = await editClassroom(client, {
+      org: "acme",
+      slug: "cs101",
+      name: "Renamed",
+      term: "Spring",
+    })
+
+    expect(result.teamDescription).toEqual({
+      changed: true,
+      slug: "classroom50-cs101",
+    })
+    expect(patched).toHaveLength(1)
+    const body = patched[0].body as { description: string }
+    expect(JSON.parse(body.description)).toEqual({
+      schema: "classroom50/team/v1",
+      name: "Renamed",
+      term: "Spring",
+    })
+    // Exactly one contents read (the pre-edit merge source): the projection
+    // must come from the committed record, never a post-commit re-read that
+    // could echo the pre-write body.
+    expect(requestRaw).toHaveBeenCalledTimes(1)
+  })
+
+  it("is best-effort: a failed team PATCH doesn't fail the committed edit", async () => {
+    const { client } = makeClient({ patchFails: true })
+
+    const result = await editClassroom(client, {
+      org: "acme",
+      slug: "cs101",
+      name: "Renamed",
+    })
+
+    expect(result.newCommitSha).toBe("new-commit-sha")
+    expect(result.teamDescription).toEqual({ changed: false })
+  })
+
+  it("skips a non-secret team rather than leaking the record", async () => {
+    const { client, patched } = makeClient({ teamPrivacy: "closed" })
+
+    const result = await editClassroom(client, {
+      org: "acme",
+      slug: "cs101",
+      name: "Renamed",
+    })
+
+    expect(result.teamDescription).toEqual({ changed: false })
+    expect(patched).toHaveLength(0)
+  })
+})
+
 // ensurePages (the re-run/init write path) must agree with checkPages (the
 // audit read path) on the same org — they decide status from the same live
 // read-back, so a re-run can't warn about a Pages site the audit shows green.

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -139,8 +139,10 @@ export {
 } from "./mutations/classroomEdit"
 export {
   reconcileStudentTeamDescription,
+  projectTeamDescriptionFromRecord,
   ClassroomSourceReadError,
   type TeamDescriptionReconcileResult,
+  type TeamDescriptionSource,
 } from "./mutations/teamDescription"
 export {
   ensureInviteTeam,

--- a/web/src/github-core/mutations/classroomEdit.ts
+++ b/web/src/github-core/mutations/classroomEdit.ts
@@ -7,12 +7,20 @@ import {
 } from "../configRepoReads"
 import { isClassroomArchived } from "@/types/classroom"
 import { prefixCommit } from "@/util/commit"
+import { logger } from "@/lib/logger"
 import {
   createBlob,
   createTreeFromEntries,
   createCommit,
   updateRef,
 } from "./gitObjects"
+import {
+  projectTeamDescriptionFromRecord,
+  type TeamDescriptionReconcileResult,
+  type TeamDescriptionSource,
+} from "./teamDescription"
+
+const log = logger.scope("mutations:classroomEdit")
 
 export type UpdateClassroomMetadataInput = {
   org: string
@@ -147,6 +155,29 @@ export async function editClassroom(
 
   const updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
 
+  // Students never read classroom.json — they render the classroom50/team/v1
+  // record projected onto the student team's description (GET /user/teams). So
+  // a rename/re-term/archive must re-project here, or existing students keep
+  // seeing the old name forever (mirrors the CLI edit's reconcile). Derived
+  // from the record just committed, not a re-read. Best-effort: the edit is
+  // already committed, and a failure (e.g. a non-owner teacher's 403 on the
+  // team PATCH) is healed by a later classroom-entry reconcile.
+  let teamDescription: TeamDescriptionReconcileResult = { changed: false }
+  try {
+    teamDescription = await projectTeamDescriptionFromRecord(
+      client,
+      org,
+      slug,
+      next as TeamDescriptionSource,
+    )
+  } catch (err) {
+    log.warn("edit classroom: team-description re-projection failed", {
+      org,
+      classroom: slug,
+      err,
+    })
+  }
+
   return {
     previousCommitSha: ref.object.sha,
     baseTreeSha: commit.tree.sha,
@@ -154,5 +185,6 @@ export async function editClassroom(
     newCommitSha: newCommit.sha,
     updatedRef,
     classroom: next,
+    teamDescription,
   }
 }

--- a/web/src/github-core/mutations/teamDescription.ts
+++ b/web/src/github-core/mutations/teamDescription.ts
@@ -2,7 +2,7 @@ import type { GitHubClient } from "../client"
 import type { GitHubTeam } from "../types"
 import { getClassroomJson } from "../configRepoReads"
 import { classroomTeamSlug } from "@/util/teamSlug"
-import { isClassroomArchived } from "@/types/classroom"
+import { isClassroomArchived, type Classroom } from "@/types/classroom"
 import { marshalTeamDescription } from "@/util/teamDescription"
 
 // The outcome of one reconcile touch, so the caller can decide whether to
@@ -53,17 +53,38 @@ export async function reconcileStudentTeamDescription(
     throw new ClassroomSourceReadError(err)
   }
 
+  return projectTeamDescriptionFromRecord(client, org, classroom, current)
+}
+
+// The classroom.json fields the team-description projection is derived from.
+export type TeamDescriptionSource = Pick<
+  Classroom,
+  "name" | "term" | "secret" | "active" | "team"
+>
+
+// The write half of reconcileStudentTeamDescription: project an already-known
+// classroom.json record onto the student team's description, with no
+// config-repo read. Split out so a mutation that just committed classroom.json
+// can re-project from the exact record it wrote — the Contents API is
+// read-after-write eventual, so an immediate re-read could echo the pre-write
+// body and write the stale name back.
+export async function projectTeamDescriptionFromRecord(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+  record: TeamDescriptionSource,
+): Promise<TeamDescriptionReconcileResult> {
   const desired = marshalTeamDescription({
-    name: current.name,
-    term: current.term,
-    secret: current.secret,
-    active: !isClassroomArchived(current),
+    name: record.name,
+    term: record.term,
+    secret: record.secret,
+    active: !isClassroomArchived(record),
   })
 
   // The persisted slug is authoritative (GitHub may re-slug on collision); fall
   // back to the derived slug for a classroom created before the team ref was
   // recorded.
-  const slug = current.team?.slug || classroomTeamSlug(classroom)
+  const slug = record.team?.slug || classroomTeamSlug(classroom)
 
   const existing = await client.request<GitHubTeam>(
     `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(slug)}`,

--- a/web/src/hooks/mutations/createEditMutations.test.ts
+++ b/web/src/hooks/mutations/createEditMutations.test.ts
@@ -13,7 +13,12 @@ const createClassroomFilesWithConflictRetry = vi.fn<
 >(() => Promise.resolve({ newCommitSha: "sha-c" }))
 const editClassroomWithConflictRetry = vi.fn<
   (...args: unknown[]) => Promise<unknown>
->(() => Promise.resolve({ newCommitSha: "sha-e" }))
+>(() =>
+  Promise.resolve({
+    newCommitSha: "sha-e",
+    teamDescription: { changed: false },
+  }),
+)
 const createAssignment = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
   Promise.resolve({ newCommitSha: "sha-a" }),
 )
@@ -119,11 +124,44 @@ describe("useEditClassroom", () => {
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: githubKeys.jsonFile(ORG, CONFIG_REPO),
     })
+    // An unchanged team description leaves the student enumeration cache alone.
+    expect(invalidate).not.toHaveBeenCalledWith({
+      queryKey: githubKeys.myTeams(),
+    })
     expect(editClassroomWithConflictRetry).toHaveBeenCalledWith(
       expect.anything(),
       { slug: CLASSROOM, org: ORG },
     )
-    expect(onWrite).toHaveBeenCalledWith({ newCommitSha: "sha-e" })
+    expect(onWrite).toHaveBeenCalledWith({
+      newCommitSha: "sha-e",
+      teamDescription: { changed: false },
+    })
+  })
+
+  it("invalidates my-teams when the edit rewrote the team description", async () => {
+    // A rename re-projects the classroom50/team/v1 record onto the student
+    // team; GET /user/teams must refresh so a teacher previewing as a student
+    // sees the new name.
+    editClassroomWithConflictRetry.mockResolvedValueOnce({
+      newCommitSha: "sha-e",
+      teamDescription: { changed: true, slug: "classroom50-cs101" },
+    })
+    const queryClient = freshClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useEditClassroom(ORG, CLASSROOM), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({
+      slug: CLASSROOM,
+      org: ORG,
+      name: "Renamed",
+    } as never)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.myTeams(),
+    })
   })
 })
 

--- a/web/src/hooks/mutations/useArchiveClassroom.test.ts
+++ b/web/src/hooks/mutations/useArchiveClassroom.test.ts
@@ -23,11 +23,18 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
 })
 
 // Drives editClassroomWithConflictRetry; switchable to fail so we can assert the
-// optimistic flip rolls back.
+// optimistic flip rolls back, and switchable teamDescription outcome so we can
+// assert the myTeams invalidation is gated on an actual description rewrite.
 let editShouldFail = false
+let editDescriptionChanged = false
 const editClassroom = vi.fn((_client: unknown, input: { active?: boolean }) => {
   if (editShouldFail) return Promise.reject(new Error("boom"))
-  return Promise.resolve(input)
+  return Promise.resolve({
+    ...input,
+    teamDescription: editDescriptionChanged
+      ? { changed: true, slug: "classroom50-cs101" }
+      : { changed: false },
+  })
 })
 
 vi.mock("@/domain/classrooms", () => ({
@@ -65,6 +72,7 @@ function setup() {
 
 beforeEach(() => {
   editShouldFail = false
+  editDescriptionChanged = false
   editClassroom.mockClear()
 })
 
@@ -114,6 +122,23 @@ describe("useArchiveClassroom", () => {
 
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: githubKeys.jsonFile(ORG, CONFIG_REPO),
+    })
+    // No description rewrite -> the student enumeration cache is untouched.
+    expect(invalidate).not.toHaveBeenCalledWith({
+      queryKey: githubKeys.myTeams(),
+    })
+  })
+
+  it("invalidates my-teams when the toggle rewrote the team description", async () => {
+    editDescriptionChanged = true
+    const { queryClient, result } = setup()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+
+    result.current.mutate(false)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: githubKeys.myTeams(),
     })
   })
 

--- a/web/src/hooks/mutations/useArchiveClassroom.ts
+++ b/web/src/hooks/mutations/useArchiveClassroom.ts
@@ -53,12 +53,18 @@ export function useArchiveClassroom(org: string, classroom: string) {
       // in the wrong lifecycle state. Toast is the call site's job.
       if (ctx) queryClient.setQueryData(classroomKey, ctx.prev)
     },
-    onSettled: () => {
+    onSettled: (data) => {
       // Repartition the classes list (Active/Archived/All) — a different query
       // than the per-classroom classroom.json flipped above.
       void queryClient.invalidateQueries({
         queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
       })
+      if (data?.teamDescription.changed) {
+        // The toggle re-projected the classroom50/team/v1 record (its `active`
+        // flag) onto the student team; refresh GET /user/teams so a teacher
+        // previewing as a student sees the lifecycle change immediately.
+        void queryClient.invalidateQueries({ queryKey: githubKeys.myTeams() })
+      }
     },
   })
 }

--- a/web/src/hooks/mutations/useEditClassroom.ts
+++ b/web/src/hooks/mutations/useEditClassroom.ts
@@ -35,6 +35,12 @@ export function useEditClassroom(
       void queryClient.invalidateQueries({
         queryKey: githubKeys.jsonFile(org, CONFIG_REPO),
       })
+      if (result.teamDescription.changed) {
+        // The edit re-projected the classroom50/team/v1 record onto the student
+        // team; refresh GET /user/teams so a teacher previewing as a student
+        // sees the new name immediately.
+        void queryClient.invalidateQueries({ queryKey: githubKeys.myTeams() })
+      }
       onWrite?.(result)
     },
   })

--- a/web/src/hooks/useClassroomReconcile.ts
+++ b/web/src/hooks/useClassroomReconcile.ts
@@ -39,7 +39,8 @@ export function useClassroomReconcile(
       withGitConflictRetry(() =>
         reconcileClassroom(client, org, classroom, creator),
       ),
-    // An archived classroom no-ops (skipped); release its key so a same-mount
+    // An archived classroom skips the team/roster writes (though it still
+    // heals the description projection); release its key so a same-mount
     // un-archive re-reconciles rather than staying latched until remount.
     isTransientSuccess: (result) => result.skipped,
     // Invalidate only the slices that actually changed, keyed on the RUN's own


### PR DESCRIPTION
## Summary

- Students never read `classroom.json` — their classroom list renders the `classroom50/team/v1` record projected onto the secret student team's description (`GET /user/teams`). The web edit flow rewrote only `classroom.json`, so a rename/re-term left existing students seeing the old classroom name indefinitely (reported in #777).
- `editClassroom` now re-projects the record onto the student team right after the config commit, mirroring the CLI edit's reconcile. It derives the projection from the just-committed record rather than re-reading `classroom.json` (the Contents API is read-after-write eventual and could echo the pre-write body), and it is best-effort: a failed team PATCH never fails the already-committed edit.
- The classroom-entry reconcile no longer skips the description projection for archived classrooms, so the record's `active: false` (and final name/term) converges even when the projection failed during the archive itself — closing the gap where the archived short-circuit left no heal path.
- `useEditClassroom` / `useArchiveClassroom` invalidate the `GET /user/teams` cache when the description was actually rewritten, so a teacher previewing as a student sees the change immediately.

## Test plan

- [x] New `editClassroom` re-projection tests: PATCH carries the just-committed name/term, exactly one contents read (no post-commit re-read), a failed PATCH doesn't fail the edit, a non-secret team is skipped.
- [x] New `reconcileClassroom` archived-path tests: description heal runs from the record the archived gate read (team/roster writes still skipped), 404 latches permanent, non-404 stays transient.
- [x] Hook tests assert the `myTeams` invalidation fires only when the description changed.
- [x] `npm run check` green (tsc, eslint, prettier, arch:validate, 4590 vitest tests).

Fixes the stale-title behavior discussed in #777.
