### PR TITLE
feat(web): restyle sidebar highlight per Primer and animate collapse

### DIFF
--- a/web/src/components/drawer/AssignmentSidebarMenu.tsx
+++ b/web/src/components/drawer/AssignmentSidebarMenu.tsx
@@ -123,7 +123,7 @@ export const AssignmentSidebarMenu = ({
   return (
     <>
       {collapsed ? (
-        <div className="flex justify-center py-2 text-sm">
+        <div className="sidebar-fade-in flex justify-center py-2 text-sm">
           <Link
             to="/$org/$classroom/assignments"
             params={{ org, classroom }}
@@ -135,7 +135,7 @@ export const AssignmentSidebarMenu = ({
           </Link>
         </div>
       ) : (
-        <div className="py-4 text-sm">
+        <div className="sidebar-fade-in py-4 text-sm">
           <Link
             to="/$org/$classroom/assignments"
             params={{ org, classroom }}
@@ -151,7 +151,7 @@ export const AssignmentSidebarMenu = ({
       )}
 
       {!collapsed && (
-        <div className="py-2">
+        <div className="sidebar-fade-in py-2">
           <h3 className="font-bold leading-tight">{assignmentName}</h3>
           <p className="text-gray-400 text-sm">{t("nav.assignment")}</p>
         </div>

--- a/web/src/components/drawer/DrawerChrome.tsx
+++ b/web/src/components/drawer/DrawerChrome.tsx
@@ -145,7 +145,7 @@ export const DrawerSidebar = () => {
       </label>
       <nav
         aria-label={t("nav.primary")}
-        className={`flex flex-col min-h-full sidebar-rail text-neutral-content transition-[width] duration-200 ease-out ${
+        className={`flex flex-col min-h-full sidebar-rail text-neutral-content transition-[width] duration-200 ease-out [&>div]:transition-[padding] [&>div]:duration-200 [&>div]:ease-out ${
           collapsed
             ? "w-16 min-w-16 [&>div]:px-2"
             : "w-60 min-w-30 [&>div]:px-6"

--- a/web/src/components/drawer/SidebarFooter.tsx
+++ b/web/src/components/drawer/SidebarFooter.tsx
@@ -137,7 +137,7 @@ function SidebarInfoControls({
           )}
           {!collapsed && (
             <>
-              <span className="flex-1 text-start">
+              <span className="sidebar-fade-in flex-1 text-start">
                 {isDark ? t("nav.darkMode") : t("nav.lightMode")}
               </span>
               <ThemeToggleTrack on={isDark} />
@@ -153,7 +153,9 @@ function SidebarInfoControls({
         >
           <GlobeIcon aria-hidden="true" className="size-4" />
           {!collapsed && (
-            <span className="flex-1 text-start">{t("nav.language")}</span>
+            <span className="sidebar-fade-in flex-1 text-start">
+              {t("nav.language")}
+            </span>
           )}
         </button>
       </li>
@@ -162,7 +164,7 @@ function SidebarInfoControls({
           <Link to="/accessibility" onClick={activate(() => {})}>
             <AccessibilityIcon aria-hidden="true" className="size-4" />
             {!collapsed && (
-              <span className="flex-1 text-start">
+              <span className="sidebar-fade-in flex-1 text-start">
                 {t("nav.accessibility")}
               </span>
             )}
@@ -179,7 +181,9 @@ function SidebarInfoControls({
         >
           <BookIcon aria-hidden="true" className="size-4" />
           {!collapsed && (
-            <span className="flex-1 text-start">{t("nav.docs")}</span>
+            <span className="sidebar-fade-in flex-1 text-start">
+              {t("nav.docs")}
+            </span>
           )}
         </a>
       </li>
@@ -191,7 +195,9 @@ function SidebarInfoControls({
         >
           <InfoIcon aria-hidden="true" className="size-4" />
           {!collapsed && (
-            <span className="flex-1 text-start">{t("nav.about")}</span>
+            <span className="sidebar-fade-in flex-1 text-start">
+              {t("nav.about")}
+            </span>
           )}
         </button>
       </li>
@@ -349,17 +355,17 @@ const AuthedSidebarFooter = () => {
           {collapsed ? (
             <MarkGithubIcon
               aria-hidden="true"
-              className="size-4 shrink-0 opacity-80"
+              className="sidebar-fade-in size-4 shrink-0 opacity-80"
             />
           ) : (
-            <>
+            <span className="sidebar-fade-in block">
               <span className="block text-[0.625rem] font-medium uppercase tracking-wide text-neutral-content/50">
                 {t("classes.githubOrganization")}
               </span>
               <span className="block break-words font-mono text-xs font-semibold text-neutral-content">
                 {org}
               </span>
-            </>
+            </span>
           )}
         </a>
       ) : null}
@@ -479,14 +485,14 @@ const AuthedSidebarFooter = () => {
             <img
               src={avatar_img}
               alt={t("nav.avatarAlt", { name })}
-              className={`rounded-full ${collapsed ? "w-7" : "w-8"}`}
+              className={`rounded-full transition-[width] duration-200 ease-out ${collapsed ? "w-7" : "w-8"}`}
             />
           </div>
 
           {collapsed && <DeployEnvBadge />}
 
           {!collapsed && (
-            <div className="min-w-0 flex-1">
+            <div className="sidebar-fade-in min-w-0 flex-1">
               <div className="truncate text-sm font-medium text-neutral-content">
                 {name}
               </div>

--- a/web/src/components/drawer/primitives.tsx
+++ b/web/src/components/drawer/primitives.tsx
@@ -67,7 +67,9 @@ export const SidebarItemBody = ({
         />
       )}
       <span className="relative z-10 shrink-0">{icon}</span>
-      {!collapsed && <span className="relative z-10 truncate">{label}</span>}
+      {!collapsed && (
+        <span className="sidebar-fade-in relative z-10 truncate">{label}</span>
+      )}
     </span>
   )
 }
@@ -99,7 +101,7 @@ export const ClassroomLogo = () => {
         <button
           type="button"
           onClick={toggle}
-          className={`${sidebarTooltip} cursor-pointer rounded-selector p-1 transition-colors hover:bg-[var(--sidebar-surface)]`}
+          className={`${sidebarTooltip} sidebar-fade-in cursor-pointer rounded-selector p-1 transition-colors hover:bg-[var(--sidebar-surface)]`}
           data-tip={t("nav.expandSidebar")}
           aria-label={t("nav.expandSidebar")}
         >
@@ -116,7 +118,7 @@ export const ClassroomLogo = () => {
     <div className="flex items-center gap-2 px-6 py-6 border-b-1 border-neutral-content/20">
       <Link
         to="/"
-        className="flex flex-1 min-w-0 items-center text-lg text-neutral-content font-bold"
+        className="sidebar-fade-in flex flex-1 min-w-0 items-center text-lg text-neutral-content font-bold"
         title={t("nav.appName")}
       >
         <MortarBoardIcon
@@ -128,7 +130,7 @@ export const ClassroomLogo = () => {
       <button
         type="button"
         onClick={toggle}
-        className="shrink-0 rounded-selector p-1 text-neutral-content/60 transition-colors hover:bg-[var(--sidebar-surface)] hover:text-neutral-content cursor-pointer"
+        className="sidebar-fade-in shrink-0 rounded-selector p-1 text-neutral-content/60 transition-colors hover:bg-[var(--sidebar-surface)] hover:text-neutral-content cursor-pointer"
         aria-label={t("nav.collapseSidebar")}
         title={t("nav.collapseSidebar")}
       >
@@ -144,7 +146,7 @@ export const ExpandSidebarButton = () => {
   if (!collapsed) return null
 
   return (
-    <div className="flex justify-center py-2">
+    <div className="sidebar-fade-in flex justify-center py-2">
       <button
         type="button"
         onClick={toggle}
@@ -164,7 +166,7 @@ export const AllClasses = ({ org }: { org: string }) => {
 
   if (collapsed) {
     return (
-      <div className="flex justify-center py-2 text-sm">
+      <div className="sidebar-fade-in flex justify-center py-2 text-sm">
         <Link
           to="/$org/classes"
           params={{ org }}
@@ -179,7 +181,7 @@ export const AllClasses = ({ org }: { org: string }) => {
   }
 
   return (
-    <div className="py-4 text-sm">
+    <div className="sidebar-fade-in py-4 text-sm">
       <Link
         to="/$org/classes"
         params={{ org }}
@@ -210,7 +212,7 @@ export const SidebarClassInfo = ({
   if (collapsed) return null
 
   return (
-    <div className="py-2">
+    <div className="sidebar-fade-in py-2">
       <h3 className="font-bold">
         {classInfo?.name ||
           classInfo?.short_name ||

--- a/web/src/components/drawer/sidebarClasses.ts
+++ b/web/src/components/drawer/sidebarClasses.ts
@@ -1,22 +1,23 @@
 // Sidebar class-name recipes (dark rail). Single source so a token rename lands once.
 
-// Row layout only. The active surface (accent border + filled background) is a
+// Row layout only. The active surface (selected background + accent bar) is a
 // separate shared-`layoutId` pill (see `sidebarActivePillClass`) that glides
 // between rows, so the row keeps just its box + a hover hint for inactive rows.
+// rounded-field is Primer's borderRadius-medium — NavList items are 6px, not
+// the 12px box radius.
 export const navItemClass = (active: boolean, collapsed: boolean) =>
-  `relative flex items-center gap-2 rounded-box px-2 py-2 ${
+  `relative flex items-center gap-2 rounded-field px-2 py-2 ${
     collapsed ? "justify-center" : ""
-  } ${
-    active
-      ? ""
-      : "rounded-box transition-colors hover:bg-[var(--sidebar-surface)]/60"
-  }`
+  } ${active ? "" : "transition-colors hover:bg-[var(--sidebar-surface)]/60"}`
 
-// The gliding active pill: fills the row with the accent left-border + surface.
-// Rendered as an absolutely-positioned sibling behind the row content and shared
-// across rows by `layoutId`, so page switches FLIP-tween it into place.
+// The gliding active pill, styled per Primer's NavList current item: a subtle
+// selected surface plus a short 4x24px pill-shaped accent bar vertically
+// centered in the start gutter (Primer draws it at inline-start -8px). The bar
+// is a `before:` pseudo so it rides along with the FLIP tween. Rendered as an
+// absolutely-positioned sibling behind the row content and shared across rows
+// by `layoutId`, so page switches FLIP-tween it into place.
 export const sidebarActivePillClass =
-  "absolute inset-0 rounded-box border-s-2 border-[var(--sidebar-accent)] bg-[var(--sidebar-surface)]"
+  "absolute inset-0 rounded-field bg-[var(--sidebar-surface)] before:absolute before:-start-2 before:top-1/2 before:h-6 before:w-1 before:-translate-y-1/2 before:rounded-full before:bg-[var(--sidebar-active-accent)] before:content-['']"
 
 // Shared sidebar tooltip tokens (dark rail): bubble + text colors every
 // collapsed-sidebar tooltip uses.

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -119,17 +119,19 @@
 }
 
 /* Sidebar accent tokens. The rail/text follow daisyUI `neutral` (deep neutral
-   gray); the logo mark and the active-row border keep to the neutral family —
-   a soft white derived from the rail's own text color (decorative, non-text) —
-   and the active/hover surface is a lifted neutral sheet. Dark uses the same
-   soft-white accent over a translucent sheet. Consumed via arbitrary values in
-   components/drawer. */
+   gray); the logo mark keeps to the neutral family — a soft white derived from
+   the rail's own text color (decorative, non-text) — and the active/hover
+   surface is a lifted neutral sheet (Dark uses a translucent sheet). The
+   active-row bar follows Primer's NavList current-item indicator
+   (fgColor-accent); the rail is a dark surface in BOTH themes, so both take
+   Primer's dark value. Consumed via arbitrary values in components/drawer. */
 [data-theme="sumi"] {
   --sidebar-accent: color-mix(
     in oklab,
     var(--color-neutral-content) 88%,
     transparent
   );
+  --sidebar-active-accent: #4493f8; /* fgColor-accent (dark) */
   --sidebar-surface: #3d444d;
 }
 [data-theme="sumi-dark"] {
@@ -138,6 +140,7 @@
     var(--color-neutral-content) 88%,
     transparent
   );
+  --sidebar-active-accent: #4493f8; /* fgColor-accent (dark) */
   --sidebar-surface: color-mix(
     in oklch,
     var(--color-neutral-content) 10%,
@@ -145,25 +148,8 @@
   );
 }
 
-/* Drawer rest-dim. The rail sits a notch darker than `neutral` while the
-   pointer is elsewhere, so the chrome recedes and page content is the focus;
-   hovering (or keyboard focus landing inside) lifts it back to full. Dimming
-   the SURFACE darker — never the text — is the AA-safe rendition: light rail
-   text on a darker ground gains contrast, so the guarded resting pairs only
-   improve (contrastModel.ts audits the dimmed rail too). Scoped to
-   hover-capable pointers so touch devices always get the full-brightness rail. */
 .sidebar-rail {
   background-color: var(--color-neutral);
-}
-@media (hover: hover) {
-  .sidebar-rail {
-    background-color: color-mix(in oklab, var(--color-neutral) 90%, black);
-    transition: background-color var(--duration-slow) var(--ease-out-soft);
-  }
-  .sidebar-rail:hover,
-  .sidebar-rail:focus-within {
-    background-color: var(--color-neutral);
-  }
 }
 
 /* Design tokens: typography (Primer primitives) and motion. Motion timing is
@@ -282,6 +268,21 @@ body {
 @keyframes shimmer {
   100% {
     transform: translateX(100%);
+  }
+}
+
+/* Sidebar collapse/expand content fade. The rail's width tweens via
+   transition-[width] (DrawerChrome), but the labels and per-state variants
+   that MOUNT on a toggle would otherwise pop in at t=0 — this short mount
+   fade eases them in alongside the width. The global reduced-motion guard
+   below zeroes it. */
+@utility sidebar-fade-in {
+  animation: sidebar-fade-in var(--duration-slow) var(--ease-out-soft) both;
+}
+
+@keyframes sidebar-fade-in {
+  from {
+    opacity: 0;
   }
 }
 

--- a/web/src/util/a11y/contrastModel.ts
+++ b/web/src/util/a11y/contrastModel.ts
@@ -42,12 +42,6 @@ export type Kind = "text" | "nonText"
 export const MODELED_BASE_CONTENT_TIERS = [30, 40, 50, 60, 70, 80, 90] as const
 export const MODELED_NEUTRAL_CONTENT_TIERS = [50, 60, 70] as const
 
-// Rest-dim factor for the sidebar rail (index.css .sidebar-rail): the rail
-// background sits at this % of `neutral` mixed toward black until hovered or
-// focused. The drift guard in contrastSource.test.ts asserts the CSS recipe
-// uses the same factor, so the audited pair can't silently diverge.
-export const SIDEBAR_REST_DIM = 90
-
 // Semantic text tokens modeled as body text on a base surface (the `text-<name>`
 // pairs built in buildTheme). The coverage guard (contrastSource.test.ts) scans
 // src/** for `text-<name>` utilities and fails if a used one is absent here, so
@@ -337,19 +331,6 @@ function buildTheme(theme: Theme): Pair[] {
     "neutral-content (hover) on sidebar surface",
     opaque(T.neutralContent),
     sidebarSurface,
-    "body",
-  )
-
-  // Rest-dimmed rail (index.css .sidebar-rail): on hover-capable pointers the
-  // rail background darkens to SIDEBAR_REST_DIM% of `neutral` toward black
-  // until hovered or focused. Text stays at the resting 72% tier, so audit
-  // that text over the dimmed surface — the darkest ground rail text ever
-  // sits on.
-  add(
-    "sidebar-rest-dim",
-    `neutral-content resting tiers (rendered ${T.sidebarMuted}%) on rest-dimmed rail`,
-    tierFg(T.neutralContent, T.sidebarMuted),
-    mixColor("oklab", T.neutral, SIDEBAR_REST_DIM, "black"),
     "body",
   )
 

--- a/web/src/util/a11y/contrastSource.test.ts
+++ b/web/src/util/a11y/contrastSource.test.ts
@@ -9,7 +9,6 @@ import {
   MODELED_BASE_CONTENT_TIERS,
   MODELED_NEUTRAL_CONTENT_TIERS,
   MODELED_TEXT_SEMANTICS,
-  SIDEBAR_REST_DIM,
   SUMI,
 } from "./contrastModel"
 
@@ -105,15 +104,6 @@ describe("model tokens stay in sync with index.css (drift guard)", () => {
         expect(parseInt(css as string, 10)).toBe(map[pct])
       }
     }
-  })
-
-  it("sidebar rest-dim factor matches the .sidebar-rail recipe", () => {
-    // The model audits the dimmed rail at SIDEBAR_REST_DIM% of `neutral`
-    // toward black; the CSS recipe must mix by the same factor or the
-    // audited pair diverges from what the browser renders.
-    expect(cssText).toContain(
-      `color-mix(in oklab, var(--color-neutral) ${SIDEBAR_REST_DIM}%, black)`,
-    )
   })
 })
 


### PR DESCRIPTION
## Summary

- Restyles the sidebar active-row highlight to match Primer's NavList current item: a subtle selected surface with the 6px item radius (borderRadius-medium) plus a short 4x24px pill-shaped accent bar in `fgColor-accent` blue, vertically centered in the start gutter. The bar rides along with the existing shared-`layoutId` FLIP glide between rows.
- Animates the drawer collapse/expand: the rail width already tweened, but labels and per-state variants popped in at t=0 — they now ease in via a new `sidebar-fade-in` mount fade (zeroed by the global reduced-motion guard), and the section padding tweens alongside the width.
- Removes the rail hover rest-dim (the drawer no longer sits darker and brightens on hover), and drops the corresponding `sidebar-rest-dim` audit pair and its drift-guard test — the dimmed rail was the darkest ground, so the remaining audited rail pairs are unaffected.

## Test plan

- [ ] Toggle between Roster/Assignments/Settings: the blue accent bar and selected surface glide between rows.
- [ ] Collapse and expand the rail: width, padding, and content fade animate together; reduced-motion disables the fade.
- [ ] Hover the rail: background stays constant; row hover hint still works.
- [ ] `npm run check` passes (contrast/VPAT guards included).