### PR TITLE
feat(web): use assignment name in breadcrumb and add hover slug reveal

### DIFF
--- a/web/src/components/breadcrumb/index.tsx
+++ b/web/src/components/breadcrumb/index.tsx
@@ -8,9 +8,15 @@ import { cx } from "@/components/ui"
 const Breadcrumb = ({
   className,
   endpoint,
+  assignmentName,
 }: {
   className?: string
   endpoint: string
+  // Resolved display name for the $assignment segment (falls back to the
+  // slug). Passed by the page because the metadata source is role-aware
+  // (private config repo for staff, public Pages for students) — the
+  // breadcrumb can't pick the right transport itself.
+  assignmentName?: string
 }) => {
   const { org, classroom, assignment } = useParams({ strict: false })
   const { data: classData } = useGetClassroom(org, classroom)
@@ -58,7 +64,7 @@ const Breadcrumb = ({
                 to="/$org/$classroom/assignments/$assignment"
                 params={{ org, classroom, assignment }}
               >
-                {assignment}
+                {assignmentName || assignment}
               </Link>
             </li>
           </>

--- a/web/src/components/submissions/SubmissionRowCells.tsx
+++ b/web/src/components/submissions/SubmissionRowCells.tsx
@@ -3,11 +3,12 @@ import { useTranslation } from "react-i18next"
 import {
   CircleSlashIcon,
   GitCommitIcon,
+  HashIcon,
   HubotIcon,
   TagIcon,
 } from "@/components/ui/icons"
 
-import { Badge } from "@/components/ui"
+import { Badge, MonoLtr } from "@/components/ui"
 import { LoadingSwap } from "@/lib/LoadingSwap"
 import {
   submissionModeBadgeKey,
@@ -128,6 +129,46 @@ export const AutogradingMeta = ({ state }: { state: AutogradingState }) => {
       {t(label)}
       {title && <span className="sr-only">{t(title)}</span>}
     </MetaItem>
+  )
+}
+
+// The slug identity affordance for both submission headings, rendered inside
+// the PageHeader title slot: names may repeat, so the slug is the only visible
+// way to tell twin assignments apart. Spelling it out inline crowds the
+// heading, so it hides behind a small hash chip — hovering the chip fades the
+// slug in beside the name and back out on leave. The slug
+// span always occupies its space (opacity-only reveal), so
+// the heading never reflows, and staying hovered anywhere over the chip+slug
+// region keeps it readable for select-and-copy. It stays in the accessibility
+// tree regardless, so screen readers always get it. Skipped entirely when the
+// slug would just echo the name.
+export const AssignmentTitleWithSlug = ({
+  name,
+  slug,
+}: {
+  name: string
+  slug: string
+}) => {
+  const { t } = useTranslation()
+  if (slug === name) return <>{name}</>
+  return (
+    <span className="inline-flex flex-wrap items-baseline gap-x-2">
+      {name}
+      <span className="group inline-flex items-baseline gap-x-2">
+        <span
+          className="badge badge-sm badge-ghost cursor-help self-center px-1.5"
+          title={t("submissions.slugTitle")}
+        >
+          <HashIcon aria-hidden="true" className="size-3" />
+        </span>
+        <MonoLtr
+          className="text-sm font-normal text-base-content/60 opacity-0 transition-opacity duration-200 ease-out group-hover:opacity-100 motion-reduce:transition-none"
+          title={t("submissions.slugTitle")}
+        >
+          {slug}
+        </MonoLtr>
+      </span>
+    </span>
   )
 }
 

--- a/web/src/components/ui/MonoLtr.tsx
+++ b/web/src/components/ui/MonoLtr.tsx
@@ -11,12 +11,14 @@ import { cx } from "./cx"
 
 export type MonoLtrProps = {
   className?: string
+  // Hover detail, e.g. explaining what kind of identifier this is.
+  title?: string
   children?: ReactNode
 }
 
-export function MonoLtr({ className, children }: MonoLtrProps) {
+export function MonoLtr({ className, title, children }: MonoLtrProps) {
   return (
-    <span dir="ltr" className={cx("font-mono", className)}>
+    <span dir="ltr" title={title} className={cx("font-mono", className)}>
       {children}
     </span>
   )

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2568,6 +2568,7 @@
     "missingParams": "Missing organization, classroom, or assignment in the URL.",
     "dueDate": "Due {{date}}",
     "noDueDate": "No due date",
+    "slugTitle": "Assignment slug — the unique identifier for this assignment; display names can repeat",
     "type": {
       "badgeEveryPush": "Submits on every push",
       "badgeTag": "Submits by tag",

--- a/web/src/pages/AssignmentSettingsPage.tsx
+++ b/web/src/pages/AssignmentSettingsPage.tsx
@@ -211,7 +211,10 @@ const AssignmentSettingsPage = () => {
 
   return (
     <PageShell>
-      <Breadcrumb endpoint={t("documentTitle.assignmentSettings")} />
+      <Breadcrumb
+        endpoint={t("documentTitle.assignmentSettings")}
+        assignmentName={assignmentData?.name}
+      />
       <AnimatedAlert tone="error" show={!!editError}>
         {editError}
       </AnimatedAlert>

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -45,6 +45,7 @@ import {
   type PushSubmission,
 } from "@/components/submissions/submissionDetailItems"
 import {
+  AssignmentTitleWithSlug,
   LastSubmittedCell,
   MetaItem,
   MetaStrip,
@@ -494,13 +495,21 @@ const StudentSubmissionPage = () => {
 
   return (
     <PageShell>
-      <Breadcrumb endpoint={t("nav.mySubmission")} />
+      <Breadcrumb
+        endpoint={t("nav.mySubmission")}
+        assignmentName={assignmentData?.name}
+      />
       <PageHeader
         loading={assignmentLoading}
         title={
-          assignmentData?.name ||
-          assignment ||
-          t("submissions.student.fallbackTitle")
+          assignmentData ? (
+            <AssignmentTitleWithSlug
+              name={assignmentData.name}
+              slug={assignmentData.slug}
+            />
+          ) : (
+            assignment || t("submissions.student.fallbackTitle")
+          )
         }
         subtitle={<AssignmentMeta assignment={assignmentData} />}
       />

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -42,6 +42,7 @@ import { BulkSubmissionTriggerModal } from "@/components/modals/BulkSubmissionTr
 import { isDefaultAutograder } from "@/domain/assignments/autograderYaml"
 import { resolveSubmissionMode } from "@/domain/assignments/submissionDetection"
 import {
+  AssignmentTitleWithSlug,
   AutogradingMeta,
   MetaItem,
   MetaStrip,
@@ -1032,7 +1033,10 @@ const SubmissionsPageContent = () => {
 
   return (
     <PageShell>
-      <Breadcrumb endpoint={t("nav.submissions")} />
+      <Breadcrumb
+        endpoint={t("nav.submissions")}
+        assignmentName={assignmentInfo?.name}
+      />
       {emptyRoster.show && (
         <EmptyRosterNotice
           org={org}
@@ -1067,7 +1071,14 @@ const SubmissionsPageContent = () => {
         />
       )}
       <PageHeader
-        title={assignmentInfo?.name}
+        title={
+          assignmentInfo && (
+            <AssignmentTitleWithSlug
+              name={assignmentInfo.name}
+              slug={assignmentInfo.slug}
+            />
+          )
+        }
         subtitle={
           // Property items are quiet meta text; only genuine states (overdue,
           // approaching deadline, late, closed) keep toned badges. The


### PR DESCRIPTION
## Summary

- The top-nav breadcrumb rendered the raw `$assignment` route param, so it showed the slug; `Breadcrumb` now takes an optional `assignmentName` and the three assignment-scoped pages (teacher gradebook, student submission, assignment settings) pass their already-resolved display name, falling back to the slug while it loads. The breadcrumb can't fetch this itself because the metadata source is role-aware (private config repo for staff vs. public Pages for students).
- Multiple assignments can share a display name, so the slug is the only user-visible disambiguator. Both submission-page headings now render a small ghost `#` chip next to the title (`AssignmentTitleWithSlug`); hovering it fades the slug in beside the name in small muted mono and back out on leave. The reveal is opacity-only (no reflow, `motion-reduce` respected), the slug stays in the accessibility tree for screen readers, the chip's tooltip explains the identifier, and the chip is skipped when the slug equals the name.
- `MonoLtr` gains an optional `title` prop rather than wrapping it in an extra span.

## Test plan

- [x] `npm run check` in `web/` (tsc, eslint, prettier, arch:validate, vitest incl. browser tests) — all green
- [ ] Hover the `#` chip on the teacher submissions page and the student submission page to confirm the fade in/out
- [ ] Confirm the breadcrumb shows the assignment name on submissions, my-submission, and assignment-settings pages
