### PR TITLE
docs(wiki): document the members page and bulk org removal shipping in 1.36

### DIFF
--- a/wiki/Course-Lifecycle-and-End-of-Term.md
+++ b/wiki/Course-Lifecycle-and-End-of-Term.md
@@ -118,7 +118,10 @@ Wrap up a finished course in this order:
 5. Remove students if you need to. Unenrolling a student removes them
    from the roster and classroom team but not from the organization, and
    never deletes repositories; removing them from the organization revokes
-   access but still deletes nothing. See
+   access but still deletes nothing. To remove a whole classroom's students
+   from the organization at once, open the organization's **Members** page,
+   filter by the classroom, select the rows, and use **Actions**, then
+   **Remove from organization**. See
    [Enroll, unenroll, and remove are separate](How-Classroom-50-Works#lifecycle-enroll-unenroll-and-remove-are-separate).
 
 ## Reusing assignments next term

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -113,6 +113,10 @@ They're separate actions, on purpose:
   their assignment repos) but still doesn't delete anything.
 - **Deleting a repository** is always a separate, manual step.
 
+Both actions are available per member and in bulk on the organization's
+**Members** page. For more information, see
+[Manage organization members](Web-Teacher-Guide#manage-organization-members).
+
 See [How Classroom 50 Works](How-Classroom-50-Works#lifecycle-enroll-unenroll-and-remove-are-separate).
 
 ## Assignments

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -255,9 +255,10 @@ To enroll students who are already org members:
    not a classroom's **Roster** page).
 2. Find each student. They show as a member with no classroom, or you can filter
    by "no classroom".
-3. Use **Add to classroom** to place them on a classroom's roster and team. To
-   do several at once, select the rows and use the bulk **Add to {classroom}**
-   action.
+3. Select each student's row.
+4. Open the **Actions** menu, then click **Add to classroom**.
+5. Pick the destination classroom in the dialog, then click **Add**. The
+   dialog previews how many members will be added before you commit.
 
 Uploading a **roster CSV** or a plain list of usernames on the **Roster** page
 also enrolls existing members: the invite is skipped, but they're still added to

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -488,9 +488,9 @@ more information, see
 > previous course) is a different action. Inviting them again does nothing:
 > GitHub reports "Already a member," and it won't put them on this classroom's
 > roster. To enroll an existing member, open the organization's **Members** page
-> in Classroom 50 and use **Add to classroom** (per member, or select several
-> for the bulk action). See
-> [Already an org member, but not on the roster](Troubleshooting#already-an-org-member-but-not-on-the-roster).
+> in Classroom 50, select their row (or several), and use **Actions**, then
+> **Add to classroom**. For more information, see
+> [Manage organization members](Web-Teacher-Guide#manage-organization-members).
 
 **Share** — shareable links for students you've already invited. The **Share
 classroom links** dialog holds two: an onboarding link, with which a student
@@ -532,6 +532,63 @@ and updates the roster to match; the same check runs when you open the page.
 While it runs, the button reads **Refreshing roster…** and the table locks
 until it finishes. The caption beside the button shows when the roster last
 changed and what the last refresh found.
+
+## Manage organization members
+
+The **Members** page lists everyone in your GitHub organization and the
+classrooms they belong to. Open your organization in Classroom 50, then select
+**Members** in the sidebar. The page is available to organization owners.
+
+> [!WARNING]
+> The page covers the whole organization, not only your students. If other
+> teachers share the organization (even without using Classroom 50), their
+> members appear here too, so take care when removing anyone.
+
+The table shows **Name**, **Username**, **Classrooms**, **Roles**, and
+**Status** columns; click a column header to sort by it. **Roles** is the
+organization role (**Owner** or **Member**), and **Status** reports only
+problems:
+
+- **Not an org member.** On a classroom roster but not in the organization
+  (for example, they left or were removed). Click **Invite** on the row to
+  restore their access.
+- **Invitation pending.** An email invitation hasn't been accepted yet.
+- **Not enrolled.** On a roster but missing from the classroom team, so
+  grade collection would miss them.
+
+The toolbar narrows the table: **Search** matches members by name, username,
+or email; a **Show** filter covers both status and organization role
+(**Owners**, **Members**); and a classroom filter shows one classroom's
+members, or members on **No classroom**.
+
+Click a row to open the member's details: their name, GitHub username and ID,
+every email address the rosters record for them, and their classroom access
+with a link to each classroom. From here you can also invite an on-roster
+non-member back to the organization, or remove a member from the organization.
+
+### Bulk member actions
+
+Select rows with the checkboxes (or the select-all in the header), then open
+the **Actions** menu:
+
+- **Add to classroom** enrolls the selected members on a classroom you pick in
+  the dialog. Members already on that classroom, and people who aren't
+  organization members yet, are skipped.
+- **Remove from classroom** unenrolls the selected members from a classroom
+  you pick. Select the checkbox in the dialog to also remove them from the
+  organization in the same run.
+- **Remove from organization** removes the selected members from the
+  organization. Each member is first unenrolled from every classroom they
+  belong to, so no roster is left pointing at a non-member.
+
+Each dialog previews what will happen (how many members are affected, and why
+any are skipped) before you confirm. Removals also require typing `confirm`,
+and the dialog warns when the selection includes organization owners or
+members enrolled in other classrooms.
+
+Neither unenrolling nor removing deletes repositories. For more information,
+see
+[Enroll, unenroll, and remove are separate](How-Classroom-50-Works#lifecycle-enroll-unenroll-and-remove-are-separate).
 
 ## Collect submissions
 


### PR DESCRIPTION
Documents the 1.36 Members-page revamp and bulk organization removal (#787) ahead of the release PR (#788), following the wiki writing style guide.

## Summary

- `Web-Teacher-Guide.md`: new "Manage organization members" section covering the table and its Status meanings, the toolbar filters, the member details modal, and the bulk member actions (Add to classroom, Remove from classroom with the org-removal opt-in, Remove from organization), including the previews, the typed confirmation, and the shared-org caveat. The "already in your organization" TIP now describes the Actions-menu flow and links to the new section.
- `Troubleshooting.md`: the enroll-existing-members steps now walk the Actions menu and destination dialog instead of the removed toolbar picker.
- `Course-Lifecycle-and-End-of-Term.md`: step 5 adds the bulk end-of-term recipe (filter by classroom, select all, Remove from organization).
- `FAQ.md`: notes both removal actions are available per member and in bulk from the Members page.

## Test plan

- [x] New copy checked against the style guide (second person, present tense, exact UI labels, no em-dashes)
- [x] Cross-page anchors verified against existing wiki headings; the new "Bulk member actions" heading avoids colliding with the submissions section's existing "Bulk actions" anchor
- [ ] After merge, confirm the publish-wiki workflow syncs the pages