### PR TITLE
docs(wiki): document the features and fixes shipping in 1.35

### DIFF
--- a/wiki/Assignment-Templates.md
+++ b/wiki/Assignment-Templates.md
@@ -1,8 +1,9 @@
 # Assignment Templates
 
 An assignment's starter code is a normal GitHub repository with the **Template
-repository** flag turned on. `gh student accept` creates a fresh private copy
-for each student; `gh student submit` re-fetches a couple of files from it on
+repository** flag turned on. `gh student accept` creates a fresh copy for
+each student (private, unless the assignment's **Repository visibility** is
+public); `gh student submit` re-fetches a couple of files from it on
 every submission. This page describes the expected layout.
 
 > [!NOTE]

--- a/wiki/Autograding-Basics.md
+++ b/wiki/Autograding-Basics.md
@@ -134,11 +134,43 @@ shape `assignment test list --json` emits:
 | `timeout` | Seconds, 1–600. Omit or 0 for the default of 10s. Applies to `setup` and `run` separately. |
 | `exit-code` | `run` only, 0–255. Omit to require 0. |
 | `points` | Required, 0–1000. A 0-point test does not affect the numeric score; a failure still sets the autograde status to `failure`. |
+| `failure-details` | Optional. How much failure detail students see: `full` (default), `actual-only`, or `none`. See [Report options](#report-options). |
+| `show-output` | Optional. `true` includes the test's captured output in the report even when it passes. See [Report options](#report-options). |
 
 At most 100 tests per assignment. Put large fixtures in files
 (`input-file` / `expected-file`) under `CLASSROOM/autograders/ASSIGNMENT/`, not
 inline. In paths and commands on this page, replace `CLASSROOM` with the
 classroom's short name and `ASSIGNMENT` with the assignment slug.
+
+#### Report options
+
+Two per-test fields control what a submission's report shows, in the Release
+body, the grade job log, and the run Summary. Both can also be set once for
+the whole assignment in a `test_defaults` block on the assignment entry (the
+web form's **Report defaults** panel below the tests table); a test's own
+value overrides the default.
+
+```json
+"test_defaults": { "failure-details": "actual-only", "show-output": true }
+```
+
+**`failure-details`** — how much of a failing run students see:
+
+| Value | Students see |
+|---|---|
+| `full` (default) | A unified diff for `exact` comparisons, otherwise the expected and actual output, plus stderr. |
+| `actual-only` | The student's own stdout/stderr only — never the expected output and never a diff, since either would reveal the answer. |
+| `none` | Only the failure kind: wrong output, wrong exit code, timeout, or setup failed. |
+
+**`show-output`** — `true` adds a passing test's captured setup and run
+output to the report and the Actions log, in a collapsed section. Off by
+default (passing output is discarded). Turn it on while authoring or
+debugging an autograder; an explicit `false` on one test opts it out of a
+`show-output: true` default.
+
+In the web app, the per-test selects sit under **Report options** in the test
+editor. From the CLI, pass `--failure-details` and `--show-output` to
+[`gh teacher assignment test add`](gh-teacher#assignment-test).
 
 ### Setup commands, dependencies, and environment variables
 
@@ -201,7 +233,10 @@ repository, publish-pages **materializes** them into the assignment's Pages
 bundle as `tests.json`. At grade time, `runner.py` runs each spec in the student checkout:
 one row per test in `result.json`, plus a failure breakdown in three places — the
 **Release body**, the **grade job log** ("Grade details"), and the **run Summary
-page**. Captured output is truncated at 2000 characters.
+page**. What the breakdown contains follows the test's
+[report options](#report-options). Captured output is clipped per block:
+2,000 characters in the Release body and Summary, 100,000 in the grade job
+log, so long compiler or build output stays readable in the log.
 
 Specs are validated three times: by the CLI at write time, by the runner
 workflow at submission setup, and by `runner.py` before executing.

--- a/wiki/CLI-Student-Guide.md
+++ b/wiki/CLI-Student-Guide.md
@@ -42,10 +42,13 @@ gh student accept <org> <classroom> <assignment>
 - `<classroom>` — the classroom your teacher set up (e.g., `cs-principles`).
 - `<assignment>` — the assignment slug (e.g., `hello`).
 
-This creates a **private** repository at
+This creates a repository at
 `<org>/<classroom>-<assignment>-<username>` from the assignment's template (or
 a new repository with a README and the autograding files if it's
-template-less), then prints a `git clone` command.
+template-less), then prints a `git clone` command. The repository is
+**private** unless your teacher configured the assignment to create public
+repositories; in that case accept warns you first that your work will be
+visible to anyone on the internet.
 
 <details>
 <summary>What accept does, step by step</summary>
@@ -53,8 +56,9 @@ template-less), then prints a `git clone` command.
 1. Auto-accepts any pending organization invitation.
 2. Looks up the assignment in the classroom's published manifest.
 3. Resolves the autograder workflow.
-4. Creates your private repository (a template copy, or a new
-   README-initialized repository).
+4. Creates your repository (a template copy, or a new
+   README-initialized repository) — private unless the assignment opts into
+   public repositories, in which case you're warned first.
 5. Commits the setup files (`.classroom50.yaml` and the autograde workflow).
 6. Opens the Feedback PR, when the assignment enables it.
 7. Sets your repo role: `push` for an individual assignment, or `admin` for a
@@ -160,8 +164,10 @@ When submit finishes, it prints two URLs:
   push, or git will report a conflict.
 - **History is preserved.** Submissions stack as commits; prior commits stay
   reachable for review.
-- **No git config required.** Commits are authored with your GitHub login and
-  noreply email, so a fresh shell submits cleanly.
+- **No git config required.** Commits are authored with the `user.name` and
+  `user.email` configured for your clone, so signed commits stay verified. In
+  a shell with no git identity, submit falls back to your GitHub login and
+  noreply email, so it still works.
 - **Build artifacts are excluded.** Only tracked and untracked-not-ignored files
   are submitted.
 

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -149,6 +149,13 @@ the `publish-pages.yaml` workflow to run once** — push to the default branch o
 trigger it from the Actions tab. The CLI prints the Pages URL
 (`https://<org>.github.io/classroom50/`) after `init`.
 
+If the organization's Pages site uses a custom domain, GitHub answers
+`github.io` requests with a redirect that students' browsers reject. Set the
+classroom's **Custom Pages domain** in the web app so browsers fetch from the
+custom domain directly; server-side readers (the CLIs and Actions workflows)
+follow the redirect and are unaffected. See
+[Using a custom Pages domain](Web-Teacher-Guide#using-a-custom-pages-domain).
+
 If `init` warns that the org workflow-token policy or reusable-workflow access is
 too restrictive, apply them yourself:
 
@@ -266,7 +273,7 @@ browser itself must reach these hosts.
 | `classroom50.fifty-foundation.workers.dev` | Web app | The GitHub proxy (OAuth sign-in and repo downloads). See [The GitHub proxy](#the-github-proxy) below. |
 | `github.com` | Web app, CLI | OAuth sign-in and CLI authentication. |
 | `api.github.com` | Web app, CLI, Actions | All GitHub REST API calls (classrooms, rosters, assignments, grading). |
-| `*.github.io` | Web app, Actions | The org's Pages config (`<org>.github.io/classroom50/…`): the assignment manifest, autograders, and the runner. |
+| `*.github.io` | Web app, Actions | The org's Pages config (`<org>.github.io/classroom50/…`): the assignment manifest, autograders, and the runner. If the org's Pages site uses a custom domain, allow that domain too — see [Using a custom Pages domain](Web-Teacher-Guide#using-a-custom-pages-domain). |
 | `codeload.github.com` | Web app | Repo archive (zip) downloads, reached through the proxy. |
 | `www.githubstatus.com` | Web app | GitHub status check for the outage banner (best-effort). |
 

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -206,7 +206,7 @@ free.
 
 | Trigger | Where |
 | --- | --- |
-| Opening the classroom's roster in the web app, or its refresh control | The web app, automatic on open and then on demand |
+| Opening the classroom's roster in the web app, or its **Refresh roster** button | The web app, automatic on open and then on demand |
 | Entering a classroom as a teacher or owner | The web app, automatic; it also repairs missing teams |
 | **Clean up invite data** | The classroom's **Settings** page, to clear stored addresses early |
 | `gh teacher roster sync <org> <classroom> --write` | The CLI, so a script or a scheduled job can run it with no browser |
@@ -253,7 +253,9 @@ Three consequences worth calling out:
 
 - **Students never see each other's work.** The "No permission" base grants
   nothing by default, and nothing grants one student access to another's
-  repository.
+  repository. The deliberate exception is an assignment whose **Repository
+  visibility** is public: its repositories are readable by anyone, which is
+  the point of a peer-review or showcase assignment.
 - **Students can read their classroom's private templates.** The whole
   classroom team gets read access so accept can copy the template. Never
   commit solutions to a template. See

--- a/wiki/Managing-Actions-Cost.md
+++ b/wiki/Managing-Actions-Cost.md
@@ -8,8 +8,10 @@ when minutes run out.
 ## What grading costs
 
 - **The organization pays.** GitHub Actions minutes are budgeted per
-  organization. Student repositories are private, so their workflow runs
-  count against the organization's included minutes.
+  organization. Student repositories are private by default, so their
+  workflow runs count against the organization's included minutes. (Runs in
+  a public repository are free on GitHub-hosted standard runners, so an
+  assignment whose **Repository visibility** is public doesn't spend them.)
 - **The Team plan includes 3,000 minutes per month.** Usage past that is
   billed, up to the organization's Actions spending limit.
 - **Each run bills at least a minute.** GitHub rounds every job up to the

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -595,6 +595,26 @@ workflow has been run." Check in order:
    invite also blocks the accept flow (see the
    [accept error table](#common-gh-student-accept-errors)).
 
+### "Couldn't load the classroom's assignments" on the accept page
+
+The accept page shows this error card, listing the URLs it tried, when the
+classroom's published assignment data couldn't be fetched from the student's
+browser. The assignment itself is usually fine. Two common causes:
+
+1. **The organization's GitHub Pages site uses a custom domain.** GitHub then
+   answers `github.io` requests with a redirect the browser rejects. Set the
+   classroom's **Custom Pages domain** in the classroom's **Settings**; see
+   [Using a custom Pages domain](Web-Teacher-Guide#using-a-custom-pages-domain).
+2. **A network problem or filter** on the student's side blocks the Pages
+   host. The card lists the exact URLs attempted, so a screenshot of it gives
+   the teacher everything needed to check them against
+   [Network and allowed domains](GitHub-Integration#network-and-allowed-domains).
+
+A custom domain that is set but mistyped or offline doesn't lock students
+out: the app falls back to the default `github.io` address. The message
+"Couldn't reach the classroom's custom Pages domain" means the domain in
+Classroom Settings needs verifying.
+
 ### "Template not found" / 404 on `gh student accept`
 
 Only applies to assignments with a template. Check, in order:

--- a/wiki/Web-Student-Guide.md
+++ b/wiki/Web-Student-Guide.md
@@ -56,6 +56,12 @@ Accepting creates a GitHub repository for you, named after the classroom, the
 assignment, and your username — for example,
 `introduction-to-computer-science-hello-assignment-username`.
 
+> [!NOTE]
+> Your repository is private unless your teacher configured the assignment to
+> create public repositories. In that case the accept page tells you before
+> you accept: anyone on the internet will be able to see your work, including
+> your code, commits, and name.
+
 Afterward, your organization page lists the assignment repository you now own:
 
 ![One assignment](images/web_assignments_student.png)

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -204,6 +204,15 @@ section — most assignments never need them:
   this when it finds such a file in the template; you can still toggle it. If the
   file is missing or can't be read, the built-in body is used, so nothing breaks.
   It is your responsibility to keep the template's contents correct.
+- **Repository visibility** — the visibility each student repository is
+  created with at accept time: **Private** (the default) or **Public**, for
+  peer-review, portfolio, or showcase assignments. Students are warned before
+  accepting a public assignment, since anyone on the internet can then see
+  their work, including code, commits, and name. If the organization doesn't
+  allow students to create public repositories, accept creates the repository
+  private instead and tells the student. The setting applies to repositories
+  created from then on; to change existing ones, use **Change repository
+  visibility** on the submissions page.
 - **Student repo access** — the role students get on their own repository.
 - **Repository features** — per-feature settings for **Issues**, **Wiki**,
   **Projects**, and **Pull requests** on student repositories. The default,
@@ -303,6 +312,12 @@ Each test has:
 - **Run command** — the command the runner executes.
 - **Timeout (seconds)** — how long to wait before terminating the test.
 - **Points** — the test's weight.
+- **Report options** — what the submission report shows for this test:
+  **Failure details shown to students** (a full diff, the student's own
+  output only, or only the failure type) and **Output when passing**. Both
+  start at the assignment's report defaults; pick another value to override
+  it for this test only. See
+  [Report options](Autograding-Basics#report-options) in Autograding Basics.
 
 The three test types add their own fields:
 
@@ -325,6 +340,10 @@ The three test types add their own fields:
 fields.
 
 ![Python pytest test](images/web_create_assignment_tests_python_pytest.png)
+
+Below the tests table, a **Report defaults** panel sets the same two report
+options for every test: **Default failure details** and **Include passing
+test output**. A test's own report options override them.
 
 When you're done, click **Create assignment**.
 
@@ -473,12 +492,46 @@ more information, see
 > for the bulk action). See
 > [Already an org member, but not on the roster](Troubleshooting#already-an-org-member-but-not-on-the-roster).
 
-**The roster list** — everyone already in this classroom. Classroom 50
-gives you two shareable links: one to accept the organization invite, and one to
-onboard students added by email. Neither link enrolls anyone on its own: invite
-the student from the roster first, then share a link so they can accept and sign
-in. Below the links, each student's status shows whether they've joined the
-organization.
+**Share** — shareable links for students you've already invited. The **Share
+classroom links** dialog holds two: an onboarding link, with which a student
+accepts the invitation and signs in to Classroom 50 in one step (the link
+most classrooms share), and a GitHub organization invitation link for a
+student who can't use the onboarding one. Neither link enrolls anyone on its
+own: invite the student from the roster first, then share a link so they can
+accept and sign in.
+
+### The roster view
+
+The table lists everyone in this classroom, one row per member, with
+**Member**, **Username**, **Role**, **Section**, and **Status** columns; click
+a column header to sort by it, and click a row to open the member's detail.
+**Section** appears only when at least one member carries a section label, and
+**Status** only while a row has something to report: a pending invitation, a
+member who needs a role, or someone not in the organization.
+
+The toolbar narrows and groups the table:
+
+- **Search** — match members by name, username, or email.
+- **Show** — one filter covering both status (**Enrolled**, **Pending**,
+  **Needs a role**, **Not in org**) and role (**Student**, **Teacher**,
+  **Head TA**, **TA**).
+- A **section filter**, shown when members have sections.
+- **Group by** — group the rows by role or by section.
+
+Selecting rows (with the row checkboxes, or the select-all in the header)
+replaces the toolbar's left side with a selection bar carrying one
+**Actions** menu: **Invite** re-sends the selected students' organization
+invitations, **Cancel** cancels their pending invitations, and **Unenroll**
+removes them from the classroom. Each action asks you to confirm, then
+reports its results. Bulk actions apply to students only; staff are managed
+in the classroom's **Settings**.
+
+**Refresh roster** checks the classroom's GitHub teams and invitations for
+anything new (members who joined or left, accepted invitations, role changes)
+and updates the roster to match; the same check runs when you open the page.
+While it runs, the button reads **Refreshing roster…** and the table locks
+until it finishes. The caption beside the button shows when the roster last
+changed and what the last refresh found.
 
 ## Collect submissions
 
@@ -597,6 +650,12 @@ assignment:
   Projects / Pull-requests settings to every existing student repository
   (repositories created before a settings change, or before features were
   inherited from the template).
+- **Change repository visibility** — make every accepted student repository
+  in the assignment public or private in one pass (organization owners only).
+  Repositories students accept later use the assignment's **Repository
+  visibility** setting instead. A row whose repository is public shows a
+  **Public** badge, and a single repository can be flipped from its row's
+  manage dialog.
 - **Update autograding triggers** — retrofit existing repositories after a
   submission-type change (see below).
 - **Pause autograding** / **Resume autograding** — disable or re-enable the
@@ -624,6 +683,10 @@ assignment:
   all submissions** button next to the **Actions** menu — and the download
   icon in an assignment's row on the **Assignments** page — opens a dialog
   with that CLI command filled in for the assignment, ready to copy.
+- **Delete assignment** — remove the assignment from the classroom, with the
+  same type-the-slug confirmation as the **Manage assignment** dialog. Student
+  repositories are kept. After deleting, you land back on the assignments
+  list.
 
 ### Download scores
 
@@ -639,7 +702,8 @@ spreadsheet or external tool. The column-by-column reference is in
   action in one place: the quick four, **Template access** (review which
   teams can read the template, and re-grant the classroom teams' read),
   **Reuse in another classroom**, and **Delete assignment** (which asks you
-  to type the slug to confirm; student repositories are kept).
+  to type the slug to confirm; student repositories are kept — the
+  submissions page's **Actions** menu carries the same **Delete assignment**).
 - **Edit an assignment** — open the assignment, then **Assignment settings**.
   Same form as creating one, pre-filled. Provisioning settings (repository
   source, built-in autograder, grading mode) are editable; a change only affects
@@ -647,9 +711,34 @@ spreadsheet or external tool. The column-by-column reference is in
   students have already accepted. **Assignment type** (Individual or Group)
   stays locked, since switching it would invalidate existing submissions.
 - **Edit a classroom** — open the classroom, then **Settings**. Same form as
-  creating one, pre-filled. The page also offers **Clean up invite data**, which
+  creating one, pre-filled. Its **Advanced settings** section holds the
+  **Custom Pages domain** field (see
+  [Using a custom Pages domain](#using-a-custom-pages-domain)). The page also
+  offers **Clean up invite data**, which
   clears the addresses held for email invitations that were never accepted. See
   [Invitations by email](How-Classroom-50-Works#invitations-by-email).
+
+### Using a custom Pages domain
+
+Classroom data that students' browsers read (the assignment list an accept
+link resolves against) is published through GitHub Pages, normally at
+`https://<ORG>.github.io/classroom50/`. If your organization's Pages site
+uses a [custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site),
+GitHub answers requests to `github.io` with a redirect that browsers reject,
+so accept links stop loading assignment data for students.
+
+To fix that, open the classroom's **Settings**, expand **Advanced settings**,
+and fill in **Custom Pages domain**. Enter the domain itself (for example
+`pages.example.edu`, read as `https://pages.example.edu/classroom50`), or a
+full `https://` URL when your published site doesn't live under
+`/classroom50`. Leave the field empty to use the default `github.io` address.
+Students' browsers try the custom domain first and fall back to `github.io`,
+so a mistyped domain can't lock students out of a working site.
+
+> [!IMPORTANT]
+> If your staff also uses the `gh teacher` CLI, upgrade it everywhere before
+> setting a custom domain: releases older than 1.35.0 don't know the field
+> and can strip it from student discovery on their next sync.
 
 ### Updating an over-budget assignment slug
 

--- a/wiki/gh-student.md
+++ b/wiki/gh-student.md
@@ -13,7 +13,7 @@ with a non-zero exit code. Pass `--verbose` / `-v` for per-step detail.
 | `whoami` | Print the authenticated GitHub user. |
 | `login` | Log in with the unified Classroom 50 scopes (`admin:org`, `read:org`, `repo`, `workflow`) — the same set `gh teacher login` requests, so one sign-in covers both. A student only exercises `read:org`, `repo`, and `workflow`. |
 | `logout` | Log out via `gh auth logout`. |
-| `accept <org> <classroom> <assignment>` | Accept an assignment: auto-accept the org invite, create your private repo, and set up autograding. |
+| `accept <org> <classroom> <assignment>` | Accept an assignment: auto-accept the org invite, create your assignment repo, and set up autograding. |
 | `invite <org>/<repo> <username>` | Invite a classmate or TA to your repo with `push` permission. |
 | `submit` | Snapshot the current branch and push it for grading. |
 
@@ -24,9 +24,14 @@ gh student accept <org> <classroom> <assignment>
 gh student accept <org> <classroom> <assignment> --key <access-key>
 ```
 
-Creates a private repo at `<org>/<classroom>-<assignment>-<username>` (a copy of
+Creates a repo at `<org>/<classroom>-<assignment>-<username>` (a copy of
 the assignment's template, or a README-initialized repo if it's template-less),
-then prints a `git clone` command.
+then prints a `git clone` command. The repo is **private** unless the
+assignment opts into public repos (`repo_visibility: public`); then accept
+warns you before creating it that your work — code, commits, and name — will
+be visible to anyone on the internet. If the organization doesn't let you
+create public repositories, accept creates a private repo instead and notes
+that your teacher can make it public later.
 
 **`--key <access-key>`** — access key for a classroom that uses an unlisted
 URL (provided by your teacher); omit for normal classrooms.
@@ -43,7 +48,9 @@ URL (provided by your teacher); omit for normal classrooms.
    *before* creating the repo, so a fetch failure leaves no half-baked repo).
 4. Creates the repo — from the template, a README-initialized (`auto_init`)
    repo, or (for an `empty_repo` assignment) a truly bare repo with steps 3, 6,
-   and 7 skipped.
+   and 7 skipped. Private by default; public when the assignment sets
+   `repo_visibility: public`, with the warning printed before creation and a
+   fallback to private when org policy denies the public create.
 5. Applies the assignment's repository features (Issues, Wiki, Projects, Pull
    requests). By default each feature **inherits the template's setting**
    (GitHub's template-generate doesn't copy them, so accept reads the template
@@ -113,7 +120,8 @@ grading. Hand-pushing any `submit/*` tag works the same.
 2. Copies submittable files (tracked + untracked-not-ignored) into a temp
    worktree, so build artifacts don't pollute the submission.
 3. Fetches the teacher's `.gitignore` and `.github/` from the template.
-4. Commits (with your GitHub login + noreply email) and pushes to the default
+4. Commits (with your git `user.name` and `user.email`; unset fields fall
+   back to your GitHub login + noreply email) and pushes to the default
    branch as a fast-forward — no force-push; prior commits stay reachable.
 5. On a submit-only assignment, pushes the `submit/…` tag at the new commit
    (reusing an existing tag if the commit already has one, so a retry never

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -626,6 +626,7 @@ the CLI warns that students with long usernames can't accept it.
 | `--empty-repo` | Truly bare repos (no README/marker/shim); autograding and feedback PR disabled; changeable on a same-slug re-add (warns; only affects future accepts); mutually exclusive with template/tests/feedback-pr/allowed-files/pass-threshold/submission-mode/submission-tag/no-autograder/init-shim. |
 | `--allowed-files <pattern>` | Ordered `.gitignore`-style pattern (repeatable, order preserved) defining which files belong to the submission. Last match wins; `!` re-includes. The autograde runner removes disallowed files before grading (control files are always kept); `gh student submit` filters them too. Omit to allow every file. See [Advanced Autograding](Advanced-Autograding#restricting-submission-files-allowed_files). |
 | `--student-permission <role>` | Collaborator role each student gets on their **own** repo at accept: `pull`, `triage`, `push`, `maintain`, or `admin`. Omit for the default (`push` individual, `admin` group). Affects future accepts only. Caution: `admin` lets the student manage the repo's settings and collaborators; the org lockdown from `init` still blocks visibility changes. |
+| `--repo-visibility private\|public` | Visibility each student repo is **created** with at accept: `private` (default) or `public` (peer-review, portfolio, or showcase work — accept warns the student upfront that their work will be publicly visible). If org policy blocks a student from creating a public repo, accept falls back to private and says so. Affects future accepts only; flip existing repos with the submissions page's **Change repository visibility**. Re-adding without the flag keeps the stored value. |
 | `--pass-threshold <0–100>` | Advisory passing bar shown on the submissions page. Off when omitted (distinct from `0`). |
 | `--submission-mode every-push\|tag` | When the autograder fires: `every-push` (default) grades every push; `tag` grades only `submit/*` tag pushes (the submit clients push the tag — plain `git push` costs no Actions minutes). Change it later with `assignment submission-mode`. |
 | `--submission-tag <pattern>` | Milestone tag (repeatable) that also triggers grading: `git tag phase1 && git push origin phase1` grades that commit. Simple globs (`v*`) work; exact names are safer. The record still lives at the canonical `submit/*` tag. Mutually exclusive with `--empty-repo`. |
@@ -849,9 +850,15 @@ gh teacher assignment test remove <org> <classroom> <slug> <test-name>
 
 Manage the declarative `tests` block — GitHub Classroom-style io/run/python
 checks graded with no `autograder.py`. `add` upserts by `--name`; it's refused
-while a per-assignment `autograder.py` exists. See
-[Autograders](Autograding-Basics#declarative-tests) for fields and semantics. For bulk
-edits, use `assignment add --tests <file.json>`.
+while a per-assignment `autograder.py` exists. Two flags control the
+submission report: `--failure-details {full,actual-only,none}` sets how much
+failure detail students see (omit for the assignment's default), and
+`--show-output` includes the test's captured setup/run output in the report
+even when it passes (`--show-output=false` opts one test out of a
+`show-output` default). See
+[Autograders](Autograding-Basics#declarative-tests) for fields and semantics
+and [Report options](Autograding-Basics#report-options) for what each level
+shows. For bulk edits, use `assignment add --tests <file.json>`.
 
 ## `autograder`
 


### PR DESCRIPTION
## Summary

- Sweeps the wiki for everything shipping in 1.35 (release PR #761): the autograder `failure-details`/`show-output` report options (#767), `repo_visibility` for generated assignment repos (#771), delete assignment in the submissions actions menu (#760), the revamped roster view with sync progress (#779), and the custom Pages domain for published classroom resources (#782).
- Also updates the student pages for the submit-identity fix (#780): commits now use the clone's `user.name`/`user.email` with the noreply fallback.
- New sections: "Report options" (Autograding-Basics), "The roster view" and "Using a custom Pages domain" (Web-Teacher-Guide), plus a Troubleshooting entry for the accept page's "Couldn't load the classroom's assignments" error card. Corrects the output-truncation note (2,000 chars in the Release body vs 100,000 in the grade job log) and the Actions-cost and who-sees-what caveats for public assignment repos.

## Test plan

- [ ] All wiki-internal `Page#anchor` links validated (450 links, 0 problems).
- [ ] New copy checked against `docs/github-docs-writing-style.md` (UI labels reproduced exactly, sentence-case headers, no banned words).