### PR TITLE
refactor(web): extend TableShell and sweep the raw table recipes

### DIFF
--- a/web/src/components/SubmitUpload.tsx
+++ b/web/src/components/SubmitUpload.tsx
@@ -8,6 +8,7 @@ import {
   FileDropzone,
   Modal,
   ModalIcon,
+  TableShell,
   type PickedFile,
 } from "@/components/ui"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
@@ -206,50 +207,47 @@ export function SubmitUpload({
               </div>
 
               {/* Name / Size / Remove table (folder drops show their path). */}
-              <div className="overflow-hidden rounded-box border border-base-200">
-                <table className="table table-sm">
-                  <thead>
-                    <tr>
-                      <th>{t("submissions.student.upload.colName")}</th>
-                      <th className="w-24">
-                        {t("submissions.student.upload.colSize")}
-                      </th>
-                      <th className="w-10 text-end sr-only">
-                        {t("submissions.student.upload.colRemove")}
-                      </th>
+              <TableShell animate={false} size="sm">
+                <thead>
+                  <tr>
+                    <th>{t("submissions.student.upload.colName")}</th>
+                    <th className="w-24">
+                      {t("submissions.student.upload.colSize")}
+                    </th>
+                    <th className="w-10 text-end sr-only">
+                      {t("submissions.student.upload.colRemove")}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {picked.map((p) => (
+                    <tr key={p.key}>
+                      <td className="max-w-0">
+                        <span className="block truncate font-mono">
+                          {p.path}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap tabular-nums text-base-content/70">
+                        {formatBytes(p.file.size)}
+                      </td>
+                      <td className="text-end">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          shape="square"
+                          aria-label={t("submissions.student.upload.remove", {
+                            path: p.path,
+                          })}
+                          disabled={submitting}
+                          onClick={() => removeAt(p.key)}
+                        >
+                          <XIcon aria-hidden="true" className="size-4" />
+                        </Button>
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody>
-                    {picked.map((p) => (
-                      <tr key={p.key}>
-                        <td className="max-w-0">
-                          <span className="block truncate font-mono">
-                            {p.path}
-                          </span>
-                        </td>
-                        <td className="whitespace-nowrap tabular-nums text-base-content/70">
-                          {formatBytes(p.file.size)}
-                        </td>
-                        <td className="text-end">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            shape="square"
-                            aria-label={t("submissions.student.upload.remove", {
-                              path: p.path,
-                            })}
-                            disabled={submitting}
-                            onClick={() => removeAt(p.key)}
-                          >
-                            <XIcon aria-hidden="true" className="size-4" />
-                          </Button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-
+                  ))}
+                </tbody>
+              </TableShell>
               <Alert tone="warning">
                 <div>
                   {t("submissions.student.upload.confirmBody", {

--- a/web/src/components/bulk/resultView.tsx
+++ b/web/src/components/bulk/resultView.tsx
@@ -6,7 +6,7 @@
 
 import { useTranslation } from "react-i18next"
 
-import { Button, Spinner } from "@/components/ui"
+import { Button, Spinner, TableShell } from "@/components/ui"
 
 // The lifecycle of a bulk run's modal: idle (closed) -> working (progress) ->
 // complete/error (results).
@@ -34,20 +34,22 @@ export const BulkResultSection = ({
 }) => (
   <div>
     <h4 className="mb-2 font-semibold">{title}</h4>
-    <div className="max-h-48 overflow-auto rounded-box border border-base-300">
-      <table className="table table-sm">
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.key}>
-              <td>
-                <code>{row.label}</code>
-              </td>
-              <td className="opacity-70">{row.detail}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <TableShell
+      animate={false}
+      size="sm"
+      frameClassName="max-h-48 overflow-auto"
+    >
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.key}>
+            <td>
+              <code>{row.label}</code>
+            </td>
+            <td className="opacity-70">{row.detail}</td>
+          </tr>
+        ))}
+      </tbody>
+    </TableShell>
   </div>
 )
 

--- a/web/src/components/ui/TableShell.test.tsx
+++ b/web/src/components/ui/TableShell.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/react"
+
+import { TableShell } from "./TableShell"
+
+afterEach(cleanup)
+
+const body = (
+  <tbody>
+    <tr>
+      <td>cell</td>
+    </tr>
+  </tbody>
+)
+
+describe("TableShell", () => {
+  it("renders the full-size house table inside the framed box by default", () => {
+    const { container } = render(<TableShell animate={false}>{body}</TableShell>)
+    const frame = container.firstElementChild as HTMLElement
+    expect(frame.className).toContain("overflow-x-auto")
+    expect(frame.className).toContain("border-base-300")
+    const table = frame.querySelector("table") as HTMLTableElement
+    expect(table.className).toContain("table")
+    expect(table.className).not.toContain("table-sm")
+  })
+
+  it("adds table-sm for the compact density", () => {
+    const { container } = render(
+      <TableShell animate={false} size="sm">
+        {body}
+      </TableShell>,
+    )
+    expect(container.querySelector("table")?.className).toContain("table-sm")
+  })
+
+  it("merges frameClassName onto the frame, not the table", () => {
+    const { container } = render(
+      <TableShell animate={false} frameClassName="max-h-48 overflow-auto">
+        {body}
+      </TableShell>,
+    )
+    const frame = container.firstElementChild as HTMLElement
+    expect(frame.className).toContain("max-h-48")
+    expect(frame.className).toContain("overflow-auto")
+    expect(container.querySelector("table")?.className).not.toContain("max-h-48")
+  })
+
+  it("keeps aria-busy and the padded recipe unchanged", () => {
+    const { container } = render(
+      <TableShell animate={false} ariaBusy padded>
+        {body}
+      </TableShell>,
+    )
+    const table = container.querySelector("table") as HTMLTableElement
+    expect(table.getAttribute("aria-busy")).toBe("true")
+    expect(table.className).toContain("[&_tbody_td]:py-4")
+  })
+})

--- a/web/src/components/ui/TableShell.test.tsx
+++ b/web/src/components/ui/TableShell.test.tsx
@@ -16,7 +16,9 @@ const body = (
 
 describe("TableShell", () => {
   it("renders the full-size house table inside the framed box by default", () => {
-    const { container } = render(<TableShell animate={false}>{body}</TableShell>)
+    const { container } = render(
+      <TableShell animate={false}>{body}</TableShell>,
+    )
     const frame = container.firstElementChild as HTMLElement
     expect(frame.className).toContain("overflow-x-auto")
     expect(frame.className).toContain("border-base-300")
@@ -43,7 +45,9 @@ describe("TableShell", () => {
     const frame = container.firstElementChild as HTMLElement
     expect(frame.className).toContain("max-h-48")
     expect(frame.className).toContain("overflow-auto")
-    expect(container.querySelector("table")?.className).not.toContain("max-h-48")
+    expect(container.querySelector("table")?.className).not.toContain(
+      "max-h-48",
+    )
   })
 
   it("keeps aria-busy and the padded recipe unchanged", () => {

--- a/web/src/components/ui/TableShell.tsx
+++ b/web/src/components/ui/TableShell.tsx
@@ -12,6 +12,9 @@ import { cx } from "./cx"
 export type TableShellProps = {
   children: ReactNode
   ariaBusy?: boolean
+  // Compact density (`table-sm`) for embedded/preview tables; md is the
+  // full-size list default.
+  size?: "sm" | "md"
   // Roomier tbody cell padding — the assignment lists' at-rest row separation.
   padded?: boolean
   // Scale-up entrance; disable when an ancestor already animates the block
@@ -22,23 +25,32 @@ export type TableShellProps = {
   // Rendered inside the frame after the table (e.g. a pagination bar).
   footer?: ReactNode
   className?: string
+  // Merged onto the frame div — for a vertical scroll cap
+  // (`max-h-48 overflow-auto`) the base recipe can't express. The frame
+  // itself stays single-sourced here.
+  frameClassName?: string
 }
 
 export function TableShell({
   children,
   ariaBusy,
+  size = "md",
   padded = false,
   animate = true,
   header,
   footer,
   className,
+  frameClassName,
 }: TableShellProps) {
-  const frameClass =
-    "overflow-x-auto rounded-box border border-base-300 bg-base-100"
+  const frameClass = cx(
+    "overflow-x-auto rounded-box border border-base-300 bg-base-100",
+    frameClassName,
+  )
   const table = (
     <table
       className={cx(
         "table [&_tr]:border-base-content/10 [&_thead_tr]:bg-base-200",
+        size === "sm" && "table-sm",
         padded && "[&_tbody_td]:py-4",
         className,
       )}

--- a/web/src/pages/accessibility/ContrastSection.tsx
+++ b/web/src/pages/accessibility/ContrastSection.tsx
@@ -162,6 +162,8 @@ function ThemeTable({
   return (
     <Card shadow={false}>
       <Card.Body className="gap-3 p-4">
+        {/* Deliberately not TableShell: the table already sits inside a Card,
+            and the shell's framed box would double-frame it. */}
         <div className="overflow-x-auto">
           <table className="table table-sm">
             <thead>

--- a/web/src/pages/accessibility/VpatSection.tsx
+++ b/web/src/pages/accessibility/VpatSection.tsx
@@ -95,6 +95,9 @@ function VpatConformanceTable({
             {t("accessibility.vpat.empty")}
           </div>
         ) : (
+          // Deliberately not TableShell: the VPAT matrix is long-form document
+          // content on the public accessibility statement, where the boxed
+          // list-frame treatment would read as UI chrome.
           <div className="overflow-x-auto">
             <table className="table w-full">
               <thead>

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react"
 import { EmptyState } from "@/components/list"
 import { useTranslation } from "react-i18next"
 
-import { Alert, SkeletonRows, Toolbar } from "@/components/ui"
+import { Alert, SkeletonRows, TableShell, Toolbar } from "@/components/ui"
 import { RoleBadges } from "./RoleBadges"
 import { StudentSortSelect } from "./StudentSortSelect"
 import { coerceImportRole } from "./rosterImportParse"
@@ -57,59 +57,55 @@ const CsvRosterView = ({
         </Toolbar>
       ) : null}
 
-      <div className="overflow-x-auto rounded-box border border-base-300 bg-base-100">
-        <table className="table" aria-busy={loading || undefined}>
-          <caption className="sr-only">
-            {t("students.csvRoster.caption")}
-          </caption>
-          <thead>
+      <TableShell animate={false} ariaBusy={loading}>
+        <caption className="sr-only">{t("students.csvRoster.caption")}</caption>
+        <thead>
+          <tr>
+            <th scope="col">{t("students.csvRoster.colName")}</th>
+            <th scope="col">{t("students.csvRoster.colSection")}</th>
+            <th scope="col">{t("students.csvRoster.colRole")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading ? (
+            <SkeletonRows rows={3} bars={["w-40", "w-16", "w-20"]} />
+          ) : rows.length === 0 ? (
             <tr>
-              <th scope="col">{t("students.csvRoster.colName")}</th>
-              <th scope="col">{t("students.csvRoster.colSection")}</th>
-              <th scope="col">{t("students.csvRoster.colRole")}</th>
+              <td colSpan={3}>
+                <EmptyState
+                  variant="bare"
+                  body={t("students.csvRoster.empty")}
+                />
+              </td>
             </tr>
-          </thead>
-          <tbody>
-            {loading ? (
-              <SkeletonRows rows={3} bars={["w-40", "w-16", "w-20"]} />
-            ) : rows.length === 0 ? (
-              <tr>
-                <td colSpan={3}>
-                  <EmptyState
-                    variant="bare"
-                    body={t("students.csvRoster.empty")}
+          ) : (
+            rows.map((student) => (
+              // studentKey falls back to the email, so two pending invites
+              // don't collide on an empty key.
+              <tr key={studentKey(student)}>
+                <td>
+                  <div className="font-bold">{displayName(student)}</div>
+                  {student.username ? (
+                    <div className="font-mono text-xs text-base-content/70">
+                      {student.username}
+                    </div>
+                  ) : student.email ? (
+                    <div className="text-xs text-base-content/70">
+                      {t("students.csvRoster.invitePending")}
+                    </div>
+                  ) : null}
+                </td>
+                <td>{student.section || "—"}</td>
+                <td>
+                  <RoleBadges
+                    roles={[coerceImportRole(student.role) ?? "student"]}
                   />
                 </td>
               </tr>
-            ) : (
-              rows.map((student) => (
-                // studentKey falls back to the email, so two pending invites
-                // don't collide on an empty key.
-                <tr key={studentKey(student)}>
-                  <td>
-                    <div className="font-bold">{displayName(student)}</div>
-                    {student.username ? (
-                      <div className="font-mono text-xs text-base-content/70">
-                        {student.username}
-                      </div>
-                    ) : student.email ? (
-                      <div className="text-xs text-base-content/70">
-                        {t("students.csvRoster.invitePending")}
-                      </div>
-                    ) : null}
-                  </td>
-                  <td>{student.section || "—"}</td>
-                  <td>
-                    <RoleBadges
-                      roles={[coerceImportRole(student.role) ?? "student"]}
-                    />
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+            ))
+          )}
+        </tbody>
+      </TableShell>
     </div>
   )
 }

--- a/web/src/pages/students/RosterImportResult.tsx
+++ b/web/src/pages/students/RosterImportResult.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { Alert } from "@/components/ui"
+import { Alert, TableShell } from "@/components/ui"
 import { ROLE_LABEL_KEY } from "@/util/classroomRoleUI"
 import type {
   BulkImportResult,
@@ -73,20 +73,22 @@ const ImportResultSection = ({
     <div>
       <h4 className="font-bold mb-2">{title}</h4>
 
-      <div className="max-h-48 overflow-auto rounded-box border border-base-300">
-        <table className="table table-sm">
-          <tbody>
-            {rows.map((row) => (
-              <tr key={row.key}>
-                <td>
-                  <code>{row.key}</code>
-                </td>
-                <td className="opacity-70">{row.detail}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <TableShell
+        animate={false}
+        size="sm"
+        frameClassName="max-h-48 overflow-auto"
+      >
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.key}>
+              <td>
+                <code>{row.key}</code>
+              </td>
+              <td className="opacity-70">{row.detail}</td>
+            </tr>
+          ))}
+        </tbody>
+      </TableShell>
     </div>
   )
 }

--- a/web/src/pages/students/RosterPreviewTable.tsx
+++ b/web/src/pages/students/RosterPreviewTable.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { Badge, Select, SkeletonCell } from "@/components/ui"
+import { Badge, Select, SkeletonCell, TableShell } from "@/components/ui"
 import type { ClassroomRole } from "@/util/teamRoster"
 import {
   ROLE_LABEL_KEY,
@@ -177,112 +177,110 @@ export const RosterPreviewTable = ({
     length: skeletonRowCount ?? rows.length,
   })
   return (
-    <div className="max-h-80 overflow-auto rounded-box border border-base-300">
-      <table className="table table-sm" aria-busy={loading || undefined}>
-        <thead>
-          <tr>
-            <th scope="col">#</th>
-            <th scope="col">{t("students.githubUsernameColumn")}</th>
-            <th scope="col">{t("students.nameColumn")}</th>
-            <th scope="col">{t("students.emailColumn")}</th>
-            <th scope="col">{t("students.sectionColumn")}</th>
-            <th scope="col">{t("students.roleColumn")}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {loading
-            ? skeletonRows.map((_, index) => (
-                <tr key={`skeleton-${index}`} aria-hidden="true">
+    <TableShell
+      animate={false}
+      size="sm"
+      frameClassName="max-h-80 overflow-auto"
+      ariaBusy={loading}
+    >
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col">{t("students.githubUsernameColumn")}</th>
+          <th scope="col">{t("students.nameColumn")}</th>
+          <th scope="col">{t("students.emailColumn")}</th>
+          <th scope="col">{t("students.sectionColumn")}</th>
+          <th scope="col">{t("students.roleColumn")}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {loading
+          ? skeletonRows.map((_, index) => (
+              <tr key={`skeleton-${index}`} aria-hidden="true">
+                <td>{index + 1}</td>
+                <SkeletonCell bar="h-4 w-24" />
+                <SkeletonCell bar="h-4 w-28" />
+                <SkeletonCell bar="h-4 w-40" />
+                <SkeletonCell bar="h-4 w-16" />
+                <SkeletonCell bar="h-8 w-32" />
+              </tr>
+            ))
+          : rows.map((row, index) => {
+              const key = identityKey(row.identity)
+              const rowChanges = changes[key] ?? []
+              const roleChange = roleChanges[key]
+              const identityChange = identityChanges[key]
+              const changed =
+                rowChanges.length > 0 ||
+                Boolean(roleChange) ||
+                Boolean(identityChange)
+              return (
+                <tr key={key} className={changed ? "bg-warning/10" : undefined}>
                   <td>{index + 1}</td>
-                  <SkeletonCell bar="h-4 w-24" />
-                  <SkeletonCell bar="h-4 w-28" />
-                  <SkeletonCell bar="h-4 w-40" />
-                  <SkeletonCell bar="h-4 w-16" />
-                  <SkeletonCell bar="h-8 w-32" />
-                </tr>
-              ))
-            : rows.map((row, index) => {
-                const key = identityKey(row.identity)
-                const rowChanges = changes[key] ?? []
-                const roleChange = roleChanges[key]
-                const identityChange = identityChanges[key]
-                const changed =
-                  rowChanges.length > 0 ||
-                  Boolean(roleChange) ||
-                  Boolean(identityChange)
-                return (
-                  <tr
-                    key={key}
-                    className={changed ? "bg-warning/10" : undefined}
-                  >
-                    <td>{index + 1}</td>
-                    <IdentityCell
-                      row={row}
-                      declaredUsername={identityChange?.declaredUsername}
-                      alreadyOnRoster={alreadyOnRosterKeys?.has(key)}
-                    />
-                    <PreviewCell
-                      value={[row.first_name, row.last_name]
-                        .filter(Boolean)
-                        .join(" ")}
-                      changes={rowChanges}
-                      cell="name"
-                    />
-                    <PreviewCell
-                      value={row.email ?? ""}
-                      changes={rowChanges}
-                      cell="email"
-                    />
-                    <PreviewCell
-                      value={row.section ?? ""}
-                      changes={rowChanges}
-                      cell="section"
-                    />
-                    <td className={roleChange ? CHANGED_CELL_CLASS : undefined}>
-                      {/* Highlight the cell like the other changed columns, but show
+                  <IdentityCell
+                    row={row}
+                    declaredUsername={identityChange?.declaredUsername}
+                    alreadyOnRoster={alreadyOnRosterKeys?.has(key)}
+                  />
+                  <PreviewCell
+                    value={[row.first_name, row.last_name]
+                      .filter(Boolean)
+                      .join(" ")}
+                    changes={rowChanges}
+                    cell="name"
+                  />
+                  <PreviewCell
+                    value={row.email ?? ""}
+                    changes={rowChanges}
+                    cell="email"
+                  />
+                  <PreviewCell
+                    value={row.section ?? ""}
+                    changes={rowChanges}
+                    cell="section"
+                  />
+                  <td className={roleChange ? CHANGED_CELL_CLASS : undefined}>
+                    {/* Highlight the cell like the other changed columns, but show
                       the role change as an inline "was <role>" hint rather than a
                       hover tooltip — a tooltip fights the native Select dropdown
                       and overlaps it. The Select already shows the new role. */}
-                      <div className="flex flex-col gap-0.5">
-                        <Select
-                          selectSize="xs"
-                          className="w-32"
-                          aria-label={t("students.assignRoleLabel")}
-                          value={rolesByUser[key] ?? "student"}
-                          onChange={(e) => {
-                            // Read the value synchronously — React nulls the event's
-                            // currentTarget after the handler returns, so a deferred
-                            // setState updater must not touch `e`.
-                            const role =
-                              coerceImportRole(e.target.value) ?? "student"
-                            onRoleChange(key, role)
-                          }}
-                        >
-                          <option value="student">
-                            {t("students.roleStudent")}
-                          </option>
-                          <option value="ta">{t("students.roleTa")}</option>
-                          <option value="hta">
-                            {t("students.roleHeadTa")}
-                          </option>
-                          <option value="teacher">
-                            {t("students.roleTeacher")}
-                          </option>
-                        </Select>
-                        {roleChange ? (
-                          <span className="text-xs opacity-70">
-                            {t("students.rolePreviousHint", {
-                              role: t(ROLE_LABEL_KEY[roleChange.from]),
-                            })}
-                          </span>
-                        ) : null}
-                      </div>
-                    </td>
-                  </tr>
-                )
-              })}
-        </tbody>
-      </table>
-    </div>
+                    <div className="flex flex-col gap-0.5">
+                      <Select
+                        selectSize="xs"
+                        className="w-32"
+                        aria-label={t("students.assignRoleLabel")}
+                        value={rolesByUser[key] ?? "student"}
+                        onChange={(e) => {
+                          // Read the value synchronously — React nulls the event's
+                          // currentTarget after the handler returns, so a deferred
+                          // setState updater must not touch `e`.
+                          const role =
+                            coerceImportRole(e.target.value) ?? "student"
+                          onRoleChange(key, role)
+                        }}
+                      >
+                        <option value="student">
+                          {t("students.roleStudent")}
+                        </option>
+                        <option value="ta">{t("students.roleTa")}</option>
+                        <option value="hta">{t("students.roleHeadTa")}</option>
+                        <option value="teacher">
+                          {t("students.roleTeacher")}
+                        </option>
+                      </Select>
+                      {roleChange ? (
+                        <span className="text-xs opacity-70">
+                          {t("students.rolePreviousHint", {
+                            role: t(ROLE_LABEL_KEY[roleChange.from]),
+                          })}
+                        </span>
+                      ) : null}
+                    </div>
+                  </td>
+                </tr>
+              )
+            })}
+      </tbody>
+    </TableShell>
   )
 }


### PR DESCRIPTION
## Summary

Final slice of the app-wide DaisyUI cleanup (after #794 buttons/badges and #795 form controls): the framed preview tables converge on `TableShell`, so the list-box treatment — frame, muted header row, house divider strength — has one source. This slice deliberately *aligns* styling, so it's the most visually-affecting of the three; the spot-check below is the real review.

- `TableShell` gains `size="sm"` (the embedded/preview density) and `frameClassName` (vertical scroll caps like `max-h-48 overflow-auto` land on the frame div without hand-rolling the recipe), plus its first unit tests.
- Four tables adopt it with their exact scroll caps and density intact: the roster upload preview (`max-h-80`), the import-result and bulk-result sections (`max-h-48`), and the roster page's CSV view. All render without the entrance animation (modal or static contexts). They gain the house header/divider treatment — the intended visual change.
- `SubmitUpload`'s student upload preview aligns to the standard frame (`border-base-300`; its lighter `border-base-200` was a one-off). Two deliberate holdouts stay frameless with why-comments: the VPAT matrix (long-form document content on the public accessibility statement, where the boxed frame would read as UI chrome) and the contrast table (already inside a `Card` — the shell would double-frame it).

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 371 files / 4669 tests, incl. the new TableShell suite)
- [ ] Reviewer spot-check (the visible part): roster upload preview + import-result tables in the modal (scroll caps, sm density, new header treatment), roster page CSV view, a bulk modal's result sections, student upload preview (standard frame now), accessibility page tables (unchanged on purpose). Both themes.
