### PR TITLE
refactor(web): consolidate the remaining progress bars and close the modal test gaps

### DIFF
--- a/web/src/components/bulk/resultView.test.tsx
+++ b/web/src/components/bulk/resultView.test.tsx
@@ -146,7 +146,10 @@ describe("BulkProgressRow", () => {
 describe("BulkProgressInline", () => {
   it("renders the status line and a valued bar", () => {
     const { container } = render(
-      <BulkProgressInline label="Opening 1 of 2" progress={{ processed: 1, total: 2 }} />,
+      <BulkProgressInline
+        label="Opening 1 of 2"
+        progress={{ processed: 1, total: 2 }}
+      />,
     )
     expect(screen.getByText("Opening 1 of 2")).toBeDefined()
     expect(getBar(container).getAttribute("value")).toBe("50")

--- a/web/src/components/bulk/resultView.test.tsx
+++ b/web/src/components/bulk/resultView.test.tsx
@@ -2,7 +2,13 @@
 import { describe, expect, it, afterEach, vi } from "vitest"
 import { render, screen, cleanup } from "@testing-library/react"
 
-import { BulkPhaseFooter } from "./resultView"
+import {
+  BulkPhaseFooter,
+  BulkProgressBlock,
+  BulkProgressInline,
+  BulkProgressRow,
+  bulkProgressPct,
+} from "./resultView"
 
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
@@ -59,4 +65,97 @@ describe("BulkPhaseFooter", () => {
       expect(onClose).toHaveBeenCalledTimes(1)
     },
   )
+})
+
+const getBar = (container: HTMLElement) => {
+  const bar = container.querySelector("progress")
+  if (!bar) throw new Error("no <progress> rendered")
+  return bar
+}
+
+describe("BulkProgressBlock", () => {
+  it("renders a valued percent bar by default", () => {
+    const { container } = render(
+      <BulkProgressBlock
+        workingLabel="working"
+        caption="3 of 4"
+        progress={{ processed: 3, total: 4 }}
+      />,
+    )
+    const bar = getBar(container)
+    expect(bar.getAttribute("value")).toBe("75")
+    expect(bar.getAttribute("max")).toBe("100")
+    expect(screen.getByText("3 of 4")).toBeDefined()
+  })
+
+  it("omits value until the first item lands with indeterminateUntilFirst", () => {
+    const { container } = render(
+      <BulkProgressBlock
+        workingLabel="working"
+        caption="starting"
+        progress={{ processed: 0, total: 8 }}
+        indeterminateUntilFirst
+      />,
+    )
+    expect(getBar(container).hasAttribute("value")).toBe(false)
+  })
+
+  it("restores the value once the first item lands", () => {
+    const { container } = render(
+      <BulkProgressBlock
+        workingLabel="working"
+        caption="1 of 8"
+        progress={{ processed: 1, total: 8 }}
+        indeterminateUntilFirst
+      />,
+    )
+    expect(getBar(container).getAttribute("value")).toBe("13")
+  })
+
+  it("renders 0, not NaN, when total is 0", () => {
+    const { container } = render(
+      <BulkProgressBlock
+        workingLabel="working"
+        caption="none"
+        progress={{ processed: 0, total: 0 }}
+      />,
+    )
+    expect(getBar(container).getAttribute("value")).toBe("0")
+  })
+})
+
+describe("BulkProgressRow", () => {
+  it("renders the message heading, both captions, and trailing children", () => {
+    const { container } = render(
+      <BulkProgressRow
+        progress={{ processed: 2, total: 5, message: "Removing…" }}
+        processedCaption="2 / 5"
+        percentCaption="40%"
+      >
+        <p>keep this tab open</p>
+      </BulkProgressRow>,
+    )
+    expect(screen.getByText("Removing…")).toBeDefined()
+    expect(screen.getByText("2 / 5")).toBeDefined()
+    expect(screen.getByText("40%")).toBeDefined()
+    expect(screen.getByText("keep this tab open")).toBeDefined()
+    expect(getBar(container).getAttribute("value")).toBe("40")
+  })
+})
+
+describe("BulkProgressInline", () => {
+  it("renders the status line and a valued bar", () => {
+    const { container } = render(
+      <BulkProgressInline label="Opening 1 of 2" progress={{ processed: 1, total: 2 }} />,
+    )
+    expect(screen.getByText("Opening 1 of 2")).toBeDefined()
+    expect(getBar(container).getAttribute("value")).toBe("50")
+  })
+})
+
+describe("bulkProgressPct", () => {
+  it("rounds the ratio and guards a zero total", () => {
+    expect(bulkProgressPct({ processed: 1, total: 3 })).toBe(33)
+    expect(bulkProgressPct({ processed: 0, total: 0 })).toBe(0)
+  })
 })

--- a/web/src/components/bulk/resultView.tsx
+++ b/web/src/components/bulk/resultView.tsx
@@ -96,9 +96,30 @@ export const BulkPhaseFooter = ({
   )
 }
 
-// The working-phase block: spinner, percent bar, caption. With
-// `indeterminateUntilFirst`, the bar omits `value` until the first item lands
-// so a slow first write animates instead of sitting at 0%.
+// One copy of the ratio math: the <progress> fill and any textual percent
+// both derive from here.
+export const bulkProgressPct = (
+  progress: Pick<BulkProgress, "processed" | "total">,
+) =>
+  progress.total > 0
+    ? Math.round((progress.processed / progress.total) * 100)
+    : 0
+
+// Shared <progress> props. With `indeterminateUntilFirst`, `value` is omitted
+// until the first item lands so a slow first write animates as an
+// indeterminate track instead of sitting at 0%.
+export const bulkProgressBarProps = (
+  progress: Pick<BulkProgress, "processed" | "total">,
+  indeterminateUntilFirst = false,
+) => ({
+  className: "progress progress-primary w-full",
+  ...(indeterminateUntilFirst && progress.processed === 0
+    ? {}
+    : { value: bulkProgressPct(progress) }),
+  max: 100,
+})
+
+// The working-phase block: spinner, percent bar, caption.
 export const BulkProgressBlock = ({
   workingLabel,
   caption,
@@ -107,24 +128,57 @@ export const BulkProgressBlock = ({
 }: {
   workingLabel: string
   caption: React.ReactNode
-  progress: BulkProgress
+  progress: Pick<BulkProgress, "processed" | "total">
   indeterminateUntilFirst?: boolean
-}) => {
-  const pct =
-    progress.total > 0
-      ? Math.round((progress.processed / progress.total) * 100)
-      : 0
-  return (
-    <div className="mt-6 flex flex-col items-center gap-3 py-6">
-      <Spinner label={workingLabel} />
-      <progress
-        className="progress progress-primary w-full"
-        {...(indeterminateUntilFirst && progress.processed === 0
-          ? {}
-          : { value: pct })}
-        max={100}
-      />
-      <p className="text-sm text-base-content/70">{caption}</p>
+}) => (
+  <div className="mt-6 flex flex-col items-center gap-3 py-6">
+    <Spinner label={workingLabel} />
+    <progress {...bulkProgressBarProps(progress, indeterminateUntilFirst)} />
+    <p className="break-all text-center text-sm text-base-content/70">
+      {caption}
+    </p>
+  </div>
+)
+
+// The action bars' working layout: message heading, bar, processed/total on
+// the left and percent on the right, then any trailing content (the
+// keep-tab-open alert).
+export const BulkProgressRow = ({
+  progress,
+  processedCaption,
+  percentCaption,
+  children,
+}: {
+  progress: BulkProgress
+  processedCaption: React.ReactNode
+  percentCaption: React.ReactNode
+  children?: React.ReactNode
+}) => (
+  <div className="mt-6">
+    <p className="mb-2 font-medium">{progress.message}</p>
+    <progress {...bulkProgressBarProps(progress)} />
+    <div className="mt-2 flex justify-between text-sm opacity-70">
+      <span>{processedCaption}</span>
+      <span>{percentCaption}</span>
     </div>
-  )
-}
+    {children}
+  </div>
+)
+
+// The submissions modals' running block: spinner-prefixed status line above
+// the bar.
+export const BulkProgressInline = ({
+  label,
+  progress,
+}: {
+  label: React.ReactNode
+  progress: Pick<BulkProgress, "processed" | "total">
+}) => (
+  <div className="mt-4 space-y-3">
+    <p className="flex items-center gap-2 text-sm text-base-content/70">
+      <Spinner size="xs" />
+      {label}
+    </p>
+    <progress {...bulkProgressBarProps(progress)} />
+  </div>
+)

--- a/web/src/components/bulk/resultView.tsx
+++ b/web/src/components/bulk/resultView.tsx
@@ -6,8 +6,7 @@
 
 import { useTranslation } from "react-i18next"
 
-import { Button } from "@/components/ui"
-import { Spinner } from "@/components/Spinner"
+import { Button, Spinner } from "@/components/ui"
 
 // The lifecycle of a bulk run's modal: idle (closed) -> working (progress) ->
 // complete/error (results).

--- a/web/src/components/modals/RenameAssignmentModal.tsx
+++ b/web/src/components/modals/RenameAssignmentModal.tsx
@@ -11,8 +11,10 @@ import {
   Modal,
   ModalIcon,
 } from "@/components/ui"
-import { Spinner } from "@/components/Spinner"
-import { BulkResultSection } from "@/components/bulk/resultView"
+import {
+  BulkProgressBlock,
+  BulkResultSection,
+} from "@/components/bulk/resultView"
 import { slugBudgetError } from "@/components/assignments/slugBudget"
 import useRenameAssignment from "@/hooks/mutations/useRenameAssignment"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
@@ -156,10 +158,6 @@ export function RenameAssignmentModal({
   }
 
   const progress = rename.progress
-  const pct =
-    progress && progress.total > 0
-      ? Math.round((progress.processed / progress.total) * 100)
-      : 0
 
   return (
     <Modal
@@ -279,25 +277,21 @@ export function RenameAssignmentModal({
       )}
 
       {busy && (
-        <div className="mt-6 flex flex-col items-center gap-3 py-6">
-          <Spinner label={t("assignments.rename.working")} />
-          <progress
-            className="progress progress-primary w-full"
-            // Omit `value` until the fan-out reports so the bar animates as an
-            // indeterminate track during the config commit.
-            {...(progress ? { value: pct } : {})}
-            max={100}
-          />
-          <p className="break-all text-center text-sm text-base-content/70">
-            {progress
+        <BulkProgressBlock
+          workingLabel={t("assignments.rename.working")}
+          // No progress yet = the config-commit step: indeterminate track.
+          progress={progress ?? { processed: 0, total: 0 }}
+          indeterminateUntilFirst
+          caption={
+            progress
               ? t("assignments.rename.progress", {
                   processed: progress.processed,
                   total: progress.total,
                   repo: progress.repo,
                 })
-              : t("assignments.rename.configStep")}
-          </p>
-        </div>
+              : t("assignments.rename.configStep")
+          }
+        />
       )}
 
       {runError !== "" && (

--- a/web/src/components/ui/Modal.test.tsx
+++ b/web/src/components/ui/Modal.test.tsx
@@ -262,6 +262,24 @@ describe("Modal", () => {
     expect(actions).toHaveLength(1)
     expect(actions[0].textContent).toContain("Close")
     expect(actions[0].textContent).toContain("Apply")
+    // Portal content appends AFTER the footer prop: the rightmost (primary)
+    // slot belongs to the portal when a host combines both.
+    expect(actions[0].textContent).toBe("CloseApply")
+  })
+
+  it("renders nothing and warns when used outside a Modal", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const { container } = render(
+      <ModalFooterPortal>
+        <button type="button">Orphan</button>
+      </ModalFooterPortal>,
+    )
+    expect(container.childNodes).toHaveLength(0)
+    expect(screen.queryByText("Orphan")).toBeNull()
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("outside a Modal"),
+    )
+    warn.mockRestore()
   })
 
   it("keeps the empty footer row hidden when neither prop nor portal fills it", () => {

--- a/web/src/components/ui/Modal.test.tsx
+++ b/web/src/components/ui/Modal.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, cleanup } from "@testing-library/react"
 import { createRef } from "react"
 
 import { Modal, ModalFooterPortal } from "./Modal"
+import { logger } from "@/lib/logger"
 
 // happy-dom doesn't implement <dialog> showModal/close; stub them so the
 // open-sync effect can run without throwing.
@@ -268,7 +269,7 @@ describe("Modal", () => {
   })
 
   it("renders nothing and warns when used outside a Modal", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {})
     const { container } = render(
       <ModalFooterPortal>
         <button type="button">Orphan</button>

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -42,8 +42,12 @@ import { Heading } from "./Heading"
 // open-only content with useLingeringOpen.
 
 // The footer container element, provided per Modal instance so
-// ModalFooterPortal can target the canonical action row.
-const ModalFooterContext = createContext<HTMLDivElement | null>(null)
+// ModalFooterPortal can target the canonical action row. `undefined` (the
+// default) means no Modal ancestor at all; `null` means inside a Modal whose
+// footer ref hasn't settled yet (first render) — only the former is a bug.
+const ModalFooterContext = createContext<HTMLDivElement | null | undefined>(
+  undefined,
+)
 
 export type ModalSize =
   "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "5xl"
@@ -239,10 +243,23 @@ export default Modal
 
 // Renders body-owned action buttons into the Modal's canonical footer row.
 // For content whose buttons need state the `footer` prop can't reach (a form
-// instance, a phase-local handler); renders nothing outside a Modal.
+// instance, a phase-local handler); renders nothing outside a Modal. Portal
+// content lands AFTER any `footer` prop content in the same row — a host that
+// combines both must put its primary action in the portal, or the prop's
+// button would sit right of it and break the primary-rightmost convention.
 export function ModalFooterPortal({ children }: { children: ReactNode }) {
   const container = useContext(ModalFooterContext)
-  if (!container) return null
+  if (container === undefined) {
+    if (import.meta.env.DEV) {
+      console.warn(
+        "ModalFooterPortal rendered outside a Modal: its children are dropped.",
+      )
+    }
+    return null
+  }
+  // Inside a Modal but the footer ref hasn't settled yet (first render);
+  // the ref-callback state flush re-renders us into the container pre-paint.
+  if (container === null) return null
   return createPortal(children, container)
 }
 

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next"
 
 import { Button } from "./Button"
 import { cx } from "./cx"
+import { logger } from "@/lib/logger"
 import { Heading } from "./Heading"
 
 // The canonical dialog. Wraps the native `<dialog className="modal">` idiom the
@@ -251,7 +252,7 @@ export function ModalFooterPortal({ children }: { children: ReactNode }) {
   const container = useContext(ModalFooterContext)
   if (container === undefined) {
     if (import.meta.env.DEV) {
-      console.warn(
+      logger.warn(
         "ModalFooterPortal rendered outside a Modal: its children are dropped.",
       )
     }

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -27,7 +27,9 @@ import { ConfirmModal } from "@/components/modals"
 import { useDeferredRun } from "@/hooks/useDeferredRun"
 import { logger } from "@/lib/logger"
 import {
+  BulkProgressRow,
   BulkResultSection,
+  bulkProgressPct,
   type BulkPhase,
   type BulkProgress,
   type BulkResultView,
@@ -226,11 +228,6 @@ const BulkActionsBar = ({
       setPhase("error")
     }
   }
-
-  const progressPercent =
-    progress.total === 0
-      ? 0
-      : Math.round((progress.processed / progress.total) * 100)
 
   return (
     <>
@@ -440,26 +437,18 @@ const BulkActionsBar = ({
         }
       >
         {phase === "working" && (
-          <div className="mt-6">
-            <p className="mb-2 font-medium">{progress.message}</p>
-            <progress
-              className="progress progress-primary w-full"
-              value={progress.processed}
-              max={progress.total || 1}
-            />
-            <div className="mt-2 flex justify-between text-sm opacity-70">
-              <span>
-                {t("orgMembers.bulk.progressProcessed", {
-                  processed: progress.processed,
-                  total: progress.total,
-                })}
-              </span>
-              <span>{progressPercent}%</span>
-            </div>
+          <BulkProgressRow
+            progress={progress}
+            processedCaption={t("orgMembers.bulk.progressProcessed", {
+              processed: progress.processed,
+              total: progress.total,
+            })}
+            percentCaption={`${bulkProgressPct(progress)}%`}
+          >
             <Alert tone="info" className="mt-6">
               <span>{t("orgMembers.bulk.keepTabOpen")}</span>
             </Alert>
-          </div>
+          </BulkProgressRow>
         )}
 
         {phase === "complete" && result && (

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -29,7 +29,9 @@ import { resendClassroomInvite, retireEmailInvites } from "@/domain/students"
 import { isMalformedGitHubId, resolveGitHubId } from "@/util/students"
 import { sortRolesByRank } from "@/util/teamRoster"
 import {
+  BulkProgressRow,
   BulkResultSection,
+  bulkProgressPct,
   type BulkPhase,
   type BulkProgress,
   type BulkResultView,
@@ -391,11 +393,6 @@ const RosterBulkActionsBar = ({
     onDone("cancel")
   }
 
-  const progressPercent =
-    progress.total === 0
-      ? 0
-      : Math.round((progress.processed / progress.total) * 100)
-
   return (
     <>
       {/* The selection cluster lives in the page toolbar and appears only
@@ -573,26 +570,18 @@ const RosterBulkActionsBar = ({
         }
       >
         {phase === "working" && (
-          <div className="mt-6">
-            <p className="mb-2 font-medium">{progress.message}</p>
-            <progress
-              className="progress progress-primary w-full"
-              value={progress.processed}
-              max={progress.total || 1}
-            />
-            <div className="mt-2 flex justify-between text-sm opacity-70">
-              <span>
-                {t("students.bulk.progressProcessed", {
-                  processed: progress.processed,
-                  total: progress.total,
-                })}
-              </span>
-              <span>{progressPercent}%</span>
-            </div>
+          <BulkProgressRow
+            progress={progress}
+            processedCaption={t("students.bulk.progressProcessed", {
+              processed: progress.processed,
+              total: progress.total,
+            })}
+            percentCaption={`${bulkProgressPct(progress)}%`}
+          >
             <Alert tone="info" className="mt-6">
               <span>{t("students.bulk.keepTabOpen")}</span>
             </Alert>
-          </div>
+          </BulkProgressRow>
         )}
 
         {phase === "complete" && result && (

--- a/web/src/pages/students/UploadRoster.test.tsx
+++ b/web/src/pages/students/UploadRoster.test.tsx
@@ -1147,9 +1147,7 @@ describe("UploadRoster footer phase branches", () => {
     const retry = screen
       .getByRole("button", { name: "students.importRetryLookup" })
       .closest("button") as HTMLButtonElement
-    expect(
-      screen.getByRole("button", { name: "common.cancel" }),
-    ).toBeTruthy()
+    expect(screen.getByRole("button", { name: "common.cancel" })).toBeTruthy()
 
     await user.click(retry)
 

--- a/web/src/pages/students/UploadRoster.test.tsx
+++ b/web/src/pages/students/UploadRoster.test.tsx
@@ -1108,3 +1108,130 @@ describe("UploadRoster legacy-encoding fallback", () => {
     ).toBeNull()
   })
 })
+
+// The footer branches took over the action rows the blocked/complete views used
+// to render in-body (see ImportProblemsReport / RosterImportResult): the retry
+// gate, the cancel reset, and the Done dismissal live on the Modal footer now.
+describe("UploadRoster footer phase branches", () => {
+  const lookupError = (status: number) =>
+    new GitHubAPIError({
+      status,
+      url: "https://api.github.com/user/42",
+      message: "boom",
+      body: null,
+      rateLimit: {
+        limit: null,
+        remaining: null,
+        used: null,
+        reset: null,
+        resource: null,
+        retryAfter: null,
+      },
+    })
+
+  it("offers the retry for transient-only blockers, and retrying re-resolves", async () => {
+    const user = userEvent.setup()
+    // A 5xx means we could not ASK GitHub about the id — the file is fine, so
+    // the footer offers the retry that actually resolves it.
+    getUserById.mockRejectedValueOnce(lookupError(500))
+    getUserById.mockResolvedValue({ login: "ada" })
+    renderModal(
+      <UploadRoster org="acme" classroom="cs50" client={client} open={true} />,
+    )
+
+    await uploadFile(user, file("roster.csv", "github_id,username\n42,ada\n"))
+    await waitFor(() =>
+      expect(screen.getByText("students.importBlocked:1")).toBeTruthy(),
+    )
+
+    const retry = screen
+      .getByRole("button", { name: "students.importRetryLookup" })
+      .closest("button") as HTMLButtonElement
+    expect(
+      screen.getByRole("button", { name: "common.cancel" }),
+    ).toBeTruthy()
+
+    await user.click(retry)
+
+    // The re-parse asks again, succeeds, and the preview replaces the report.
+    await waitFor(() => expect(getUserById).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /noChangesToApply/ }),
+      ).toBeTruthy(),
+    )
+    expect(screen.queryByText(/students.importBlocked/)).toBeNull()
+    expect(
+      screen.queryByRole("button", { name: "students.importRetryLookup" }),
+    ).toBeNull()
+  })
+
+  it("offers no retry when any blocker is a content problem; Cancel resets", async () => {
+    const user = userEvent.setup()
+    renderModal(
+      <UploadRoster org="acme" classroom="cs50" client={client} open={true} />,
+    )
+
+    // "n/a" is a bad email — a file the teacher has to fix; a retry would
+    // deterministically fail, so it must not be offered.
+    await uploadFile(
+      user,
+      file("roster.csv", "username,email\nada,ada@x.edu\nbob,n/a\n"),
+    )
+    await waitFor(() =>
+      expect(screen.getByText("students.importBlocked:1")).toBeTruthy(),
+    )
+    expect(
+      screen.queryByRole("button", { name: "students.importRetryLookup" }),
+    ).toBeNull()
+
+    await user.click(screen.getByRole("button", { name: "common.cancel" }))
+    await waitFor(() =>
+      expect(screen.getByText("students.uploadDropPrompt")).toBeTruthy(),
+    )
+  })
+
+  it("dismisses a completed import with the footer Done", async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    bulkEnrollStudentsInClassroom.mockResolvedValue({
+      addedStudents: [],
+      skippedStudents: [],
+    })
+    bulkInviteByEmail.mockResolvedValue({
+      invited: [{ email: "zoe@x.edu", role: "student" }],
+      skipped: [],
+      failed: [],
+      deferred: [],
+    })
+    renderModal(
+      <UploadRoster
+        org="acme"
+        classroom="cs50"
+        client={client}
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    )
+
+    await uploadFile(user, file("roster.csv", "email\nzoe@x.edu\n"))
+    await user.click(
+      await waitFor(() => {
+        const b = screen
+          .getByRole("button", { name: /importAndInviteMembers/ })
+          .closest("button") as HTMLButtonElement
+        expect(b.disabled).toBe(false)
+        return b
+      }),
+    )
+
+    const done = await waitFor(
+      () =>
+        screen
+          .getByRole("button", { name: "students.done" })
+          .closest("button") as HTMLButtonElement,
+    )
+    await user.click(done)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@/domain/students"
 import type { GitHubClient } from "@/github-core/client"
 import { Alert, Button, Modal } from "@/components/ui"
+import { BulkProgressRow, bulkProgressPct } from "@/components/bulk/resultView"
 import {
   classifyRosterUpload,
   hasTeacherPromotion,
@@ -671,11 +672,6 @@ const UploadRoster = ({
     if (outcome.emailResult) onEmailSuccess?.(outcome.emailResult)
   }
 
-  const progressPercent =
-    progress.total === 0
-      ? 0
-      : Math.round((progress.processed / progress.total) * 100)
-
   return (
     <>
       <input
@@ -941,31 +937,20 @@ const UploadRoster = ({
         )}
 
         {phase === "importing" && (
-          <div className="mt-6">
-            <p className="mb-2 font-medium">{progress.message}</p>
-
-            <progress
-              className="progress progress-primary w-full"
-              value={progress.processed}
-              max={progress.total || 1}
-            />
-
-            <div className="mt-2 flex justify-between text-sm opacity-70">
-              <span>
-                {t("students.progressProcessed", {
-                  processed: progress.processed,
-                  total: progress.total,
-                })}
-              </span>
-              <span>
-                {t("students.progressPercent", { percent: progressPercent })}
-              </span>
-            </div>
-
+          <BulkProgressRow
+            progress={progress}
+            processedCaption={t("students.progressProcessed", {
+              processed: progress.processed,
+              total: progress.total,
+            })}
+            percentCaption={t("students.progressPercent", {
+              percent: bulkProgressPct(progress),
+            })}
+          >
             <Alert tone="info" className="mt-6">
               <span>{t("students.keepTabOpen")}</span>
             </Alert>
-          </div>
+          </BulkProgressRow>
         )}
 
         {/* Every upload lands on ONE screen, even one that carried both kinds of

--- a/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
+++ b/web/src/pages/submissions/DownloadAllSubmissionsModal.tsx
@@ -2,7 +2,8 @@ import { useEffect } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { FileZipIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, ModalIcon, Spinner } from "@/components/ui"
+import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
+import { BulkProgressInline } from "@/components/bulk/resultView"
 import useDownloadAllSubmissions from "@/hooks/mutations/useDownloadAllSubmissions"
 import {
   BULK_DOWNLOAD_WARN_THRESHOLD,
@@ -204,20 +205,16 @@ export function DownloadAllSubmissionsModal({
           )}
         </div>
       ) : running ? (
-        <div className="mt-4 space-y-3">
-          <p className="flex items-center gap-2 text-sm text-base-content/70">
-            <Spinner size="xs" />
-            {t("submissions.downloadAll.running", {
-              done: progress?.done ?? 0,
-              total: progress?.total ?? count,
-            })}
-          </p>
-          <progress
-            className="progress progress-primary w-full"
-            value={progress?.done ?? 0}
-            max={progress?.total ?? count}
-          />
-        </div>
+        <BulkProgressInline
+          label={t("submissions.downloadAll.running", {
+            done: progress?.done ?? 0,
+            total: progress?.total ?? count,
+          })}
+          progress={{
+            processed: progress?.done ?? 0,
+            total: progress?.total ?? count,
+          }}
+        />
       ) : (
         <div className="mt-3 space-y-2 text-sm leading-6 text-base-content/70">
           <p>

--- a/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
+++ b/web/src/pages/submissions/OpenAllFeedbackPrsModal.tsx
@@ -2,7 +2,8 @@ import { useEffect } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { GitPullRequestIcon } from "@/components/ui/icons"
 
-import { Alert, Button, Modal, ModalIcon, Spinner } from "@/components/ui"
+import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
+import { BulkProgressInline } from "@/components/bulk/resultView"
 import useOpenAllFeedbackPrs from "@/hooks/mutations/useOpenAllFeedbackPrs"
 import type { OpenAllRepoResult } from "@/domain/assignments"
 import type { AssignmentMode } from "@/types/classroom"
@@ -191,20 +192,16 @@ export function OpenAllFeedbackPrsModal({
         </div>
       ) : running ? (
         /* Running — live progress. */
-        <div className="mt-4 space-y-3">
-          <p className="flex items-center gap-2 text-sm text-base-content/70">
-            <Spinner size="xs" />
-            {t("submissions.openAllPrs.running", {
-              done: progress?.done ?? 0,
-              total: progress?.total ?? count,
-            })}
-          </p>
-          <progress
-            className="progress progress-primary w-full"
-            value={progress?.done ?? 0}
-            max={progress?.total ?? count}
-          />
-        </div>
+        <BulkProgressInline
+          label={t("submissions.openAllPrs.running", {
+            done: progress?.done ?? 0,
+            total: progress?.total ?? count,
+          })}
+          progress={{
+            processed: progress?.done ?? 0,
+            total: progress?.total ?? count,
+          }}
+        />
       ) : (
         /* Confirm. */
         <div className="mt-3 space-y-2 text-sm leading-6 text-base-content/70">


### PR DESCRIPTION
## Summary

Follow-up to #758, finishing the progress-bar consolidation it started.

- The six inline `<progress>` copies collapse into three thin presentations in `components/bulk/resultView.tsx` — `BulkProgressBlock` (spinner + centered caption), a new `BulkProgressRow` (the action bars' and UploadRoster's message + bar + counts row, trailing alert as children), and a new `BulkProgressInline` (the submissions modals' spinner-status line) — all deriving their fill from one `bulkProgressBarProps`/`bulkProgressPct` helper, so the value/max/indeterminate logic lives in exactly one place and the three per-file `progressPercent` computations are gone. One deliberate visual nuance: RenameAssignmentModal's bar now stays indeterminate until the first repo reports instead of flashing a momentary 0%.
- Test gaps from the #758 review close: `BulkProgressBlock` and the two new presentations get direct unit tests (valued bar, indeterminate omit-then-restore, the `total === 0` NaN guard), and UploadRoster's footer phase branches regain the render/click coverage lost in the footer lift — transient-only blockers offer a retry that actually re-resolves, content blockers get Cancel only, complete's Done closes the modal.
- `ModalFooterPortal` fails loudly instead of silently: a portal with no Modal ancestor warns in dev (via `lib/logger`; the normal first-render null-ref window inside a Modal stays silent), and the footer-prop -> portal append order is documented and pinned by an ordering test so a host combining both can't break the primary-rightmost convention.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 367 files / 4658 tests)
- [x] New unit tests: bulk progress presentations + pct math (10 cases), UploadRoster footer branches (3), ModalFooterPortal outside-a-Modal + ordering (2)
- [ ] Reviewer spot-check: a roster or org-members bulk run's progress dialog, roster upload importing/blocked/complete, rename-assignment fan-out (indeterminate config step), open-all-PRs / download-all progress, both themes
