### PR TITLE
feat(web): support a custom Pages domain for published classroom resources

### DIFF
--- a/cli/gh-teacher/internal/classroom/classroom.go
+++ b/cli/gh-teacher/internal/classroom/classroom.go
@@ -215,7 +215,7 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 	// classroom50/team/v1 bootstrap record so a plain student can enumerate
 	// their classrooms (and read the capability secret) without config-repo
 	// access — safe because the team is secret.
-	teamDesc, err := configrepo.MarshalTeamDescription(name, term, secret, true)
+	teamDesc, err := configrepo.MarshalTeamDescription(name, term, secret, "", true)
 	if err != nil {
 		return err
 	}

--- a/cli/gh-teacher/internal/classroom/migrate.go
+++ b/cli/gh-teacher/internal/classroom/migrate.go
@@ -286,7 +286,7 @@ func performMigration(client githubapi.Client, out, errOut io.Writer, plan migra
 	// classroom50/team/v1 bootstrap record so students can enumerate the
 	// classroom without config-repo access. Migrated classrooms get a plain
 	// (listed) URL — no secret — so the description omits it.
-	teamDesc, err := configrepo.MarshalTeamDescription(plan.Classroom.Name, plan.Term, "", true)
+	teamDesc, err := configrepo.MarshalTeamDescription(plan.Classroom.Name, plan.Term, "", "", true)
 	if err != nil {
 		return err
 	}

--- a/cli/gh-teacher/internal/configrepo/classroom.go
+++ b/cli/gh-teacher/internal/configrepo/classroom.go
@@ -20,6 +20,12 @@ type ClassroomJSON struct {
 	// publish-pages serves resources under `<classroom>/<secret>/...`; empty =
 	// plain path. Opt-in, so omitted on unprotected classrooms.
 	Secret string `json:"secret,omitempty"`
+	// PagesBaseURL is the optional base URL where the org's published Pages
+	// resources are actually served, for orgs with a custom Pages domain (the
+	// github.io 301 fails the browser's CORS check). Empty = the github.io
+	// default. Web-authored (Classroom Settings); the CLI round-trips it and
+	// projects it into the team description.
+	PagesBaseURL string `json:"pages_base_url,omitempty"`
 	// Team is the per-classroom team granting rostered students read on
 	// private org-owned templates. Omitted on pre-feature classrooms.
 	Team *TeamRef `json:"team,omitempty"`
@@ -41,7 +47,8 @@ type ClassroomJSON struct {
 // other key is diverted to Extra. Keep in lockstep with ClassroomJSON's tags.
 var knownClassroomKeys = map[string]struct{}{
 	"schema": {}, "name": {}, "short_name": {}, "term": {}, "org": {},
-	"secret": {}, "team": {}, "teams": {}, "active": {}, "migrated_from": {},
+	"secret": {}, "pages_base_url": {}, "team": {}, "teams": {}, "active": {},
+	"migrated_from": {},
 }
 
 // UnmarshalJSON captures unknown top-level keys into Extra, then decodes

--- a/cli/gh-teacher/internal/configrepo/pagesbaseurl.go
+++ b/cli/gh-teacher/internal/configrepo/pagesbaseurl.go
@@ -1,0 +1,34 @@
+package configrepo
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/foundation50/classroom50-cli-shared/contract"
+)
+
+// PagesBaseURLPattern bounds a classroom's custom Pages base URL, compiled from
+// the single-sourced contract.PagesBaseURLPattern.
+var PagesBaseURLPattern = regexp.MustCompile(contract.PagesBaseURLPattern)
+
+// ValidatePagesBaseURL checks a custom Pages base URL (classroom.json /
+// team-description `pages_base_url`): https, no whitespace/query/fragment (the
+// pattern), plus the normalized-form invariants the pattern can't express — no
+// trailing slash (URL builders append `/<classroom>/...`) and no userinfo.
+// Empty is rejected; callers allowing "no custom domain" branch on emptiness
+// first. Mirrors the web's isValidPagesBaseUrl — keep in lockstep.
+func ValidatePagesBaseURL(base string) error {
+	if !PagesBaseURLPattern.MatchString(base) {
+		return fmt.Errorf("invalid pages_base_url %q: must be %s", base, contract.PagesBaseURLPatternDescription)
+	}
+	if strings.HasSuffix(base, "/") {
+		return fmt.Errorf("invalid pages_base_url %q: must not end with a trailing slash", base)
+	}
+	u, err := url.Parse(base)
+	if err != nil || u.Host == "" || u.User != nil {
+		return fmt.Errorf("invalid pages_base_url %q: must be %s", base, contract.PagesBaseURLPatternDescription)
+	}
+	return nil
+}

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -304,7 +304,7 @@ func ReconcileClassroomTeamDescription(client githubapi.Client, org, shortName, 
 		return false, nil
 	}
 
-	desired, err := MarshalTeamDescription(c.Name, c.Term, c.Secret, !c.IsArchived())
+	desired, err := MarshalTeamDescription(c.Name, c.Term, c.Secret, c.PagesBaseURL, !c.IsArchived())
 	if err != nil {
 		return false, err
 	}

--- a/cli/gh-teacher/internal/configrepo/team_http_test.go
+++ b/cli/gh-teacher/internal/configrepo/team_http_test.go
@@ -35,7 +35,7 @@ func TestEnsureClassroomTeam_WritesDescription(t *testing.T) {
 	t.Cleanup(server.Close)
 	client := githubtest.NewTestClient(t, server)
 
-	desc, err := MarshalTeamDescription("Intro CS", "Fall 2026", "a1b2c3d4", true)
+	desc, err := MarshalTeamDescription("Intro CS", "Fall 2026", "a1b2c3d4", "", true)
 	if err != nil {
 		t.Fatalf("MarshalTeamDescription: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestEnsureClassroomTeam_WritesDescription(t *testing.T) {
 // rotated secret / renamed classroom propagates to the student-facing record.
 func TestEnsureClassroomTeam_AdoptReconcilesDescription(t *testing.T) {
 	var patched map[string]any
-	newDesc, err := MarshalTeamDescription("Intro CS", "Fall 2026", "newsecret", true)
+	newDesc, err := MarshalTeamDescription("Intro CS", "Fall 2026", "newsecret", "", true)
 	if err != nil {
 		t.Fatalf("MarshalTeamDescription: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestEnsureClassroomTeam_AdoptReconcilesDescription(t *testing.T) {
 // secret team whose description already equals the desired record issues no
 // PATCH (idempotent reconcile).
 func TestEnsureClassroomTeam_AdoptSkipsPatchWhenDescriptionMatches(t *testing.T) {
-	desc, err := MarshalTeamDescription("Intro CS", "", "", true)
+	desc, err := MarshalTeamDescription("Intro CS", "", "", "", true)
 	if err != nil {
 		t.Fatalf("MarshalTeamDescription: %v", err)
 	}

--- a/cli/gh-teacher/internal/configrepo/teamdescription.go
+++ b/cli/gh-teacher/internal/configrepo/teamdescription.go
@@ -27,17 +27,23 @@ type TeamDescription struct {
 	Term string `json:"term,omitempty"`
 	// Capability secret, present only for an unlisted classroom.
 	Secret string `json:"secret,omitempty"`
+	// Custom Pages base URL, present only when the org serves its published
+	// Pages resources off the default github.io host.
+	PagesBaseURL string `json:"pages_base_url,omitempty"`
 	// Lifecycle flag; omitted when active (the default) to save bytes.
 	Active *bool `json:"active,omitempty"`
 }
 
 // MarshalTeamDescription encodes the bootstrap record for a student team's
 // description. `secret` is included only when non-empty AND valid (a malformed
-// secret is dropped rather than persisted into a URL segment). `active` is
-// omitted when true (readers default absent -> active). Returns "" for a record
-// with no populated fields beyond the schema is still valid — the schema
-// sentinel alone lets a reader recognize a v1 record.
-func MarshalTeamDescription(name, term, secret string, active bool) (string, error) {
+// secret is dropped rather than persisted into a URL segment). `pagesBaseURL`
+// likewise, but it degrades silently — the value may come from a hand-edited
+// classroom.json, and dropping it just falls back to the github.io default
+// (matches the web writer). `active` is omitted when true (readers default
+// absent -> active). Returns "" for a record with no populated fields beyond
+// the schema is still valid — the schema sentinel alone lets a reader
+// recognize a v1 record.
+func MarshalTeamDescription(name, term, secret, pagesBaseURL string, active bool) (string, error) {
 	desc := TeamDescription{
 		Schema: contract.TeamSchemaV1,
 		Name:   name,
@@ -50,6 +56,9 @@ func MarshalTeamDescription(name, term, secret string, active bool) (string, err
 			return "", fmt.Errorf("team description secret: %w", err)
 		}
 		desc.Secret = secret
+	}
+	if pagesBaseURL != "" && ValidatePagesBaseURL(pagesBaseURL) == nil {
+		desc.PagesBaseURL = pagesBaseURL
 	}
 	if !active {
 		desc.Active = &active

--- a/cli/gh-teacher/internal/configrepo/teamdescription_test.go
+++ b/cli/gh-teacher/internal/configrepo/teamdescription_test.go
@@ -14,7 +14,7 @@ import (
 // when valid.
 func TestMarshalTeamDescription(t *testing.T) {
 	t.Run("unlisted active classroom includes secret, omits active", func(t *testing.T) {
-		got, err := MarshalTeamDescription("Intro CS", "Fall 2026", "a1b2c3d4", true)
+		got, err := MarshalTeamDescription("Intro CS", "Fall 2026", "a1b2c3d4", "", true)
 		if err != nil {
 			t.Fatalf("MarshalTeamDescription: %v", err)
 		}
@@ -40,7 +40,7 @@ func TestMarshalTeamDescription(t *testing.T) {
 	})
 
 	t.Run("listed classroom omits secret", func(t *testing.T) {
-		got, err := MarshalTeamDescription("Intro CS", "", "", true)
+		got, err := MarshalTeamDescription("Intro CS", "", "", "", true)
 		if err != nil {
 			t.Fatalf("MarshalTeamDescription: %v", err)
 		}
@@ -57,7 +57,7 @@ func TestMarshalTeamDescription(t *testing.T) {
 	})
 
 	t.Run("archived classroom writes active=false", func(t *testing.T) {
-		got, err := MarshalTeamDescription("Intro CS", "", "", false)
+		got, err := MarshalTeamDescription("Intro CS", "", "", "", false)
 		if err != nil {
 			t.Fatalf("MarshalTeamDescription: %v", err)
 		}
@@ -72,18 +72,55 @@ func TestMarshalTeamDescription(t *testing.T) {
 	})
 
 	t.Run("malformed secret is rejected, not persisted", func(t *testing.T) {
-		if _, err := MarshalTeamDescription("Intro CS", "", "BAD-secret!", true); err == nil {
+		if _, err := MarshalTeamDescription("Intro CS", "", "BAD-secret!", "", true); err == nil {
 			t.Error("expected an error for a malformed secret, got nil")
 		}
 	})
 
+	t.Run("valid pages_base_url is included", func(t *testing.T) {
+		got, err := MarshalTeamDescription("Intro CS", "", "", "https://cs.example.edu/classroom50", true)
+		if err != nil {
+			t.Fatalf("MarshalTeamDescription: %v", err)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(got), &decoded); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if decoded["pages_base_url"] != "https://cs.example.edu/classroom50" {
+			t.Errorf("pages_base_url = %v, want %q", decoded["pages_base_url"], "https://cs.example.edu/classroom50")
+		}
+	})
+
+	t.Run("malformed pages_base_url is dropped, not persisted", func(t *testing.T) {
+		for _, bad := range []string{
+			"http://cs.example.edu",
+			"https://cs.example.edu/",
+			"https://cs.example.edu/x?y=1",
+			"cs.example.edu",
+		} {
+			got, err := MarshalTeamDescription("Intro CS", "", "", bad, true)
+			if err != nil {
+				t.Fatalf("MarshalTeamDescription(%q): %v", bad, err)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(got), &decoded); err != nil {
+				t.Fatalf("invalid JSON: %v", err)
+			}
+			if _, present := decoded["pages_base_url"]; present {
+				t.Errorf("pages_base_url %q must be dropped, got %v", bad, decoded["pages_base_url"])
+			}
+		}
+	})
+
 	t.Run("stays under the size budget", func(t *testing.T) {
-		// A realistic worst case: long name + term + secret. Must stay well
-		// under ~250 chars so the description never risks GitHub's field limit.
+		// A realistic worst case: long name + term + secret + custom base URL.
+		// Must stay well under ~250 chars so the description never risks
+		// GitHub's field limit.
 		got, err := MarshalTeamDescription(
 			"Introduction to Computer Science and Programming",
 			"Fall Semester 2026",
 			"a1b2c3d4e5f6g7h8",
+			"https://pages.cs.example-university.edu/classroom50",
 			true,
 		)
 		if err != nil {
@@ -113,10 +150,11 @@ func TestMarshalTeamDescription_SharedFixtureParity(t *testing.T) {
 	var doc struct {
 		Cases []struct {
 			Input struct {
-				Name   string `json:"name"`
-				Term   string `json:"term"`
-				Secret string `json:"secret"`
-				Active bool   `json:"active"`
+				Name         string `json:"name"`
+				Term         string `json:"term"`
+				Secret       string `json:"secret"`
+				PagesBaseURL string `json:"pages_base_url"`
+				Active       bool   `json:"active"`
 			} `json:"input"`
 			Encoded string `json:"encoded"`
 		} `json:"cases"`
@@ -128,7 +166,7 @@ func TestMarshalTeamDescription_SharedFixtureParity(t *testing.T) {
 		t.Fatal("shared fixture has no cases")
 	}
 	for _, c := range doc.Cases {
-		got, err := MarshalTeamDescription(c.Input.Name, c.Input.Term, c.Input.Secret, c.Input.Active)
+		got, err := MarshalTeamDescription(c.Input.Name, c.Input.Term, c.Input.Secret, c.Input.PagesBaseURL, c.Input.Active)
 		if err != nil {
 			t.Fatalf("MarshalTeamDescription(%+v): %v", c.Input, err)
 		}

--- a/cli/shared/contract/contract.go
+++ b/cli/shared/contract/contract.go
@@ -198,6 +198,21 @@ const (
 	// secret" error, kept in lockstep with SecretPattern.
 	SecretPatternDescription = "4-64 lowercase letters or digits ([a-z0-9])"
 
+	// PagesBaseURLPattern is the anchored regex a classroom's custom Pages base
+	// URL (classroom.json / team-description `pages_base_url`) must match: an
+	// https URL, no whitespace/query/fragment, bounded so the team-description
+	// record stays within its size budget. A shape gate only — writers also
+	// normalize (strip the trailing slash, reject userinfo) via
+	// configrepo.ValidatePagesBaseURL and the web's pagesBaseUrl util.
+	// Mirrored, with NO compile-time link, in schemas/classroom-v1.schema.json,
+	// schemas/classroom-team-v1.schema.json, and the web GUI
+	// (web/src/util/pagesBaseUrl.ts) — update every copy in lockstep.
+	PagesBaseURLPattern = `^https://[^\s?#]{1,110}$`
+
+	// PagesBaseURLPatternDescription is the human-readable summary in the
+	// "invalid pages_base_url" error, kept in lockstep with PagesBaseURLPattern.
+	PagesBaseURLPatternDescription = "an https:// base URL with no whitespace, query, or fragment (at most 118 chars)"
+
 	// CommitPrefix marks every tool-authored commit so teacher and student can
 	// tell them apart from their own in the repo history. Prepended (via
 	// PrefixCommit) by every CLI commit path; hand-mirrored with NO compile-time

--- a/cli/shared/contract/contract_test.go
+++ b/cli/shared/contract/contract_test.go
@@ -105,6 +105,13 @@ func TestContractLiterals(t *testing.T) {
 		// and the web GUI validator. Update every copy in lockstep on change.
 		{"SecretPattern", SecretPattern, "^[a-z0-9]{4,64}$"},
 		{"SecretPatternDescription", SecretPatternDescription, "4-64 lowercase letters or digits ([a-z0-9])"},
+		// PagesBaseURLPattern / PagesBaseURLPatternDescription are mirrored,
+		// with NO compile-time link, in schemas/classroom-v1.schema.json,
+		// schemas/classroom-team-v1.schema.json, and the web GUI
+		// (web/src/util/pagesBaseUrl.ts). Update every copy in lockstep on
+		// change.
+		{"PagesBaseURLPattern", PagesBaseURLPattern, `^https://[^\s?#]{1,110}$`},
+		{"PagesBaseURLPatternDescription", PagesBaseURLPatternDescription, "an https:// base URL with no whitespace, query, or fragment (at most 118 chars)"},
 		// CommitPrefix is mirrored, with NO compile-time link, in the web GUI
 		// (web/src/util/commit.ts COMMIT_PREFIX) and
 		// cli/gh-teacher/skeleton/dotgithub/workflows/collect-scores.yaml.

--- a/cli/shared/testdata/team_description_cases.json
+++ b/cli/shared/testdata/team_description_cases.json
@@ -44,6 +44,36 @@
         "active": false
       },
       "encoded": "{\"schema\":\"classroom50/team/v1\",\"name\":\"CS\",\"secret\":\"a1b2c3d4\",\"active\":false}"
+    },
+    {
+      "input": {
+        "name": "CS",
+        "term": "Fall 2026",
+        "secret": "a1b2c3d4",
+        "pages_base_url": "https://cs.example.edu/classroom50",
+        "active": true
+      },
+      "encoded": "{\"schema\":\"classroom50/team/v1\",\"name\":\"CS\",\"term\":\"Fall 2026\",\"secret\":\"a1b2c3d4\",\"pages_base_url\":\"https://cs.example.edu/classroom50\"}"
+    },
+    {
+      "input": {
+        "name": "CS",
+        "term": "",
+        "secret": "",
+        "pages_base_url": "https://pages.example.edu",
+        "active": false
+      },
+      "encoded": "{\"schema\":\"classroom50/team/v1\",\"name\":\"CS\",\"pages_base_url\":\"https://pages.example.edu\",\"active\":false}"
+    },
+    {
+      "input": {
+        "name": "CS",
+        "term": "",
+        "secret": "",
+        "pages_base_url": "http://insecure.example.edu/classroom50",
+        "active": true
+      },
+      "encoded": "{\"schema\":\"classroom50/team/v1\",\"name\":\"CS\"}"
     }
   ]
 }

--- a/schemas/classroom-team-v1.schema.json
+++ b/schemas/classroom-team-v1.schema.json
@@ -24,6 +24,11 @@
       "type": "string",
       "pattern": "^[a-z0-9]{4,64}$",
       "description": "Capability-URL access key, present only for an unlisted classroom (mirrors classroom.json.secret). Lets a member fetch this classroom's published Pages resources at the unguessable `<classroom>/<secret>/...` path before accepting any assignment. Obscurity, not access control. Omitted for a listed classroom."
+    },
+    "pages_base_url": {
+      "type": "string",
+      "pattern": "^https://[^\\s?#]{1,110}$",
+      "description": "Base URL where the org's published Pages resources are served, mirrored from classroom.json.pages_base_url for orgs with a custom GitHub Pages domain (the github.io 301 fails the browser's CORS check). Lets a student's browser fetch published resources directly from the custom domain, falling back to the github.io default. Omitted when the org uses the default github.io host."
     }
   }
 }

--- a/schemas/classroom-v1.schema.json
+++ b/schemas/classroom-v1.schema.json
@@ -59,6 +59,11 @@
       "pattern": "^[a-z0-9]{4,64}$",
       "description": "Optional access key for an unlisted classroom. When present, publish-pages serves this classroom's resources at an unguessable URL (`<classroom>/<secret>/...`) that every consumer inserts; when omitted, the plain `<classroom>/...` path. Obscurity, not access control — anyone with the link can read the files. Opt-in via `gh teacher classroom add --unlisted`."
     },
+    "pages_base_url": {
+      "type": "string",
+      "pattern": "^https://[^\\s?#]{1,110}$",
+      "description": "Optional base URL where this org's published Pages resources are actually served, for orgs with a custom GitHub Pages domain (github.io answers a 301 the browser's CORS check rejects — foundation50/classroom50#776). Everything before the `/<classroom>[/<secret>]/...` segment, no trailing slash: `https://<domain>/classroom50` for an org-root custom domain, `https://<domain>` for a CNAME on the classroom50 repo itself. Browser readers try this base first and fall back to the `https://<org>.github.io/classroom50` default; server-side readers (CLIs, Actions) follow the redirect and may ignore it. Fleet caveat: gh-teacher releases that predate this field re-derive the team-description projection WITHOUT it on their next reconcile (the description compare is exact-string), stripping the custom domain from student discovery until a current writer restores it — upgrade every teacher's CLI before setting this."
+    },
     "active": {
       "type": "boolean",
       "description": "Classroom lifecycle flag: false = archived, true or ABSENT = active (legacy classrooms read as active). Written only when a teacher toggles archive/unarchive. Archived classrooms drop out of the default classes list and block new assignments/edits; once published to classrooms-index.json the student accept page refuses too."

--- a/web/src/components/drawer/AssignmentSidebarMenu.tsx
+++ b/web/src/components/drawer/AssignmentSidebarMenu.tsx
@@ -14,6 +14,7 @@ import useGetClassroom from "@/hooks/useGetClassroom"
 import useGetClassroomAssignments from "@/hooks/useGetClassAssignments"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
+import { useClassroomSecret } from "@/hooks/useStudentClassrooms"
 import useGetAssignmentRepo from "@/hooks/useGetAssignmentRepo"
 import { studentRepoName } from "@/util/studentRepo"
 import { SidebarItemBody, SidebarNavItem } from "./primitives"
@@ -68,11 +69,20 @@ export const AssignmentSidebarMenu = ({
     enabled: isActuallyStaff,
   })
   const secret = studentSecret || classroomMeta?.secret
+  // Custom Pages base URL: team record for a real student, classroom.json for
+  // actual staff (same dual sourcing as the secret above).
+  const { pagesBaseUrl: teamPagesBaseUrl, isLoading: loadingBootstrap } =
+    useClassroomSecret(org, classroom)
+  const pagesBaseUrl = teamPagesBaseUrl || classroomMeta?.pages_base_url
   const { assignment: publicAssignment } = usePagesAssignments(
     org,
     classroom,
     secret,
-    { assignmentSlug: assignment },
+    {
+      assignmentSlug: assignment,
+      pagesBaseUrl,
+      enabled: !loadingBootstrap,
+    },
   )
   const assignmentName =
     teacherAssignments?.assignments.find((a) => a.slug === assignment)?.name ||

--- a/web/src/components/org/OrgRepos.test.tsx
+++ b/web/src/components/org/OrgRepos.test.tsx
@@ -19,6 +19,14 @@ vi.mock("@/hooks/useGetMyOrgRepos", () => ({
 vi.mock("@/hooks/useDotClassroom50", () => ({
   default: () => ({}),
 }))
+vi.mock("@/hooks/useStudentClassrooms", () => ({
+  useClassroomSecret: () => ({
+    secret: undefined,
+    pagesBaseUrl: undefined,
+    isLoading: false,
+    isError: false,
+  }),
+}))
 vi.mock("@/hooks/usePagesAssignments", () => ({
   default: () => ({ assignment: undefined }),
 }))

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -20,6 +20,7 @@ import { assignmentDescription } from "@/types/classroom"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
+import { useClassroomSecret } from "@/hooks/useStudentClassrooms"
 import { EnterDiv } from "@/lib/motionComponents"
 
 const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
@@ -27,11 +28,22 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
   const [descriptionOpen, setDescriptionOpen] = useState(false)
   const cl50Yaml = useDotClassroom50(org, repo.name)
   const { classroom, assignment, secret } = cl50Yaml
+  // Custom Pages base URL from the student's team-description record; the
+  // read waits for it so a custom-domain org never fires a doomed github.io
+  // fetch. One shared GET /user/teams query backs every card.
+  const { pagesBaseUrl, isLoading: loadingBootstrap } = useClassroomSecret(
+    org,
+    classroom || undefined,
+  )
   const { assignment: assignmentData } = usePagesAssignments(
     org,
     classroom,
     secret,
-    { assignmentSlug: assignment },
+    {
+      assignmentSlug: assignment,
+      pagesBaseUrl,
+      enabled: !loadingBootstrap,
+    },
   )
 
   const description = assignmentDescription(assignmentData)

--- a/web/src/components/org/StudentAssignmentList.tsx
+++ b/web/src/components/org/StudentAssignmentList.tsx
@@ -364,10 +364,11 @@ export function StudentAssignmentList({
 }) {
   const { t } = useTranslation()
   const { user } = useGithubAuth()
-  const { secret, isLoading: loadingSecret } = useClassroomSecret(
-    org,
-    classroom,
-  )
+  const {
+    secret,
+    pagesBaseUrl,
+    isLoading: loadingSecret,
+  } = useClassroomSecret(org, classroom)
   const { sortKey, changeSort } = useListPrefsState(studentAssignmentListPrefs)
   const [query, setQuery] = useState("")
   const [filters, setFilters] = useState<StudentAssignmentFilters>({
@@ -378,7 +379,10 @@ export function StudentAssignmentList({
     data: assignments,
     isLoading: loadingAssignmentsData,
     isError,
-  } = usePagesAssignments(org, classroom, secret, { enabled: !loadingSecret })
+  } = usePagesAssignments(org, classroom, secret, {
+    enabled: !loadingSecret,
+    pagesBaseUrl,
+  })
   // Acceptance (the CTA and the red badge) is derived from the org repo list;
   // fold its load into the gate so a row never paints "Accept" and then
   // flips to "View my submission" once the repos land.

--- a/web/src/domain/assignments/accept.ts
+++ b/web/src/domain/assignments/accept.ts
@@ -520,10 +520,20 @@ export async function acceptAssignment(params: {
   // Undefined for an unprotected classroom (plain path). Not read from
   // classroom.json — students can't access the private config repo.
   secret?: string
+  // Custom Pages base URL for an org off the github.io default, from the
+  // team-description bootstrap record. Undefined = the default host.
+  pagesBaseUrl?: string
   onStepUpdate?: OnAcceptStepUpdate
 }): Promise<AcceptAssignmentResult> {
-  const { client, org, classroom, assignmentSlug, secret, onStepUpdate } =
-    params
+  const {
+    client,
+    org,
+    classroom,
+    assignmentSlug,
+    secret,
+    pagesBaseUrl,
+    onStepUpdate,
+  } = params
 
   log.info("accept assignment: started", { org, classroom, assignmentSlug })
 
@@ -582,7 +592,14 @@ export async function acceptAssignment(params: {
       },
       onStepUpdate,
     },
-    () => fetchAssignmentFromPages(org, classroom, assignmentSlug, secret),
+    () =>
+      fetchAssignmentFromPages(
+        org,
+        classroom,
+        assignmentSlug,
+        secret,
+        pagesBaseUrl,
+      ),
   )
 
   const sourceOwner = assignment.template?.owner
@@ -766,6 +783,7 @@ export async function acceptAssignment(params: {
             classroom,
             autograder: assignment.autograder,
             secret,
+            pagesBaseUrl,
             // Preliminary branch; the default shim is re-rendered post-create
             // with the assignment repo's actual default branch (below).
             branch: sourceBranch || "main",

--- a/web/src/domain/assignments/autograderYaml.ts
+++ b/web/src/domain/assignments/autograderYaml.ts
@@ -2,6 +2,10 @@ import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { classroomPagesSegment } from "@/util/secret"
 import { safeShimTagPatterns } from "@/util/submissionTags"
 import { fetchTextWithFriendlyErrors } from "../queries/assignments"
+import {
+  attemptedPagesUrls,
+  CUSTOM_HOST_TIMEOUT_MS,
+} from "@/github-core/queries"
 import { localizedError } from "@/types/localizedMessage"
 import type { SubmissionMode } from "@/types/classroom"
 
@@ -75,15 +79,23 @@ export function createClassroom50Yaml(params: {
   return lines.join("\n")
 }
 
-function pagesAutograderUrl(params: {
+// The URL(s) a teacher-authored autograder fetch attempts: custom Pages base
+// first when set, github.io fallback — same order and dedupe as the
+// assignments-manifest read (attemptedPagesUrls owns the recipe).
+function pagesAutograderUrls(params: {
   org: string
   classroom: string
   name: string
   secret?: string
-}) {
-  const { org, classroom, name, secret } = params
+  pagesBaseUrl?: string
+}): string[] {
+  const { org, classroom, name, secret, pagesBaseUrl } = params
   const segment = classroomPagesSegment(classroom, secret)
-  return `https://${org}.github.io/${CONFIG_REPO}/${segment}/autograders/${name}.yaml`
+  return attemptedPagesUrls(
+    org,
+    `${segment}/autograders/${name}.yaml`,
+    pagesBaseUrl,
+  )
 }
 
 // The shim's on.push.tags flow sequence: the teacher's milestone patterns (if
@@ -150,6 +162,9 @@ export async function resolveAutograderWorkflow(params: {
   classroom: string
   autograder?: string
   secret?: string
+  // Custom Pages base URL for an org off the github.io default; the
+  // teacher-authored autograder is fetched from it first, like the manifest.
+  pagesBaseUrl?: string
   // The assignment repo's default branch (the shim's push trigger) and the
   // config repo's default branch (the reusable-workflow ref). Only used for the
   // built-in default shim; teacher-authored autograders are branch-agnostic.
@@ -168,6 +183,7 @@ export async function resolveAutograderWorkflow(params: {
     classroom,
     autograder,
     secret,
+    pagesBaseUrl,
     branch,
     configBranch,
     submissionMode,
@@ -185,11 +201,40 @@ export async function resolveAutograderWorkflow(params: {
   // Narrowed: isDefaultAutograder returns true for undefined/"default", so a
   // non-default autograder name is a non-empty string here.
   const autograderName = autograder as string
+  const label = {
+    key: "pagesErrors.autograderLabel",
+    params: { autograderName },
+  }
 
-  const workflow = await fetchTextWithFriendlyErrors(
-    pagesAutograderUrl({ org, classroom, name: autograderName, secret }),
-    { key: "pagesErrors.autograderLabel", params: { autograderName } },
-  )
+  const urls = pagesAutograderUrls({
+    org,
+    classroom,
+    name: autograderName,
+    secret,
+    pagesBaseUrl,
+  })
+
+  // Custom-domain-first with github.io fallback, mirroring
+  // fetchPagesAssignments. Only the (bounded) custom attempt may be a
+  // non-final URL; the last attempt's error is the one surfaced.
+  let workflow: string | undefined
+  let lastErr: unknown
+  for (const [i, url] of urls.entries()) {
+    const isFallbackable = i < urls.length - 1
+    try {
+      workflow = await fetchTextWithFriendlyErrors(
+        url,
+        label,
+        isFallbackable ? { timeoutMs: CUSTOM_HOST_TIMEOUT_MS } : undefined,
+      )
+      break
+    } catch (err) {
+      lastErr = err
+    }
+  }
+  if (workflow === undefined) {
+    throw lastErr
+  }
 
   if (!workflow.includes("jobs:")) {
     throw localizedError({

--- a/web/src/domain/queries/assignments.ts
+++ b/web/src/domain/queries/assignments.ts
@@ -1,10 +1,5 @@
 import type { GitHubClient } from "@/github-core/client"
-import {
-  extractAssignments,
-  fetchJson,
-  pagesAssignmentUrl,
-  type AssignmentsJson,
-} from "@/github-core/queries"
+import { fetchPagesAssignments } from "@/github-core/queries"
 import type { Assignment } from "@/types/classroom"
 import { decodeBase64Utf8 } from "@/util/github"
 import { CONFIG_REPO } from "@/util/configRepo"
@@ -48,10 +43,22 @@ export async function getAssignmentsFile(
 export async function fetchTextWithFriendlyErrors(
   url: string,
   label: LocalizedMessage,
+  opts?: { timeoutMs?: number },
 ): Promise<string> {
-  const response = await fetch(url)
   const named = (key: string, params?: Record<string, string | number>) =>
     localizedError({ key, params: { ...params, label } })
+
+  let response: Response
+  try {
+    response = await fetch(
+      url,
+      opts?.timeoutMs ? { signal: AbortSignal.timeout(opts.timeoutMs) } : {},
+    )
+  } catch {
+    // Network failure, DNS, CORS-blocked redirect, or the custom-host timeout
+    // — named so the view never renders a raw "Failed to fetch".
+    throw named("pagesErrors.fetchNetworkFailed")
+  }
 
   if (response.status === 404) {
     throw named("pagesErrors.notPublished")
@@ -75,12 +82,16 @@ export async function fetchAssignmentFromPages(
   classroom: string,
   assignmentSlug: string,
   secret?: string,
+  pagesBaseUrl?: string,
 ): Promise<Assignment> {
-  const json = await fetchJson<AssignmentsJson>(
-    pagesAssignmentUrl(org, classroom, secret),
+  // Shares fetchPagesAssignments so the accept flow gets the same
+  // custom-domain-then-default fallback as the page-level reads.
+  const assignments = await fetchPagesAssignments(
+    org,
+    classroom,
+    secret,
+    pagesBaseUrl,
   )
-
-  const assignments = extractAssignments(json)
   const assignment = assignments.find((entry) => entry.slug === assignmentSlug)
 
   if (!assignment) {

--- a/web/src/github-core/mutations.test.ts
+++ b/web/src/github-core/mutations.test.ts
@@ -92,6 +92,33 @@ describe("buildClassroomUpdate", () => {
   it("omits every optional field when none are provided (identity merge)", () => {
     expect(buildClassroomUpdate(base, {})).toEqual(base)
   })
+
+  it('pages_base_url: non-empty sets, undefined preserves, "" deletes', () => {
+    const url = "https://pages.example.edu/classroom50"
+
+    const set = buildClassroomUpdate(base, { pages_base_url: url })
+    expect(set.pages_base_url).toBe(url)
+
+    // An edit that omits the field (e.g. a pure archive toggle) must not
+    // touch a persisted custom domain.
+    const preserved = buildClassroomUpdate(
+      { ...base, pages_base_url: url },
+      { active: false },
+    )
+    expect(preserved.pages_base_url).toBe(url)
+
+    // Clearing deletes the key outright — never writes an empty string an
+    // old reader would trip on.
+    const cleared = buildClassroomUpdate(
+      { ...base, pages_base_url: url },
+      { pages_base_url: "" },
+    )
+    expect("pages_base_url" in cleared).toBe(false)
+
+    // Clearing an already-absent field stays a no-op (no key introduced).
+    const noop = buildClassroomUpdate(base, { pages_base_url: "" })
+    expect("pages_base_url" in noop).toBe(false)
+  })
 })
 
 // editClassroom enforces "archived classrooms are read-only" on the write path

--- a/web/src/github-core/mutations/classroomEdit.ts
+++ b/web/src/github-core/mutations/classroomEdit.ts
@@ -55,6 +55,10 @@ export type EditClassroomInput = {
   // Archive lifecycle: false = archive, true = unarchive. Omitted leaves the
   // current value (or its absence) intact. See isClassroomArchived.
   active?: boolean
+  // Custom Pages base URL (normalized; see normalizePagesBaseUrl). Omitted
+  // leaves the persisted value intact; "" clears it (the key is deleted, not
+  // written empty, so old readers never see an empty string).
+  pages_base_url?: string
 }
 
 export type EditClassroomResult = Awaited<ReturnType<typeof editClassroom>>
@@ -65,28 +69,36 @@ export type EditClassroomResult = Awaited<ReturnType<typeof editClassroom>>
 // - writes name/term/active ONLY when provided, so a pure archive toggle
 //   preserves the persisted name/term. `active` is a meaningful boolean (false =
 //   archived), so unarchive writes `true` rather than deleting the key.
+// - pages_base_url set when non-empty; "" deletes the key (clearing the custom
+//   domain must not leave an empty string an old reader would trip on).
 export function buildClassroomUpdate(
   current: Record<string, unknown>,
   fields: {
     name?: string
     term?: string
     active?: boolean
+    pages_base_url?: string
   },
 ): Record<string, unknown> {
-  const { name, term, active } = fields
-  return {
+  const { name, term, active, pages_base_url } = fields
+  const next = {
     ...current,
     ...(name !== undefined ? { name } : {}),
     ...(term !== undefined ? { term } : {}),
     ...(active !== undefined ? { active } : {}),
+    ...(pages_base_url ? { pages_base_url } : {}),
   }
+  if (pages_base_url === "") {
+    delete next.pages_base_url
+  }
+  return next
 }
 
 export async function editClassroom(
   client: GitHubClient,
   input: EditClassroomInput,
 ) {
-  const { org, slug, term, name, active } = input
+  const { org, slug, term, name, active, pages_base_url } = input
 
   // Org policy can seed the config repo on a non-`main` branch, so both the ref
   // read and the write must target the real branch.
@@ -114,7 +126,8 @@ export async function editClassroom(
   // `active === undefined`, so a payload bundling a settings change with
   // `active: false` (a stale tab, direct API call, or CLI/agent) can't slip an
   // edit past the guard by re-asserting the archived state.
-  const editsSettings = name !== undefined || term !== undefined
+  const editsSettings =
+    name !== undefined || term !== undefined || pages_base_url !== undefined
   if (editsSettings && active !== true && isClassroomArchived(current)) {
     throw new Error(
       `Classroom "${slug}" is archived — settings are read-only. Unarchive it first to make changes.`,
@@ -125,6 +138,7 @@ export async function editClassroom(
     name,
     term,
     active,
+    pages_base_url,
   })
 
   const blob = await createBlob(client, {

--- a/web/src/github-core/mutations/teamDescription.ts
+++ b/web/src/github-core/mutations/teamDescription.ts
@@ -59,7 +59,7 @@ export async function reconcileStudentTeamDescription(
 // The classroom.json fields the team-description projection is derived from.
 export type TeamDescriptionSource = Pick<
   Classroom,
-  "name" | "term" | "secret" | "active" | "team"
+  "name" | "term" | "secret" | "pages_base_url" | "active" | "team"
 >
 
 // The write half of reconcileStudentTeamDescription: project an already-known
@@ -78,6 +78,7 @@ export async function projectTeamDescriptionFromRecord(
     name: record.name,
     term: record.term,
     secret: record.secret,
+    pagesBaseUrl: record.pages_base_url,
     active: !isClassroomArchived(record),
   })
 

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -106,6 +106,10 @@ export {
 export {
   fetchJson,
   pagesAssignmentUrl,
+  defaultPagesBaseUrl,
+  attemptedPagesUrls,
+  attemptedPagesAssignmentUrls,
+  CUSTOM_HOST_TIMEOUT_MS,
   classroomsIndexUrl,
   orgPublishesClassroom50Pages,
   extractAssignments,

--- a/web/src/github-core/queries/pagesReads.test.ts
+++ b/web/src/github-core/queries/pagesReads.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  attemptedPagesAssignmentUrls,
+  fetchPagesAssignments,
+} from "./pagesReads"
+
+const ORG = "acme"
+const CLASSROOM = "cs101"
+const CUSTOM_BASE = "https://pages.example.edu/classroom50"
+const DEFAULT_URL = `https://${ORG}.github.io/classroom50/${CLASSROOM}/assignments.json`
+const CUSTOM_URL = `${CUSTOM_BASE}/${CLASSROOM}/assignments.json`
+
+const MANIFEST = {
+  schema: "classroom50/assignments/v1",
+  assignments: [{ slug: "hw1", name: "HW 1" }],
+}
+
+type StubResponse =
+  | { ok: true; body?: unknown }
+  | { ok: false; status: number }
+  | { network: true }
+
+// Route-keyed fetch stub recording call order, so ordering and fallback
+// assertions read directly off the visited URLs.
+const stubFetch = (routes: Record<string, StubResponse>) => {
+  const calls: string[] = []
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      calls.push(url)
+      const route = routes[url]
+      if (!route) throw new Error(`unstubbed fetch: ${url}`)
+      if ("network" in route) {
+        return Promise.reject(new TypeError("Failed to fetch"))
+      }
+      if (!route.ok) {
+        return Promise.resolve({ status: route.status, ok: false })
+      }
+      return Promise.resolve({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve(route.body ?? MANIFEST),
+      })
+    }),
+  )
+  return calls
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("attemptedPagesAssignmentUrls", () => {
+  it("lists custom first, then the github.io default", () => {
+    expect(
+      attemptedPagesAssignmentUrls(ORG, CLASSROOM, undefined, CUSTOM_BASE),
+    ).toEqual([CUSTOM_URL, DEFAULT_URL])
+  })
+
+  it("is default-only without a custom base", () => {
+    expect(attemptedPagesAssignmentUrls(ORG, CLASSROOM)).toEqual([DEFAULT_URL])
+  })
+
+  it("dedupes when the custom base IS the default", () => {
+    expect(
+      attemptedPagesAssignmentUrls(
+        ORG,
+        CLASSROOM,
+        undefined,
+        `https://${ORG}.github.io/classroom50`,
+      ),
+    ).toEqual([DEFAULT_URL])
+  })
+
+  it("inserts the capability secret into both hosts' paths", () => {
+    expect(
+      attemptedPagesAssignmentUrls(ORG, CLASSROOM, "a1b2c3d4", CUSTOM_BASE),
+    ).toEqual([
+      `${CUSTOM_BASE}/${CLASSROOM}/a1b2c3d4/assignments.json`,
+      `https://${ORG}.github.io/classroom50/${CLASSROOM}/a1b2c3d4/assignments.json`,
+    ])
+  })
+})
+
+describe("fetchPagesAssignments", () => {
+  it("reads the custom host first and never touches the default on success", async () => {
+    const calls = stubFetch({ [CUSTOM_URL]: { ok: true } })
+    const assignments = await fetchPagesAssignments(
+      ORG,
+      CLASSROOM,
+      undefined,
+      CUSTOM_BASE,
+    )
+    expect(assignments[0].slug).toBe("hw1")
+    expect(calls).toEqual([CUSTOM_URL])
+  })
+
+  it("falls back to the default host when the custom host fails", async () => {
+    const calls = stubFetch({
+      [CUSTOM_URL]: { network: true },
+      [DEFAULT_URL]: { ok: true },
+    })
+    const assignments = await fetchPagesAssignments(
+      ORG,
+      CLASSROOM,
+      undefined,
+      CUSTOM_BASE,
+    )
+    expect(assignments[0].slug).toBe("hw1")
+    expect(calls).toEqual([CUSTOM_URL, DEFAULT_URL])
+  })
+
+  it("combines both hosts' failure with the custom attempt as the detail", async () => {
+    stubFetch({
+      [CUSTOM_URL]: { network: true },
+      [DEFAULT_URL]: { network: true },
+    })
+    await expect(
+      fetchPagesAssignments(ORG, CLASSROOM, undefined, CUSTOM_BASE),
+    ).rejects.toMatchObject({
+      localized: {
+        key: "pagesErrors.classroomUnreachableBothHosts",
+        params: {
+          customUrl: CUSTOM_URL,
+          defaultUrl: DEFAULT_URL,
+          detail: { key: "pagesErrors.customHostUnreachable" },
+        },
+      },
+    })
+  })
+
+  it("keeps the custom host's 404 as the detail when both hosts fail", async () => {
+    stubFetch({
+      [CUSTOM_URL]: { ok: false, status: 404 },
+      [DEFAULT_URL]: { network: true },
+    })
+    await expect(
+      fetchPagesAssignments(ORG, CLASSROOM, undefined, CUSTOM_BASE),
+    ).rejects.toMatchObject({
+      localized: {
+        key: "pagesErrors.classroomUnreachableBothHosts",
+        params: { detail: { key: "pagesErrors.classroomNotPublished" } },
+      },
+    })
+  })
+
+  it("fetches once when the custom base equals the default", async () => {
+    const calls = stubFetch({ [DEFAULT_URL]: { ok: true } })
+    await fetchPagesAssignments(
+      ORG,
+      CLASSROOM,
+      undefined,
+      `https://${ORG}.github.io/classroom50`,
+    )
+    expect(calls).toEqual([DEFAULT_URL])
+  })
+
+  it("keeps the single-host error semantics without a custom base", async () => {
+    stubFetch({ [DEFAULT_URL]: { ok: false, status: 404 } })
+    await expect(fetchPagesAssignments(ORG, CLASSROOM)).rejects.toMatchObject({
+      localized: { key: "pagesErrors.classroomNotPublished" },
+    })
+  })
+
+  it("names a bare network failure instead of leaking 'Failed to fetch'", async () => {
+    stubFetch({ [DEFAULT_URL]: { network: true } })
+    await expect(fetchPagesAssignments(ORG, CLASSROOM)).rejects.toMatchObject({
+      localized: { key: "pagesErrors.classroomNetworkFailed" },
+    })
+  })
+})

--- a/web/src/github-core/queries/pagesReads.ts
+++ b/web/src/github-core/queries/pagesReads.ts
@@ -6,11 +6,15 @@ import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubAPIError } from "../errors"
 import { classroomPagesSegment } from "@/util/secret"
 import { log } from "./shared"
-import { localizedError } from "@/types/localizedMessage"
+import { localizedError, localizedMessageOf } from "@/types/localizedMessage"
 
-export async function fetchJson<T>(url: string): Promise<T> {
+export async function fetchJson<T>(
+  url: string,
+  timeoutMs?: number,
+): Promise<T> {
   const response = await fetch(url, {
     cache: "no-store",
+    ...(timeoutMs ? { signal: AbortSignal.timeout(timeoutMs) } : {}),
   })
 
   if (response.status === 404) {
@@ -27,13 +31,23 @@ export async function fetchJson<T>(url: string): Promise<T> {
   return response.json() as Promise<T>
 }
 
+// The github.io base every published resource lives under by default.
+// An org with a custom Pages domain overrides it per classroom via
+// classroom.json's `pages_base_url` (see fetchPagesAssignments).
+export function defaultPagesBaseUrl(org: string) {
+  return `https://${org}.github.io/${CONFIG_REPO}`
+}
+
 export function pagesAssignmentUrl(
   org: string,
   classroom: string,
   secret?: string,
+  // Normalized custom base (classroom.json / team-description
+  // `pages_base_url`); absent = the github.io default.
+  pagesBaseUrl?: string,
 ) {
   const segment = classroomPagesSegment(classroom, secret)
-  return `https://${org}.github.io/${CONFIG_REPO}/${segment}/assignments.json`
+  return `${pagesBaseUrl || defaultPagesBaseUrl(org)}/${segment}/assignments.json`
 }
 
 // Public, unauthenticated signal that an org is a real Classroom50 org: the
@@ -91,17 +105,111 @@ export function extractAssignments(json: AssignmentsJson): Assignment[] {
   return json.assignments
 }
 
+// One attempt against one host: fetch + shape-check. A bare fetch failure
+// (network, DNS, a CORS-blocked redirect, or the custom-host timeout — the
+// browser hides which) is named here so the view never renders a raw
+// "Failed to fetch". `networkErrorKey` lets the custom-host attempt carry
+// custom-domain-specific remediation copy.
+async function fetchAssignmentsManifest(
+  url: string,
+  opts?: { timeoutMs?: number; networkErrorKey?: string },
+): Promise<Assignment[]> {
+  let json: AssignmentsJson
+  try {
+    json = await fetchJson<AssignmentsJson>(url, opts?.timeoutMs)
+  } catch (err) {
+    if (localizedMessageOf(err)) throw err
+    throw localizedError({
+      key: opts?.networkErrorKey ?? "pagesErrors.classroomNetworkFailed",
+    })
+  }
+  return extractAssignments(json)
+}
+
+// Bound the custom-host attempt: a black-holing teacher-typed domain must not
+// stall every student read behind the browser's multi-minute default timeout.
+// Matches the 5s bound orgPublishesClassroom50Pages already uses; the
+// github.io attempt stays unbounded (a known-good host, and the last resort).
+export const CUSTOM_HOST_TIMEOUT_MS = 5000
+
+// The URL(s) a published-resource read attempts, in order: the custom base
+// first when one is set, then the github.io default — deduped when they
+// coincide. The single source for the fallback order AND every "tried to
+// load" error surface (the accept page renders this list), so the two can't
+// drift. `relPath` is the path below the Pages base (no leading slash).
+export function attemptedPagesUrls(
+  org: string,
+  relPath: string,
+  pagesBaseUrl?: string,
+): string[] {
+  const defaultUrl = `${defaultPagesBaseUrl(org)}/${relPath}`
+  const customUrl = pagesBaseUrl ? `${pagesBaseUrl}/${relPath}` : undefined
+  return customUrl && customUrl !== defaultUrl
+    ? [customUrl, defaultUrl]
+    : [defaultUrl]
+}
+
+export function attemptedPagesAssignmentUrls(
+  org: string,
+  classroom: string,
+  secret?: string,
+  pagesBaseUrl?: string,
+): string[] {
+  return attemptedPagesUrls(
+    org,
+    `${classroomPagesSegment(classroom, secret)}/assignments.json`,
+    pagesBaseUrl,
+  )
+}
+
 export async function fetchPagesAssignments(
   org: string,
   classroom: string,
   secret?: string,
+  pagesBaseUrl?: string,
 ): Promise<Assignment[]> {
-  const json = await fetchJson<AssignmentsJson>(
-    pagesAssignmentUrl(org, classroom, secret),
+  const urls = attemptedPagesAssignmentUrls(
+    org,
+    classroom,
+    secret,
+    pagesBaseUrl,
   )
-  const assignments = extractAssignments(json)
 
-  return assignments
+  if (urls.length === 1) {
+    return fetchAssignmentsManifest(urls[0])
+  }
+
+  // Custom Pages domain first — github.io answers such an org with a 301 the
+  // browser's CORS check rejects (issue #776). Fall back to the default host
+  // so a stale/wrong custom domain can't lock students out of a working
+  // github.io site. Both failing throws a combined error naming both URLs,
+  // with the CUSTOM host's failure as the detail: it is the org's intended
+  // source, so its error is the actionable one — the default host's failure is
+  // usually just the CORS-doomed 301 this feature exists to bypass.
+  const [customUrl, defaultUrl] = urls
+  let customErr: unknown
+  try {
+    return await fetchAssignmentsManifest(customUrl, {
+      timeoutMs: CUSTOM_HOST_TIMEOUT_MS,
+      networkErrorKey: "pagesErrors.customHostUnreachable",
+    })
+  } catch (err) {
+    customErr = err
+  }
+  try {
+    return await fetchAssignmentsManifest(defaultUrl)
+  } catch {
+    throw localizedError({
+      key: "pagesErrors.classroomUnreachableBothHosts",
+      params: {
+        customUrl,
+        defaultUrl,
+        detail: localizedMessageOf(customErr) ?? {
+          key: "pagesErrors.customHostUnreachable",
+        },
+      },
+    })
+  }
 }
 
 export type Classroom50OrgSummary = {

--- a/web/src/hooks/mutations/useAcceptAssignment.ts
+++ b/web/src/hooks/mutations/useAcceptAssignment.ts
@@ -19,11 +19,13 @@ export function useAcceptAssignment(params: {
   classroom: string
   assignmentSlug: string
   secret?: string
+  pagesBaseUrl?: string
   onStepUpdate: OnAcceptStepUpdate
 }) {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
-  const { org, classroom, assignmentSlug, secret, onStepUpdate } = params
+  const { org, classroom, assignmentSlug, secret, pagesBaseUrl, onStepUpdate } =
+    params
 
   return useMutation({
     mutationFn: () =>
@@ -33,6 +35,7 @@ export function useAcceptAssignment(params: {
         classroom,
         assignmentSlug,
         secret,
+        pagesBaseUrl,
         onStepUpdate,
       }),
     onSuccess: () => {

--- a/web/src/hooks/usePagesAssignments.ts
+++ b/web/src/hooks/usePagesAssignments.ts
@@ -24,11 +24,28 @@ const usePagesAssignments = (
     // When set, the result also exposes `assignment` (the entry with this slug),
     // so single-assignment callers don't reimplement the `.find`.
     assignmentSlug?: string
+    // Custom Pages base URL for an org off the github.io default (see
+    // fetchPagesAssignments). Sourced like `secret`: the team-description
+    // bootstrap record for students, classroom.json for teachers.
+    pagesBaseUrl?: string
   },
 ) => {
   const query = useQuery({
-    queryKey: ["pages", "assignments", org, classroom, secret ?? ""],
-    queryFn: () => fetchPagesAssignments(org ?? "", classroom ?? "", secret),
+    queryKey: [
+      "pages",
+      "assignments",
+      org,
+      classroom,
+      secret ?? "",
+      options?.pagesBaseUrl ?? "",
+    ],
+    queryFn: () =>
+      fetchPagesAssignments(
+        org ?? "",
+        classroom ?? "",
+        secret,
+        options?.pagesBaseUrl,
+      ),
     enabled: (options?.enabled ?? true) && Boolean(org && classroom),
     // Pages is a public projection that changes rarely; cache it for 10 minutes.
     // Don't retry — a 404 (protected/unprotected path mismatch or a not-yet-

--- a/web/src/hooks/useStudentClassrooms.test.tsx
+++ b/web/src/hooks/useStudentClassrooms.test.tsx
@@ -243,7 +243,12 @@ describe("useClassroomSecret", () => {
       }),
     )
     const { result } = renderHook(() => useClassroomSecret("acme", "ml"))
-    expect(result.current).toEqual({ secret: "a1b2c3d4", isLoading: false })
+    expect(result.current).toEqual({
+      secret: "a1b2c3d4",
+      pagesBaseUrl: undefined,
+      isLoading: false,
+      isError: false,
+    })
   })
 
   it("returns undefined for a classroom with no matching team", () => {
@@ -262,13 +267,23 @@ describe("useClassroomSecret", () => {
     expect(useQueryMock).toHaveBeenCalledWith(
       expect.objectContaining({ enabled: false }),
     )
-    expect(result.current).toEqual({ secret: undefined, isLoading: false })
+    expect(result.current).toEqual({
+      secret: undefined,
+      pagesBaseUrl: undefined,
+      isLoading: false,
+      isError: false,
+    })
   })
 
   it("reports isLoading while the enabled read is in flight", () => {
     useQueryMock.mockReturnValue(teams({ fetchStatus: "fetching" }))
     const { result } = renderHook(() => useClassroomSecret("acme", "ml"))
-    expect(result.current).toEqual({ secret: undefined, isLoading: true })
+    expect(result.current).toEqual({
+      secret: undefined,
+      pagesBaseUrl: undefined,
+      isLoading: true,
+      isError: false,
+    })
   })
 
   it("never reports isLoading when disabled, even mid-flight", () => {

--- a/web/src/hooks/useStudentClassrooms.ts
+++ b/web/src/hooks/useStudentClassrooms.ts
@@ -23,6 +23,10 @@ export type StudentClassroom = {
   // assignments even before the student accepts anything. Absent when listed or
   // when the team predates the schema.
   secret?: string
+  // Custom Pages base URL for orgs off the github.io default; readers fetch
+  // published resources from it first, falling back to github.io. Absent when
+  // the org uses the default host.
+  pagesBaseUrl?: string
 }
 
 export type UseStudentClassroomsResult = {
@@ -91,6 +95,7 @@ export function useStudentClassrooms(
           term: desc.term,
           active: desc.active,
           secret: desc.secret,
+          pagesBaseUrl: desc.pages_base_url,
         })
       } else if (!existing) {
         // Staff-only membership (no student team seen yet): record the classroom
@@ -118,20 +123,35 @@ export function useStudentClassrooms(
 
 export default useStudentClassrooms
 
-// A student's capability secret for a classroom, from the team-description
-// bootstrap record (config-free). `enabled: false` skips the GET /user/teams
-// read for callers that already hold the secret (e.g., an accept link's ?k=).
-// `isLoading` tracks that read; false when disabled (nothing to wait on).
+// A student's bootstrap record for a classroom, from the team-description
+// record (config-free): the capability secret for an unlisted classroom and
+// the custom Pages base URL for an org off the github.io default. `enabled:
+// false` skips the GET /user/teams read for callers that need neither (e.g.,
+// a teacher-side reader that already holds classroom.json). `isLoading` tracks
+// that read; false when disabled (nothing to wait on).
 export function useClassroomSecret(
   org: string | undefined,
   classroom: string | undefined,
   enabled = true,
-): { secret: string | undefined; isLoading: boolean } {
-  const { classrooms, isLoading } = useStudentClassrooms(
+): {
+  secret: string | undefined
+  pagesBaseUrl: string | undefined
+  isLoading: boolean
+  // Settled failure of the underlying teams read: the bootstrap record —
+  // including any custom Pages base URL — could NOT be checked. Callers stay
+  // fail-open but can stop claiming "no custom domain" as fact.
+  isError: boolean
+} {
+  const { classrooms, isLoading, isError } = useStudentClassrooms(
     enabled ? org : undefined,
   )
-  const secret = classroom
-    ? classrooms.find((c) => c.classroom === classroom)?.secret
+  const record = classroom
+    ? classrooms.find((c) => c.classroom === classroom)
     : undefined
-  return { secret, isLoading: enabled ? isLoading : false }
+  return {
+    secret: record?.secret,
+    pagesBaseUrl: record?.pagesBaseUrl,
+    isLoading: enabled ? isLoading : false,
+    isError: enabled ? isError : false,
+  }
 }

--- a/web/src/hooks/useSubmissionAssignment.ts
+++ b/web/src/hooks/useSubmissionAssignment.ts
@@ -32,6 +32,15 @@ export function useSubmissionAssignment(
     // Capability-URL secret for a protected classroom's Pages path. Ignored for
     // the config source (the authenticated repo read needs no secret).
     secret?: string
+    // Custom Pages base URL for an org off the github.io default. Ignored for
+    // the config source, like `secret`.
+    pagesBaseUrl?: string
+    // Gate the PAGES read while its secret/base-URL sources are still being
+    // resolved: fetching early would hit the wrong host/path, 404 or
+    // CORS-fail, and flash an error the settled read then clears. Defaults
+    // true; the config source ignores it (an authenticated read needs no
+    // Pages coordinates).
+    enabled?: boolean
   },
 ): {
   assignment: Assignment | undefined
@@ -47,8 +56,9 @@ export function useSubmissionAssignment(
     enabled: useConfig,
   })
   const pagesQuery = usePagesAssignments(org, classroom, options.secret, {
-    enabled: !useConfig,
+    enabled: !useConfig && (options.enabled ?? true),
     assignmentSlug: assignment,
+    pagesBaseUrl: options.pagesBaseUrl,
   })
 
   const active = useConfig ? configQuery : pagesQuery

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -930,7 +930,8 @@
     "classroomSlugInvalid": "Classroom slug must be {{description}}.",
     "classroomSlugTooLong": "Classroom slug is {{length}} characters; new classrooms are capped at {{max}} — it prefixes every student repository name, which GitHub limits to {{limit}} characters.",
     "assignmentSlugTaken": "An assignment \"{{slug}}\" already exists in this classroom.",
-    "groupSizeRange": "Group size must be a whole number between {{min}} and {{max}}."
+    "groupSizeRange": "Group size must be a whole number between {{min}} and {{max}}.",
+    "customDomainInvalid": "Enter a domain like pages.example.edu or a full https:// URL (no query, fragment, or trailing slash)."
   },
   "toasts": {
     "classroomSettingsSaved": "Classroom settings saved. Publishing to the student site now — the banner above tracks progress.",
@@ -2360,6 +2361,9 @@
       "slugPlaceholder": "e.g., ap-cs-principles",
       "term": "Classroom term",
       "termPlaceholder": "e.g., Fall 2026",
+      "customDomain": "Custom Pages domain",
+      "customDomainPlaceholder": "e.g., pages.example.edu",
+      "customDomainHint": "Only needed if your organization's GitHub Pages site uses a custom domain (github.io then redirects, which blocks students' browsers from loading assignment data). Enter the domain, or a full https:// URL if your published site doesn't live under /classroom50. Leave empty to use the default github.io address. If your staff also uses the gh-teacher CLI, upgrade it everywhere first — older releases can undo this setting.",
       "secretInvalid": "Secret must be {{description}}.",
       "protectPagesLabel": "Use an unlisted link for this classroom",
       "protectPagesHint": "Publishes this classroom's assignment data at an unguessable URL instead of one anyone can reach by guessing the org name. This is obscurity, not real access control: anyone who gets the link can read it, and links can leak (browser history, referrers, search crawlers). Off by default.",
@@ -2419,6 +2423,10 @@
     "deployInFlight": "The classroom's published files may still be deploying. Wait a minute, then try again.",
     "classroomNotPublished": "This classroom isn't published yet. It may not exist, or the publish workflow may not have run. Ask your teacher to publish it, then try again.",
     "classroomFetchFailed": "Couldn't load this classroom's published files (HTTP {{status}}). Ask your teacher to confirm the classroom is published, then try again.",
+    "classroomNetworkFailed": "Couldn't reach the classroom's published site. This can be a network problem on your side, or the organization's GitHub Pages site may use a custom domain — in that case, ask your teacher to set the custom Pages domain in Classroom Settings.",
+    "customHostUnreachable": "Couldn't reach the classroom's custom Pages domain. It may be mistyped, offline, or blocked — ask your teacher to verify the custom Pages domain in Classroom Settings.",
+    "fetchNetworkFailed": "{{label}} couldn't be loaded because the published site couldn't be reached. Check your connection and try again, or ask your teacher to verify the classroom's published files.",
+    "classroomUnreachableBothHosts": "Couldn't load this classroom's published files from {{customUrl}} or {{defaultUrl}}. {{detail}}",
     "assignmentNotInManifest": "Assignment \"{{assignmentSlug}}\" isn't in this classroom's published assignments. Check the link, or ask your teacher to publish the assignment.",
     "autograderMalformed": "Autograder \"{{autograderName}}\" may be malformed YAML. Ask your teacher to check the file in the classroom50 repository.",
     "manifestVersionUnsupported": "This classroom uses a newer assignment format (v{{version}}) than this copy of Classroom 50 supports. Reload the page, or ask your teacher to update Classroom 50.",
@@ -2465,6 +2473,15 @@
       "unableToLoad": "Unable to load assignment",
       "expectedSlug": "Expected to find assignment slug:",
       "checkUrl": "Check that the URL is correct, or ask your teacher to confirm that this assignment has been added to <file>assignments.json</file>."
+    },
+    "loadError": {
+      "badge": "Classroom unavailable",
+      "title": "Couldn't load the classroom's assignments",
+      "body": "This classroom's published assignment data couldn't be loaded, so <assignment>{{assignment}}</assignment> can't be shown. The assignment itself may be fine — the published data just couldn't be reached from your browser.",
+      "detailTitle": "What went wrong",
+      "urlsLabel": "Tried to load:",
+      "bootstrapUnknown": "Your classroom list couldn't be checked, so if this classroom uses a custom Pages domain it wasn't discovered — the address above may not be the one your class actually uses. Reload the page to retry.",
+      "retryHint": "Try again in a minute. If this keeps happening, share a screenshot of this page with your teacher — it has everything they need to fix it."
     },
     "locked": {
       "badge": "Locked",

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -13,6 +13,7 @@ import {
 import { Spinner } from "@/components/Spinner"
 import {
   Alert,
+  Badge,
   Button,
   Card,
   Markdown,
@@ -32,6 +33,7 @@ import { type AcceptStepId, type AcceptStepStatus } from "@/domain/assignments"
 import {
   localizedMessageOf,
   resolveLocalizedMessage,
+  errorText,
   type LocalizedMessage,
 } from "@/types/localizedMessage"
 import { useAcceptAndVerifyMembership } from "@/hooks/mutations/useAcceptAndVerifyMembership"
@@ -40,6 +42,7 @@ import {
   MembershipError,
 } from "@/components/MembershipError"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
+import { attemptedPagesAssignmentUrls } from "@/github-core/queries"
 import { useClassroomEnrollment } from "@/hooks/useClassroomEnrollment"
 import { isOwnerGitHubOrgRole } from "@/authz"
 import { useClassroomSecret } from "@/hooks/useStudentClassrooms"
@@ -151,12 +154,26 @@ const UserInfo = ({ user }: { user: GitHubUser | null }) => {
   )
 }
 
-const AssignmentNotFound = ({
+// One scaffold for every terminal accept-page state (not found / load error /
+// locked / closed / not enrolled): tone badge + title + body, optional detail
+// sections, and the signed-in-as footer. One recipe, one source — the
+// per-state components below only choose copy and detail content.
+const AcceptErrorCard = ({
+  tone,
+  icon,
+  badge,
+  title,
+  body,
+  children,
   user,
-  assignment,
 }: {
+  tone: "error" | "warning"
+  icon: React.ReactNode
+  badge: string
+  title: string
+  body: React.ReactNode
+  children?: React.ReactNode
   user: GitHubUser | null
-  assignment?: string
 }) => {
   const { t } = useTranslation()
   return (
@@ -164,58 +181,19 @@ const AssignmentNotFound = ({
       <AcceptCard>
         <Card.Body className="gap-8">
           <div>
-            <span className="badge badge-error badge-soft gap-2">
-              <AlertIcon aria-hidden="true" className="size-4" />
-              {t("accept.notFound.badge")}
-            </span>
+            <Badge tone={tone} size="md" className="gap-2">
+              {icon}
+              {badge}
+            </Badge>
 
             <Heading as="h1" variant="title-medium" className="mt-6">
-              {t("accept.notFound.title")}
+              {title}
             </Heading>
 
-            <p className="mt-2 text-base text-base-content/70">
-              <Trans
-                i18nKey="accept.notFound.body"
-                values={{ assignment }}
-                components={{
-                  assignment: (
-                    <MonoLtr className="font-semibold text-base-content" />
-                  ),
-                }}
-              />
-            </p>
+            <p className="mt-2 text-base text-base-content/70">{body}</p>
           </div>
 
-          <div className="rounded-box border border-error/20 bg-error/5 p-5">
-            <div className="flex items-start gap-4">
-              <div className="rounded-full bg-error/10 p-3 text-error">
-                <AlertIcon aria-hidden="true" className="size-6" />
-              </div>
-
-              <div className="min-w-0">
-                <div className="font-bold text-error">
-                  {t("accept.notFound.unableToLoad")}
-                </div>
-
-                <div className="mt-1 text-sm text-base-content/70">
-                  {t("accept.notFound.expectedSlug")}
-                </div>
-
-                <pre className="mt-3 overflow-x-auto rounded-field bg-base-100 p-3 text-sm">
-                  {assignment}
-                </pre>
-              </div>
-            </div>
-          </div>
-
-          <div className="rounded-box border border-base-300 bg-base-100 p-4 text-sm text-base-content/70">
-            <Trans
-              i18nKey="accept.notFound.checkUrl"
-              components={{
-                file: <MonoLtr className="text-base-content" />,
-              }}
-            />
-          </div>
+          {children}
 
           <div className="divider my-0" />
 
@@ -232,6 +210,140 @@ const AssignmentNotFound = ({
   )
 }
 
+// The red detail panel shared by the not-found and load-error cards.
+const ErrorDetailPanel = ({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) => (
+  <div className="rounded-box border border-error/20 bg-error/5 p-5">
+    <div className="flex items-start gap-4">
+      <div className="rounded-full bg-error/10 p-3 text-error">
+        <AlertIcon aria-hidden="true" className="size-6" />
+      </div>
+
+      <div className="min-w-0">
+        <div className="font-bold text-error">{title}</div>
+        {children}
+      </div>
+    </div>
+  </div>
+)
+
+const AssignmentNotFound = ({
+  user,
+  assignment,
+}: {
+  user: GitHubUser | null
+  assignment?: string
+}) => {
+  const { t } = useTranslation()
+  return (
+    <AcceptErrorCard
+      tone="error"
+      icon={<AlertIcon aria-hidden="true" className="size-4" />}
+      badge={t("accept.notFound.badge")}
+      title={t("accept.notFound.title")}
+      body={
+        <Trans
+          i18nKey="accept.notFound.body"
+          values={{ assignment }}
+          components={{
+            assignment: <MonoLtr className="font-semibold text-base-content" />,
+          }}
+        />
+      }
+      user={user}
+    >
+      <ErrorDetailPanel title={t("accept.notFound.unableToLoad")}>
+        <div className="mt-1 text-sm text-base-content/70">
+          {t("accept.notFound.expectedSlug")}
+        </div>
+
+        <pre className="mt-3 overflow-x-auto rounded-field bg-base-100 p-3 text-sm">
+          {assignment}
+        </pre>
+      </ErrorDetailPanel>
+
+      <div className="rounded-box border border-base-300 bg-base-100 p-4 text-sm text-base-content/70">
+        <Trans
+          i18nKey="accept.notFound.checkUrl"
+          components={{
+            file: <MonoLtr className="text-base-content" />,
+          }}
+        />
+      </div>
+    </AcceptErrorCard>
+  )
+}
+
+// Shown when the published assignments manifest couldn't be LOADED at all —
+// network failure, a CORS-blocked custom-domain redirect, a 404'd Pages site,
+// or a malformed manifest. Distinct from AssignmentNotFound, which means the
+// manifest loaded fine but lacks the slug. Renders the failure detail and the
+// URL(s) attempted so a student's screenshot alone is diagnosable.
+const AssignmentLoadError = ({
+  user,
+  assignment,
+  error,
+  urls,
+  bootstrapUnknown,
+}: {
+  user: GitHubUser | null
+  assignment?: string
+  error: unknown
+  urls: string[]
+  // The teams read failed, so a custom Pages domain (if the classroom has
+  // one) could not be discovered — the URL list may be incomplete.
+  bootstrapUnknown?: boolean
+}) => {
+  const { t } = useTranslation()
+  return (
+    <AcceptErrorCard
+      tone="error"
+      icon={<AlertIcon aria-hidden="true" className="size-4" />}
+      badge={t("accept.loadError.badge")}
+      title={t("accept.loadError.title")}
+      body={
+        <Trans
+          i18nKey="accept.loadError.body"
+          values={{ assignment }}
+          components={{
+            assignment: <MonoLtr className="font-semibold text-base-content" />,
+          }}
+        />
+      }
+      user={user}
+    >
+      <ErrorDetailPanel title={t("accept.loadError.detailTitle")}>
+        <div className="mt-1 text-sm text-base-content/70">
+          {errorText(t, error)}
+        </div>
+
+        <div className="mt-3 text-sm text-base-content/70">
+          {t("accept.loadError.urlsLabel")}
+        </div>
+
+        <pre className="mt-1 overflow-x-auto rounded-field bg-base-100 p-3 text-sm">
+          {urls.join("\n")}
+        </pre>
+
+        {bootstrapUnknown && (
+          <div className="mt-3 text-sm text-base-content/70">
+            {t("accept.loadError.bootstrapUnknown")}
+          </div>
+        )}
+      </ErrorDetailPanel>
+
+      <div className="rounded-box border border-base-300 bg-base-100 p-4 text-sm text-base-content/70">
+        {t("accept.loadError.retryHint")}
+      </div>
+    </AcceptErrorCard>
+  )
+}
+
 // Shown when the requested assignment is locked. A locked assignment is closed
 // to every student (see the Assignment.locked contract), so the accept CTA and
 // mutation are never reached — this is a terminal state, not a retryable error.
@@ -244,44 +356,22 @@ const AssignmentLocked = ({
 }) => {
   const { t } = useTranslation()
   return (
-    <AcceptLayout>
-      <AcceptCard>
-        <Card.Body className="gap-8">
-          <div>
-            <span className="badge badge-warning badge-soft gap-2">
-              <LockIcon aria-hidden="true" className="size-4" />
-              {t("accept.locked.badge")}
-            </span>
-
-            <Heading as="h1" variant="title-medium" className="mt-6">
-              {t("accept.locked.title")}
-            </Heading>
-
-            <p className="mt-2 text-base text-base-content/70">
-              <Trans
-                i18nKey="accept.locked.body"
-                values={{ assignment }}
-                components={{
-                  assignment: (
-                    <MonoLtr className="font-semibold text-base-content" />
-                  ),
-                }}
-              />
-            </p>
-          </div>
-
-          <div className="divider my-0" />
-
-          <div className="space-y-3">
-            <label className="label p-0 text-base font-semibold">
-              {t("accept.signedInAs")}
-            </label>
-
-            <UserInfo user={user} />
-          </div>
-        </Card.Body>
-      </AcceptCard>
-    </AcceptLayout>
+    <AcceptErrorCard
+      tone="warning"
+      icon={<LockIcon aria-hidden="true" className="size-4" />}
+      badge={t("accept.locked.badge")}
+      title={t("accept.locked.title")}
+      body={
+        <Trans
+          i18nKey="accept.locked.body"
+          values={{ assignment }}
+          components={{
+            assignment: <MonoLtr className="font-semibold text-base-content" />,
+          }}
+        />
+      }
+      user={user}
+    />
   )
 }
 
@@ -298,44 +388,22 @@ const AssignmentClosed = ({
 }) => {
   const { t } = useTranslation()
   return (
-    <AcceptLayout>
-      <AcceptCard>
-        <Card.Body className="gap-8">
-          <div>
-            <span className="badge badge-warning badge-soft gap-2">
-              <CalendarIcon aria-hidden="true" className="size-4" />
-              {t("accept.closed.badge")}
-            </span>
-
-            <Heading as="h1" variant="title-medium" className="mt-6">
-              {t("accept.closed.title")}
-            </Heading>
-
-            <p className="mt-2 text-base text-base-content/70">
-              <Trans
-                i18nKey="accept.closed.body"
-                values={{ assignment }}
-                components={{
-                  assignment: (
-                    <MonoLtr className="font-semibold text-base-content" />
-                  ),
-                }}
-              />
-            </p>
-          </div>
-
-          <div className="divider my-0" />
-
-          <div className="space-y-3">
-            <label className="label p-0 text-base font-semibold">
-              {t("accept.signedInAs")}
-            </label>
-
-            <UserInfo user={user} />
-          </div>
-        </Card.Body>
-      </AcceptCard>
-    </AcceptLayout>
+    <AcceptErrorCard
+      tone="warning"
+      icon={<CalendarIcon aria-hidden="true" className="size-4" />}
+      badge={t("accept.closed.badge")}
+      title={t("accept.closed.title")}
+      body={
+        <Trans
+          i18nKey="accept.closed.body"
+          values={{ assignment }}
+          components={{
+            assignment: <MonoLtr className="font-semibold text-base-content" />,
+          }}
+        />
+      }
+      user={user}
+    />
   )
 }
 
@@ -350,36 +418,14 @@ const AssignmentClosed = ({
 const NotEnrolled = ({ user }: { user: GitHubUser | null }) => {
   const { t } = useTranslation()
   return (
-    <AcceptLayout>
-      <AcceptCard>
-        <Card.Body className="gap-8">
-          <div>
-            <span className="badge badge-warning badge-soft gap-2">
-              <LockIcon aria-hidden="true" className="size-4" />
-              {t("accept.notEnrolled.badge")}
-            </span>
-
-            <Heading as="h1" variant="title-medium" className="mt-6">
-              {t("accept.notEnrolled.title")}
-            </Heading>
-
-            <p className="mt-2 text-base text-base-content/70">
-              {t("accept.notEnrolled.body")}
-            </p>
-          </div>
-
-          <div className="divider my-0" />
-
-          <div className="space-y-3">
-            <label className="label p-0 text-base font-semibold">
-              {t("accept.signedInAs")}
-            </label>
-
-            <UserInfo user={user} />
-          </div>
-        </Card.Body>
-      </AcceptCard>
-    </AcceptLayout>
+    <AcceptErrorCard
+      tone="warning"
+      icon={<LockIcon aria-hidden="true" className="size-4" />}
+      badge={t("accept.notEnrolled.badge")}
+      title={t("accept.notEnrolled.title")}
+      body={t("accept.notEnrolled.body")}
+      user={user}
+    />
   )
 }
 
@@ -698,13 +744,16 @@ const AcceptAssignmentPage = () => {
   const linkSecret =
     typeof search.k === "string" && search.k !== "" ? search.k : undefined
 
-  // Fallback for a bare accept link (no ?k=): an already-enrolled student's own
-  // team description carries the classroom's capability secret.
-  const { secret: teamSecret, isLoading: loadingSecret } = useClassroomSecret(
-    org,
-    classroom,
-    !linkSecret,
-  )
+  // Bootstrap record from the student's own team description. Also the
+  // fallback secret source for a bare accept link (no ?k=) — but read ALWAYS
+  // (even when the link carries ?k=) because the custom Pages base URL for an
+  // org off the github.io default is only discoverable here, never in the link.
+  const {
+    secret: teamSecret,
+    pagesBaseUrl,
+    isLoading: loadingSecret,
+    isError: bootstrapError,
+  } = useClassroomSecret(org, classroom)
   const secret = linkSecret ?? teamSecret
 
   const { user } = useGithubAuth()
@@ -721,8 +770,14 @@ const AcceptAssignmentPage = () => {
   const { verdict: enrollmentVerdict, isLoading: loadingEnrollment } =
     useClassroomEnrollment(org, classroom, username)
 
-  const { data: assignmentsData, isLoading: loadingAssignmentsData } =
-    usePagesAssignments(org, classroom, secret, { enabled: !loadingSecret })
+  const {
+    data: assignmentsData,
+    isLoading: loadingAssignmentsData,
+    error: assignmentsError,
+  } = usePagesAssignments(org, classroom, secret, {
+    enabled: !loadingSecret,
+    pagesBaseUrl,
+  })
   const loadingAssignments = loadingSecret || loadingAssignmentsData
   const {
     data: orgInvite,
@@ -769,6 +824,7 @@ const AcceptAssignmentPage = () => {
     classroom: classroom ?? "",
     assignmentSlug: assignment ?? "",
     secret,
+    pagesBaseUrl,
     onStepUpdate: (update) =>
       setSteps((prev) => ({
         ...prev,
@@ -889,6 +945,30 @@ const AcceptAssignmentPage = () => {
     !isOwnerGitHubOrgRole(orgInvite.role)
   ) {
     return <NotEnrolled user={user} />
+  }
+
+  // The manifest couldn't be loaded at all (vs. loaded-but-slug-missing below).
+  // Renders the failure and the exact URL(s) attempted so a screenshot is
+  // enough to triage — see discussion #776, where a CORS-blocked custom-domain
+  // redirect masqueraded as "assignment not found".
+  if (assignmentsError) {
+    return (
+      <AssignmentLoadError
+        user={user}
+        assignment={assignment}
+        error={assignmentsError}
+        urls={attemptedPagesAssignmentUrls(
+          org ?? "",
+          classroom ?? "",
+          secret,
+          pagesBaseUrl,
+        )}
+        // A failed teams read means a custom Pages domain couldn't be
+        // discovered (fail-open kept the fetch going on the default host);
+        // say so instead of presenting the github.io URL as the whole story.
+        bootstrapUnknown={bootstrapError && !pagesBaseUrl}
+      />
+    )
   }
 
   if (!assignmentData) {

--- a/web/src/pages/AssignmentSettingsPage.test.tsx
+++ b/web/src/pages/AssignmentSettingsPage.test.tsx
@@ -71,6 +71,14 @@ vi.mock("@/hooks/usePagesAssignments", () => ({
 vi.mock("@/hooks/useDotClassroom50", () => ({
   default: () => ({ data: null, isLoading: false }),
 }))
+vi.mock("@/hooks/useStudentClassrooms", () => ({
+  useClassroomSecret: () => ({
+    secret: undefined,
+    pagesBaseUrl: undefined,
+    isLoading: false,
+    isError: false,
+  }),
+}))
 vi.mock("@/hooks/useDocumentTitle", () => ({
   useDocumentTitle: () => undefined,
 }))

--- a/web/src/pages/AssignmentSettingsPage.tsx
+++ b/web/src/pages/AssignmentSettingsPage.tsx
@@ -14,6 +14,7 @@ import { can } from "@/authz"
 import useGetAssignmentRepo from "@/hooks/useGetAssignmentRepo"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
+import { useClassroomSecret } from "@/hooks/useStudentClassrooms"
 
 import { useGithubAuth } from "@/auth/useGithubAuth"
 import { GroupCollaboratorsModal } from "@/components/modals/GroupCollaboratorsModal"
@@ -43,8 +44,19 @@ const EditAssignmentFormStudent = ({
   // the student's repo .classroom50.yaml — the source they can read (not the
   // private classroom.json). Empty for unprotected -> plain path.
   const { secret } = useDotClassroom50(org, assignmentRepo?.name ?? "")
+  // Custom Pages base URL from the team-description bootstrap record; the
+  // read waits for it so a custom-domain org never fires a doomed github.io
+  // fetch.
+  const { pagesBaseUrl, isLoading: loadingBootstrap } = useClassroomSecret(
+    org,
+    classroom,
+  )
   const { isLoading: loadingPublic, assignment: assignmentData } =
-    usePagesAssignments(org, classroom, secret, { assignmentSlug: assignment })
+    usePagesAssignments(org, classroom, secret, {
+      assignmentSlug: assignment,
+      pagesBaseUrl,
+      enabled: !loadingBootstrap,
+    })
 
   const [collaboratorsOpen, setCollaboratorsOpen] = useState(false)
 
@@ -55,7 +67,7 @@ const EditAssignmentFormStudent = ({
   )
   const assignmentMode = assignmentData?.mode
 
-  if (loadingPublic || loadingRepo) {
+  if (loadingPublic || loadingRepo || loadingBootstrap) {
     return <FormSkeleton fields={3} label={t("assignmentSettings.loading")} />
   }
 

--- a/web/src/pages/ClassroomSettingsPage.tsx
+++ b/web/src/pages/ClassroomSettingsPage.tsx
@@ -76,6 +76,8 @@ const EditClassroomContent = ({
                     slug: classroom,
                     org,
                     term: values.term,
+                    // Already normalized by the form; "" clears the key.
+                    pages_base_url: values.customDomain,
                   },
                   {
                     onError: (err) => {

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -32,13 +32,7 @@ import usePagesAssignments from "@/hooks/usePagesAssignments"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { classroomPagesSegment } from "@/util/secret"
 import { githubOrgUrl } from "@/util/orgUrl"
-import { CONFIG_REPO } from "@/util/configRepo"
-
-// Pages base for an org's classroom50 config repo. `classroom50` is the fixed
-// repo name, not the org name. Single-sourced so every row derives from it.
-function pagesBaseUrl(org: string) {
-  return `https://${org}.github.io/${CONFIG_REPO}`
-}
+import { defaultPagesBaseUrl } from "@/github-core/queries"
 
 // "engine" = generic, org-agnostic bootstrap code (identical for every org);
 // "data" = org-specific content (classrooms, assignments, autograders).
@@ -246,16 +240,24 @@ function ClassroomResources({
   index?: number
 }) {
   const { t } = useTranslation()
-  const base = pagesBaseUrl(org)
   const { data: classroomData, isLoading: classroomLoading } = useGetClassroom(
     org,
     classroom,
   )
   const secret = classroomData?.secret
+  // Classroom-scoped rows live at the custom Pages base when the classroom
+  // declares one (github.io only redirects there, and CORS-fails in a
+  // browser); the org-level pane below stays on the github.io default, which
+  // is where the engine files are canonically addressed.
+  const base = classroomData?.pages_base_url || defaultPagesBaseUrl(org)
   // Gate on the classroom read: fetching before the secret resolves would hit
-  // the unprotected path and 404 a protected classroom.
+  // the unprotected path and 404 a protected classroom. The same read carries
+  // pages_base_url, so the reachability probe checks the real host too.
   const { data: assignments, isPending: assignmentsPending } =
-    usePagesAssignments(org, classroom, secret, { enabled: !classroomLoading })
+    usePagesAssignments(org, classroom, secret, {
+      enabled: !classroomLoading,
+      pagesBaseUrl: classroomData?.pages_base_url,
+    })
   const [open, setOpen] = useState(true)
 
   // Hold skeletons until both reads settle so the resource rows and the "N
@@ -397,7 +399,7 @@ function ClassroomResources({
 
 export const PublishedResourcesPane = ({ org }: { org: string }) => {
   const { t } = useTranslation()
-  const base = pagesBaseUrl(org)
+  const base = defaultPagesBaseUrl(org)
   const { classes, isLoading: classesLoading } = useGetClasses(org)
 
   // Org-level resources are classroom-independent: the public index and the two

--- a/web/src/pages/StudentSubmissionPage.test.tsx
+++ b/web/src/pages/StudentSubmissionPage.test.tsx
@@ -84,6 +84,14 @@ vi.mock("@/hooks/useDotClassroom50", () => ({
   default: () => ({ secret: undefined }),
 }))
 
+vi.mock("@/hooks/useStudentClassrooms", () => ({
+  useClassroomSecret: () => ({
+    secret: undefined,
+    pagesBaseUrl: undefined,
+    isLoading: false,
+  }),
+}))
+
 // The submit-guidance block uses clipboard; stub it so the page test stays
 // focused on the submission-details surface.
 vi.mock("@/components/SubmitGuidance", () => ({

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -16,6 +16,7 @@ import { useSubmissionAssignment } from "@/hooks/useSubmissionAssignment"
 import useGetAssignmentRepo from "@/hooks/useGetAssignmentRepo"
 import useGetClassroom from "@/hooks/useGetClassroom"
 import useDotClassroom50 from "@/hooks/useDotClassroom50"
+import { useClassroomSecret } from "@/hooks/useStudentClassrooms"
 import { studentRepoName } from "@/util/studentRepo"
 import {
   formatDueDateTime,
@@ -461,6 +462,14 @@ const StudentSubmissionPage = () => {
   // secret; the repo secret covers the post-accept case.
   const { data: classroomMeta } = useGetClassroom(org, classroom)
   const secret = repoSecret || classroomMeta?.secret || undefined
+  // Custom Pages base URL: the team-description bootstrap record for a real
+  // student, classroom.json for a staff preview (mirrors the secret sourcing).
+  // The pages read is gated on the team read settling, so a custom-domain
+  // classroom never fires a doomed github.io fetch that flashes an error.
+  const { pagesBaseUrl: teamPagesBaseUrl, isLoading: loadingBootstrap } =
+    useClassroomSecret(org, classroom)
+  const pagesBaseUrl =
+    teamPagesBaseUrl || classroomMeta?.pages_base_url || undefined
 
   // Student page is student-gated by the route, so its assignment metadata comes
   // from PUBLIC GitHub Pages (source:"pages") — students can't read the private
@@ -468,12 +477,17 @@ const StudentSubmissionPage = () => {
   // path.
   const {
     assignment: assignmentData,
-    isLoading: assignmentLoading,
+    isLoading: loadingAssignment,
     isError: assignmentError,
   } = useSubmissionAssignment(org, classroom, assignment, {
     source: "pages",
     secret,
+    pagesBaseUrl,
+    enabled: !loadingBootstrap,
   })
+  // Hold the header/description skeletons while the gate is still resolving,
+  // not just while the pages read itself is in flight.
+  const assignmentLoading = loadingAssignment || loadingBootstrap
   const description = assignmentDescription(assignmentData)
   const submissionMode = assignmentData?.submission_mode
   const submissionTags = assignmentData?.submission_tags

--- a/web/src/pages/assignments/sections/CollapsibleAdvanced.tsx
+++ b/web/src/pages/assignments/sections/CollapsibleAdvanced.tsx
@@ -5,9 +5,10 @@ import { Collapse, cx } from "@/components/ui"
 import { useRevealOnExpand } from "@/hooks/useRevealOnExpand"
 
 // The collapsible "Advanced settings" disclosure shared by the Repository Setup
-// and autograder panes. One recipe, one source — both render through this so the
-// chevron/heading treatment can't drift. Deliberately compact and info-colored
-// rather than heading-sized: it's a secondary affordance the common path skips.
+// and autograder panes (and Classroom Settings' custom-domain field). One
+// recipe, one source — all render through this so the chevron/heading
+// treatment can't drift. Deliberately compact and info-colored rather than
+// heading-sized: it's a secondary affordance the common path skips.
 //
 // A button + AnimatePresence rather than native <details>/<summary>: the browser
 // display-toggles a <details> body, so its height can't be animated. This shares

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -12,6 +12,8 @@ import { classroomConfigTreeUrl } from "@/util/orgUrl"
 import { useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { isClassroomArchived, type Classroom } from "@/types/classroom"
+import { normalizePagesBaseUrl } from "@/util/pagesBaseUrl"
+import { CollapsibleAdvanced } from "@/pages/assignments/sections/CollapsibleAdvanced"
 import {
   Button,
   Card,
@@ -24,10 +26,14 @@ import {
 export type EditClassroomFormValues = {
   name: string
   term: string
+  // Raw "custom Pages domain" input: a bare domain or a full https base URL;
+  // "" = no custom domain. Normalized at submit (see normalizePagesBaseUrl).
+  customDomain: string
 }
 
 type EditClassroomFormProps = {
   defaultValues?: Partial<EditClassroomFormValues>
+  // Receives the values with customDomain already NORMALIZED ("" = clear).
   onSubmit: (values: EditClassroomFormValues) => void | Promise<void>
   cl?: Classroom
 }
@@ -289,6 +295,7 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
     defaultValues: {
       name: cl?.name || cl?.short_name || "",
       term: cl?.term || "",
+      customDomain: cl?.pages_base_url || "",
     } satisfies EditClassroomFormValues,
     validators: {
       onSubmit: ({ value }) => {
@@ -296,6 +303,9 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
           {}
         if (!value.name.trim()) {
           errors.name = t("validation.classroomNameRequired")
+        }
+        if (normalizePagesBaseUrl(value.customDomain) === null) {
+          errors.customDomain = t("validation.customDomainInvalid")
         }
 
         return Object.keys(errors).length > 0
@@ -309,6 +319,8 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
       await onSubmit({
         name: value.name.trim(),
         term: value.term.trim(),
+        // The validator already rejected a null normalization.
+        customDomain: normalizePagesBaseUrl(value.customDomain) ?? "",
       })
       setSubmitted(true)
     },
@@ -436,6 +448,43 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
               </FormField>
             )}
           </form.Field>
+
+          {/* Rare, org-level concern (custom Pages domain) — tucked behind the
+              shared Advanced disclosure so the common name/term path stays
+              uncluttered. */}
+          <div className="mb-4">
+            <CollapsibleAdvanced>
+              <form.Field name="customDomain">
+                {(field) => (
+                  <FormField
+                    label={t("classes.form.customDomain")}
+                    htmlFor={field.name}
+                    hint={t("classes.form.customDomainHint")}
+                    error={
+                      field.state.meta.errors.length > 0
+                        ? field.state.meta.errors[0]
+                        : undefined
+                    }
+                    className="mb-4"
+                  >
+                    {({ id, describedById, invalid }) => (
+                      <Input
+                        id={id}
+                        name={field.name}
+                        dir="ltr"
+                        aria-describedby={describedById}
+                        invalid={invalid}
+                        placeholder={t("classes.form.customDomainPlaceholder")}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                      />
+                    )}
+                  </FormField>
+                )}
+              </form.Field>
+            </CollapsibleAdvanced>
+          </div>
 
           <Card.Actions className="justify-end p-2">
             <form.Subscribe

--- a/web/src/types/classroom.ts
+++ b/web/src/types/classroom.ts
@@ -27,6 +27,11 @@ export type Classroom = {
   // else the plain `<classroom>/...` path. Opt-in, off by default. In lockstep
   // with the CLI's classroom-v1 schema (`[a-z0-9]{4,64}`).
   secret?: string
+  // Optional custom Pages base URL for orgs whose Pages site is served off the
+  // github.io default (the github.io 301 fails the browser's CORS check —
+  // issue #776). Everything before `/<classroom>[/<secret>]/...`, normalized
+  // (https, no trailing slash). In lockstep with the CLI's classroom-v1 schema.
+  pages_base_url?: string
 }
 
 // A minimal GitHub team identity (slug is authoritative for ops; id is the

--- a/web/src/util/pagesBaseUrl.test.ts
+++ b/web/src/util/pagesBaseUrl.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import {
+  isValidPagesBaseUrl,
+  normalizePagesBaseUrl,
+  PAGES_BASE_URL_PATTERN,
+} from "./pagesBaseUrl"
+
+describe("isValidPagesBaseUrl", () => {
+  it("accepts a normalized org-root custom-domain base", () => {
+    expect(isValidPagesBaseUrl("https://cs.example.edu/classroom50")).toBe(true)
+  })
+
+  it("accepts a repo-CNAME base with no path", () => {
+    expect(isValidPagesBaseUrl("https://pages.example.edu")).toBe(true)
+  })
+
+  it("rejects empty, http, trailing slash, query/fragment, userinfo, whitespace", () => {
+    expect(isValidPagesBaseUrl("")).toBe(false)
+    expect(isValidPagesBaseUrl("http://cs.example.edu/classroom50")).toBe(false)
+    expect(isValidPagesBaseUrl("https://cs.example.edu/classroom50/")).toBe(
+      false,
+    )
+    expect(isValidPagesBaseUrl("https://cs.example.edu/x?y=1")).toBe(false)
+    expect(isValidPagesBaseUrl("https://cs.example.edu/x#frag")).toBe(false)
+    expect(isValidPagesBaseUrl("https://user:pw@cs.example.edu/x")).toBe(false)
+    expect(isValidPagesBaseUrl("https://cs.example.edu/a b")).toBe(false)
+  })
+
+  it("rejects an over-long URL (pattern bound)", () => {
+    const long = `https://cs.example.edu/${"a".repeat(120)}`
+    expect(isValidPagesBaseUrl(long)).toBe(false)
+  })
+})
+
+describe("normalizePagesBaseUrl", () => {
+  it("returns '' for empty/whitespace input (clear the setting)", () => {
+    expect(normalizePagesBaseUrl("")).toBe("")
+    expect(normalizePagesBaseUrl("   ")).toBe("")
+  })
+
+  it("expands a bare domain to the org-root custom-domain layout", () => {
+    expect(normalizePagesBaseUrl("cs.example.edu")).toBe(
+      "https://cs.example.edu/classroom50",
+    )
+    expect(normalizePagesBaseUrl("  CS.Example.EDU  ")).toBe(
+      "https://cs.example.edu/classroom50",
+    )
+  })
+
+  it("takes a full https URL verbatim minus the trailing slash", () => {
+    expect(normalizePagesBaseUrl("https://pages.example.edu")).toBe(
+      "https://pages.example.edu",
+    )
+    expect(normalizePagesBaseUrl("https://cs.example.edu/classroom50/")).toBe(
+      "https://cs.example.edu/classroom50",
+    )
+  })
+
+  it("rejects a dotless host, http, and malformed URLs", () => {
+    expect(normalizePagesBaseUrl("localhost")).toBeNull()
+    expect(normalizePagesBaseUrl("http://cs.example.edu")).toBeNull()
+    expect(normalizePagesBaseUrl("https://cs.example.edu/x?y=1")).toBeNull()
+    expect(normalizePagesBaseUrl("not a url")).toBeNull()
+  })
+
+  it("always yields a value isValidPagesBaseUrl accepts (or ''/null)", () => {
+    for (const input of [
+      "cs.example.edu",
+      "https://pages.example.edu/",
+      "https://cs.example.edu/classroom50",
+    ]) {
+      const out = normalizePagesBaseUrl(input)
+      expect(out).not.toBeNull()
+      expect(isValidPagesBaseUrl(out!)).toBe(true)
+    }
+  })
+})
+
+describe("PAGES_BASE_URL_PATTERN parity", () => {
+  // Byte-mirror of contract.PagesBaseURLPattern (cli/shared) and the schema
+  // pattern in classroom-v1 / classroom-team-v1 — a cross-language contract
+  // with no compile-time link. Pin against both schema files so a one-sided
+  // edit fails here.
+  it("matches the schema patterns", () => {
+    const tsPattern = PAGES_BASE_URL_PATTERN.source.replace(/\\\//g, "/")
+    for (const schemaFile of [
+      "../../../schemas/classroom-v1.schema.json",
+      "../../../schemas/classroom-team-v1.schema.json",
+    ]) {
+      const schema = JSON.parse(
+        readFileSync(
+          fileURLToPath(new URL(schemaFile, import.meta.url)),
+          "utf8",
+        ),
+      ) as { properties: { pages_base_url: { pattern: string } } }
+      expect(schema.properties.pages_base_url.pattern).toBe(tsPattern)
+    }
+  })
+})

--- a/web/src/util/pagesBaseUrl.ts
+++ b/web/src/util/pagesBaseUrl.ts
@@ -1,0 +1,59 @@
+// Custom Pages base-URL helpers for orgs with a custom GitHub Pages domain.
+// github.io answers such an org with a 301 the browser's CORS check rejects
+// (foundation50/classroom50#776), so classroom.json / the team-description
+// bootstrap record can carry `pages_base_url` — everything before the
+// `/<classroom>[/<secret>]/...` segment — and readers fetch it directly,
+// falling back to the github.io default. Kept in lockstep with the CLI's
+// configrepo.ValidatePagesBaseURL and the classroom-v1 / classroom-team-v1
+// JSON schemas.
+
+import { CONFIG_REPO } from "./configRepo"
+
+// Mirrors contract.PagesBaseURLPattern (cli/shared) and both schemas' pattern.
+export const PAGES_BASE_URL_PATTERN = /^https:\/\/[^\s?#]{1,110}$/
+
+// A bare hostname a teacher may type instead of a full URL: dot-separated
+// labels of [a-z0-9-], no scheme or path. Deliberately requires at least one
+// dot — a custom Pages domain is always a registrable name, and the dot is
+// what disambiguates "they typed a domain" from a malformed URL.
+const HOSTNAME_PATTERN =
+  /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/
+
+// isValidPagesBaseUrl reports whether a value is a valid NORMALIZED base URL:
+// the pattern (https, no whitespace/query/fragment, bounded) plus the
+// invariants the pattern can't express — no trailing slash (URL builders
+// append `/<classroom>/...`) and no userinfo. Empty is NOT valid; callers that
+// allow "no custom domain" branch on emptiness first. Mirrors the CLI's
+// ValidatePagesBaseURL — keep in lockstep.
+export function isValidPagesBaseUrl(value: string): boolean {
+  if (!PAGES_BASE_URL_PATTERN.test(value)) return false
+  if (value.endsWith("/")) return false
+  try {
+    const url = new URL(value)
+    return url.hostname !== "" && url.username === "" && url.password === ""
+  } catch {
+    return false
+  }
+}
+
+// normalizePagesBaseUrl turns what a teacher typed into the stored form, or
+// null when it can't be one:
+//   - "" -> "" (clear the setting)
+//   - a bare domain (`cs.example.edu`) -> `https://cs.example.edu/classroom50`,
+//     the layout GitHub serves for an org-root custom domain (the common case);
+//   - a full https URL -> verbatim minus any trailing slash, for the rarer
+//     CNAME-on-the-classroom50-repo layout where the repo segment is absent.
+export function normalizePagesBaseUrl(input: string): string | null {
+  const trimmed = input.trim()
+  if (trimmed === "") return ""
+
+  if (!trimmed.includes("://")) {
+    const host = trimmed.toLowerCase().replace(/\/+$/, "")
+    if (!HOSTNAME_PATTERN.test(host)) return null
+    const candidate = `https://${host}/${CONFIG_REPO}`
+    return isValidPagesBaseUrl(candidate) ? candidate : null
+  }
+
+  const candidate = trimmed.replace(/\/+$/, "")
+  return isValidPagesBaseUrl(candidate) ? candidate : null
+}

--- a/web/src/util/teamDescription.test.ts
+++ b/web/src/util/teamDescription.test.ts
@@ -37,6 +37,27 @@ describe("parseTeamDescription", () => {
     expect(parsed.secret).toBeUndefined()
   })
 
+  it("parses a valid pages_base_url and drops a malformed one", () => {
+    const valid = parseTeamDescription(
+      JSON.stringify({
+        schema: "classroom50/team/v1",
+        name: "CS",
+        pages_base_url: "https://cs.example.edu/classroom50",
+      }),
+    )
+    expect(valid.pages_base_url).toBe("https://cs.example.edu/classroom50")
+
+    const invalid = parseTeamDescription(
+      JSON.stringify({
+        schema: "classroom50/team/v1",
+        name: "CS",
+        pages_base_url: "http://cs.example.edu/",
+      }),
+    )
+    expect(invalid.name).toBe("CS")
+    expect(invalid.pages_base_url).toBeUndefined()
+  })
+
   it("ignores unknown future fields (additive evolution)", () => {
     const desc = JSON.stringify({
       schema: "classroom50/team/v1",
@@ -103,6 +124,33 @@ describe("marshalTeamDescription", () => {
     expect(JSON.parse(out).active).toBe(false)
   })
 
+  it("includes a valid pages_base_url", () => {
+    const out = marshalTeamDescription({
+      name: "CS",
+      pagesBaseUrl: "https://cs.example.edu/classroom50",
+      active: true,
+    })
+    expect(JSON.parse(out).pages_base_url).toBe(
+      "https://cs.example.edu/classroom50",
+    )
+  })
+
+  it("drops a malformed pages_base_url rather than persisting it", () => {
+    for (const bad of [
+      "http://cs.example.edu",
+      "https://cs.example.edu/",
+      "https://cs.example.edu/x?y=1",
+      "cs.example.edu",
+    ]) {
+      const out = marshalTeamDescription({
+        name: "CS",
+        pagesBaseUrl: bad,
+        active: true,
+      })
+      expect(JSON.parse(out).pages_base_url).toBeUndefined()
+    }
+  })
+
   it("round-trips through parseTeamDescription", () => {
     const out = marshalTeamDescription({
       name: "Intro CS",
@@ -154,7 +202,13 @@ describe("marshalTeamDescription — shared fixture parity", () => {
   )
   const doc = JSON.parse(readFileSync(fileURLToPath(fixtureUrl), "utf8")) as {
     cases: {
-      input: { name?: string; term?: string; secret?: string; active: boolean }
+      input: {
+        name?: string
+        term?: string
+        secret?: string
+        pages_base_url?: string
+        active: boolean
+      }
       encoded: string
     }[]
   }
@@ -165,7 +219,15 @@ describe("marshalTeamDescription — shared fixture parity", () => {
 
   for (const [i, c] of doc.cases.entries()) {
     it(`case ${i} encodes byte-identically to the Go writer`, () => {
-      expect(marshalTeamDescription(c.input)).toBe(c.encoded)
+      expect(
+        marshalTeamDescription({
+          name: c.input.name,
+          term: c.input.term,
+          secret: c.input.secret,
+          pagesBaseUrl: c.input.pages_base_url,
+          active: c.input.active,
+        }),
+      ).toBe(c.encoded)
     })
   }
 })

--- a/web/src/util/teamDescription.ts
+++ b/web/src/util/teamDescription.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import { SECRET_PATTERN, isValidSecret } from "./secret"
+import { isValidPagesBaseUrl } from "./pagesBaseUrl"
 import { escapeForGoJsonParity } from "./goJsonEscape"
 
 // Schema sentinel for the classroom50/team/v1 bootstrap record stored in a
@@ -24,6 +25,13 @@ const TeamDescriptionSchema = z.object({
   // pattern-checked and degrades to "no secret" rather than failing the parse
   // (mirrors the .classroom50.yaml secret handling).
   secret: z.string().regex(SECRET_PATTERN).optional().catch(undefined),
+  // Custom Pages base URL for orgs off the github.io default; degrades to
+  // undefined (= use the default) like `secret` rather than failing the parse.
+  pages_base_url: z
+    .string()
+    .refine(isValidPagesBaseUrl)
+    .optional()
+    .catch(undefined),
 })
 
 export type TeamDescription = z.infer<typeof TeamDescriptionSchema>
@@ -51,19 +59,24 @@ export function parseTeamDescription(
 // byte-for-byte mirror of the Go MarshalTeamDescription
 // (cli/gh-teacher/internal/configrepo/teamdescription.go). Compact JSON, empty
 // name/term omitted, `secret` included only when valid ([a-z0-9]{4,64}; a
-// malformed value is dropped, not persisted into a URL segment), and `active`
-// omitted when true (readers default absent -> active) to save bytes. Kept small
-// (well under ~250 chars): per-assignment data lives on Pages, never here.
+// malformed value is dropped, not persisted into a URL segment),
+// `pages_base_url` included only when valid (a malformed value degrades to the
+// github.io default), and `active` omitted when true (readers default absent ->
+// active) to save bytes. Kept small (well under ~250 chars): per-assignment
+// data lives on Pages, never here.
 export function marshalTeamDescription(input: {
   name?: string
   term?: string
   secret?: string
+  pagesBaseUrl?: string
   active: boolean
 }): string {
   const record: Record<string, unknown> = { schema: TEAM_DESCRIPTION_SCHEMA }
   if (input.name) record.name = input.name
   if (input.term) record.term = input.term
   if (input.secret && isValidSecret(input.secret)) record.secret = input.secret
+  if (input.pagesBaseUrl && isValidPagesBaseUrl(input.pagesBaseUrl))
+    record.pages_base_url = input.pagesBaseUrl
   if (!input.active) record.active = false
   return escapeForGoJsonParity(JSON.stringify(record))
 }


### PR DESCRIPTION
## Summary

Fixes the failure behind discussion #776: an org with a custom GitHub Pages domain makes `<org>.github.io` answer a 301 without CORS headers, so every browser fetch of published classroom data fails and students see a misleading "assignment not found" on accept links.

- Teachers can set an optional **Custom Pages domain** in Classroom Settings (behind the Advanced-settings disclosure). It is normalized to a `pages_base_url` https base URL, stored in `classroom.json`, and projected into the `classroom50/team/v1` student-team description so students discover it from `GET /user/teams` without config-repo access.
- Every student-facing Pages read (accept manifest, teacher-authored autograder fetch, assignment list, submission view, sidebar/repos cards, published-resources diagnostics) now fetches the custom domain first (bounded at 5s) and falls back to github.io, with reads gated on the bootstrap record so no doomed github.io fetch fires early.
- The accept page now distinguishes "the published data couldn't be loaded" (new error card showing the localized failure and the exact URLs attempted — screenshot-diagnosable) from "the manifest loaded but the slug is missing", and notes when a failed teams read means a custom domain couldn't be discovered.
- Contract updated everywhere in lockstep: `classroom-v1` and `classroom-team-v1` schemas (additive), the Go mirrors (`ClassroomJSON`, `MarshalTeamDescription`, new `ValidatePagesBaseURL`), the TS mirrors, and the shared byte-parity fixture. The schema documents the fleet caveat that pre-field gh-teacher releases strip the projection on reconcile — upgrade CLIs before setting the field.

## Test plan

- [x] `npm run check` in `web/` (tsc, eslint + boundaries, prettier, arch:validate, 4618 vitest tests incl. new fallback-matrix, normalization, marshal/parse, and buildClassroomUpdate set/clear tests)
- [x] `go build ./... && go test ./...` in `cli/gh-teacher`, `cli/gh-student`, `cli/shared` (cross-language parity fixtures green)
- [x] `audit_i18n.py --strict`
- [ ] Manual: on a custom-domain org (e.g. the #776 reporter's), set the domain in Classroom Settings and confirm a student accept link loads and accepts end-to-end