### PR TITLE
docs(wiki): restore the Teacher-Guide page as a redirect stub

### DIFF
--- a/wiki/Teacher-Guide.md
+++ b/wiki/Teacher-Guide.md
@@ -1,0 +1,12 @@
+# Teacher Guide
+
+New to Classroom 50? Begin at the [Home](Home) page or
+the [Quickstart](Quickstart).
+
+Looking for the teacher walkthrough? Start from the guide that matches how
+you use Classroom 50:
+
+- **[Web Teacher Guide](Web-Teacher-Guide)** — run a course from the web app
+  at [classroom50.org](https://www.classroom50.org), no installation needed.
+- **[CLI Teacher Guide](CLI-Teacher-Guide)** — the same walkthrough with the
+  `gh teacher` command-line tool.


### PR DESCRIPTION
## Summary

The GitHub Classroom sunset announcement links to this wiki's `Teacher-Guide` page, which currently 404s: the page was renamed to `CLI-Teacher-Guide` (with `Web-Teacher-Guide` added alongside) in #87, and the destructive wiki mirror deleted the old name on the next publish. GitHub wikis have no redirects, so this recreates `wiki/Teacher-Guide.md` as a short stub pointing readers to Home, the Quickstart, and both teacher guides — the same approach as the existing `Autograders` stub. The page reappears at the old URL once this merges and the publish-wiki workflow runs.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
