### PR TITLE
refactor(web): add Checkbox and Radio primitives and sweep the hand-rolled controls

### DIFF
--- a/web/src/components/ui/Checkbox.test.tsx
+++ b/web/src/components/ui/Checkbox.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { Checkbox } from "./Checkbox"
+
+afterEach(cleanup)
+
+const getBox = () => screen.getByRole("checkbox") as HTMLInputElement
+
+describe("Checkbox", () => {
+  it("renders the sm house recipe by default", () => {
+    render(<Checkbox aria-label="pick" />)
+    expect(getBox().className).toBe("checkbox checkbox-sm")
+  })
+
+  it("maps tones to their color classes", () => {
+    render(<Checkbox aria-label="pick" tone="error" />)
+    expect(getBox().className).toContain("checkbox-error")
+  })
+
+  it("drops the size class at md and merges className extras", () => {
+    render(<Checkbox aria-label="pick" size="md" className="mt-0.5" />)
+    const box = getBox()
+    expect(box.className).not.toContain("checkbox-sm")
+    expect(box.className).toContain("mt-0.5")
+  })
+
+  it("spreads input props through (checked, disabled)", () => {
+    render(<Checkbox aria-label="pick" checked disabled onChange={() => {}} />)
+    const box = getBox()
+    expect(box.checked).toBe(true)
+    expect(box.disabled).toBe(true)
+  })
+})

--- a/web/src/components/ui/Checkbox.tsx
+++ b/web/src/components/ui/Checkbox.tsx
@@ -1,0 +1,43 @@
+import type { ComponentProps } from "react"
+
+import { cx } from "./cx"
+
+// The canonical checkbox chrome. Wraps daisyUI `checkbox` so the inline
+// recipes share one mapping; `sm` is the house size. Positional extras
+// (`mt-0.5`, `size-6`) ride `className`. Label association stays the
+// caller's concern — this is the input only.
+export type CheckboxTone = "neutral" | "primary" | "error"
+export type CheckboxSize = "sm" | "md"
+
+const TONE_CLASS: Record<CheckboxTone, string> = {
+  neutral: "",
+  primary: "checkbox-primary",
+  error: "checkbox-error",
+}
+
+const SIZE_CLASS: Record<CheckboxSize, string> = {
+  sm: "checkbox-sm",
+  md: "",
+}
+
+export type CheckboxProps = {
+  tone?: CheckboxTone
+  size?: CheckboxSize
+} & Omit<ComponentProps<"input">, "type" | "size">
+
+export function Checkbox({
+  tone = "neutral",
+  size = "sm",
+  className,
+  ...props
+}: CheckboxProps) {
+  return (
+    <input
+      type="checkbox"
+      className={cx("checkbox", SIZE_CLASS[size], TONE_CLASS[tone], className)}
+      {...props}
+    />
+  )
+}
+
+export default Checkbox

--- a/web/src/components/ui/Radio.test.tsx
+++ b/web/src/components/ui/Radio.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { Radio } from "./Radio"
+
+afterEach(cleanup)
+
+const getRadio = () => screen.getByRole("radio") as HTMLInputElement
+
+describe("Radio", () => {
+  it("renders the bare radio base by default", () => {
+    render(<Radio aria-label="pick" />)
+    expect(getRadio().className).toBe("radio")
+  })
+
+  it("maps size and tone and merges className extras", () => {
+    render(
+      <Radio aria-label="pick" size="sm" tone="primary" className="mt-0.5" />,
+    )
+    expect(getRadio().className).toBe("radio radio-sm radio-primary mt-0.5")
+  })
+
+  it("spreads input props through (name, value, checked)", () => {
+    render(
+      <Radio
+        aria-label="pick"
+        name="g"
+        value="a"
+        checked
+        onChange={() => {}}
+      />,
+    )
+    const radio = getRadio()
+    expect(radio.name).toBe("g")
+    expect(radio.value).toBe("a")
+    expect(radio.checked).toBe(true)
+  })
+})

--- a/web/src/components/ui/Radio.tsx
+++ b/web/src/components/ui/Radio.tsx
@@ -1,0 +1,41 @@
+import type { ComponentProps } from "react"
+
+import { cx } from "./cx"
+
+// The canonical radio chrome. Wraps daisyUI `radio`; unlike Checkbox the
+// house size is the default (`md` = bare `radio`). Positional extras
+// (`mt-1`) ride `className`; label association stays the caller's concern.
+export type RadioTone = "neutral" | "primary"
+export type RadioSize = "sm" | "md"
+
+const TONE_CLASS: Record<RadioTone, string> = {
+  neutral: "",
+  primary: "radio-primary",
+}
+
+const SIZE_CLASS: Record<RadioSize, string> = {
+  sm: "radio-sm",
+  md: "",
+}
+
+export type RadioProps = {
+  tone?: RadioTone
+  size?: RadioSize
+} & Omit<ComponentProps<"input">, "type" | "size">
+
+export function Radio({
+  tone = "neutral",
+  size = "md",
+  className,
+  ...props
+}: RadioProps) {
+  return (
+    <input
+      type="radio"
+      className={cx("radio", SIZE_CLASS[size], TONE_CLASS[tone], className)}
+      {...props}
+    />
+  )
+}
+
+export default Radio

--- a/web/src/components/ui/SelectAllCheckbox.tsx
+++ b/web/src/components/ui/SelectAllCheckbox.tsx
@@ -1,4 +1,4 @@
-import { cx } from "./cx"
+import { Checkbox } from "./Checkbox"
 
 // The tri-state select-all checkbox (checked / indeterminate / empty), shared
 // by Toolbar.Selection and table headers that host select-all in the select
@@ -20,9 +20,8 @@ export function SelectAllCheckbox({
   className?: string
 }) {
   return (
-    <input
-      type="checkbox"
-      className={cx("checkbox checkbox-sm", className)}
+    <Checkbox
+      className={className}
       aria-label={ariaLabel}
       disabled={disabled}
       checked={allSelected}

--- a/web/src/components/ui/Toggle.test.tsx
+++ b/web/src/components/ui/Toggle.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { Toggle } from "./Toggle"
+
+afterEach(cleanup)
+
+const getToggle = () => screen.getByRole("checkbox") as HTMLInputElement
+
+describe("Toggle", () => {
+  it("renders the primary house tone by default", () => {
+    render(<Toggle aria-label="switch" />)
+    expect(getToggle().className).toBe("toggle toggle-primary")
+  })
+
+  it("maps neutral/warning tones and the sm size", () => {
+    render(<Toggle aria-label="switch" tone="warning" size="sm" />)
+    expect(getToggle().className).toBe("toggle toggle-sm toggle-warning")
+  })
+
+  it("merges className extras and spreads input props", () => {
+    render(
+      <Toggle
+        aria-label="switch"
+        tone="neutral"
+        className="mt-0.5"
+        checked
+        onChange={() => {}}
+      />,
+    )
+    const toggle = getToggle()
+    expect(toggle.className).toBe("toggle mt-0.5")
+    expect(toggle.checked).toBe(true)
+  })
+})

--- a/web/src/components/ui/Toggle.tsx
+++ b/web/src/components/ui/Toggle.tsx
@@ -1,0 +1,43 @@
+import type { ComponentProps } from "react"
+
+import { cx } from "./cx"
+
+// The canonical switch chrome (a checkbox wearing daisyUI `toggle`).
+// `primary` is the house tone (ToggleField's settings recipe); `neutral`
+// and `warning` cover the divergent inline sites. Label layout stays the
+// caller's concern — ToggleField owns the standard settings-row recipe.
+export type ToggleTone = "neutral" | "primary" | "warning"
+export type ToggleSize = "sm" | "md"
+
+const TONE_CLASS: Record<ToggleTone, string> = {
+  neutral: "",
+  primary: "toggle-primary",
+  warning: "toggle-warning",
+}
+
+const SIZE_CLASS: Record<ToggleSize, string> = {
+  sm: "toggle-sm",
+  md: "",
+}
+
+export type ToggleProps = {
+  tone?: ToggleTone
+  size?: ToggleSize
+} & Omit<ComponentProps<"input">, "type" | "size">
+
+export function Toggle({
+  tone = "primary",
+  size = "md",
+  className,
+  ...props
+}: ToggleProps) {
+  return (
+    <input
+      type="checkbox"
+      className={cx("toggle", SIZE_CLASS[size], TONE_CLASS[tone], className)}
+      {...props}
+    />
+  )
+}
+
+export default Toggle

--- a/web/src/components/ui/ToggleField.tsx
+++ b/web/src/components/ui/ToggleField.tsx
@@ -1,4 +1,5 @@
 import { HelpTooltip } from "./FormField"
+import { Toggle } from "./Toggle"
 
 // A boolean toggle rendered as a DaisyUI switch with a bold label and an
 // optional `?` help affordance — the single source for the settings-toggle
@@ -24,10 +25,8 @@ export function ToggleField({
 }) {
   return (
     <label htmlFor={id} className="flex cursor-pointer items-center gap-3">
-      <input
+      <Toggle
         id={id}
-        type="checkbox"
-        className="toggle toggle-primary"
         checked={checked}
         onBlur={onBlur}
         onChange={(e) => onChange(e.target.checked)}

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -23,6 +23,8 @@ export { Checkbox } from "./Checkbox"
 export type { CheckboxProps, CheckboxTone, CheckboxSize } from "./Checkbox"
 export { Radio } from "./Radio"
 export type { RadioProps, RadioTone, RadioSize } from "./Radio"
+export { Toggle } from "./Toggle"
+export type { ToggleProps, ToggleTone, ToggleSize } from "./Toggle"
 
 export { Input } from "./Input"
 export type { InputProps, InputSize } from "./Input"

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -21,6 +21,8 @@ export { Badge } from "./Badge"
 export type { BadgeProps, BadgeTone, BadgeSize } from "./Badge"
 export { Checkbox } from "./Checkbox"
 export type { CheckboxProps, CheckboxTone, CheckboxSize } from "./Checkbox"
+export { Radio } from "./Radio"
+export type { RadioProps, RadioTone, RadioSize } from "./Radio"
 
 export { Input } from "./Input"
 export type { InputProps, InputSize } from "./Input"

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -19,6 +19,8 @@ export type { CardProps } from "./Card"
 
 export { Badge } from "./Badge"
 export type { BadgeProps, BadgeTone, BadgeSize } from "./Badge"
+export { Checkbox } from "./Checkbox"
+export type { CheckboxProps, CheckboxTone, CheckboxSize } from "./Checkbox"
 
 export { Input } from "./Input"
 export type { InputProps, InputSize } from "./Input"

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -14,6 +14,7 @@ import {
   Alert,
   AnimatedAlert,
   Button,
+  Checkbox,
   SelectAllCheckbox,
   SelectSeparatorOption,
   SkeletonRows,
@@ -819,9 +820,8 @@ const OrgMembersPage = () => {
                       onClick={() => setSelectedKey(row.key)}
                     >
                       <td className="w-0">
-                        <input
-                          type="checkbox"
-                          className="checkbox checkbox-sm size-6"
+                        <Checkbox
+                          className="size-6"
                           aria-label={
                             isSelf(row)
                               ? t("orgMembers.bulk.selfNotSelectable")

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { useHiddenOrgs } from "@/context/hiddenOrgs/HiddenOrgsProvider"
 import {
   Button,
   Card,
+  Radio,
   RouterButton,
   SectionAnchorHeading,
   cx,
@@ -239,11 +240,12 @@ function PreferenceRadioGroup<T extends string>({
             htmlFor={id}
             className="flex cursor-pointer items-start gap-3 rounded-field border border-base-300 px-3 py-2 has-[:checked]:border-primary has-[:checked]:bg-primary/5"
           >
-            <input
+            <Radio
               id={id}
-              type="radio"
               name={name}
-              className="radio radio-sm radio-primary mt-0.5"
+              size="sm"
+              tone="primary"
+              className="mt-0.5"
               value={option.value}
               checked={value === option.value}
               onChange={() => onChange(option.value)}

--- a/web/src/pages/assignments/AdvancedSection.tsx
+++ b/web/src/pages/assignments/AdvancedSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { FormField, Input, Textarea } from "@/components/ui"
+import { FormField, Input, Radio, Textarea } from "@/components/ui"
 import { parseAllowedFiles } from "@/util/allowedFiles"
 import { parseReleaseAssets } from "@/util/releaseAssets"
 import { RUNTIME_LANGUAGES } from "@/util/runtime"
@@ -45,10 +45,8 @@ export const AdvancedSection = ({
                 htmlFor={`${field.name}-hosted`}
                 className="label cursor-pointer gap-2 p-0"
               >
-                <input
+                <Radio
                   id={`${field.name}-hosted`}
-                  type="radio"
-                  className="radio"
                   name={field.name}
                   value="hosted"
                   checked={field.state.value === "hosted"}
@@ -60,10 +58,8 @@ export const AdvancedSection = ({
                 htmlFor={`${field.name}-container`}
                 className="label cursor-pointer gap-2 p-0"
               >
-                <input
+                <Radio
                   id={`${field.name}-container`}
-                  type="radio"
-                  className="radio"
                   name={field.name}
                   value="container"
                   checked={field.state.value === "container"}

--- a/web/src/pages/assignments/AdvancedSection.tsx
+++ b/web/src/pages/assignments/AdvancedSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { FormField, Input, Radio, Textarea } from "@/components/ui"
+import { FormField, Input, Radio, Textarea, Toggle } from "@/components/ui"
 import { parseAllowedFiles } from "@/util/allowedFiles"
 import { parseReleaseAssets } from "@/util/releaseAssets"
 import { RUNTIME_LANGUAGES } from "@/util/runtime"
@@ -320,9 +320,9 @@ export const AdvancedSection = ({
                   <div className="mt-4">
                     <div className="flex items-center gap-1.5">
                       <label className="label cursor-pointer justify-start gap-3 p-0 font-bold">
-                        <input
-                          type="checkbox"
-                          className="toggle toggle-sm"
+                        <Toggle
+                          tone="neutral"
+                          size="sm"
                           checked={toggle.state.value}
                           onChange={(e) =>
                             toggle.handleChange(e.target.checked)

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -186,6 +186,9 @@ const AutogradingTestModal = ({
             {t("assignments.autograder.testType")}
           </legend>
           <div className="join w-full">
+            {/* daisyUI's btn-radio segmented control — not the Radio recipe,
+                and a SegmentedControl primitive stays gated on a second
+                consumer. */}
             {TYPE_OPTIONS.map((option) => (
               <input
                 key={option.value}

--- a/web/src/pages/assignments/sections/AutogradingStateField.tsx
+++ b/web/src/pages/assignments/sections/AutogradingStateField.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { Alert, FormField } from "@/components/ui"
+import { Alert, FormField, Radio } from "@/components/ui"
 import type { AssignmentForm } from "../assignmentFormModel"
 import type { AutogradingState } from "@/domain/assignments/autogradingState"
 
@@ -71,10 +71,9 @@ export function AutogradingStateField({
                       htmlFor={`${field.name}-${option}`}
                       className="flex cursor-pointer items-start justify-start gap-3"
                     >
-                      <input
+                      <Radio
                         id={`${field.name}-${option}`}
-                        type="radio"
-                        className="radio mt-1"
+                        className="mt-1"
                         name={field.name}
                         value={option}
                         checked={selected === option}

--- a/web/src/pages/assignments/sections/DetailsSection.tsx
+++ b/web/src/pages/assignments/sections/DetailsSection.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { nextAvailableSlug, slugify } from "@/util/slug"
 import { assignmentSlugBudget } from "@/util/repoNameBudget"
-import { Alert, FormField, Input, Textarea } from "@/components/ui"
+import { Alert, FormField, Input, Radio, Textarea } from "@/components/ui"
 import { GROUP_SIZE_MAX, GROUP_SIZE_MIN } from "@/types/classroom"
 import { slugBudgetError, type AssignmentForm } from "../assignmentFormModel"
 import { deriveFormShape } from "../formShape"
@@ -233,10 +233,8 @@ export function DetailsSection({
                   htmlFor={`${field.name}-${value}`}
                   className="label cursor-pointer gap-2 p-0"
                 >
-                  <input
+                  <Radio
                     id={`${field.name}-${value}`}
-                    type="radio"
-                    className="radio"
                     name={field.name}
                     value={value}
                     checked={field.state.value === value}

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -3,7 +3,7 @@ import { InlineSpinner } from "@/components/Spinner"
 import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { LinkExternalIcon, SyncIcon } from "@/components/ui/icons"
-import { Alert, Button, cx, FormField, Select } from "@/components/ui"
+import { Alert, Button, cx, FormField, Radio, Select } from "@/components/ui"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
 import { getRepo } from "@/github-core/repoReads"
 import { parseTemplateRef, repoContentsPathExists } from "@/domain/assignments"
@@ -83,10 +83,9 @@ export function RepositorySetupSection({
                       htmlFor={`${field.name}-${option}`}
                       className="flex cursor-pointer items-start justify-start gap-3"
                     >
-                      <input
+                      <Radio
                         id={`${field.name}-${option}`}
-                        type="radio"
-                        className="radio mt-1"
+                        className="mt-1"
                         name={field.name}
                         value={option}
                         checked={field.state.value === option}

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -18,7 +18,14 @@ import {
   CLASSROOM_SHORT_NAME_MAX_LEN,
   GITHUB_REPO_NAME_MAX_LEN,
 } from "@/util/repoNameBudget"
-import { Button, Card, FormField, Input, Heading } from "@/components/ui"
+import {
+  Button,
+  Card,
+  FormField,
+  Input,
+  Heading,
+  Toggle,
+} from "@/components/ui"
 
 export type CreateClassroomFormValues = {
   name: string
@@ -270,9 +277,8 @@ const CreateClassroomForm = ({
                   positive — the control IS associated. */}
               {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
               <label className="flex cursor-pointer items-start gap-3">
-                <input
-                  type="checkbox"
-                  className="toggle toggle-primary mt-0.5"
+                <Toggle
+                  className="mt-0.5"
                   checked={field.state.value}
                   onChange={(e) => {
                     const on = e.target.checked

--- a/web/src/pages/migration/SelectSourceStep.tsx
+++ b/web/src/pages/migration/SelectSourceStep.tsx
@@ -13,7 +13,7 @@ import {
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { SkeletonRegion, EmptyState } from "@/components/list"
-import { Alert, Badge, Button, Card, rtlFlip } from "@/components/ui"
+import { Alert, Badge, Button, Card, Checkbox, rtlFlip } from "@/components/ui"
 import { listClassroomsWithOrg } from "@/migration/classroomApi"
 import type { ClassroomWithOrg } from "@/migration/types"
 
@@ -109,9 +109,7 @@ export const SelectSourceStep = ({
         <p className="text-base-content/70">{t("migration.select.body")}</p>
 
         <label className="mt-2 flex w-fit cursor-pointer items-center gap-2 text-sm text-base-content/70">
-          <input
-            type="checkbox"
-            className="checkbox checkbox-sm"
+          <Checkbox
             checked={includeArchived}
             onChange={(e) => setIncludeArchived(e.target.checked)}
           />

--- a/web/src/pages/migration/migrationItemCard.tsx
+++ b/web/src/pages/migration/migrationItemCard.tsx
@@ -18,6 +18,7 @@ import {
 import {
   Badge,
   Collapse,
+  Checkbox,
   InlineMessage,
   Input,
   Spinner,
@@ -340,9 +341,8 @@ export const MigrationItemCard = ({
         </div>
         {selectable ? (
           <label className="flex shrink-0 cursor-pointer items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              className="checkbox checkbox-sm checkbox-primary"
+            <Checkbox
+              tone="primary"
               checked={selected}
               onChange={() => onToggle?.()}
             />

--- a/web/src/pages/orgMembers/RemoveConfirmDialog.tsx
+++ b/web/src/pages/orgMembers/RemoveConfirmDialog.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next"
 
-import { AnimatedAlert, FormField, Select } from "@/components/ui"
+import { AnimatedAlert, Checkbox, FormField, Select } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import { canTargetForUnenroll } from "@/util/classroomRoleUI"
 import type { OrgMemberRow } from "@/util/orgMembers"
@@ -151,9 +151,9 @@ const RemoveConfirmDialog = ({
                 checkbox there). Ticking it widens the run to the WHOLE
                 selection — the label carries the full count to say so. */}
             <label className="flex cursor-pointer items-start gap-3">
-              <input
-                type="checkbox"
-                className="checkbox checkbox-sm checkbox-error mt-0.5"
+              <Checkbox
+                tone="error"
+                className="mt-0.5"
                 checked={alsoRemoveFromOrg}
                 onChange={(e) => onAlsoRemoveFromOrgChange(e.target.checked)}
               />

--- a/web/src/pages/orgSettings/OrgActionsSection.tsx
+++ b/web/src/pages/orgSettings/OrgActionsSection.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { LinkExternalIcon } from "@/components/ui/icons"
 
-import { Badge, Spinner } from "@/components/ui"
+import { Badge, Spinner, Toggle } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import { CalloutDiv } from "@/lib/motionComponents"
 import { useToast } from "@/context/notifications/NotificationProvider"
@@ -204,10 +204,10 @@ const OrgActionsSection = ({
             htmlFor="autograde-pause-toggle"
             className="flex items-start gap-3"
           >
-            <input
+            <Toggle
               id="autograde-pause-toggle"
-              type="checkbox"
-              className="toggle toggle-warning mt-0.5"
+              tone="warning"
+              className="mt-0.5"
               checked={paused}
               disabled={toggleDisabled}
               aria-label={t("orgSettings.actions.toggleLabel")}

--- a/web/src/pages/students/PreflightRecap.tsx
+++ b/web/src/pages/students/PreflightRecap.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { Alert } from "@/components/ui"
+import { Alert, Checkbox } from "@/components/ui"
 import { ROLE_LABEL_KEY } from "@/util/classroomRoleUI"
 import type { PreflightResult } from "@/util/rosterUploadPreflight"
 
@@ -78,9 +78,8 @@ export const PreflightRecap = ({
             ))}
           </ul>
           <label className="flex items-start gap-2 text-sm">
-            <input
-              type="checkbox"
-              className="checkbox checkbox-sm mt-0.5"
+            <Checkbox
+              className="mt-0.5"
               checked={mismatchConfirmed}
               onChange={(e) =>
                 onMismatchConfirmedChange(e.currentTarget.checked)
@@ -150,9 +149,8 @@ export const PreflightRecap = ({
             </p>
           ) : null}
           <label className="flex items-start gap-2 text-sm">
-            <input
-              type="checkbox"
-              className="checkbox checkbox-sm mt-0.5"
+            <Checkbox
+              className="mt-0.5"
               checked={roleChangesConfirmed}
               onChange={(e) =>
                 onRoleChangesConfirmedChange(e.currentTarget.checked)
@@ -185,9 +183,8 @@ export const PreflightRecap = ({
             })}
           </p>
           <label className="flex items-start gap-2 text-sm">
-            <input
-              type="checkbox"
-              className="checkbox checkbox-sm mt-0.5"
+            <Checkbox
+              className="mt-0.5"
               checked={metadataConfirmed}
               onChange={(e) =>
                 onMetadataConfirmedChange(e.currentTarget.checked)

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -45,7 +45,14 @@ import {
   STATE_BADGE_TONE,
   STATE_LABEL_KEY,
 } from "@/util/classroomRoleUI"
-import { Badge, Button, EmphasisLtr, Modal, Select } from "@/components/ui"
+import {
+  Badge,
+  Button,
+  Checkbox,
+  EmphasisLtr,
+  Modal,
+  Select,
+} from "@/components/ui"
 
 // Roster-owned detail modal (single native <dialog>), opened by clicking a
 // roster row. Shares the identity header with the Org Members modal; everything
@@ -838,9 +845,8 @@ const RosterMemberModal = ({
 
                 {roleChanged && roleGrantsOwner ? (
                   <label className="flex items-start gap-2 rounded-box border border-error/30 bg-error/5 p-3 text-sm">
-                    <input
-                      type="checkbox"
-                      className="checkbox checkbox-sm mt-0.5"
+                    <Checkbox
+                      className="mt-0.5"
                       checked={roleOwnerConfirmed}
                       onChange={(e) =>
                         setRoleOwnerConfirmed(e.currentTarget.checked)

--- a/web/src/pages/students/RosterRow.tsx
+++ b/web/src/pages/students/RosterRow.tsx
@@ -1,7 +1,7 @@
 import { ChevronRightIcon } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
 import Avatar from "@/components/avatar"
-import { Badge, rtlFlip } from "@/components/ui"
+import { Badge, Checkbox, rtlFlip } from "@/components/ui"
 import { RoleBadges } from "./RoleBadges"
 import {
   CellPlaceholder,
@@ -71,9 +71,8 @@ export const RosterRow = ({
   return (
     <ClickableTr className="group/row hover:bg-base-200" onClick={open}>
       <td className="w-0">
-        <input
-          type="checkbox"
-          className="checkbox checkbox-sm size-6"
+        <Checkbox
+          className="size-6"
           aria-label={
             selfRow
               ? t("students.bulk.selfNotSelectable")


### PR DESCRIPTION
## Summary

Second slice of the app-wide DaisyUI cleanup (after #794's buttons/badges): checkboxes, radios, and toggles get primitives, so the control chrome has one source instead of ~18 inline class recipes.

- New `Checkbox` (tone: neutral/primary/error, size: sm as the house default) adopted at nine sites across seven files — roster/org-members row selection, the remove-confirm gate, the three roster-upload confirm gates, the member modal's owner gate, and the migration selection — with positional extras (`size-6` tap targets, `mt-0.5`) riding `className`. `SelectAllCheckbox`'s input now rides the same primitive, single-sourcing the tri-state chrome.
- New `Radio` (bare `radio` default; SettingsPage's `radio-sm radio-primary` pair maps to size/tone) adopted at six sites across the assignment form sections and the settings page.
- New low-level `Toggle` (primary house tone, plus the neutral/warning/sm variants the bypass sites needed): `ToggleField` renders it internally with an unchanged API, and the three files that bypassed ToggleField for divergent tones or layouts adopt `Toggle` directly.
- All label/aria wiring is verbatim; class output is byte-identical to the originals. `AutogradingTestsPane`'s btn-radio segmented control stays inline with a why-comment — a `SegmentedControl` primitive stays gated on a second consumer.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 370 files / 4668 tests, incl. new Checkbox/Radio/Toggle unit suites)
- [ ] Reviewer spot-check: roster + org-members row selection and tri-state select-all, remove-confirm and roster-upload confirm gates, settings page radios, assignment form radios/toggles, create-classroom protection toggle, org-settings autograde pause (warning tone), migration source selection. Both themes; keyboard focus rings on all three control types.
