### PR TITLE
refactor(web): sweep hand-rolled btn and badge recipes onto the ui primitives

### DIFF
--- a/web/src/components/drawer/DrawerChrome.tsx
+++ b/web/src/components/drawer/DrawerChrome.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { type ReactNode } from "react"
 import { Outlet, useRouterState } from "@tanstack/react-router"
 import { AnimatePresence, motion } from "motion/react"
+import { Button } from "@/components/ui"
 import Drawer, { MOBILE_DRAWER_ID, useSidebarCollapse } from "./collapseContext"
 import {
   SidebarContent,
@@ -76,12 +77,17 @@ export const DrawerContent = ({ children }: { children: ReactNode }) => {
     // White canvas per GitHub Product UI: content sits on base-100 and muted
     // panels/cards carry the base-200 gray.
     <div className="drawer-content min-h-screen bg-base-100">
-      <a
+      <Button
+        as="a"
         href="#main-content"
-        className="btn btn-primary btn-sm sr-only focus:not-sr-only focus:fixed focus:top-3 focus:start-3 focus:z-50"
+        variant="primary"
+        size="sm"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:start-3 focus:z-50"
       >
         {t("common.skipToMainContent")}
-      </a>
+      </Button>
+      {/* A label, not a Button: daisyUI's drawer opens via the checkbox this
+          label toggles — no JS handler to attach a Button to. */}
       <label
         htmlFor={MOBILE_DRAWER_ID}
         aria-label={t("nav.openMenu")}

--- a/web/src/components/drawer/SidebarFooter.tsx
+++ b/web/src/components/drawer/SidebarFooter.tsx
@@ -10,6 +10,7 @@ import {
   SignOutIcon,
   SunIcon,
 } from "@/components/ui/icons"
+import { Badge } from "@/components/ui"
 import {
   useParams,
   useMatchRoute,
@@ -503,13 +504,16 @@ const AuthedSidebarFooter = () => {
                     )}
                   </span>
                   {viewAs && canPreviewRoles ? (
-                    <span
-                      className="badge badge-warning badge-xs gap-1"
+                    <Badge
+                      tone="warning"
+                      size="xs"
+                      soft={false}
+                      className="gap-1"
                       title={t("nav.rolePreviewTooltip")}
                     >
                       <EyeIcon aria-hidden="true" className="size-3" />
                       {t("nav.preview")}
-                    </span>
+                    </Badge>
                   ) : null}
                   <DeployEnvBadge />
                 </div>

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -133,6 +133,9 @@ function OrgPicker({
                       <Badge tone="warning" size="sm" className="shrink-0">
                         {t("orgs.newOrg.notSupportedBadge")}
                       </Badge>
+                      {/* Deliberately a span wearing the btn recipe: the whole
+                          row is a <button> (no nesting allowed), and these chips
+                          advertise that row's click affordance. */}
                       <span className="btn btn-outline btn-xs shrink-0">
                         {t("orgs.newOrg.details")}
                       </span>

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -14,7 +14,14 @@ import {
 } from "@/components/ui/icons"
 
 import { EmptyState } from "@/components/list"
-import { Button, Card, Markdown, Modal, Heading } from "@/components/ui"
+import {
+  Button,
+  Card,
+  Markdown,
+  Modal,
+  Heading,
+  RouterButton,
+} from "@/components/ui"
 import type { GitHubRepo } from "@/github-core/types"
 import { assignmentDescription } from "@/types/classroom"
 import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
@@ -64,15 +71,18 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
       className="relative col-span-12 border border-base-200 md:col-span-6 xl:col-span-4"
     >
       {canManageGroup && classroom && assignment && (
-        <Link
+        <RouterButton
           to="/$org/$classroom/assignments/$assignment/settings"
           params={{ org, classroom, assignment }}
-          className="btn btn-ghost btn-sm btn-circle absolute end-3 top-3 z-10 text-base-content/70 hover:text-primary"
+          variant="ghost"
+          size="sm"
+          shape="circle"
+          className="absolute end-3 top-3 z-10 text-base-content/70 hover:text-primary"
           aria-label={t("classes.repo.manageGroupAria", { assignment })}
           title={t("classes.repo.manageGroupTitle")}
         >
           <PencilIcon aria-hidden="true" className="size-4" />
-        </Link>
+        </RouterButton>
       )}
 
       <Card.Body className="gap-4">

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -15,6 +15,7 @@ import {
 
 import { EmptyState } from "@/components/list"
 import {
+  Badge,
   Button,
   Card,
   Markdown,
@@ -151,16 +152,16 @@ const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
         <Card.Actions className="items-center justify-between gap-2 pt-1">
           <div className="flex items-center gap-2">
             {assignmentData?.mode === "individual" && (
-              <div className="badge badge-ghost badge-sm py-3">
+              <Badge ghost className="py-3">
                 <PersonIcon aria-hidden="true" className="size-4" />{" "}
                 {t("classes.repo.individual")}
-              </div>
+              </Badge>
             )}
             {assignmentData?.mode === "group" && (
-              <div className="badge badge-ghost badge-sm py-3">
+              <Badge ghost className="py-3">
                 <PeopleIcon aria-hidden="true" className="size-4" />{" "}
                 {t("classes.repo.group")}
-              </div>
+              </Badge>
             )}
           </div>
 

--- a/web/src/components/org/StudentAssignmentList.test.tsx
+++ b/web/src/components/org/StudentAssignmentList.test.tsx
@@ -39,6 +39,36 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   }
 })
 
+// RouterButton (createLink) needs a router context; stub it to the same
+// data-attribute-carrying anchor as the Link mock above so the accept-link
+// search assertion keeps working without a RouterProvider.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>()
+  return {
+    ...actual,
+    RouterButton: ({
+      children,
+      to,
+      params,
+      search,
+    }: {
+      children?: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+      search?: Record<string, string>
+    }) => (
+      <a
+        href="https://example.test/link"
+        data-to={to}
+        data-params={JSON.stringify(params ?? {})}
+        data-search={JSON.stringify(search ?? {})}
+      >
+        {children}
+      </a>
+    ),
+  }
+})
+
 const pagesAssignments = vi.fn()
 const orgRepos = vi.fn()
 const studentClassrooms = vi.fn()

--- a/web/src/components/org/StudentAssignmentList.tsx
+++ b/web/src/components/org/StudentAssignmentList.tsx
@@ -12,6 +12,7 @@ import {
 import {
   Alert,
   Badge,
+  RouterButton,
   SkeletonRows,
   SortableTh,
   TableShell,
@@ -58,27 +59,27 @@ function AssignmentCta({
   const { t } = useTranslation()
   if (accepted) {
     return (
-      <Link
-        type="button"
+      <RouterButton
         to="/$org/$classroom/assignments/$assignment/submission"
         params={{ org, classroom, assignment: assignment.slug }}
-        className="btn btn-outline btn-primary btn-sm"
+        variant="outline"
+        size="sm"
       >
         {t("assignments.discover.viewSubmission")}
-      </Link>
+      </RouterButton>
     )
   }
   return (
-    <Link
-      type="button"
+    <RouterButton
       to="/$org/$classroom/assignments/$assignment/accept"
       params={{ org, classroom, assignment: assignment.slug }}
       search={secret ? { k: secret } : undefined}
-      className="btn btn-primary btn-sm"
+      variant="primary"
+      size="sm"
     >
       <FileAddedIcon aria-hidden="true" className="size-4" />
       {t("assignments.discover.accept")}
-    </Link>
+    </RouterButton>
   )
 }
 

--- a/web/src/components/settings/LanguageSwitcher.tsx
+++ b/web/src/components/settings/LanguageSwitcher.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
 
-import { AnimatedAlert, Button, rtlFlip } from "@/components/ui"
+import { AnimatedAlert, Badge, Button, rtlFlip } from "@/components/ui"
 import { useLanguage } from "@/hooks/useLanguage"
 import { useLanguageRegistry } from "@/hooks/useLanguageRegistry"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
@@ -403,22 +403,21 @@ export const LanguageSwitcher = ({
                     <span className="flex items-center gap-2">
                       {languageLabel(c, lang)}
                       {source && (
-                        <span
-                          className={`badge badge-sm ${
-                            source === "registry"
-                              ? "badge-ghost"
-                              : "badge-outline"
-                          }`}
+                        // badge-outline is deliberately not a Badge feature;
+                        // it rides className for this one source chip.
+                        <Badge
+                          ghost={source === "registry"}
+                          className={
+                            source === "registry" ? undefined : "badge-outline"
+                          }
                         >
                           {source === "registry"
                             ? t("language.sourceRegistry")
                             : t("language.sourceUser")}
-                        </span>
+                        </Badge>
                       )}
                       {cov !== undefined && cov < 1 && (
-                        <span className="badge badge-ghost badge-sm">
-                          {Math.round(cov * 100)}%
-                        </span>
+                        <Badge ghost>{Math.round(cov * 100)}%</Badge>
                       )}
                     </span>
                     <Button
@@ -445,12 +444,12 @@ export const LanguageSwitcher = ({
                 code: languageLabel(preview.code, lang),
               })}
             </span>
-            <span className="badge badge-ghost badge-sm">
+            <Badge ghost>
               {t("language.previewCoverage", {
                 percent: Math.round(preview.coverage * 100),
                 keys: preview.keyCount,
               })}
-            </span>
+            </Badge>
           </div>
           {preview.sample.length > 0 && (
             <div className="flex flex-col gap-1">

--- a/web/src/components/settings/LanguageSwitcher.tsx
+++ b/web/src/components/settings/LanguageSwitcher.tsx
@@ -53,6 +53,7 @@ export const LanguageSwitcher = ({
 
   const [code, setCode] = useState("")
   const [url, setUrl] = useState("")
+  const uploadInputRef = useRef<HTMLInputElement>(null)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [needsCode, setNeedsCode] = useState(false)
@@ -348,21 +349,30 @@ export const LanguageSwitcher = ({
             </div>
           )}
 
-          <label className="btn btn-sm btn-outline w-full">
+          {/* Hidden input + Button (the UploadRoster pattern) instead of a
+              label wearing btn classes, so the picker is a real button. */}
+          <input
+            ref={uploadInputRef}
+            type="file"
+            accept="application/json,.json"
+            className="hidden"
+            onChange={(e) => void handleFile(e)}
+            disabled={busy}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            disabled={busy}
+            onClick={() => uploadInputRef.current?.click()}
+          >
             {busy && !preview ? (
               <InlineSpinner />
             ) : (
               <UploadIcon className="size-4" aria-hidden="true" />
             )}
             {t("language.uploadFile")}
-            <input
-              type="file"
-              accept="application/json,.json"
-              className="hidden"
-              onChange={(e) => void handleFile(e)}
-              disabled={busy}
-            />
-          </label>
+          </Button>
 
           <div className="flex flex-row gap-2">
             <input

--- a/web/src/components/submissions/SubmissionRowCells.tsx
+++ b/web/src/components/submissions/SubmissionRowCells.tsx
@@ -161,7 +161,9 @@ export const SubmissionCountCell = ({
     >
       <div className="flex items-center gap-1.5">
         {/* Success-toned like the Submitted progress bars: a green chip = a
-            submission exists. Hover deepens the fill as the click affordance. */}
+            submission exists. Hover deepens the fill as the click affordance.
+            A real <button> wearing the badge recipe — Badge renders a span,
+            and this chip is interactive, so it stays inline. */}
         <button
           type="button"
           className="badge badge-sm badge-success badge-soft whitespace-nowrap gap-1 hover:bg-success/20 cursor-pointer"

--- a/web/src/components/ui/TablePagination.tsx
+++ b/web/src/components/ui/TablePagination.tsx
@@ -3,6 +3,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from "./icons"
 
 import { cx } from "./cx"
 import { rtlFlip } from "./icons"
+import { Button } from "./Button"
 import { Select } from "./Select"
 
 // A conventional table pager: a "Show N entries" size selector, a "N to M of T"
@@ -71,9 +72,9 @@ export function TablePagination({
       </span>
 
       <nav className="join" aria-label={t("common.pagination.navAria")}>
-        <button
-          type="button"
-          className="btn btn-sm join-item"
+        <Button
+          size="sm"
+          className="join-item"
           disabled={page <= 0}
           onClick={() => onPageChange(page - 1)}
           aria-label={t("common.pagination.previous")}
@@ -82,33 +83,34 @@ export function TablePagination({
             aria-hidden="true"
             className={cx("size-4", rtlFlip)}
           />
-        </button>
+        </Button>
         {pages.map((p, i) =>
           p === null ? (
-            <button
+            <Button
               key={`gap-${i}`}
-              type="button"
-              className="btn btn-sm join-item btn-disabled"
+              size="sm"
+              className="join-item btn-disabled"
               tabIndex={-1}
               aria-hidden="true"
             >
               …
-            </button>
+            </Button>
           ) : (
-            <button
+            <Button
               key={p}
-              type="button"
-              className={cx("btn btn-sm join-item", p === page && "btn-active")}
+              size="sm"
+              className="join-item"
+              active={p === page}
               aria-current={p === page ? "page" : undefined}
               onClick={() => onPageChange(p)}
             >
               {p + 1}
-            </button>
+            </Button>
           ),
         )}
-        <button
-          type="button"
-          className="btn btn-sm join-item"
+        <Button
+          size="sm"
+          className="join-item"
           disabled={page >= pageCount - 1}
           onClick={() => onPageChange(page + 1)}
           aria-label={t("common.pagination.next")}
@@ -117,7 +119,7 @@ export function TablePagination({
             aria-hidden="true"
             className={cx("size-4", rtlFlip)}
           />
-        </button>
+        </Button>
       </nav>
     </div>
   )

--- a/web/src/pages/AcceptAssignmentPage.test.tsx
+++ b/web/src/pages/AcceptAssignmentPage.test.tsx
@@ -141,6 +141,18 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   }
 })
 
+// RouterButton (createLink) needs a router context; stub just that primitive
+// to a plain anchor so the accepted state renders without a RouterProvider.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>()
+  return {
+    ...actual,
+    RouterButton: ({ children }: { children?: ReactNode }) => (
+      <a href="/mock">{children}</a>
+    ),
+  }
+})
+
 import AcceptAssignmentPage from "./AcceptAssignmentPage"
 import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
 import { __resetGitHubHealthForTest } from "@/lib/githubHealth/githubHealthStore"

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -19,6 +19,7 @@ import {
   Markdown,
   MonoLtr,
   Heading,
+  RouterButton,
 } from "@/components/ui"
 import { assignmentDescription } from "@/types/classroom"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
@@ -1112,8 +1113,10 @@ const AcceptAssignmentPage = () => {
                     exit="exit"
                     className="flex flex-col gap-4 overflow-hidden"
                   >
-                    <a
-                      className="btn btn-primary w-full text-lg p-5"
+                    <Button
+                      as="a"
+                      variant="primary"
+                      className="w-full text-lg p-5"
                       href={
                         acceptMutation?.data?.repo.html_url ||
                         `https://www.github.com/${org}/${checkedRepo?.name}`
@@ -1122,7 +1125,7 @@ const AcceptAssignmentPage = () => {
                       rel="noreferrer"
                     >
                       {t("accept.openRepository")}
-                    </a>
+                    </Button>
 
                     {assignmentData?.mode === "group" && (
                       <Button
@@ -1135,13 +1138,17 @@ const AcceptAssignmentPage = () => {
                     )}
 
                     {org && classroom && (
-                      <Link
+                      // outline variant (primary outline) aligns this with its
+                      // Edit-collaborators sibling above; it was a bare neutral
+                      // outline before.
+                      <RouterButton
                         to="/$org/$classroom"
                         params={{ org, classroom }}
-                        className="btn btn-outline w-full text-lg p-5"
+                        variant="outline"
+                        className="w-full text-lg p-5"
                       >
                         {t("accept.goToClassroom")}
-                      </Link>
+                      </RouterButton>
                     )}
                   </motion.div>
                 )}

--- a/web/src/pages/AcceptAssignmentPage.tsx
+++ b/web/src/pages/AcceptAssignmentPage.tsx
@@ -993,21 +993,19 @@ const AcceptAssignmentPage = () => {
       <AcceptCard>
         <EnterDiv className="card-body gap-4">
           <div className="flex justify-between">
-            <span className="badge badge-primary badge-soft">
+            <Badge tone="primary" size="md">
               <PersonIcon aria-hidden="true" className="size-4" />
               {assignmentData?.mode && modeLabelKey[assignmentData.mode]
                 ? t(modeLabelKey[assignmentData.mode])
                 : ""}
-            </span>
-            <span
-              className={`badge ${pastDue ? "badge-error badge-soft" : ""}`}
-            >
+            </Badge>
+            <Badge tone={pastDue ? "error" : "neutral"} size="md">
               {assignmentData?.due
                 ? t(pastDue ? "accept.pastDue" : "accept.due", {
                     date: formatDueDateTime(assignmentData.due),
                   })
                 : t("accept.noDueDate")}
-            </span>
+            </Badge>
           </div>
           <Heading as="h1" variant="title-medium" className="pt-2">
             {assignmentData?.name}

--- a/web/src/pages/AssignmentsPage.test.tsx
+++ b/web/src/pages/AssignmentsPage.test.tsx
@@ -27,6 +27,18 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   }
 })
 
+// RouterButton (createLink) needs a router context; stub just that primitive
+// to a plain anchor so the page renders without a RouterProvider.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>()
+  return {
+    ...actual,
+    RouterButton: ({ children }: { children?: ReactNode }) => (
+      <a href="/mock">{children}</a>
+    ),
+  }
+})
+
 const studentCount = vi.fn()
 const getStudents = vi.fn()
 const getClassroom = vi.fn()

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -13,7 +13,13 @@ import {
   type AssignmentFilters,
   type AssignmentSort,
 } from "@/pages/assignments/assignmentList"
-import { Badge, Button, DropdownMenu, EmphasisLtr } from "@/components/ui"
+import {
+  Badge,
+  Button,
+  DropdownMenu,
+  EmphasisLtr,
+  RouterButton,
+} from "@/components/ui"
 import {
   NoSearchResults,
   SkeletonRegion,
@@ -52,14 +58,16 @@ const NewAssignmentButton = ({
   return (
     <>
       <div className="join">
-        <Link
+        <RouterButton
           to="/$org/$classroom/assignments/new"
           params={{ org, classroom }}
-          className="btn btn-primary btn-sm join-item"
+          variant="primary"
+          size="sm"
+          className="join-item"
         >
           <PlusIcon aria-hidden="true" className="size-4" />{" "}
           {t("assignments.newButton.assignment")}
-        </Link>
+        </RouterButton>
         {/* Not a join-item: see NewClassroomButton in ClassesPage.tsx. */}
         <div className="dropdown dropdown-end -ms-px">
           <Button

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -17,7 +17,14 @@ import {
   SkeletonRegion,
   ToolbarSkeleton,
 } from "@/components/list"
-import { Alert, Button, Card, DropdownMenu, EmphasisLtr } from "@/components/ui"
+import {
+  Alert,
+  Button,
+  Card,
+  DropdownMenu,
+  EmphasisLtr,
+  RouterButton,
+} from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import MissingParams from "@/components/MissingParams"
 import { useOrgStaff } from "@/hooks/useOrgStaff"
@@ -38,14 +45,15 @@ const NewClassroomButton = ({ org }: { org: string }) => {
   const { t } = useTranslation()
   return (
     <div className="join">
-      <Link
+      <RouterButton
         to="/$org/classes/new"
         params={{ org }}
-        className="btn btn-primary join-item"
+        variant="primary"
+        className="join-item"
       >
         <PlusIcon aria-hidden="true" className="size-4" />
         {t("classes.empty.createButton")}
-      </Link>
+      </RouterButton>
       {/* Not a join-item itself: daisyUI resets the join radius vars for a
           join-item's children, which would square the inner button's corners.
           The wrapper still inherits the vars as the join's last child; -ms-px

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -327,6 +327,8 @@ function OrgActions({ summary }: { summary: Classroom50OrgSummary }) {
 
 function NoAccessBadge() {
   return (
+    // badge-neutral is deliberately not a Badge tone (Badge's neutral is the
+    // uncolored chip), so this lock chip keeps its inline recipe.
     <span className="badge badge-neutral gap-1">
       <LockIcon aria-hidden="true" className="size-3" />
       <Trans

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -46,6 +46,7 @@ import {
   Button,
   Card,
   DropdownMenu,
+  RouterButton,
   Toolbar,
   cx,
   Heading,
@@ -312,14 +313,15 @@ function OrgActions({ summary }: { summary: Classroom50OrgSummary }) {
 
   if (!canOpen) return null
   return (
-    <Link
+    <RouterButton
       to="/$org"
       params={{ org: org.login }}
       aria-label={t("orgs.card.openAria", { org: org.login })}
-      className="btn btn-primary btn-sm"
+      variant="primary"
+      size="sm"
     >
       {t("orgs.card.open")}
-    </Link>
+    </RouterButton>
   )
 }
 

--- a/web/src/pages/assignments/AssignmentsTable.test.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.test.tsx
@@ -22,6 +22,18 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   }
 })
 
+// RouterButton (createLink) needs a router context; stub just that primitive
+// to a plain anchor so the table renders without a RouterProvider.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>()
+  return {
+    ...actual,
+    RouterButton: ({ children }: { children?: ReactNode }) => (
+      <a href="/mock">{children}</a>
+    ),
+  }
+})
+
 vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({}),
 }))

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -41,6 +41,7 @@ import {
   Button,
   MetricCount,
   MetricBar,
+  RouterButton,
   SkeletonRows,
   SortableTh,
   TableShell,
@@ -533,8 +534,10 @@ const AssignmentsTable = ({
                       classroom={classroom}
                       assignment={assignment}
                     />
-                    <Link
-                      className="btn btn-circle btn-sm btn-ghost"
+                    <RouterButton
+                      shape="circle"
+                      size="sm"
+                      variant="ghost"
                       to="/$org/$classroom/assignments/$assignment/settings"
                       params={{
                         org,
@@ -555,7 +558,7 @@ const AssignmentsTable = ({
                       ) : (
                         <EyeIcon aria-hidden="true" className="size-4" />
                       )}
-                    </Link>
+                    </RouterButton>
                     {canMutate && (
                       <LockAssignmentAction
                         org={org}

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -1,5 +1,6 @@
 import { ConfirmModal } from "@/components/modals"
 import {
+  Badge,
   Button,
   Card,
   EmphasisLtr,
@@ -432,10 +433,12 @@ function ClassroomBadges({ summary }: { summary: ClassroomSummary }) {
   const { t } = useTranslation()
   return (
     <div className="flex items-center gap-2">
-      <span className="badge badge-soft badge-primary">
+      <Badge tone="primary" size="md">
         {summary.term || t("classes.noTermSpecified")}
-      </span>
+      </Badge>
       {summary.archived && (
+        // badge-neutral is deliberately not a Badge tone (Badge's neutral is
+        // the uncolored chip), so the archived chip keeps its inline recipe.
         <span className="badge badge-soft badge-neutral">
           {t("classes.archived")}
         </span>

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -1,5 +1,11 @@
 import { ConfirmModal } from "@/components/modals"
-import { Button, Card, EmphasisLtr, Heading } from "@/components/ui"
+import {
+  Button,
+  Card,
+  EmphasisLtr,
+  Heading,
+  RouterButton,
+} from "@/components/ui"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { GitHubAPIError } from "@/github-core/errors"
 import { useArchiveClassroom } from "@/hooks/mutations/useArchiveClassroom"
@@ -487,17 +493,18 @@ function ViewRosterButton({
 }) {
   const { t } = useTranslation()
   return (
-    <Link
-      type="button"
+    <RouterButton
       to="/$org/$classroom/roster"
       params={{ org, classroom: slug }}
       aria-label={t("classes.viewRosterAria", {
         classroom: classroomName,
       })}
-      className={`btn btn-outline btn-primary btn-sm ${block ? "flex-1" : ""}`}
+      variant="outline"
+      size="sm"
+      className={block ? "flex-1" : undefined}
     >
       {t("classes.viewRoster")}
-    </Link>
+    </RouterButton>
   )
 }
 
@@ -514,17 +521,18 @@ function ViewAssignmentsButton({
 }) {
   const { t } = useTranslation()
   return (
-    <Link
-      type="button"
+    <RouterButton
       to="/$org/$classroom/assignments"
       params={{ org, classroom: slug }}
       aria-label={t("classes.viewAssignmentsAria", {
         classroom: classroomName,
       })}
-      className={`btn btn-outline btn-primary btn-sm ${block ? "flex-1" : ""}`}
+      variant="outline"
+      size="sm"
+      className={block ? "flex-1" : undefined}
     >
       {t("classes.viewAssignments")}
-    </Link>
+    </RouterButton>
   )
 }
 

--- a/web/src/pages/classes/ClassroomList.test.tsx
+++ b/web/src/pages/classes/ClassroomList.test.tsx
@@ -13,6 +13,18 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   return { ...actual, Link: ({ children }: { children?: unknown }) => children }
 })
 
+// RouterButton (createLink) needs a router context; stub just that primitive
+// to a plain anchor so the list renders without a RouterProvider.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>()
+  return {
+    ...actual,
+    RouterButton: ({ children }: { children?: React.ReactNode }) => (
+      <a href="/mock">{children}</a>
+    ),
+  }
+})
+
 // Drive the sort key; changeSort is captured so a test can flip it at runtime.
 let sortKey = "name-asc"
 const changeSort = vi.fn((k: string) => {

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenu,
   Input,
   LabeledControl,
+  RouterButton,
   Select,
 } from "@/components/ui"
 import useClassroomSummaries, {
@@ -258,15 +259,16 @@ const ClassroomList = ({
         <div className="mx-1 hidden h-6 w-px self-center bg-base-300 sm:block" />
 
         <div className="join">
-          <Link
+          <RouterButton
             to="/$org/classes/new"
             params={{ org }}
-            type="button"
-            className="btn btn-primary btn-sm join-item"
+            variant="primary"
+            size="sm"
+            className="join-item"
           >
             <PlusIcon aria-hidden="true" className="size-4" />
             {t("classes.newClass")}
-          </Link>
+          </RouterButton>
           {/* Not a join-item: see NewClassroomButton in ClassesPage.tsx. */}
           <div className="dropdown dropdown-end -ms-px">
             <Button

--- a/web/src/pages/classes/StudentClassroomList.tsx
+++ b/web/src/pages/classes/StudentClassroomList.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@tanstack/react-router"
 import {
   ArrowSwitchIcon,
   BookIcon,
@@ -21,6 +20,7 @@ import {
   Card,
   Input,
   LabeledControl,
+  RouterButton,
   Select,
   Heading,
 } from "@/components/ui"
@@ -64,17 +64,18 @@ function ViewAssignmentsLink({
 }) {
   const { t } = useTranslation()
   return (
-    <Link
-      type="button"
+    <RouterButton
       to="/$org/$classroom/assignments"
       params={{ org, classroom }}
       aria-label={t("classes.viewAssignmentsAria", {
         classroom: classroomName,
       })}
-      className={`btn btn-outline btn-primary btn-sm ${block ? "w-full" : ""}`}
+      variant="outline"
+      size="sm"
+      className={block ? "w-full" : undefined}
     >
       {t("classes.viewAssignments")}
-    </Link>
+    </RouterButton>
   )
 }
 

--- a/web/src/pages/migration/ConfirmStep.tsx
+++ b/web/src/pages/migration/ConfirmStep.tsx
@@ -7,7 +7,6 @@
 
 import { useMemo, useState } from "react"
 import { keepPreviousData, useQuery } from "@tanstack/react-query"
-import { Link } from "@tanstack/react-router"
 import { Trans, useTranslation } from "react-i18next"
 import { AlertIcon, LinkExternalIcon, SyncIcon } from "@/components/ui/icons"
 
@@ -22,6 +21,7 @@ import {
   Input,
   Modal,
   ModalIcon,
+  RouterButton,
   Spinner,
   Toolbar,
 } from "@/components/ui"
@@ -382,15 +382,18 @@ export const ConfirmStep = ({
                   <p className="mt-1 text-sm text-base-content/70">
                     {t("migration.access.step1Body", { org: accessOrg })}
                   </p>
-                  <a
+                  <Button
+                    as="a"
                     href={githubOAuthGrantUrl()}
                     target="_blank"
                     rel="noreferrer"
-                    className="btn btn-primary btn-sm mt-3"
+                    variant="primary"
+                    size="sm"
+                    className="mt-3"
                   >
                     {t("migration.access.step1Button")}
                     <LinkExternalIcon aria-hidden="true" className="size-4" />
-                  </a>
+                  </Button>
                 </div>
               </div>
             </li>
@@ -407,15 +410,18 @@ export const ConfirmStep = ({
                   <p className="mt-1 text-sm text-base-content/70">
                     {t("migration.access.step2Body", { org: accessOrg })}
                   </p>
-                  <a
+                  <Button
+                    as="a"
                     href={githubOrgOAuthPolicyUrl(accessOrg)}
                     target="_blank"
                     rel="noreferrer"
-                    className="btn btn-ghost btn-sm mt-3"
+                    variant="ghost"
+                    size="sm"
+                    className="mt-3"
                   >
                     {t("migration.access.step2Button", { org: accessOrg })}
                     <LinkExternalIcon aria-hidden="true" className="size-4" />
-                  </a>
+                  </Button>
                 </div>
               </div>
             </li>
@@ -732,13 +738,13 @@ export const ConfirmStep = ({
 
             {done && result ? (
               <Card.Actions className="mt-4 justify-end">
-                <Link
+                <RouterButton
                   to="/$org/$classroom"
                   params={{ org: targetOrg, classroom: result.shortName }}
-                  className="btn btn-primary"
+                  variant="primary"
                 >
                   {t("migration.execute.viewClass")}
-                </Link>
+                </RouterButton>
               </Card.Actions>
             ) : (
               !blocked && (

--- a/web/src/pages/migration/ImportClassroomPage.tsx
+++ b/web/src/pages/migration/ImportClassroomPage.tsx
@@ -4,19 +4,14 @@
 // machine. The review step runs the import in place after confirmation.
 
 import { useState } from "react"
-import {
-  Link,
-  getRouteApi,
-  useNavigate,
-  useParams,
-} from "@tanstack/react-router"
+import { getRouteApi, useNavigate, useParams } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { CheckIcon } from "@/components/ui/icons"
 
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
 import MissingParams from "@/components/MissingParams"
-import { Alert, Button, Card, Spinner, cx } from "@/components/ui"
+import { Alert, Button, Card, RouterButton, Spinner, cx } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useOrgClassroom50Status } from "@/hooks/useOrgClassroom50Status"
 import { githubOrgOAuthPolicyUrl } from "@/auth/constants"
@@ -94,9 +89,9 @@ const OrgSetupGate = ({ org }: { org: string }) => {
           {t("migration.gate.body", { org })}
         </p>
         <Card.Actions className="mt-4">
-          <Link to="/$org/setup" params={{ org }} className="btn btn-primary">
+          <RouterButton to="/$org/setup" params={{ org }} variant="primary">
             {t("migration.gate.setupButton")}
-          </Link>
+          </RouterButton>
         </Card.Actions>
       </Card.Body>
     </Card>


### PR DESCRIPTION
## Summary

First slice of the app-wide DaisyUI cleanup (consolidated modal plan item 3a): every hand-rolled `btn` and `badge` class recipe outside the primitives moves onto `Button`/`RouterButton`/`Badge`, so a recipe change lands in one place instead of drifting across ~22 inline copies.

- Thirteen `<Link className="btn ...">` sites across ten files adopt `RouterButton` (variant/size/shape props; positional utilities like `join-item` ride `className`), and the bare btn-classed anchors — the skip-to-content link, the accept page's open-repository action, ConfirmStep's OAuth links — adopt `Button as="a"`. `ui/TablePagination` stops bypassing its sibling `Button` (the ellipsis chip keeps its exact non-focusable semantics). Affected page tests stub `RouterButton` to a plain anchor the way the existing `createLink` consumers' tests already do.
- Ghost/soft/tone badge chips across seven files adopt `Badge` props. Three shapes deliberately stay inline with why-comments: the two `badge-neutral` chips (`Badge`'s neutral is the uncolored chip by design) and the submissions row's interactive badge (a real `<button>`; `Badge` renders a span).
- Judgment cases from the plan: `LanguageSwitcher`'s file picker becomes the hidden-input + `Button` pattern `UploadRoster` uses (a real button instead of a label wearing btn classes); `NewOrgModal`'s chips stay spans with a why-comment — the row itself is a `<button>`, so they can't nest. One intentional visual change: the accept page's go-to-classroom link aligns to the `outline` variant (primary outline) to match its edit-collaborators sibling; it was a bare neutral outline.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 367 files / 4658 tests)
- [ ] Reviewer spot-check: classes/orgs cards (view roster/assignments, open), assignments table gear + new-assignment join, accept page (student view — note the outline-color alignment), migration import/confirm steps, drawer skip-link focus (Tab from address bar), table pagination active/disabled/ellipsis states, language switcher upload button, badges on orgs/classes/submissions/sidebar. Both themes.
