### PR TITLE
fix(web): show load errors instead of first-use empty states

### DIFF
--- a/web/src/hooks/useGetClasses.test.tsx
+++ b/web/src/hooks/useGetClasses.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+// Pins the error-vs-empty split (Primer degraded experiences): a failed read
+// must surface isError so pages never render their first-use empty states on
+// it, while a 404 stays the legitimate zero for a fresh org.
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+import { GitHubAPIError } from "@/github-core/errors"
+
+let responseStatus = 500
+let responseBody: string | null = null
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({
+    requestRaw: (path: string) =>
+      responseBody !== null
+        ? Promise.resolve(responseBody)
+        : Promise.reject(
+            new GitHubAPIError({
+              status: responseStatus,
+              url: `https://api.github.com${path}`,
+              message: `HTTP ${responseStatus}`,
+              body: null,
+              rateLimit: {} as never,
+            }),
+          ),
+  }),
+}))
+
+import useGetClasses from "./useGetClasses"
+
+afterEach(() => {
+  cleanup()
+  responseStatus = 500
+  responseBody = null
+})
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    {children}
+  </QueryClientProvider>
+)
+
+describe("useGetClasses error-vs-empty split", () => {
+  it("surfaces a non-404 failure as isError", async () => {
+    responseStatus = 500
+    const { result } = renderHook(() => useGetClasses("acme"), { wrapper })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.classes).toEqual([])
+  })
+
+  it("treats a 404 as the legitimate empty, not an error", async () => {
+    responseStatus = 404
+    const { result } = renderHook(() => useGetClasses("acme"), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isError).toBe(false)
+    expect(result.current.classes).toEqual([])
+  })
+
+  it("filters the listing to classroom dirs on success", async () => {
+    responseBody = JSON.stringify([
+      { type: "dir", name: "cs50" },
+      { type: "dir", name: ".github" },
+      { type: "file", name: "README.md" },
+    ])
+    const { result } = renderHook(() => useGetClasses("acme"), { wrapper })
+    await waitFor(() => expect(result.current.classes).toHaveLength(1))
+    expect(result.current.isError).toBe(false)
+    expect(result.current.classes[0]?.name).toBe("cs50")
+  })
+})

--- a/web/src/hooks/useGetClasses.ts
+++ b/web/src/hooks/useGetClasses.ts
@@ -1,6 +1,7 @@
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useQuery } from "@tanstack/react-query"
 import { jsonFileQuery } from "@/github-core/queries"
+import { GitHubAPIError } from "@/github-core/errors"
 import { CONFIG_REPO } from "@/util/configRepo"
 import type { GitHubFileListing } from "@/github-core/types"
 
@@ -9,6 +10,12 @@ const useGetClasses = (org: string | undefined) => {
   const classesQuery = useQuery(
     jsonFileQuery<GitHubFileListing[]>(client, org ?? "", CONFIG_REPO, ""),
   )
+
+  // A 404 (no config repo yet, or an empty repo root) is the legitimate
+  // "no classrooms" zero for a fresh org — not a failure.
+  const notFound =
+    classesQuery.error instanceof GitHubAPIError &&
+    classesQuery.error.status === 404
 
   return {
     classes: classesQuery.data
@@ -20,6 +27,13 @@ const useGetClasses = (org: string | undefined) => {
     // empty state: an empty `classes` array during the fetch is otherwise
     // indistinguishable from a genuinely empty org.
     isLoading: classesQuery.isLoading,
+    // Surfaced for the same reason on the failure side: rendering the
+    // first-use empty state on a failed read tells a teacher their classrooms
+    // are gone (Primer degraded-experiences: never error-as-empty).
+    isError: classesQuery.isError && !notFound,
+    refetch: () => {
+      void classesQuery.refetch()
+    },
   }
 }
 

--- a/web/src/hooks/useGetOrgs.ts
+++ b/web/src/hooks/useGetOrgs.ts
@@ -58,6 +58,13 @@ const useGetOrgs = () => {
     // states in to keep the page's spinner covering the whole chain.
     isLoading: memberships.isLoading || summaries.isLoading,
     isFetching: memberships.isFetching || summaries.isFetching,
+    // Same folding on the failure side, so a failed memberships read can't
+    // masquerade as "no organizations" downstream.
+    isError: memberships.isError || summaries.isError,
+    refetch: () => {
+      void memberships.refetch()
+      void summaries.refetch()
+    },
   }
 }
 

--- a/web/src/hooks/useGetStudents.test.tsx
+++ b/web/src/hooks/useGetStudents.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+// Pins the error-vs-empty split for the roster read: a failed roster.csv read
+// surfaces isError (so views never render "empty roster" on it), while a
+// missing file (404) stays the legitimate zero for a new classroom.
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+import { GitHubAPIError } from "@/github-core/errors"
+
+let responseStatus = 500
+let responseBody: string | null = null
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({
+    requestRaw: (path: string) =>
+      responseBody !== null
+        ? Promise.resolve(responseBody)
+        : Promise.reject(
+            new GitHubAPIError({
+              status: responseStatus,
+              url: `https://api.github.com${path}`,
+              message: `HTTP ${responseStatus}`,
+              body: null,
+              rateLimit: {} as never,
+            }),
+          ),
+  }),
+}))
+
+import useGetStudents from "./useGetStudents"
+
+afterEach(() => {
+  cleanup()
+  responseStatus = 500
+  responseBody = null
+})
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    {children}
+  </QueryClientProvider>
+)
+
+describe("useGetStudents error-vs-empty split", () => {
+  it("surfaces a non-404 failure as isError", async () => {
+    responseStatus = 500
+    const { result } = renderHook(() => useGetStudents("acme", "cs50"), {
+      wrapper,
+    })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.students).toEqual([])
+  })
+
+  it("treats a missing roster.csv (404) as the legitimate empty", async () => {
+    responseStatus = 404
+    const { result } = renderHook(() => useGetStudents("acme", "cs50"), {
+      wrapper,
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isError).toBe(false)
+    expect(result.current.students).toEqual([])
+  })
+
+  it("parses roster rows on success without isError", async () => {
+    responseBody = "username,role\nada,student\n"
+    const { result } = renderHook(() => useGetStudents("acme", "cs50"), {
+      wrapper,
+    })
+    await waitFor(() => expect(result.current.students).toHaveLength(1))
+    expect(result.current.isError).toBe(false)
+  })
+})

--- a/web/src/hooks/useGetStudents.ts
+++ b/web/src/hooks/useGetStudents.ts
@@ -7,6 +7,7 @@ import {
   githubKeys,
   rosterRawFileQuery,
 } from "@/github-core/queries"
+import { GitHubAPIError } from "@/github-core/errors"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { toStudent } from "@/util/roster"
 import { rosterPath } from "@/util/rosterPath"
@@ -34,7 +35,12 @@ const useGetStudents = (
 ) => {
   const client = useGitHubClient()
   const queryClient = useQueryClient()
-  const { data: students, isLoading } = useQuery({
+  const {
+    data: students,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
     ...csvFileQuery<Student>(
       client,
       org ?? "",
@@ -43,6 +49,11 @@ const useGetStudents = (
     ),
     select: selectStudents,
   })
+
+  // A missing roster.csv 404s — the legitimate "no one enrolled yet" zero for
+  // a new classroom, not a failure.
+  const rosterMissing =
+    error instanceof GitHubAPIError && error.status === 404
 
   // A parallel strict read of the raw bytes purely to detect malformed rows and
   // report them per line. Kept separate from the display read above (which
@@ -68,6 +79,10 @@ const useGetStudents = (
   return {
     students: students ?? EMPTY_STUDENTS,
     isLoading,
+    // Surfaced so a failed roster read never renders as an empty roster
+    // (Primer degraded-experiences: error-as-empty reads as data loss).
+    // recheckRoster doubles as the retry affordance.
+    isError: isError && !rosterMissing,
     parseProblems,
     // Re-read the raw roster.csv so a teacher who just fixed the file can
     // re-verify it in place (also refetches the tolerant display read).

--- a/web/src/hooks/useGetStudents.ts
+++ b/web/src/hooks/useGetStudents.ts
@@ -52,8 +52,7 @@ const useGetStudents = (
 
   // A missing roster.csv 404s — the legitimate "no one enrolled yet" zero for
   // a new classroom, not a failure.
-  const rosterMissing =
-    error instanceof GitHubAPIError && error.status === 404
+  const rosterMissing = error instanceof GitHubAPIError && error.status === 404
 
   // A parallel strict read of the raw bytes purely to detect malformed rows and
   // report them per line. Kept separate from the display read above (which

--- a/web/src/hooks/useOrgMembersOverview.ts
+++ b/web/src/hooks/useOrgMembersOverview.ts
@@ -33,6 +33,9 @@ export type OrgMembersOverview = {
   ownerIds: Set<string>
   isLoading: boolean
   isError: boolean
+  // Retry for the members read behind `isError` (the meta/roster enrichment
+  // queries degrade independently).
+  refetchMembers: () => void
   // classroom path -> resolved GitHub team slug (classroom.json.team.slug, else
   // the derived classroomTeamSlug). The SAME slug teamMembersByClassroom
   // keys from, so optimistic team-cache writes on the Members page target the
@@ -218,6 +221,9 @@ const useOrgMembersOverview = (org: string | undefined): OrgMembersOverview => {
     ownerIds,
     isLoading,
     isError,
+    refetchMembers: () => {
+      void membersQuery.refetch()
+    },
     teamSlugByClassroom,
     displayNameByClassroom,
     notes,

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -3307,6 +3307,7 @@
     "filterOwners": "Owners",
     "filterMembers": "Members",
     "loadError": "Couldn't load organization members.",
+    "retry": "Retry",
     "noMatch": "No members match your search.",
     "noMembersInClassroom": "No members in {{classroom}}.",
     "noMembersNoClassroom": "No members without a classroom.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -947,6 +947,8 @@
   "orgs": {
     "headingCl50": "Classroom 50 organizations",
     "loadingTitle": "Loading your organizations…",
+    "loadError": "Couldn't load your organizations from GitHub. This is a load error — your organizations aren't gone.",
+    "retry": "Retry",
     "emptyTitle": "No Classroom 50 organizations yet",
     "emptyBody": "Organizations you belong to that use Classroom 50 will appear here. If you expect one, ask your teacher to confirm you've been added, then refresh.",
     "toolbar": {
@@ -1518,6 +1520,8 @@
       "sortByName": "Sort by name",
       "sortByDue": "Sort by due date",
       "empty": "No assignments created.",
+      "loadError": "Couldn't load assignments from GitHub. This is a load error — your assignments aren't gone.",
+      "retry": "Retry",
       "individual": "Individual",
       "group": "Group",
       "noDueDate": "No due date",
@@ -2212,6 +2216,9 @@
     "missingOrg": "Missing organization.",
     "missingOrgOrClassroom": "Missing organization or classroom.",
     "couldNotLoad": "Could not load classroom data.",
+    "loadError": "Couldn't load classrooms from GitHub. This is a load error — your classrooms aren't gone.",
+    "roleLoadError": "Couldn't check your role in this organization.",
+    "retry": "Retry",
     "loadingClassroom": "Loading classroom",
     "configRepo": "classroom50 repository",
     "configRepoTitle": "Open this classroom's folder in the classroom50 repository on GitHub",

--- a/web/src/pages/AssignmentsPage.test.tsx
+++ b/web/src/pages/AssignmentsPage.test.tsx
@@ -142,14 +142,15 @@ describe("Assignments header student count", () => {
     expect(screen.getByText("…")).toBeTruthy()
   })
 
-  it("shows the placeholder on a role-count error, not a wrong number", () => {
+  it("hides the count entirely on a role-count error, not a wrong number", () => {
     studentCount.mockReturnValue({
       studentCount: undefined,
       isLoading: false,
       isError: true,
     })
     render(<TeacherAssignmentsView org="acme" classroom="cs101" />)
-    expect(screen.getByText("…")).toBeTruthy()
+    // Not the loading "…" either — that reads as still-loading forever.
+    expect(screen.queryByText("…")).toBeNull()
     expect(screen.queryByText(/assignments\.studentCount/)).toBeNull()
   })
 })

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from "react-i18next"
 
 import AssignmentsTable from "@/pages/assignments/AssignmentsTable"
 import AssignmentsToolbar from "@/pages/assignments/AssignmentsToolbar"
+import { GitHubAPIError } from "@/github-core/errors"
 import { ClassroomCollectButton } from "@/pages/assignments/ClassroomCollectButton"
 import {
   DEFAULT_FILTERS,
@@ -117,8 +118,19 @@ export const TeacherAssignmentsView = ({
   classroom: string
 }) => {
   const { t } = useTranslation()
-  const { data: classData, isLoading: assignmentsLoading } =
-    useGetClassroomAssignments(org, classroom)
+  const {
+    data: classData,
+    isLoading: assignmentsLoading,
+    error: assignmentsErrorObj,
+    refetch: refetchAssignments,
+  } = useGetClassroomAssignments(org, classroom)
+  // A missing assignments.json 404s — the legitimate zero for a brand-new
+  // classroom (same split as ClassroomCard). Only a non-404 failure must be
+  // surfaced as an error instead of the empty state.
+  const assignmentsNotFound =
+    assignmentsErrorObj instanceof GitHubAPIError &&
+    assignmentsErrorObj.status === 404
+  const assignmentsError = Boolean(assignmentsErrorObj) && !assignmentsNotFound
   // Authoritative student-role count for the header and the table denominator,
   // so neither counts teachers/TAs. The count comes from team membership
   // (one source); roster.csv identity is fetched by useStudentCount internally.
@@ -274,6 +286,8 @@ export const TeacherAssignmentsView = ({
           allAssignments={sourceAssignments}
           studentCount={studentCount}
           loading={assignmentsLoading}
+          loadError={assignmentsError}
+          onRetryLoad={() => void refetchAssignments()}
           archived={archived}
           canAuthor={canAuthor}
           sort={sort}

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -218,9 +218,13 @@ export const TeacherAssignmentsView = ({
         subtitle={
           <>
             {classroomData?.term ? `${classroomData?.term} • ` : ""}
-            {studentsLoading || studentCountError
+            {studentsLoading
               ? "…"
-              : t("assignments.studentCount", { count: studentCount ?? 0 })}
+              : // A failed count is hidden entirely (never a wrong number);
+                // the perpetual "…" read as still-loading.
+                studentCountError
+                ? null
+                : t("assignments.studentCount", { count: studentCount ?? 0 })}
           </>
         }
       />

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -169,8 +169,19 @@ const ClassesPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.classes"))
   const { org } = useParams({ strict: false })
-  const { classes, isLoading: classesLoading } = useGetClasses(org)
-  const { isStaff, isNonStaff, isLoading: roleLoading } = useOrgStaff(org)
+  const {
+    classes,
+    isLoading: classesLoading,
+    isError: classesError,
+    refetch: refetchClasses,
+  } = useGetClasses(org)
+  const {
+    isStaff,
+    isNonStaff,
+    isLoading: roleLoading,
+    isError: roleError,
+    refetch: refetchRole,
+  } = useOrgStaff(org)
   const { data: membership, isLoading: loadingMembership } =
     useGetOwnOrgMembership(org)
   const { githubOrgRole } = useGitHubOrgRole()
@@ -208,6 +219,24 @@ const ClassesPage = () => {
           <ToolbarSkeleton />
           <CardGridSkeleton cardClassName="col-span-6 h-32 xl:col-span-4" />
         </SkeletonRegion>
+      ) : roleError ? (
+        // A settled role-read failure used to render neither list nor empty
+        // state — a silent blank region. Name the failure and offer retry.
+        <Alert tone="error" className="items-start">
+          <span className="text-sm">{t("classes.roleLoadError")}</span>
+          <Button variant="ghost" size="sm" onClick={() => refetchRole()}>
+            {t("classes.retry")}
+          </Button>
+        </Alert>
+      ) : isStaff && classesError ? (
+        // Never render the first-use "create your first classroom" pane on a
+        // failed read — it tells a teacher their classrooms are gone.
+        <Alert tone="error" className="items-start">
+          <span className="text-sm">{t("classes.loadError")}</span>
+          <Button variant="ghost" size="sm" onClick={() => refetchClasses()}>
+            {t("classes.retry")}
+          </Button>
+        </Alert>
       ) : (
         <>
           {classes.length === 0 && isStaff && <CreateClassroomPane org={org} />}

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from "react-i18next"
 import { useParams } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
 import {
+  AlertIcon,
   ChevronRightIcon,
   FilterIcon,
   LinkExternalIcon,
@@ -121,6 +122,7 @@ const OrgMembersPage = () => {
     ownerIds,
     isLoading,
     isError,
+    refetchMembers,
     teamSlugByClassroom,
     displayNameByClassroom,
     notes,
@@ -784,9 +786,27 @@ const OrgMembersPage = () => {
                   <tr>
                     <td
                       colSpan={MEMBERS_COL_COUNT}
-                      className="py-10 text-center text-sm text-error"
+                      className="px-6 py-10 text-center"
                     >
-                      {t("orgMembers.loadError")}
+                      <span
+                        role="alert"
+                        className="inline-flex items-center gap-2 text-sm text-error"
+                      >
+                        <AlertIcon
+                          aria-hidden="true"
+                          className="size-4 shrink-0"
+                        />
+                        {t("orgMembers.loadError")}
+                      </span>
+                      <div className="mt-3">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={refetchMembers}
+                        >
+                          {t("orgMembers.retry")}
+                        </Button>
+                      </div>
                     </td>
                   </tr>
                 )}

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -485,7 +485,13 @@ const OrgsPage = () => {
   const { t } = useTranslation()
   useDocumentTitle(t("documentTitle.organizations"))
   const queryClient = useQueryClient()
-  const { data: orgs = [], isLoading, isFetching } = useGetOrgs()
+  const {
+    data: orgs = [],
+    isLoading,
+    isFetching,
+    isError,
+    refetch,
+  } = useGetOrgs()
   const { data: pendingInvites = [] } = usePendingOrgInvites()
 
   const { viewMode, sortKey, changeView, changeSort } =
@@ -608,6 +614,19 @@ const OrgsPage = () => {
                 cardClassName="col-span-12 h-36 md:col-span-6"
               />
             </SkeletonRegion>
+          </>
+        ) : isError ? (
+          // Never render the "no organizations yet — ask your teacher" empty
+          // state on a failed read: it misdiagnoses a load failure as a
+          // roster problem.
+          <>
+            <PageHeader title={t("orgs.headingCl50")} />
+            <Alert tone="error" className="items-start">
+              <span className="text-sm">{t("orgs.loadError")}</span>
+              <Button variant="ghost" size="sm" onClick={() => refetch()}>
+                {t("orgs.retry")}
+              </Button>
+            </Alert>
           </>
         ) : (
           <>

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -142,7 +142,7 @@ const TeamRosterContent = ({
                   </Badge>
                 ) : null}
               </>
-            ) : (
+            ) : rosterError ? null : ( // hide the counts on error, never a stuck "Loading roster…"
               <span>{t("students.enrolledCountLoading")}</span>
             )}
             <span aria-hidden="true" className="text-base-content/30">

--- a/web/src/pages/StudentListPage.tsx
+++ b/web/src/pages/StudentListPage.tsx
@@ -240,7 +240,10 @@ const CsvRosterContent = ({
   classroom: string
 }) => {
   const { t } = useTranslation()
-  const { students, isLoading } = useGetStudents(org, classroom)
+  const { students, isLoading, isError, recheckRoster } = useGetStudents(
+    org,
+    classroom,
+  )
 
   return (
     <>
@@ -256,7 +259,12 @@ const CsvRosterContent = ({
           </span>
         }
       />
-      <CsvRosterView students={students} loading={isLoading} />
+      <CsvRosterView
+        students={students}
+        loading={isLoading}
+        loadError={isError}
+        onRetryLoad={recheckRoster}
+      />
     </>
   )
 }

--- a/web/src/pages/assignments/AssignmentsTable.test.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.test.tsx
@@ -76,6 +76,35 @@ const assignment = (over: Partial<Assignment> = {}): Assignment =>
   ({ slug: "hw1", name: "HW 1", mode: "individual", ...over }) as Assignment
 
 const inOrgTemplate = { owner: "acme", repo: "tmpl", branch: "main" }
+
+describe("AssignmentsTable load error vs empty state", () => {
+  it("renders the error row with retry instead of the empty state", () => {
+    const onRetryLoad = vi.fn()
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[]}
+        loadError
+        onRetryLoad={onRetryLoad}
+      />,
+    )
+    // The anti-misinformation assertion: a failed read must never render
+    // "No assignments created."
+    expect(screen.queryByText("assignments.table.empty")).toBeNull()
+    expect(screen.getByText("assignments.table.loadError")).toBeTruthy()
+    fireEvent.click(
+      screen.getByRole("button", { name: "assignments.table.retry" }),
+    )
+    expect(onRetryLoad).toHaveBeenCalledTimes(1)
+  })
+
+  it("still renders the genuine empty state when there is no error", () => {
+    wrap(<AssignmentsTable org="acme" classroom="cs101" assignments={[]} />)
+    expect(screen.getByText("assignments.table.empty")).toBeTruthy()
+    expect(screen.queryByText("assignments.table.loadError")).toBeNull()
+  })
+})
 const ACCESS_ARIA = "assignments.template.accessModal.triggerAria"
 const MANAGE_ARIA = "assignments.manageModal.openAria"
 

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -107,6 +107,8 @@ const AssignmentsTable = ({
   allAssignments,
   studentCount,
   loading = false,
+  loadError = false,
+  onRetryLoad,
   archived = false,
   canAuthor = false,
   sort,
@@ -134,6 +136,11 @@ const AssignmentsTable = ({
   // the submission ratio. undefined while the count is still resolving.
   studentCount?: number
   loading?: boolean
+  // A failed (non-404) assignments.json read. Rendered as an error row with
+  // retry — never as the "No assignments created" empty state, which would
+  // tell a teacher their assignments are gone.
+  loadError?: boolean
+  onRetryLoad?: () => void
   // When archived, hide per-row mutating actions (edit/reuse/delete); viewing
   // stays available.
   archived?: boolean
@@ -264,7 +271,25 @@ const AssignmentsTable = ({
           animate="animate"
         >
           {loading && <SkeletonRows bars={SKELETON_BARS} />}
-          {!loading && !assignments?.length && (
+          {!loading && loadError && (
+            <tr>
+              <td colSpan={7} className="px-6 py-10 text-center">
+                <span
+                  role="alert"
+                  className="inline-flex items-center gap-2 text-sm text-error"
+                >
+                  <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
+                  {t("assignments.table.loadError")}
+                </span>
+                <div className="mt-3">
+                  <Button variant="ghost" size="sm" onClick={onRetryLoad}>
+                    {t("assignments.table.retry")}
+                  </Button>
+                </div>
+              </td>
+            </tr>
+          )}
+          {!loading && !loadError && !assignments?.length && (
             <tr>
               <td colSpan={7}>
                 <EmptyState
@@ -275,6 +300,7 @@ const AssignmentsTable = ({
             </tr>
           )}
           {!loading &&
+            !loadError &&
             assignments?.map((assignment) => (
               <ClickableTr key={assignment.slug} className="hover:bg-base-200">
                 <td

--- a/web/src/pages/students/CsvRosterView.test.tsx
+++ b/web/src/pages/students/CsvRosterView.test.tsx
@@ -135,4 +135,23 @@ describe("CsvRosterView", () => {
     // Last-name order: Adams (Zed) before Brown (Amy).
     expect(names()).toEqual(["Zed Adams", "Amy Brown"])
   })
+
+  it("renders the load error with retry instead of the empty state", () => {
+    const onRetryLoad = vi.fn()
+    render(<CsvRosterView students={[]} loadError onRetryLoad={onRetryLoad} />)
+    // The anti-misinformation assertion: a failed read must never render the
+    // "empty roster" copy.
+    expect(screen.queryByText("students.csvRoster.empty")).toBeNull()
+    expect(screen.getByText("students.rosterLoadError")).toBeTruthy()
+    fireEvent.click(
+      screen.getByRole("button", { name: "students.rosterRetry" }),
+    )
+    expect(onRetryLoad).toHaveBeenCalledTimes(1)
+  })
+
+  it("still renders the genuine empty state when there is no error", () => {
+    render(<CsvRosterView students={[]} />)
+    expect(screen.getByText("students.csvRoster.empty")).toBeTruthy()
+    expect(screen.queryByText("students.rosterLoadError")).toBeNull()
+  })
 })

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -2,7 +2,14 @@ import { useMemo, useState } from "react"
 import { EmptyState } from "@/components/list"
 import { useTranslation } from "react-i18next"
 
-import { Alert, SkeletonRows, TableShell, Toolbar } from "@/components/ui"
+import {
+  Alert,
+  Button,
+  SkeletonRows,
+  TableShell,
+  Toolbar,
+} from "@/components/ui"
+import { AlertIcon } from "@/components/ui/icons"
 import { RoleBadges } from "./RoleBadges"
 import { StudentSortSelect } from "./StudentSortSelect"
 import { coerceImportRole } from "./rosterImportParse"
@@ -29,12 +36,18 @@ function displayName(student: Student): string {
 const CsvRosterView = ({
   students,
   loading = false,
+  loadError = false,
+  onRetryLoad,
 }: {
   students: Student[]
   // Hold skeleton rows while roster.csv loads — the empty-while-loading array
   // is indistinguishable from a genuinely empty roster, so rendering on it
   // flashes the "empty roster" row.
   loading?: boolean
+  // A failed (non-404) roster read. Rendered as an error row with retry —
+  // never as the "empty roster" row, which reads as data loss.
+  loadError?: boolean
+  onRetryLoad?: () => void
 }) => {
   const { t } = useTranslation()
   const [sortMode, setSortMode] =
@@ -69,6 +82,23 @@ const CsvRosterView = ({
         <tbody>
           {loading ? (
             <SkeletonRows rows={3} bars={["w-40", "w-16", "w-20"]} />
+          ) : loadError ? (
+            <tr>
+              <td colSpan={3} className="px-6 py-10 text-center">
+                <span
+                  role="alert"
+                  className="inline-flex items-center gap-2 text-sm text-error"
+                >
+                  <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
+                  {t("students.rosterLoadError")}
+                </span>
+                <div className="mt-3">
+                  <Button variant="ghost" size="sm" onClick={onRetryLoad}>
+                    {t("students.rosterRetry")}
+                  </Button>
+                </div>
+              </td>
+            </tr>
           ) : rows.length === 0 ? (
             <tr>
               <td colSpan={3}>


### PR DESCRIPTION
## Summary

First slice of a Primer UI-patterns alignment pass (their degraded-experiences guidance): a failed GitHub read no longer renders a first-use empty state. Before this, a transient 500/403 on the orgs, classes, assignments, or roster read showed "No Classroom 50 organizations yet… ask your teacher", "Create your first classroom", "No assignments created.", or "No one is listed in roster.csv yet." — telling users their data was gone when it was a load failure.

- `useGetClasses` and `useGetStudents` now expose `isError` (they previously swallowed it, so callers couldn't distinguish a failed read from a genuinely empty org/roster), with the 404 split folded in at the hook: a fresh org's missing config listing and a missing `roster.csv` remain genuine zeros that keep the welcoming empty states. `useGetOrgs` folds the memberships fan-out's error state the same way it already folded loading.
- The four pages branch error-before-empty with the house error-with-retry block, reusing existing copy conventions ("This is a load error — your classrooms aren't gone"). ClassesPage also names a previously silent failure: a settled role-read error used to render nothing at all under the header.
- Count degradations follow the hide-never-wrong rule: the assignments header count and roster badges hide on error instead of showing a perpetual "…" / "Loading roster…", and the org-members error row gains the icon + retry treatment the roster table already had.
- New tests pin the invariant both ways at hooks (error/404/success matrix) and components: failed read -> retry row and never the empty copy; no error -> the empty state still renders.

## Test plan

- [x] `npm run check` (tsc, eslint, prettier, arch:validate, vitest — 373 files / 4679 tests, incl. 3 new suites)
- [ ] Reviewer spot-check (DevTools offline mode or a revoked token): orgs, classes, assignments, and roster pages each show the error block with a working retry; a brand-new org/classroom still shows the welcoming empty states (the 404 paths); the assignments header count disappears rather than sticking at "…".
