### PR TITLE
fix(web): standardize feedback notifications on Primer messaging patterns

### DIFF
--- a/web/src/components/PermissionErrorBoundary.tsx
+++ b/web/src/components/PermissionErrorBoundary.tsx
@@ -27,7 +27,7 @@ function PermissionDeniedMessage() {
       <div className="flex size-16 items-center justify-center rounded-box bg-warning/10 text-warning">
         <ShieldXIcon aria-hidden="true" className="size-8" />
       </div>
-      <Alert tone="warning" className="max-w-md flex-col text-center">
+      <Alert tone="unavailable" className="max-w-md flex-col text-center">
         <Heading as="h1" variant="title-medium">
           {t("permissionDenied.title")}
         </Heading>

--- a/web/src/components/QueryErrorAlert.tsx
+++ b/web/src/components/QueryErrorAlert.tsx
@@ -17,7 +17,7 @@ export function QueryErrorAlert({
 }) {
   const { t } = useTranslation()
   return (
-    <Alert tone="error" className={className}>
+    <Alert tone="unavailable" className={className}>
       <div>
         {message}
         <Button variant="ghost" size="sm" className="ms-2" onClick={onRetry}>

--- a/web/src/components/SubmitUpload.test.tsx
+++ b/web/src/components/SubmitUpload.test.tsx
@@ -15,7 +15,7 @@ vi.mock("react-i18next", async (importOriginal) => {
 
 const notify = vi.fn()
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify, dismiss: vi.fn() }),
+  useToast: () => ({ notify, announce: vi.fn(), dismiss: vi.fn() }),
 }))
 
 const mutateAsync = vi.fn()
@@ -145,14 +145,16 @@ describe("SubmitUpload", () => {
     expect(await screen.findByText("solution/src/util.c")).toBeTruthy()
   })
 
-  it("rejects a reserved control path with a warning toast", () => {
+  it("rejects a reserved control path with an in-modal message", () => {
     render(<SubmitUpload org="acme" repo="r" assignment="hw" />)
     openModal()
     dropFlat([drop(".classroom50.yaml"), drop("ok.py")])
 
-    expect(notify).toHaveBeenCalledWith(
-      expect.objectContaining({ tone: "warning" }),
-    )
+    // The skip is reported inside the open dialog, not as a page toast.
+    expect(
+      screen.getByText(/submissions\.student\.upload\.reservedPath/),
+    ).toBeTruthy()
+    expect(notify).not.toHaveBeenCalled()
     expect(screen.getByText("ok.py")).toBeTruthy()
     expect(screen.queryByText(".classroom50.yaml")).toBeNull()
   })

--- a/web/src/components/SubmitUpload.tsx
+++ b/web/src/components/SubmitUpload.tsx
@@ -65,39 +65,49 @@ export function SubmitUpload({
   const [open, setOpen] = useState(false)
   const [picked, setPicked] = useState<Picked[]>([])
   const [noFilesError, setNoFilesError] = useState(false)
+  // Files skipped by the last add (unsafe or reserved paths), surfaced inside
+  // the open dialog rather than as page toasts. Replaced wholesale on each
+  // add so the list always describes the most recent pick.
+  const [skippedFiles, setSkippedFiles] = useState<
+    { tone: "error" | "warning"; message: string }[]
+  >([])
   const submitting = mutation.isPending
 
   const addFiles = (files: PickedFile[]) => {
     setNoFilesError(false)
+    const skipped: { tone: "error" | "warning"; message: string }[] = []
+    const accepted: Picked[] = []
+    for (const { file, relativePath } of files) {
+      let path: string
+      try {
+        path = normalizeRepoPath(relativePath)
+      } catch {
+        // An unsafe path (traversal) is dropped and reported rather than
+        // silently included.
+        skipped.push({
+          tone: "error",
+          message: t("submissions.student.upload.unsafePath", {
+            name: relativePath,
+          }),
+        })
+        continue
+      }
+      // Reject reserved control paths (.github/**, .classroom50.yaml): the
+      // domain preserves the real ones, so an upload here would be ignored.
+      if (isReservedUploadPath(path)) {
+        skipped.push({
+          tone: "warning",
+          message: t("submissions.student.upload.reservedPath", { path }),
+        })
+        continue
+      }
+      accepted.push({ path, file, key: `${path}:${file.lastModified}` })
+    }
+    setSkippedFiles(skipped)
     setPicked((prev) => {
       const byPath = new Map(prev.map((p) => [p.path, p]))
-      for (const { file, relativePath } of files) {
-        let path: string
-        try {
-          path = normalizeRepoPath(relativePath)
-        } catch {
-          // An unsafe path (traversal) is dropped with a toast rather than
-          // silently included.
-          notify({
-            tone: "error",
-            message: t("submissions.student.upload.unsafePath", {
-              name: relativePath,
-            }),
-          })
-          continue
-        }
-        // Reject reserved control paths (.github/**, .classroom50.yaml): the
-        // domain preserves the real ones, so an upload here would be ignored.
-        if (isReservedUploadPath(path)) {
-          notify({
-            tone: "warning",
-            message: t("submissions.student.upload.reservedPath", { path }),
-          })
-          continue
-        }
-        // Last pick of a path wins (re-uploading a file replaces the prior one).
-        byPath.set(path, { path, file, key: `${path}:${file.lastModified}` })
-      }
+      // Last pick of a path wins (re-uploading a file replaces the prior one).
+      for (const p of accepted) byPath.set(p.path, p)
       return Array.from(byPath.values()).sort((a, b) =>
         a.path.localeCompare(b.path),
       )
@@ -118,6 +128,7 @@ export function SubmitUpload({
   const openModal = () => {
     setPicked([])
     setNoFilesError(false)
+    setSkippedFiles([])
     setOpen(true)
   }
 
@@ -133,6 +144,8 @@ export function SubmitUpload({
         picked.map(({ path, file }) => ({ path, file })),
       )
       setOpen(false)
+      // Kept as a toast: the dialog is closing and grading continues in the
+      // background, so the outcome isn't otherwise evident.
       notify({
         tone: "success",
         durationMs: 6000,
@@ -275,6 +288,16 @@ export function SubmitUpload({
               buttonLabel={t("submissions.student.upload.choose")}
               disabled={submitting}
             />
+          )}
+
+          {skippedFiles.length > 0 && (
+            <div className="flex flex-col gap-1">
+              {skippedFiles.map(({ tone, message }) => (
+                <InlineMessage key={message} tone={tone}>
+                  {message}
+                </InlineMessage>
+              ))}
+            </div>
           )}
 
           {noFilesError && (

--- a/web/src/components/SubmitUpload.tsx
+++ b/web/src/components/SubmitUpload.tsx
@@ -293,7 +293,9 @@ export function SubmitUpload({
           {skippedFiles.length > 0 && (
             <div className="flex flex-col gap-1">
               {skippedFiles.map(({ tone, message }) => (
-                <InlineMessage key={message} tone={tone}>
+                // role="alert" so the insertion is announced — these replaced
+                // toasts, and there is no focus move to carry the message.
+                <InlineMessage key={message} tone={tone} role="alert">
                   {message}
                 </InlineMessage>
               ))}

--- a/web/src/components/modals/ConfirmModal.test.tsx
+++ b/web/src/components/modals/ConfirmModal.test.tsx
@@ -110,3 +110,65 @@ describe("ConfirmModal — children and confirmDisabled", () => {
     expect(onConfirm).toHaveBeenCalledTimes(1)
   })
 })
+
+// The rejection contract every converted feedback flow now relies on
+// (archive/delete classroom, staff remove, invite cleanup): a rejecting
+// onConfirm renders its message inside the dialog, keeps it open, and
+// re-enables confirm for a retry. Deleting the catch in a refactor would
+// silently destroy all failure feedback for those flows.
+describe("ConfirmModal — rejecting onConfirm", () => {
+  it("renders the thrown message in-dialog, stays open, and allows retry", async () => {
+    const onConfirm = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("classes.deleteFailed localized"))
+      .mockResolvedValueOnce(undefined)
+    const onClose = vi.fn()
+    render(
+      <ConfirmModal
+        open
+        needsConfirm={false}
+        title="title"
+        confirmText="confirm"
+        onConfirm={onConfirm}
+        onClose={onClose}
+      />,
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("components.confirmModal.confirm"))
+    })
+    expect(screen.getByText("classes.deleteFailed localized")).toBeTruthy()
+    expect(onClose).not.toHaveBeenCalled()
+
+    // The confirm re-enables and a retry that resolves closes the dialog.
+    const confirm = screen.getByText(
+      "components.confirmModal.confirm",
+    ) as HTMLButtonElement
+    expect(confirm.disabled).toBe(false)
+    await act(async () => {
+      fireEvent.click(confirm)
+    })
+    expect(onConfirm).toHaveBeenCalledTimes(2)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("falls back to the generic error for a non-Error rejection", async () => {
+    const onConfirm = vi.fn().mockRejectedValue("boom")
+    render(
+      <ConfirmModal
+        open
+        needsConfirm={false}
+        title="title"
+        confirmText="confirm"
+        onConfirm={onConfirm}
+        onClose={vi.fn()}
+      />,
+    )
+    await act(async () => {
+      fireEvent.click(screen.getByText("components.confirmModal.confirm"))
+    })
+    expect(
+      screen.getByText("components.confirmModal.genericError"),
+    ).toBeTruthy()
+  })
+})

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -74,7 +74,6 @@ export function GroupCollaboratorsModal({
   maxGroupSize,
   students = [],
 }: GroupCollaboratorsModalProps) {
-  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Synchronous re-entrancy guard: isSaving (mutation.isPending) updates a tick
   // late, so a rapid double-click could start two overlapping saves.
   const savingRef = useRef(false)
@@ -147,13 +146,6 @@ export function GroupCollaboratorsModal({
     setSaved(false)
     setInvalidCollaborators(new Set())
   }, [open])
-
-  useEffect(
-    () => () => {
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
-    },
-    [],
-  )
 
   const clearInvalidCollaborator = (username: string) => {
     const normalized = normalizeUsername(username)
@@ -336,9 +328,9 @@ export function GroupCollaboratorsModal({
       }
 
       await refetchCollaborators()
+      // Persists until the next edit or save attempt (Primer: don't
+      // auto-dismiss status messages on a timer).
       setSaved(true)
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
-      savedTimerRef.current = setTimeout(() => setSaved(false), 3000)
     } finally {
       savingRef.current = false
     }

--- a/web/src/components/modals/OrgDetailsModal.test.tsx
+++ b/web/src/components/modals/OrgDetailsModal.test.tsx
@@ -139,6 +139,25 @@ describe("OrgDetailsModal", () => {
     )
   })
 
+  it("renders a failed save as an in-dialog banner and stays in edit mode", async () => {
+    planDetails.mockReturnValue({
+      data: { name: "Old Name", description: "old" },
+    })
+    mutateAsync.mockRejectedValueOnce(new Error("boom"))
+    render(<OrgDetailsModal summary={summary()} open onClose={() => {}} />)
+
+    await userEvent.click(screen.getByText("orgs.detailsModal.edit"))
+    await userEvent.click(screen.getByText("orgs.detailsModal.save"))
+
+    // The failure stays inside the dialog (no toast), edit mode is retained
+    // so the teacher can retry.
+    expect(
+      await screen.findByText(/orgs\.detailsModal\.saveError/),
+    ).toBeTruthy()
+    expect(notify).not.toHaveBeenCalled()
+    expect(screen.getByText("orgs.detailsModal.save")).toBeTruthy()
+  })
+
   it("defaults a bare website host to https:// on save", async () => {
     planDetails.mockReturnValue({ data: { name: "Acme", blog: "" } })
     render(<OrgDetailsModal summary={summary()} open onClose={() => {}} />)

--- a/web/src/components/modals/OrgDetailsModal.test.tsx
+++ b/web/src/components/modals/OrgDetailsModal.test.tsx
@@ -19,8 +19,9 @@ vi.mock("@/hooks/mutations/useUpdateOrgProfile", () => ({
 }))
 
 const notify = vi.fn()
+const announce = vi.fn()
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify, dismiss: vi.fn() }),
+  useToast: () => ({ notify, announce, dismiss: vi.fn() }),
 }))
 
 // happy-dom lacks <dialog> showModal/close; stub them so <Modal> renders open.
@@ -130,8 +131,11 @@ describe("OrgDetailsModal", () => {
     expect(mutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({ name: "New Name" }),
     )
-    expect(notify).toHaveBeenCalledWith(
-      expect.objectContaining({ tone: "success" }),
+    // Evident success (the modal flips back to view mode): no toast, just
+    // the SR announcement.
+    expect(notify).not.toHaveBeenCalled()
+    expect(announce).toHaveBeenCalledWith(
+      expect.stringContaining("orgs.detailsModal.saved"),
     )
   })
 

--- a/web/src/components/modals/OrgDetailsModal.tsx
+++ b/web/src/components/modals/OrgDetailsModal.tsx
@@ -138,6 +138,10 @@ function OrgDetailsModal({
     <Modal
       open={open}
       onClose={onClose}
+      // While the save is in flight the dialog is the error's only home
+      // (saveError renders here and reset-on-open wipes it), so a mid-save
+      // dismissal would silently lose the failure.
+      closeDisabled={updateProfile.isPending}
       size="2xl"
       title={<span className="block truncate">{heading}</span>}
       subtitle={

--- a/web/src/components/modals/OrgDetailsModal.tsx
+++ b/web/src/components/modals/OrgDetailsModal.tsx
@@ -3,7 +3,14 @@ import { useEffect, useId, useState } from "react"
 import { useForm } from "@tanstack/react-form"
 import { useTranslation } from "react-i18next"
 
-import { Button, FormField, Input, Modal, Textarea } from "@/components/ui"
+import {
+  AnimatedAlert,
+  Button,
+  FormField,
+  Input,
+  Modal,
+  Textarea,
+} from "@/components/ui"
 import { GitHubLink } from "@/components/GitHubLink"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
@@ -50,11 +57,12 @@ function OrgDetailsModal({
   onClose: () => void
 }) {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const { announce } = useToast()
   // Ties the footer's submit button (outside the <form> element) to the form.
   const formId = useId()
   const { org, membership } = summary
   const [editing, setEditing] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   // Fetch on the login unconditionally (not gated on `open`): same
   // ["github","orgs",login] key the card already fetches, so React Query
@@ -89,19 +97,17 @@ function OrgDetailsModal({
       else update.blog = normalizedBlog
       try {
         await updateProfile.mutateAsync(update)
-        notify({
-          tone: "success",
-          durationMs: 4000,
-          message: t("orgs.detailsModal.saved", { org: heading }),
-        })
+        // The modal flips back to view mode with the fresh values — SR
+        // announcement only (Primer: success messaging sparingly).
+        announce(t("orgs.detailsModal.saved", { org: heading }))
         setEditing(false)
       } catch (err) {
-        notify({
-          tone: "error",
-          message: t("orgs.detailsModal.saveError", {
+        // A dialog-action failure belongs inside the dialog, not a page toast.
+        setSaveError(
+          t("orgs.detailsModal.saveError", {
             error: err instanceof Error ? err.message : "",
           }),
-        })
+        )
       }
     },
   })
@@ -110,17 +116,22 @@ function OrgDetailsModal({
     // Reset to the latest fetched values — details may have loaded after the
     // form initialized with empty defaults.
     form.reset(currentValues())
+    setSaveError(null)
     setEditing(true)
   }
 
   const stopEditing = () => {
     form.reset(currentValues())
+    setSaveError(null)
     setEditing(false)
   }
 
   // Reset on open, never at close — see the close-animation note in ui/Modal.
   useEffect(() => {
-    if (open) setEditing(false)
+    if (open) {
+      setEditing(false)
+      setSaveError(null)
+    }
   }, [open])
 
   return (
@@ -208,9 +219,17 @@ function OrgDetailsModal({
           className="mt-5 flex flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault()
+            setSaveError(null)
             void form.handleSubmit()
           }}
         >
+          <AnimatedAlert
+            tone="error"
+            show={saveError != null}
+            className="text-sm"
+          >
+            {saveError}
+          </AnimatedAlert>
           <form.Field name="name">
             {(field) => (
               <FormField

--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -113,7 +113,6 @@ export function RepoAccessModal({
   assignmentName,
   students = [],
 }: RepoAccessModalProps) {
-  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const savingRef = useRef(false)
   const { user } = useGithubAuth()
   const { t } = useTranslation()
@@ -191,13 +190,6 @@ export function RepoAccessModal({
     setSaved(false)
     setInvalidLogins(new Set())
   }, [open])
-
-  useEffect(
-    () => () => {
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
-    },
-    [],
-  )
 
   const clearInvalid = (login: string) => {
     const normalized = normalizeUsername(login)
@@ -377,9 +369,9 @@ export function RepoAccessModal({
       }
 
       await refetchCollaborators()
+      // Persists until the next edit or save attempt (Primer: don't
+      // auto-dismiss status messages on a timer).
       setSaved(true)
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
-      savedTimerRef.current = setTimeout(() => setSaved(false), 3000)
     } finally {
       savingRef.current = false
     }

--- a/web/src/components/modals/TemplateAccessModal.test.tsx
+++ b/web/src/components/modals/TemplateAccessModal.test.tsx
@@ -30,7 +30,7 @@ vi.mock("@/context/githubOrgRole/GitHubOrgRoleProvider", () => ({
 
 const notify = vi.fn()
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify, dismiss: vi.fn() }),
+  useToast: () => ({ notify, announce: vi.fn(), dismiss: vi.fn() }),
 }))
 
 const listRepoTeams = vi.fn()
@@ -168,7 +168,7 @@ describe("TemplateAccessModal", () => {
     )
   })
 
-  it("toasts success and disables fix after a clean grant (no re-flash)", async () => {
+  it("shows an in-modal success and disables fix after a clean grant (no re-flash)", async () => {
     orgRole = "owner"
     // Student team absent, so Fix starts enabled.
     listRepoTeams.mockResolvedValue([])
@@ -183,9 +183,11 @@ describe("TemplateAccessModal", () => {
     const onSuccess = reconcileMutate.mock.calls[0][1].onSuccess
     act(() => onSuccess({ warning: undefined }))
 
-    expect(notify).toHaveBeenCalledWith(
-      expect.objectContaining({ tone: "success" }),
-    )
+    // Feedback stays inside the open dialog rather than firing a page toast.
+    expect(
+      screen.getByText("assignments.template.reconcile.success"),
+    ).toBeTruthy()
+    expect(notify).not.toHaveBeenCalled()
     // Even though the eventually-consistent list is still empty, the button
     // stays disabled and the empty state is suppressed — no post-success
     // re-flash / re-enable.
@@ -199,7 +201,7 @@ describe("TemplateAccessModal", () => {
     ).toBeNull()
   })
 
-  it("toasts the warning and keeps fix enabled when the grant fails", async () => {
+  it("shows the in-modal failure and keeps fix enabled when the grant fails", async () => {
     orgRole = "owner"
     listRepoTeams.mockResolvedValue([])
     renderModal()
@@ -213,9 +215,10 @@ describe("TemplateAccessModal", () => {
     const onSuccess = reconcileMutate.mock.calls[0][1].onSuccess
     act(() => onSuccess({ warning: "student grant failed" }))
 
-    expect(notify).toHaveBeenCalledWith(
-      expect.objectContaining({ tone: "error" }),
-    )
+    expect(
+      screen.getByText(/assignments\.template\.reconcile\.failed/),
+    ).toBeTruthy()
+    expect(notify).not.toHaveBeenCalled()
     // A failed grant must not latch "satisfied" — the owner can retry.
     expect(screen.getByText(FIX_ACTION).closest("button")?.disabled).toBe(false)
   })

--- a/web/src/components/modals/TemplateAccessModal.tsx
+++ b/web/src/components/modals/TemplateAccessModal.tsx
@@ -7,7 +7,14 @@ import {
   ShieldCheckIcon,
 } from "@/components/ui/icons"
 
-import { Badge, Button, Modal, ModalIcon, Spinner } from "@/components/ui"
+import {
+  AnimatedAlert,
+  Badge,
+  Button,
+  Modal,
+  ModalIcon,
+  Spinner,
+} from "@/components/ui"
 import type { Assignment } from "@/types/classroom"
 import type { GitHubRepoTeam } from "@/github-core/types"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
@@ -15,7 +22,6 @@ import { useGitHubOrgRole } from "@/context/githubOrgRole/GitHubOrgRoleProvider"
 import { can } from "@/authz"
 import { repoTeamsQuery } from "@/github-core/queries"
 import { useReconcileTemplateAccess } from "@/hooks/mutations/useReconcileTemplateAccess"
-import { useToast } from "@/context/notifications/NotificationProvider"
 import { classroomTeamSlug } from "@/util/teamSlug"
 import { githubTemplateRepoUrl } from "@/util/orgUrl"
 
@@ -44,7 +50,6 @@ export const TemplateAccessModal = ({
 }) => {
   const { t } = useTranslation()
   const client = useGitHubClient()
-  const { notify } = useToast()
   const { githubOrgRole } = useGitHubOrgRole()
   const isOwner = can("manageOrg", { githubOrgRole })
   const reconcile = useReconcileTemplateAccess()
@@ -54,6 +59,11 @@ export const TemplateAccessModal = ({
   // would re-enable and the list re-flash "no teams" right after the success
   // toast. Cleared when the refetch settles with the granted team present.
   const [granted, setGranted] = useState(false)
+  // Outcome of the last Fix run, rendered as an in-dialog banner.
+  const [fixOutcome, setFixOutcome] = useState<{
+    tone: "success" | "error"
+    message: string
+  } | null>(null)
 
   const template = assignment.template
   const inOrg = !!template && template.owner.toLowerCase() === org.toLowerCase()
@@ -93,6 +103,7 @@ export const TemplateAccessModal = ({
 
   const handleFix = () => {
     setGranted(false)
+    setFixOutcome(null)
     reconcile.mutate(
       {
         org,
@@ -102,15 +113,18 @@ export const TemplateAccessModal = ({
         locked: assignment.locked,
       },
       {
+        // Outcome feedback stays inside the open dialog (Primer): success is
+        // only partially evident (the Fix button disables), and a failure
+        // needs to sit next to the action that caused it.
         onSuccess: (result) => {
           if (result.warning) {
-            notify({
+            setFixOutcome({
               tone: "error",
               message: `${t("assignments.template.reconcile.failed")} ${result.warning}`,
             })
           } else {
             setGranted(true)
-            notify({
+            setFixOutcome({
               tone: "success",
               message: t("assignments.template.reconcile.success"),
             })
@@ -168,6 +182,13 @@ export const TemplateAccessModal = ({
       }
     >
       <section className="mt-5">
+        <AnimatedAlert
+          tone={fixOutcome?.tone ?? "success"}
+          show={fixOutcome != null}
+          className="mb-4 text-sm"
+        >
+          {fixOutcome?.message}
+        </AnimatedAlert>
         <div className="flex items-center justify-between gap-3">
           <h4 className="text-sm font-semibold text-base-content/80">
             {t("assignments.template.accessModal.templateHeading")}

--- a/web/src/components/modals/TemplateAccessModal.tsx
+++ b/web/src/components/modals/TemplateAccessModal.tsx
@@ -8,13 +8,14 @@ import {
 } from "@/components/ui/icons"
 
 import {
-  AnimatedAlert,
   Badge,
   Button,
   Modal,
   ModalIcon,
+  OutcomeAlert,
   Spinner,
 } from "@/components/ui"
+import type { AlertOutcome } from "@/components/ui"
 import type { Assignment } from "@/types/classroom"
 import type { GitHubRepoTeam } from "@/github-core/types"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
@@ -60,10 +61,7 @@ export const TemplateAccessModal = ({
   // toast. Cleared when the refetch settles with the granted team present.
   const [granted, setGranted] = useState(false)
   // Outcome of the last Fix run, rendered as an in-dialog banner.
-  const [fixOutcome, setFixOutcome] = useState<{
-    tone: "success" | "error"
-    message: string
-  } | null>(null)
+  const [fixOutcome, setFixOutcome] = useState<AlertOutcome | null>(null)
 
   const template = assignment.template
   const inOrg = !!template && template.owner.toLowerCase() === org.toLowerCase()
@@ -182,13 +180,7 @@ export const TemplateAccessModal = ({
       }
     >
       <section className="mt-5">
-        <AnimatedAlert
-          tone={fixOutcome?.tone ?? "success"}
-          show={fixOutcome != null}
-          className="mb-4 text-sm"
-        >
-          {fixOutcome?.message}
-        </AnimatedAlert>
+        <OutcomeAlert outcome={fixOutcome} className="mb-4 text-sm" />
         <div className="flex items-center justify-between gap-3">
           <h4 className="text-sm font-semibold text-base-content/80">
             {t("assignments.template.accessModal.templateHeading")}

--- a/web/src/components/ui/Alert.tsx
+++ b/web/src/components/ui/Alert.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import {
   AlertIcon,
   CheckCircleIcon,
+  CircleSlashIcon,
   InfoIcon,
   StopIcon,
   XIcon,
@@ -22,13 +23,17 @@ import { cx } from "./cx"
 // `role` defaults by tone — "alert" (assertive) only for errors, "status"
 // (polite) otherwise — matching the app-wide messaging ARIA convention.
 
-export type AlertTone = "info" | "success" | "warning" | "error"
+export type AlertTone = "info" | "success" | "warning" | "error" | "unavailable"
 
 const TONE_CLASS: Record<AlertTone, string> = {
   info: "alert-info",
   success: "alert-success",
   warning: "alert-warning",
   error: "alert-error",
+  // Primer's `unavailable` state (degraded reads, permission gates): the
+  // bare neutral alert — deliberately not a color, so a page of degraded
+  // sections reads calm rather than alarming.
+  unavailable: "",
 }
 
 // The single source of truth for the alert tone->class recipe. Reused by the
@@ -45,6 +50,7 @@ export const ALERT_TONE_ICON: Record<AlertTone, typeof InfoIcon> = {
   success: CheckCircleIcon,
   warning: AlertIcon,
   error: StopIcon,
+  unavailable: CircleSlashIcon,
 }
 
 export function alertToneRole(tone: AlertTone): "alert" | "status" {

--- a/web/src/components/ui/Alert.tsx
+++ b/web/src/components/ui/Alert.tsx
@@ -57,6 +57,14 @@ export function alertToneRole(tone: AlertTone): "alert" | "status" {
   return tone === "error" ? "alert" : "status"
 }
 
+// One shared shape for "the outcome of the last action", rendered via
+// <OutcomeAlert>. Sites narrow the tone union in their own state types but
+// share this contract instead of re-declaring it inline.
+export type AlertOutcome = {
+  tone: AlertTone
+  message: string
+}
+
 export type AlertProps = {
   tone: AlertTone
   soft?: boolean

--- a/web/src/components/ui/OutcomeAlert.tsx
+++ b/web/src/components/ui/OutcomeAlert.tsx
@@ -1,0 +1,32 @@
+import { AnimatedAlert } from "./AnimatedAlert"
+import type { AlertOutcome } from "./Alert"
+
+// The one way to render an action-outcome banner from `AlertOutcome | null`
+// state: collapsed when null, animated in when set. Single-sources the
+// `tone/show/message` triple that hosts used to hand-roll (with drifting
+// hidden-state fallback tones — "info" here is invisible while hidden).
+
+export type OutcomeAlertProps = {
+  outcome: AlertOutcome | null | undefined
+  className?: string
+  onDismiss?: () => void
+}
+
+export function OutcomeAlert({
+  outcome,
+  className,
+  onDismiss,
+}: OutcomeAlertProps) {
+  return (
+    <AnimatedAlert
+      tone={outcome?.tone ?? "info"}
+      show={outcome != null}
+      className={className}
+      onDismiss={onDismiss}
+    >
+      {outcome?.message}
+    </AnimatedAlert>
+  )
+}
+
+export default OutcomeAlert

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -52,13 +52,16 @@ export type { DropdownMenuProps } from "./DropdownMenu"
 export { SelectAllCheckbox } from "./SelectAllCheckbox"
 
 export { Alert, ALERT_TONE_ICON, alertToneClass, alertToneRole } from "./Alert"
-export type { AlertProps, AlertTone } from "./Alert"
+export type { AlertProps, AlertTone, AlertOutcome } from "./Alert"
 
 export { InlineMessage } from "./InlineMessage"
 export type { InlineMessageProps, InlineMessageTone } from "./InlineMessage"
 
 export { AnimatedAlert } from "./AnimatedAlert"
 export type { AnimatedAlertProps } from "./AnimatedAlert"
+
+export { OutcomeAlert } from "./OutcomeAlert"
+export type { OutcomeAlertProps } from "./OutcomeAlert"
 
 export { Collapse } from "./Collapse"
 

--- a/web/src/context/notifications/NotificationProvider.test.tsx
+++ b/web/src/context/notifications/NotificationProvider.test.tsx
@@ -89,4 +89,30 @@ describe("NotificationProvider announce", () => {
     // No visible toast accompanies it.
     expect(container.querySelector(".toast .alert")).toBeNull()
   })
+
+  it("joins announcements fired inside one flush window instead of dropping", async () => {
+    function FireTwo() {
+      const { announce } = useToast()
+      return (
+        <button
+          onClick={() => {
+            announce("First done.")
+            announce("Second done.")
+          }}
+        >
+          fire
+        </button>
+      )
+    }
+    const { container } = render(
+      <NotificationProvider>
+        <FireTwo />
+      </NotificationProvider>,
+    )
+    const region = container.querySelector('div.sr-only[role="status"]')
+    await userEvent.click(screen.getByText("fire"))
+    await waitFor(() =>
+      expect(region?.textContent).toBe("First done. Second done."),
+    )
+  })
 })

--- a/web/src/context/notifications/NotificationProvider.test.tsx
+++ b/web/src/context/notifications/NotificationProvider.test.tsx
@@ -64,3 +64,29 @@ describe("NotificationProvider toast action", () => {
     expect(screen.queryByText("Undo")).toBeNull()
   })
 })
+
+describe("NotificationProvider announce", () => {
+  function FireAnnounce() {
+    const { announce } = useToast()
+    return <button onClick={() => announce("Classroom deleted.")}>fire</button>
+  }
+
+  it("renders an always-mounted sr-only polite region and fills it on announce", async () => {
+    const { container } = render(
+      <NotificationProvider>
+        <FireAnnounce />
+      </NotificationProvider>,
+    )
+    // The live region must exist BEFORE it changes to be announced.
+    const region = container.querySelector('div.sr-only[role="status"]')
+    expect(region).toBeTruthy()
+    expect(region?.getAttribute("aria-live")).toBe("polite")
+    expect(region?.textContent).toBe("")
+
+    await userEvent.click(screen.getByText("fire"))
+    // Content lands after the clear-then-set tick (re-announce support).
+    await waitFor(() => expect(region?.textContent).toBe("Classroom deleted."))
+    // No visible toast accompanies it.
+    expect(container.querySelector(".toast .alert")).toBeNull()
+  })
+})

--- a/web/src/context/notifications/NotificationProvider.tsx
+++ b/web/src/context/notifications/NotificationProvider.tsx
@@ -62,6 +62,10 @@ export type NotifyInput = {
 type NotificationContextValue = {
   notify: (input: NotifyInput) => string
   dismiss: (id: string) => void
+  // Screen-reader-only polite announcement, for outcomes that are visually
+  // evident (a row disappears, a badge flips) and so need no toast — Primer:
+  // success messaging sparingly, but the state change must still reach AT.
+  announce: (message: string) => void
 }
 
 const NotificationContext = createContext<NotificationContextValue | null>(null)
@@ -83,8 +87,18 @@ const MAX_TOASTS = 5
 // keyed dedup, dismissible); migrating that onto notify()/useToast is a follow-up.
 export function NotificationProvider({ children }: PropsWithChildren) {
   const [toasts, setToasts] = useState<Toast[]>([])
+  const [announcement, setAnnouncement] = useState("")
   // Track auto-dismiss timers so a keyed replace / manual dismiss clears them.
   const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
+  const announceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const announce = useCallback((message: string) => {
+    // Clear-then-set so repeating the same message re-announces (a live
+    // region only fires on content change).
+    setAnnouncement("")
+    if (announceTimer.current) clearTimeout(announceTimer.current)
+    announceTimer.current = setTimeout(() => setAnnouncement(message), 50)
+  }, [])
 
   const clearTimer = useCallback((id: string) => {
     const timer = timers.current.get(id)
@@ -157,14 +171,24 @@ export function NotificationProvider({ children }: PropsWithChildren) {
     return () => {
       map.forEach((timer) => clearTimeout(timer))
       map.clear()
+      if (announceTimer.current) clearTimeout(announceTimer.current)
     }
   }, [])
 
-  const value = useMemo(() => ({ notify, dismiss }), [notify, dismiss])
+  const value = useMemo(
+    () => ({ notify, dismiss, announce }),
+    [notify, dismiss, announce],
+  )
 
   return (
     <NotificationContext.Provider value={value}>
       {children}
+      {/* Always rendered (a live region must exist before it changes to be
+          announced); visually hidden — the visible outcome is the UI change
+          the announcement describes. */}
+      <div role="status" aria-live="polite" className="sr-only">
+        {announcement}
+      </div>
       <ToastViewport toasts={toasts} onDismiss={dismiss} />
     </NotificationContext.Provider>
   )

--- a/web/src/context/notifications/NotificationProvider.tsx
+++ b/web/src/context/notifications/NotificationProvider.tsx
@@ -91,13 +91,20 @@ export function NotificationProvider({ children }: PropsWithChildren) {
   // Track auto-dismiss timers so a keyed replace / manual dismiss clears them.
   const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
   const announceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Announcements landing inside one flush window are joined, not clobbered —
+  // a second announce() must never silently drop the first.
+  const pendingAnnouncements = useRef<string[]>([])
 
   const announce = useCallback((message: string) => {
     // Clear-then-set so repeating the same message re-announces (a live
     // region only fires on content change).
     setAnnouncement("")
+    pendingAnnouncements.current.push(message)
     if (announceTimer.current) clearTimeout(announceTimer.current)
-    announceTimer.current = setTimeout(() => setAnnouncement(message), 50)
+    announceTimer.current = setTimeout(() => {
+      setAnnouncement(pendingAnnouncements.current.join(" "))
+      pendingAnnouncements.current = []
+    }, 50)
   }, [])
 
   const clearTimer = useCallback((id: string) => {

--- a/web/src/pages/AssignmentSettingsPage.tsx
+++ b/web/src/pages/AssignmentSettingsPage.tsx
@@ -277,12 +277,12 @@ const AssignmentSettingsPage = () => {
             }}
             onSuccess={(result) => {
               // Surface a non-fatal template-grant warning inline; else show
-              // the success banner.
+              // the success banner. It persists until the next save clears it
+              // via onMutate (Primer: don't auto-dismiss status messages).
               if (result?.templateGrantWarning) {
                 setEditWarning(result.templateGrantWarning)
               } else {
                 setEditSuccess(true)
-                setTimeout(() => setEditSuccess(false), 3000)
               }
               window.scrollTo({ top: 0, behavior: "smooth" })
             }}

--- a/web/src/pages/ClassroomSettingsPage.tsx
+++ b/web/src/pages/ClassroomSettingsPage.tsx
@@ -12,7 +12,7 @@ import useGetClassroom from "@/hooks/useGetClassroom"
 import { Trans, useTranslation } from "react-i18next"
 import { useEditClassroom } from "@/hooks/mutations/useEditClassroom"
 import { isClassroomArchived } from "@/types/classroom"
-import { useToast } from "@/context/notifications/NotificationProvider"
+import { useState } from "react"
 import { useTrackPublishDeploy } from "@/hooks/useTrackPublishDeploy"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import RequireRole from "@/components/RequireRole"
@@ -27,9 +27,14 @@ const EditClassroomContent = ({
   classroom: string
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
   const trackPublishDeploy = useTrackPublishDeploy()
   const runSave = useSafeSubmit()
+  // Save outcome, rendered inline near the form's actions (Primer: feedback
+  // for a page form belongs next to it, not in a corner toast).
+  const [saveOutcome, setSaveOutcome] = useState<{
+    tone: "success" | "error"
+    message: string
+  } | null>(null)
   const { data: cl, isLoading: loadingClassroom } = useGetClassroom(
     org,
     classroom,
@@ -68,6 +73,8 @@ const EditClassroomContent = ({
           />
           <EditClassroomForm
             cl={cl}
+            saveOutcome={saveOutcome}
+            onEdit={() => setSaveOutcome(null)}
             onSubmit={(values) =>
               runSave(() =>
                 editClassroomMutation.mutateAsync(
@@ -81,7 +88,7 @@ const EditClassroomContent = ({
                   },
                   {
                     onError: (err) => {
-                      notify({
+                      setSaveOutcome({
                         tone: "error",
                         message:
                           err instanceof GitHubAPIError && err.status === 409
@@ -92,14 +99,10 @@ const EditClassroomContent = ({
                       })
                     },
                     onSuccess: () => {
-                      // Plain-text message only: NotificationProvider is mounted
-                      // ABOVE the RouterProvider, so a TanStack <Link> here has
-                      // no router context and throws on render, blanking the
-                      // app. Settings update in place via the hook's
-                      // invalidations, so no navigation link is needed.
-                      notify({
+                      // Settings update in place via the hook's invalidations,
+                      // so the confirmation sits by the save button it answers.
+                      setSaveOutcome({
                         tone: "success",
-                        durationMs: 5000,
                         message: t("toasts.classroomSettingsSaved"),
                       })
                     },

--- a/web/src/pages/ClassroomSettingsPage.tsx
+++ b/web/src/pages/ClassroomSettingsPage.tsx
@@ -18,6 +18,7 @@ import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import RequireRole from "@/components/RequireRole"
 import { LoadingSwap } from "@/lib/LoadingSwap"
 import { Alert, EmphasisLtr } from "@/components/ui"
+import type { AlertOutcome } from "@/components/ui"
 
 const EditClassroomContent = ({
   org,
@@ -31,10 +32,7 @@ const EditClassroomContent = ({
   const runSave = useSafeSubmit()
   // Save outcome, rendered inline near the form's actions (Primer: feedback
   // for a page form belongs next to it, not in a corner toast).
-  const [saveOutcome, setSaveOutcome] = useState<{
-    tone: "success" | "error"
-    message: string
-  } | null>(null)
+  const [saveOutcome, setSaveOutcome] = useState<AlertOutcome | null>(null)
   const { data: cl, isLoading: loadingClassroom } = useGetClassroom(
     org,
     classroom,

--- a/web/src/pages/CreateAssignmentPage.test.tsx
+++ b/web/src/pages/CreateAssignmentPage.test.tsx
@@ -101,7 +101,7 @@ vi.mock("@/hooks/useTrackPublishDeploy", () => ({
   useTrackPublishDeploy: () => vi.fn(),
 }))
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify: vi.fn() }),
+  useToast: () => ({ notify: vi.fn(), announce: vi.fn() }),
 }))
 
 const navigateMock = vi.fn()

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -1,4 +1,5 @@
 import { useParams, useNavigate } from "@tanstack/react-router"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { useGithubAuth } from "@/auth/useGithubAuth"
@@ -25,6 +26,9 @@ const CreateClassroomPage = () => {
   const trackPublishDeploy = useTrackPublishDeploy()
   const { user } = useGithubAuth()
   const { org } = useParams({ strict: false })
+  // Failed-create message, rendered inline in the form (the flow stays on
+  // this page on error; only success navigates away).
+  const [createError, setCreateError] = useState<string | null>(null)
 
   const createClassroomMutation = useCreateClassroom(
     org ?? "",
@@ -49,8 +53,10 @@ const CreateClassroomPage = () => {
       <RequireRole allow="owner">
         <PageHeader title={t("classes.createTitle")} />
         <CreateClassroomForm
-          onSubmit={(values) =>
-            createClassroomMutation.mutateAsync(
+          submitError={createError}
+          onSubmit={(values) => {
+            setCreateError(null)
+            return createClassroomMutation.mutateAsync(
               {
                 name: values.name,
                 classroom: values.slug,
@@ -62,12 +68,13 @@ const CreateClassroomPage = () => {
               {
                 onError: (err) => {
                   logWriteFailure(log, err, "create classroom failed")
-                  notify({
-                    tone: "error",
-                    message: t("toasts.classroomCreateFailed", {
+                  // Stays on the form, so the failure renders inline next to
+                  // the create button rather than as a corner toast.
+                  setCreateError(
+                    t("toasts.classroomCreateFailed", {
                       message: err.message,
                     }),
-                  })
+                  )
                 },
                 onSuccess: (_result, variables) => {
                   // Toast before navigating: the provider is mounted above the
@@ -84,7 +91,7 @@ const CreateClassroomPage = () => {
                 },
               },
             )
-          }
+          }}
         />
       </RequireRole>
     </PageShell>

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -416,7 +416,18 @@ const OrgMembersPage = () => {
     if (!org || invitingKey) return
     setInvitingKey(row.key)
     try {
-      await runInviteMember(client, org, row, notify, () => refreshInvite(), t)
+      await runInviteMember(
+        client,
+        org,
+        row,
+        {
+          onSuccess: (message) =>
+            notify({ tone: "success", durationMs: 6000, message }),
+          onError: (message) => notify({ tone: "error", message }),
+        },
+        () => refreshInvite(),
+        t,
+      )
     } finally {
       setInvitingKey(null)
     }

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -410,6 +410,8 @@ const OrgMembersPage = () => {
 
   // Inline row invite for an on-roster non-member (mirrors the detail-drawer
   // action). Invites by github_id so a stale username doesn't matter.
+  // Feedback stays a toast for this caller: a dense table row has no inline
+  // slot, and the success must outlive the eventually-consistent refetch.
   const handleQuickInvite = async (row: OrgMemberRow) => {
     if (!org || invitingKey) return
     setInvitingKey(row.key)

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import {
+  AnimatedAlert,
   Button,
   FormField,
   HelpTooltip,
@@ -431,7 +432,7 @@ function SetTokenModal({
 export const OrgSettingsPane = ({ highlighted }: { highlighted?: boolean }) => {
   const { t } = useTranslation()
   const { org } = useParams({ strict: false })
-  const { notify } = useToast()
+  const { announce } = useToast()
 
   const { data: tokenStatus, isLoading: tokenStatusLoading } =
     useGetServiceTokenStatus(org ?? "")
@@ -460,9 +461,14 @@ export const OrgSettingsPane = ({ highlighted }: { highlighted?: boolean }) => {
   const renameMutation = useRenameServiceToken(org)
 
   const [modalOpen, setModalOpen] = useState(false)
+  // Advisory-metadata warning from the last save, shown as a banner in this
+  // section (the save dialog is closed by then, and a chip alone can't
+  // explain "expiry not tracked").
+  const [metadataWarning, setMetadataWarning] = useState(false)
 
   const openModal = () => {
     saveMutation.reset()
+    setMetadataWarning(false)
     setModalOpen(true)
   }
 
@@ -474,15 +480,10 @@ export const OrgSettingsPane = ({ highlighted }: { highlighted?: boolean }) => {
       // clean "saved", so the teacher isn't misled by a later "expiry not
       // tracked" chip.
       if (saveMutation.data && saveMutation.data.metadataRecorded === false) {
-        notify({
-          tone: "warning",
-          message: t("orgSettings.serviceToken.savedNoMetadata"),
-        })
+        setMetadataWarning(true)
       } else {
-        notify({
-          tone: "success",
-          message: t("orgSettings.serviceToken.saved"),
-        })
+        // The status chip flips to "present" — SR announcement only.
+        announce(t("orgSettings.serviceToken.saved"))
       }
     }
   }
@@ -494,6 +495,14 @@ export const OrgSettingsPane = ({ highlighted }: { highlighted?: boolean }) => {
       titleAdornment={<HelpTooltip help={t("orgSettings.serviceToken.help")} />}
       className={sectionHighlightClass(highlighted ?? false)}
     >
+      <AnimatedAlert
+        tone="warning"
+        show={metadataWarning}
+        className="mb-3 text-sm"
+        onDismiss={() => setMetadataWarning(false)}
+      >
+        {t("orgSettings.serviceToken.savedNoMetadata")}
+      </AnimatedAlert>
       {tokenStatusLoading ? (
         <div
           className="flex flex-wrap items-center justify-between gap-3"

--- a/web/src/pages/OrgSetupPage.tsx
+++ b/web/src/pages/OrgSetupPage.tsx
@@ -240,12 +240,12 @@ const OrgSteps = ({
 
 const NotAdminAlert = () => {
   const { t } = useTranslation()
-  return <Alert tone="error">{t("setup.notAdmin")}</Alert>
+  return <Alert tone="unavailable">{t("setup.notAdmin")}</Alert>
 }
 
 const NotTeamOrEnterpriseNotice = () => {
   const { t } = useTranslation()
-  return <Alert tone="error">{t("setup.notTeamOrEnterprise")}</Alert>
+  return <Alert tone="unavailable">{t("setup.notTeamOrEnterprise")}</Alert>
 }
 
 // Derive the wizard stage from what exists on GitHub (config repo + service

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -46,6 +46,7 @@ import {
   Button,
   Card,
   DropdownMenu,
+  InlineMessage,
   RouterButton,
   Toolbar,
   cx,
@@ -74,6 +75,9 @@ function PendingInviteCard({ invite }: { invite: GitHubOrgMembership }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { notify } = useToast()
+  // Accept failure, rendered inside this invite card (Primer: feedback next
+  // to the action). Success keeps its toast — it rides the navigation away.
+  const [acceptError, setAcceptError] = useState(false)
   const org = invite.organization
   const isOwner = isOwnerGitHubOrgRole(invite.role)
 
@@ -126,6 +130,11 @@ function PendingInviteCard({ invite }: { invite: GitHubOrgMembership }) {
         </div>
 
         <Card.Actions className="mt-5 items-center justify-end gap-2">
+          {acceptError && (
+            <InlineMessage tone="error" className="me-auto">
+              {t("orgs.invites.acceptError", { org: org.login })}
+            </InlineMessage>
+          )}
           <GitHubLink
             href={`https://github.com/orgs/${org.login}/invitation`}
             label={t("orgs.invites.viewOnGitHub")}
@@ -138,9 +147,12 @@ function PendingInviteCard({ invite }: { invite: GitHubOrgMembership }) {
             size="sm"
             loading={accept.isPending}
             loadingLabel={t("orgs.invites.accepting")}
-            onClick={() =>
+            onClick={() => {
+              setAcceptError(false)
               accept.mutate(undefined, {
                 onSuccess: () => {
+                  // Kept as a toast: it must survive the navigation below
+                  // (the provider mounts above the router).
                   notify({
                     tone: "success",
                     message: t("orgs.invites.accepted", { org: org.login }),
@@ -148,13 +160,10 @@ function PendingInviteCard({ invite }: { invite: GitHubOrgMembership }) {
                   navigate({ to: "/$org", params: { org: org.login } })
                 },
                 onError: () => {
-                  notify({
-                    tone: "error",
-                    message: t("orgs.invites.acceptError", { org: org.login }),
-                  })
+                  setAcceptError(true)
                 },
               })
-            }
+            }}
           >
             {t("orgs.invites.acceptOpen")}
           </Button>
@@ -232,6 +241,8 @@ function HideOrgMenu({
 
   const handleHide = () => {
     hide(org.login)
+    // Kept as a toast: the card disappears, so this is the Undo's only home
+    // (Primer error-forgiveness pattern).
     notify({
       tone: "info",
       key: `org-hidden-${org.login}`,

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -131,7 +131,9 @@ function PendingInviteCard({ invite }: { invite: GitHubOrgMembership }) {
 
         <Card.Actions className="mt-5 items-center justify-end gap-2">
           {acceptError && (
-            <InlineMessage tone="error" className="me-auto">
+            // role="alert" so the insertion is announced — this replaced an
+            // error toast, and no focus move carries the message.
+            <InlineMessage tone="error" role="alert" className="me-auto">
               {t("orgs.invites.acceptError", { org: org.login })}
             </InlineMessage>
           )}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -1178,13 +1178,13 @@ const SubmissionsPageContent = () => {
       />
 
       {isLockedAssignment && (
-        <Alert tone="warning" role="status">
+        <Alert tone="info" role="status">
           {t("submissions.lockedNotice")}
         </Alert>
       )}
 
       {isClosedAssignment && !isLockedAssignment && (
-        <Alert tone="warning" role="status">
+        <Alert tone="info" role="status">
           {t("submissions.closedNotice")}
         </Alert>
       )}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -878,21 +878,23 @@ const SubmissionsPageContent = () => {
     classroom && assignment ? { classroom, assignment } : undefined,
   )
   const regradeAll = useTriggerRegrade({ org, classroom, assignment })
-  const { notify } = useToast()
+  const { notify, announce } = useToast()
   // Lock/unlock this assignment. The page owns the mutation (like Regrade all)
   // and surfaces the non-fatal template-access warning; the menu just triggers
   // the confirm. Gated on authoring rights at the call site.
   const setLock = useSetAssignmentLock(org ?? "", classroom ?? "", (result) => {
     if (result.templateAccessWarning) {
+      // Kept as a toast: a non-fatal partial outcome with no page anchor.
       notify({ tone: "warning", message: result.templateAccessWarning })
       return
     }
-    notify({
-      tone: "success",
-      message: result.locked
+    // The locked/closed banner and header badge flip in place — SR
+    // announcement only (Primer: success messaging sparingly).
+    announce(
+      result.locked
         ? t("submissions.lock.lockSuccess")
         : t("submissions.lock.unlockSuccess"),
-    })
+    )
   })
   // Same delete mechanism as the assignments table's manage hub (removes the
   // assignments.json entry; student repos are kept).

--- a/web/src/pages/assignments/AssignmentRowActions.tsx
+++ b/web/src/pages/assignments/AssignmentRowActions.tsx
@@ -287,7 +287,7 @@ export const LockAssignmentAction = ({
   variant?: ActionVariant
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const { notify, announce } = useToast()
   const [open, setOpen] = useState(false)
   const locked = Boolean(assignment.locked)
   const label = assignmentName(assignment)
@@ -312,15 +312,16 @@ export const LockAssignmentAction = ({
       }
   const setLock = useSetAssignmentLock(org, classroom, (result) => {
     if (result.templateAccessWarning) {
+      // Kept as a toast: a non-fatal partial outcome with no page anchor.
       notify({ tone: "warning", message: result.templateAccessWarning })
       return
     }
-    notify({
-      tone: "success",
-      message: result.locked
+    // The row's lock icon flips in place — SR announcement only.
+    announce(
+      result.locked
         ? t("assignments.table.lockSuccess", { name: label })
         : t("assignments.table.unlockSuccess", { name: label }),
-    })
+    )
   })
 
   return (

--- a/web/src/pages/assignments/AssignmentsTable.test.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.test.tsx
@@ -42,7 +42,7 @@ vi.mock("@/context/github/GitHubProvider", () => ({
 // the table test doesn't exercise notifications, so stub the hook rather than
 // wrapping every render in a provider.
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify: () => {} }),
+  useToast: () => ({ notify: () => {}, announce: () => {} }),
 }))
 
 // The modal is exercised in its own test; here we stub it to a marker so the

--- a/web/src/pages/assignments/ClassroomCollectButton.test.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.test.tsx
@@ -11,7 +11,7 @@ vi.mock("react-i18next", async (importOriginal) => {
 
 const notify = vi.fn()
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify, dismiss: vi.fn() }),
+  useToast: () => ({ notify, announce: vi.fn(), dismiss: vi.fn() }),
 }))
 
 const collect = vi.fn()

--- a/web/src/pages/assignments/ClassroomCollectButton.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.tsx
@@ -181,6 +181,9 @@ export function ClassroomCollectButton({
 
   useEffect(() => {
     if (collect.phase !== "failed" || collect.failure !== "dispatch") return
+    // Kept as a toast: the dispatch is fire-and-forget and this button can
+    // unmount (route change) before the failure lands; the keyed toast is
+    // the one surface guaranteed to survive.
     notify({
       tone: "error",
       key: `collect-scores:${classroom}`,

--- a/web/src/pages/classes/ClaimTeacherNotice.test.tsx
+++ b/web/src/pages/classes/ClaimTeacherNotice.test.tsx
@@ -13,6 +13,7 @@ vi.mock("react-i18next", async (importOriginal) => {
 const orgRoleMock = vi.fn()
 const classroomCtxMock = vi.fn()
 const notifyMock = vi.fn()
+const announceMock = vi.fn()
 const ensureTeamMock = vi.fn()
 const grantWriteMock = vi.fn()
 const addUserMock = vi.fn()
@@ -30,7 +31,7 @@ vi.mock("@/auth/useGithubAuth", () => ({
   useGithubAuth: () => ({ user: { login: "owner1" } }),
 }))
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify: notifyMock, announce: vi.fn() }),
+  useToast: () => ({ notify: notifyMock, announce: announceMock }),
 }))
 vi.mock("@/github-core/mutations", () => ({
   ensureClassroomRoleTeam: (...a: unknown[]) => ensureTeamMock(...a),
@@ -110,12 +111,10 @@ describe("ClaimTeacherNotice self-add", () => {
         role: "maintainer",
       },
     )
-    expect(notifyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ tone: "success" }),
-    )
+    expect(announceMock).toHaveBeenCalledWith("classes.claimTeacher.success")
   })
 
-  it("surfaces an error toast when the add fails", async () => {
+  it("surfaces the failure inline in the notice when the add fails", async () => {
     orgRoleMock.mockReturnValue({ githubOrgRole: "owner" })
     classroomCtxMock.mockReturnValue({ actualRole: "student" })
     ensureTeamMock.mockResolvedValue({ slug: "classroom50-cs101-teacher" })
@@ -125,8 +124,10 @@ describe("ClaimTeacherNotice self-add", () => {
     wrap(<ClaimTeacherNotice org="acme" classroom="cs101" />)
     await userEvent.click(screen.getByText(action))
 
-    expect(notifyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ tone: "error" }),
-    )
+    // Rendered inline in the notice, not as a page toast.
+    expect(
+      await screen.findByText(/classes\.claimTeacher\.failed/),
+    ).toBeTruthy()
+    expect(notifyMock).not.toHaveBeenCalled()
   })
 })

--- a/web/src/pages/classes/ClaimTeacherNotice.test.tsx
+++ b/web/src/pages/classes/ClaimTeacherNotice.test.tsx
@@ -30,7 +30,7 @@ vi.mock("@/auth/useGithubAuth", () => ({
   useGithubAuth: () => ({ user: { login: "owner1" } }),
 }))
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify: notifyMock }),
+  useToast: () => ({ notify: notifyMock, announce: vi.fn() }),
 }))
 vi.mock("@/github-core/mutations", () => ({
   ensureClassroomRoleTeam: (...a: unknown[]) => ensureTeamMock(...a),

--- a/web/src/pages/classes/ClaimTeacherNotice.tsx
+++ b/web/src/pages/classes/ClaimTeacherNotice.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { InlineSpinner } from "@/components/Spinner"
 import { ShieldIcon } from "@/components/ui/icons"
@@ -6,7 +7,7 @@ import { useGitHubOrgRole } from "@/context/githubOrgRole/GitHubOrgRoleProvider"
 import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 import { can } from "@/authz"
 import { useClaimTeacher } from "@/hooks/mutations/useClaimTeacher"
-import { Alert, Button } from "@/components/ui"
+import { Alert, Button, InlineMessage } from "@/components/ui"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("classroom:claim-teacher")
@@ -26,35 +27,38 @@ export function ClaimTeacherNotice({
   classroom: string
 }) {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const { announce } = useToast()
   const { githubOrgRole } = useGitHubOrgRole()
   const { actualRole } = useClassroomRoleContext()
+  const [claimError, setClaimError] = useState<string | null>(null)
 
   const claimMutation = useClaimTeacher(org, classroom, {
     somethingWentWrong: t("classes.somethingWentWrong"),
   })
 
-  const claim = () =>
+  const claim = () => {
+    setClaimError(null)
     claimMutation.mutate(undefined, {
       onSuccess: () => {
-        notify({
-          tone: "success",
-          message: t("classes.claimTeacher.success"),
-        })
+        // The notice itself disappears once the role refetch settles — SR
+        // announcement only.
+        announce(t("classes.claimTeacher.success"))
       },
       onError: (err) => {
         log.warn("claim teacher failed", { org, classroom, err })
-        notify({
-          tone: "error",
-          message: t("classes.claimTeacher.failed", {
+        // Rendered inside this notice (Primer: feedback next to the control
+        // that caused it).
+        setClaimError(
+          t("classes.claimTeacher.failed", {
             message:
               err instanceof Error
                 ? err.message
                 : t("classes.somethingWentWrong"),
           }),
-        })
+        )
       },
     })
+  }
 
   // Only an org owner who currently resolves to `student` here needs repair. A
   // TA/teacher of this classroom, or a non-owner, never sees it. `unresolved`
@@ -65,7 +69,7 @@ export function ClaimTeacherNotice({
   return (
     <Alert
       tone="info"
-      className="mb-4 flex-col items-start gap-2 sm:flex-row sm:items-center"
+      className="mb-4 flex-col items-start gap-2 sm:flex-row sm:items-center sm:flex-wrap"
     >
       <ShieldIcon aria-hidden="true" className="size-4 shrink-0" />
       <span className="flex-1 text-sm">
@@ -84,6 +88,11 @@ export function ClaimTeacherNotice({
         )}
         {t("classes.claimTeacher.action")}
       </Button>
+      {claimError != null && (
+        <InlineMessage tone="error" className="w-full">
+          {claimError}
+        </InlineMessage>
+      )}
     </Alert>
   )
 }

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -353,6 +353,7 @@ function ClassroomMenu({
                       : t("classes.somethingWentWrong"),
                 },
               ),
+              { cause: err },
             )
           }
         }}
@@ -418,6 +419,7 @@ function ClassroomMenu({
                     ? err.message
                     : t("classes.somethingWentWrong"),
               }),
+              { cause: err },
             )
           }
         }}

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -115,7 +115,7 @@ function ClassroomMenu({
   onMenuOpenChange?: (open: boolean) => void
 }) {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const { notify, announce } = useToast()
   const [open, setOpen] = useState(false)
   const [archiveOpen, setArchiveOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -327,34 +327,34 @@ function ClassroomMenu({
         needsConfirm={false}
         dangerous={false}
         onConfirm={async () => {
-          await archiveMutation.mutateAsync(archived, {
-            onSuccess: (_r, active) => {
-              notify({
-                tone: "success",
-                durationMs: 5000,
-                message: active
-                  ? t("classes.unarchivedToast", { classroom: slug })
-                  : t("classes.archivedToast", { classroom: slug }),
-              })
-            },
-            onError: (err) => {
-              notify({
-                tone: "error",
-                message: t(
-                  archived
-                    ? "classes.unarchiveFailed"
-                    : "classes.archiveFailed",
-                  {
-                    classroom: slug,
-                    error:
-                      err instanceof Error
-                        ? err.message
-                        : t("classes.somethingWentWrong"),
-                  },
-                ),
-              })
-            },
-          })
+          try {
+            await archiveMutation.mutateAsync(archived, {
+              onSuccess: (_r, active) => {
+                // The badge flips in place — SR announcement only (Primer:
+                // no visual success message for an evident outcome).
+                announce(
+                  active
+                    ? t("classes.unarchivedToast", { classroom: slug })
+                    : t("classes.archivedToast", { classroom: slug }),
+                )
+              },
+            })
+          } catch (err) {
+            // Rethrow with the localized copy so the failure surfaces inside
+            // the confirm dialog (Primer: dialog errors stay in the dialog).
+            throw new Error(
+              t(
+                archived ? "classes.unarchiveFailed" : "classes.archiveFailed",
+                {
+                  classroom: slug,
+                  error:
+                    err instanceof Error
+                      ? err.message
+                      : t("classes.somethingWentWrong"),
+                },
+              ),
+            )
+          }
         }}
         onClose={() => setArchiveOpen(false)}
       />
@@ -377,51 +377,49 @@ function ClassroomMenu({
         cancelLabel={t("classes.deleteClassroomCancel")}
         dangerous
         onConfirm={async () => {
-          await deleteMutation.mutateAsync(
-            { org, classroom: slug },
-            {
-              onSuccess: (result) => {
-                // deleteClassroom returns { deleted: false } as a no-op (e.g.
-                // the dir was already gone). Don't claim success in that case.
-                if (!result.deleted) {
-                  notify({
-                    tone: "warning",
-                    message: t("classes.deleteNoop", { classroom: slug }),
-                  })
-                  return
-                }
-                // The list flow stays put (no navigate), so it is the natural
-                // place to surface the non-fatal team-cleanup warning that the
-                // edit page silently drops.
-                if (result.teamDeleteWarning) {
-                  notify({
-                    tone: "warning",
-                    message: t("classes.deleteTeamWarning", {
-                      classroom: slug,
-                    }),
-                  })
-                } else {
-                  notify({
-                    tone: "success",
-                    durationMs: 5000,
-                    message: t("classes.deletedToast", { classroom: slug }),
-                  })
-                }
+          try {
+            await deleteMutation.mutateAsync(
+              { org, classroom: slug },
+              {
+                onSuccess: (result) => {
+                  // deleteClassroom returns { deleted: false } as a no-op (e.g.
+                  // the dir was already gone). Don't claim success in that case.
+                  if (!result.deleted) {
+                    notify({
+                      tone: "warning",
+                      message: t("classes.deleteNoop", { classroom: slug }),
+                    })
+                    return
+                  }
+                  // The list flow stays put (no navigate), so it is the natural
+                  // place to surface the non-fatal team-cleanup warning that the
+                  // edit page silently drops.
+                  if (result.teamDeleteWarning) {
+                    notify({
+                      tone: "warning",
+                      message: t("classes.deleteTeamWarning", {
+                        classroom: slug,
+                      }),
+                    })
+                  } else {
+                    // The card disappears — SR announcement only.
+                    announce(t("classes.deletedToast", { classroom: slug }))
+                  }
+                },
               },
-              onError: (err) => {
-                notify({
-                  tone: "error",
-                  message: t("classes.deleteFailed", {
-                    classroom: slug,
-                    error:
-                      err instanceof Error
-                        ? err.message
-                        : t("classes.somethingWentWrong"),
-                  }),
-                })
-              },
-            },
-          )
+            )
+          } catch (err) {
+            // Surfaces inside the confirm dialog rather than a corner toast.
+            throw new Error(
+              t("classes.deleteFailed", {
+                classroom: slug,
+                error:
+                  err instanceof Error
+                    ? err.message
+                    : t("classes.somethingWentWrong"),
+              }),
+            )
+          }
         }}
         onClose={() => setDeleteOpen(false)}
       />

--- a/web/src/pages/classes/ClassroomStaffSection.test.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import { act, fireEvent, render, screen, cleanup } from "@testing-library/react"
 import type { GitHubUser } from "@/github-core/types"
 
 // Drive the defense-in-depth gate directly off the classroom role: a non-teacher
@@ -52,8 +52,14 @@ const noopMutation = { mutate: vi.fn(), isPending: false }
 vi.mock("@/hooks/mutations/useAddStaffMember", () => ({
   useAddStaffMember: () => noopMutation,
 }))
+// Rejectable so a test can drive the remove flow's rethrow-into-ConfirmModal
+// contract; resolved by default.
+const removeStaffMutation = {
+  mutateAsync: vi.fn(() => Promise.resolve()),
+  isPending: false,
+}
 vi.mock("@/hooks/mutations/useRemoveStaffMember", () => ({
-  default: () => noopMutation,
+  default: () => removeStaffMutation,
 }))
 vi.mock("@/hooks/mutations/useResendClassroomInvite", () => ({
   default: () => noopMutation,
@@ -89,6 +95,8 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   roleMock.mockReset()
+  removeStaffMutation.mutateAsync.mockClear()
+  removeStaffMutation.mutateAsync.mockImplementation(() => Promise.resolve())
   resetQueryData()
 })
 
@@ -150,5 +158,32 @@ describe("ClassroomStaffSection — teacher self-removal from the teacher team",
 
     expect(screen.queryByText("classes.staff.you")).toBeNull()
     expect(screen.getByTitle("classes.staff.removeRole")).toBeTruthy()
+  })
+})
+
+// Pins the converted feedback contract: a failed remove rethrows its
+// localized message into the ConfirmModal error slot (the flow's only
+// failure surface since the toast was dropped) and the dialog stays open.
+describe("ClassroomStaffSection — remove failure surfaces in the confirm dialog", () => {
+  it("renders the rethrown localized failure in-dialog and keeps it open", async () => {
+    roleMock.mockReturnValue({ role: "teacher" })
+    viewerData = { id: 1, login: "tina" }
+    membersByRole.set("classroom50-cs101-ta", [member("bob", 2)])
+    removeStaffMutation.mutateAsync.mockImplementation(() =>
+      Promise.reject(new Error("boom")),
+    )
+
+    render(<ClassroomStaffSection org="acme" classroom="cs101" />)
+    // Open the confirm from the row action, then confirm (single-step).
+    fireEvent.click(screen.getByTitle("classes.staff.removeRole"))
+    await act(async () => {
+      fireEvent.click(screen.getByText("classes.staff.removeRole"))
+    })
+
+    expect(removeStaffMutation.mutateAsync).toHaveBeenCalledWith("bob")
+    // The localized message (the t() key here) renders inside the dialog,
+    // which stays open for a retry — the row remains listed.
+    expect(screen.getByText("classes.staff.removeFailed")).toBeTruthy()
+    expect(screen.getByText("classes.staff.confirmRemoveTitle")).toBeTruthy()
   })
 })

--- a/web/src/pages/classes/ClassroomStaffSection.test.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.test.tsx
@@ -17,7 +17,7 @@ vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({ request: vi.fn() }),
 }))
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify: vi.fn() }),
+  useToast: () => ({ notify: vi.fn(), announce: vi.fn() }),
 }))
 
 // Per-query-key data so a test can seed team members (to render StaffMemberRow)

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -609,7 +609,11 @@ const PendingStaffRow = ({
         </div>
       </div>
       {rowError != null && (
-        <InlineMessage tone="error">{rowError}</InlineMessage>
+        // role="alert" so the insertion is announced — this replaced an
+        // error toast, and no focus move carries the message.
+        <InlineMessage tone="error" role="alert">
+          {rowError}
+        </InlineMessage>
       )}
     </li>
   )

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -40,6 +40,7 @@ import {
   Badge,
   Card,
   FormField,
+  InlineMessage,
   Input,
   Select,
   Heading,
@@ -120,9 +121,12 @@ const AddStaff = ({
   disabled: boolean
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const { announce } = useToast()
   const [username, setUsername] = useState("")
   const [usernameError, setUsernameError] = useState(false)
+  // Server-side add failure, surfaced on the username field (it's almost
+  // always about that username: unknown user, already staff, no rights).
+  const [addError, setAddError] = useState<string | null>(null)
   const usernameInputRef = useRef<HTMLInputElement>(null)
   const [role, setRole] = useState<StaffRole>("ta")
 
@@ -143,19 +147,19 @@ const AddStaff = ({
           usernameInputRef.current?.focus()
           return
         }
+        setAddError(null)
         addMutation.mutate(
           { username, role },
           {
             onSuccess: ({ trimmed, role: addedRole }) => {
               setUsername("")
-              notify({
-                tone: "success",
-                durationMs: 5000,
-                message: t("toasts.staffAdded", {
+              // The new row appears in the list — SR announcement only.
+              announce(
+                t("toasts.staffAdded", {
                   username: trimmed,
                   role: t(ROLE_LABEL_KEY[addedRole]),
                 }),
-              })
+              )
             },
             onError: (err) => {
               const message =
@@ -164,10 +168,8 @@ const AddStaff = ({
                   : err instanceof Error
                     ? err.message
                     : t("classes.somethingWentWrong")
-              notify({
-                tone: "error",
-                message: t("classes.staff.addFailed", { message }),
-              })
+              setAddError(t("classes.staff.addFailed", { message }))
+              usernameInputRef.current?.focus()
             },
           },
         )
@@ -177,7 +179,11 @@ const AddStaff = ({
         <FormField
           label={t("classes.staff.githubUsername")}
           htmlFor="staff-username"
-          error={usernameError ? t("classes.staff.enterUsername") : undefined}
+          error={
+            usernameError
+              ? t("classes.staff.enterUsername")
+              : (addError ?? undefined)
+          }
         >
           {({ id, describedById, invalid }) => (
             <Input
@@ -193,6 +199,7 @@ const AddStaff = ({
               onChange={(e) => {
                 setUsername(e.target.value)
                 setUsernameError(false)
+                setAddError(null)
               }}
             />
           )}
@@ -357,7 +364,7 @@ const StaffMemberRow = ({
   disabled: boolean
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const { announce } = useToast()
   const { data: viewer } = useGitHubViewer()
   const [confirmingRemove, setConfirmingRemove] = useState(false)
 
@@ -428,31 +435,28 @@ const StaffMemberRow = ({
         })}
         confirmLabel={t("classes.staff.removeRole", { role: roleLabel })}
         onConfirm={async () => {
-          setConfirmingRemove(false)
-          await removeMutation.mutateAsync(member.login, {
-            onSuccess: () => {
-              notify({
-                tone: "success",
-                durationMs: 4000,
-                message: t("classes.staff.removedToast", {
-                  login: member.login,
-                  role: rolePlural,
-                }),
-              })
-            },
-            onError: (err) => {
-              notify({
-                tone: "error",
-                message: t("classes.staff.removeFailed", {
-                  login: member.login,
-                  error:
-                    err instanceof Error
-                      ? err.message
-                      : t("classes.somethingWentWrong"),
-                }),
-              })
-            },
-          })
+          try {
+            await removeMutation.mutateAsync(member.login)
+            // The row disappears from the list — SR announcement only.
+            announce(
+              t("classes.staff.removedToast", {
+                login: member.login,
+                role: rolePlural,
+              }),
+            )
+          } catch (err) {
+            // Surfaces inside the confirm dialog rather than a corner toast.
+            throw new Error(
+              t("classes.staff.removeFailed", {
+                login: member.login,
+                error:
+                  err instanceof Error
+                    ? err.message
+                    : t("classes.somethingWentWrong"),
+              }),
+              { cause: err },
+            )
+          }
         }}
         onClose={() => setConfirmingRemove(false)}
       />
@@ -479,8 +483,11 @@ const PendingStaffRow = ({
   disabled: boolean
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const { notify, announce } = useToast()
   const who = invite.login || invite.email || String(invite.id)
+  // Per-row action failure, rendered inline under the row (Primer: feedback
+  // closest to the control that caused it).
+  const [rowError, setRowError] = useState<string | null>(null)
 
   const resendMutation = useResendClassroomInvite(
     org,
@@ -497,109 +504,113 @@ const PendingStaffRow = ({
   const busy = resendMutation.isPending || cancelMutation.isPending
 
   return (
-    <li className="flex items-center gap-2 rounded-selector px-2 py-1.5 transition-colors hover:bg-base-300/40">
-      <span className="flex min-w-0 grow items-center gap-2 text-sm">
-        <span className="grid size-6 shrink-0 place-items-center rounded-full bg-base-200 text-base-content/50">
-          <PaperAirplaneIcon aria-hidden="true" className="size-3" />
+    <li className="flex flex-col gap-1 rounded-selector px-2 py-1.5 transition-colors hover:bg-base-300/40">
+      <div className="flex items-center gap-2">
+        <span className="flex min-w-0 grow items-center gap-2 text-sm">
+          <span className="grid size-6 shrink-0 place-items-center rounded-full bg-base-200 text-base-content/50">
+            <PaperAirplaneIcon aria-hidden="true" className="size-3" />
+          </span>
+          <span className="truncate">
+            {invite.login ? `@${invite.login}` : invite.email}
+          </span>
+          <Badge size="xs" tone="warning" ghost className="shrink-0">
+            {t("classes.staff.pendingBadge")}
+          </Badge>
         </span>
-        <span className="truncate">
-          {invite.login ? `@${invite.login}` : invite.email}
-        </span>
-        <Badge size="xs" tone="warning" ghost className="shrink-0">
-          {t("classes.staff.pendingBadge")}
-        </Badge>
-      </span>
-      <div className="flex shrink-0 items-center">
-        {invite.login ? (
+        <div className="flex shrink-0 items-center">
+          {invite.login ? (
+            <Button
+              variant="ghost"
+              size="xs"
+              shape="square"
+              title={t("classes.staff.resend")}
+              disabled={disabled || busy}
+              onClick={() => {
+                setRowError(null)
+                void submit(() =>
+                  resendMutation.mutateAsync(
+                    {
+                      login: invite.login,
+                      invitationId: invite.id,
+                      emailOnlyMessage: t("classes.staff.resendEmailOnly"),
+                    },
+                    {
+                      // Kept as a toast: a resend changes nothing visible in
+                      // the row, so the outcome isn't otherwise evident.
+                      onSuccess: () =>
+                        notify({
+                          tone: "success",
+                          durationMs: 4000,
+                          message: t("classes.staff.resentToast", { who }),
+                        }),
+                      onError: (err) =>
+                        setRowError(
+                          t("classes.staff.resendFailed", {
+                            who,
+                            error:
+                              err instanceof Error
+                                ? err.message
+                                : t("classes.somethingWentWrong"),
+                          }),
+                        ),
+                    },
+                  ),
+                )
+              }}
+            >
+              {resendMutation.isPending ? (
+                <InlineSpinner />
+              ) : (
+                <PaperAirplaneIcon aria-hidden="true" className="size-4" />
+              )}
+            </Button>
+          ) : null}
           <Button
             variant="ghost"
             size="xs"
             shape="square"
-            title={t("classes.staff.resend")}
+            className="text-error"
+            title={t("classes.staff.cancelInvite")}
             disabled={disabled || busy}
-            onClick={() =>
+            onClick={() => {
+              setRowError(null)
               void submit(() =>
-                resendMutation.mutateAsync(
+                cancelMutation.mutateAsync(
                   {
-                    login: invite.login,
                     invitationId: invite.id,
-                    emailOnlyMessage: t("classes.staff.resendEmailOnly"),
+                    // Only an email-only invite has a metadata team to tear down.
+                    inviteEmail: invite.login ? undefined : invite.email,
                   },
                   {
+                    // The pending row disappears — SR announcement only.
                     onSuccess: () =>
-                      notify({
-                        tone: "success",
-                        durationMs: 4000,
-                        message: t("classes.staff.resentToast", { who }),
-                      }),
+                      announce(t("classes.staff.cancelledToast", { who })),
                     onError: (err) =>
-                      notify({
-                        tone: "error",
-                        message: t("classes.staff.resendFailed", {
+                      setRowError(
+                        t("classes.staff.cancelFailed", {
                           who,
                           error:
                             err instanceof Error
                               ? err.message
                               : t("classes.somethingWentWrong"),
                         }),
-                      }),
+                      ),
                   },
                 ),
               )
-            }
+            }}
           >
-            {resendMutation.isPending ? (
+            {cancelMutation.isPending ? (
               <InlineSpinner />
             ) : (
-              <PaperAirplaneIcon aria-hidden="true" className="size-4" />
+              <XCircleIcon aria-hidden="true" className="size-4" />
             )}
           </Button>
-        ) : null}
-        <Button
-          variant="ghost"
-          size="xs"
-          shape="square"
-          className="text-error"
-          title={t("classes.staff.cancelInvite")}
-          disabled={disabled || busy}
-          onClick={() =>
-            void submit(() =>
-              cancelMutation.mutateAsync(
-                {
-                  invitationId: invite.id,
-                  // Only an email-only invite has a metadata team to tear down.
-                  inviteEmail: invite.login ? undefined : invite.email,
-                },
-                {
-                  onSuccess: () =>
-                    notify({
-                      tone: "success",
-                      durationMs: 4000,
-                      message: t("classes.staff.cancelledToast", { who }),
-                    }),
-                  onError: (err) =>
-                    notify({
-                      tone: "error",
-                      message: t("classes.staff.cancelFailed", {
-                        who,
-                        error:
-                          err instanceof Error
-                            ? err.message
-                            : t("classes.somethingWentWrong"),
-                      }),
-                    }),
-                },
-              ),
-            )
-          }
-        >
-          {cancelMutation.isPending ? (
-            <InlineSpinner />
-          ) : (
-            <XCircleIcon aria-hidden="true" className="size-4" />
-          )}
-        </Button>
+        </div>
       </div>
+      {rowError != null && (
+        <InlineMessage tone="error">{rowError}</InlineMessage>
+      )}
     </li>
   )
 }

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -20,6 +20,7 @@ import {
   GITHUB_REPO_NAME_MAX_LEN,
 } from "@/util/repoNameBudget"
 import {
+  AnimatedAlert,
   Button,
   Card,
   FormField,
@@ -45,11 +46,15 @@ type CreateClassroomFormProps = {
   // Returns the submit's settling promise (or void) so the form can await the
   // real write and latch its loading state only on success.
   onSubmit: (values: CreateClassroomFormValues) => void | Promise<unknown>
+  // The host page's failed-create message, rendered inline above the actions
+  // (Primer: feedback for a page form belongs next to it, not a toast).
+  submitError?: string | null
 }
 
 const CreateClassroomForm = ({
   defaultValues,
   onSubmit,
+  submitError,
 }: CreateClassroomFormProps) => {
   const { t } = useTranslation()
   const { org = "" } = useParams({ strict: false })
@@ -373,6 +378,13 @@ const CreateClassroomForm = ({
           )}
         </form.Field>
 
+        <AnimatedAlert
+          tone="error"
+          show={submitError != null}
+          className="text-sm"
+        >
+          {submitError}
+        </AnimatedAlert>
         <Card.Actions className="justify-end p-2">
           <form.Subscribe selector={(state) => [state.isSubmitting]}>
             {([isSubmitting]) => {

--- a/web/src/pages/classes/EditClassroomForm.test.tsx
+++ b/web/src/pages/classes/EditClassroomForm.test.tsx
@@ -14,7 +14,7 @@ vi.mock("react-i18next", async (importOriginal) => {
 
 const notify = vi.fn()
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify }),
+  useToast: () => ({ notify, announce: vi.fn() }),
 }))
 
 // The hook under the call site: mutateAsync resolves with whatever the current

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -38,6 +38,11 @@ type EditClassroomFormProps = {
   // Receives the values with customDomain already NORMALIZED ("" = clear).
   onSubmit: (values: EditClassroomFormValues) => void | Promise<void>
   cl?: Classroom
+  // The host page's save outcome, rendered inline above the actions (Primer:
+  // post-submit feedback near the save button, not a corner toast).
+  saveOutcome?: { tone: "success" | "error"; message: string } | null
+  // Fires on any edit so the host can clear a stale saveOutcome.
+  onEdit?: () => void
 }
 
 export const DeleteClassroomButton = ({
@@ -192,6 +197,7 @@ const ArchiveClassroomButton = ({
                       : t("classes.somethingWentWrong"),
                 },
               ),
+              { cause: err },
             )
           }
         }}
@@ -272,6 +278,7 @@ const CleanupInviteDataButton = ({
                     ? err.message
                     : t("classes.somethingWentWrong"),
               }),
+              { cause: err },
             )
           }
         }}
@@ -281,7 +288,12 @@ const CleanupInviteDataButton = ({
   )
 }
 
-const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
+const EditClassroomForm = ({
+  onSubmit,
+  cl,
+  saveOutcome,
+  onEdit,
+}: EditClassroomFormProps) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { org, classroom } = useParams({ strict: false })
@@ -342,8 +354,14 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
       // Any edit clears the unchanged-submit notice — hooked on the DOM
       // events rather than the form model, so controls that sync through
       // local state still clear it.
-      onInput={() => setNoChangesNotice(false)}
-      onChange={() => setNoChangesNotice(false)}
+      onInput={() => {
+        setNoChangesNotice(false)
+        onEdit?.()
+      }}
+      onChange={() => {
+        setNoChangesNotice(false)
+        onEdit?.()
+      }}
       onSubmit={(e) => {
         e.preventDefault()
         e.stopPropagation()
@@ -509,6 +527,14 @@ const EditClassroomForm = ({ onSubmit, cl }: EditClassroomFormProps) => {
               cleared by any edit via the form-level onInput/onChange. */}
           <AnimatedAlert tone="info" show={noChangesNotice} className="text-sm">
             {t("classes.form.noChangesToSave")}
+          </AnimatedAlert>
+          {/* Save outcome from the host page, in the same near-actions slot. */}
+          <AnimatedAlert
+            tone={saveOutcome?.tone ?? "success"}
+            show={saveOutcome != null}
+            className="text-sm"
+          >
+            {saveOutcome?.message}
           </AnimatedAlert>
           <Card.Actions className="justify-end p-2">
             <form.Subscribe selector={(state) => [state.isSubmitting]}>

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -123,7 +123,7 @@ const ArchiveClassroomButton = ({
   archived: boolean
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const { announce } = useToast()
   const [open, setOpen] = useState(false)
 
   // A pure archive/unarchive write: editClassroom preserves name/term when
@@ -172,32 +172,27 @@ const ArchiveClassroomButton = ({
         onConfirm={async () => {
           try {
             await archiveMutation.mutateAsync(archived)
-            notify({
-              tone: "success",
-              durationMs: 5000,
-              message: archived
+            // The page state flips in place — SR announcement only.
+            announce(
+              archived
                 ? t("classes.unarchivedToast", { classroom })
                 : t("classes.archivedToast", { classroom }),
-            })
+            )
           } catch (err) {
-            notify({
-              tone: "error",
-              message: archived
-                ? t("classes.unarchiveFailed", {
-                    classroom,
-                    error:
-                      err instanceof Error
-                        ? err.message
-                        : t("classes.somethingWentWrong"),
-                  })
-                : t("classes.archiveFailed", {
-                    classroom,
-                    error:
-                      err instanceof Error
-                        ? err.message
-                        : t("classes.somethingWentWrong"),
-                  }),
-            })
+            // Rethrow with localized copy so the failure surfaces inside the
+            // confirm dialog (Primer: dialog errors stay in the dialog).
+            throw new Error(
+              t(
+                archived ? "classes.unarchiveFailed" : "classes.archiveFailed",
+                {
+                  classroom,
+                  error:
+                    err instanceof Error
+                      ? err.message
+                      : t("classes.somethingWentWrong"),
+                },
+              ),
+            )
           }
         }}
         onClose={() => setOpen(false)}
@@ -258,6 +253,8 @@ const CleanupInviteDataButton = ({
         onConfirm={async () => {
           try {
             const result = await purgeMutation.mutateAsync()
+            // Kept as a toast: the recovered/purged counts aren't evident
+            // anywhere in the UI once the dialog closes.
             notify({
               tone: "success",
               durationMs: 6000,
@@ -267,15 +264,15 @@ const CleanupInviteDataButton = ({
               }),
             })
           } catch (err) {
-            notify({
-              tone: "error",
-              message: t("classes.inviteCleanup.failed", {
+            // Surfaces inside the confirm dialog rather than a corner toast.
+            throw new Error(
+              t("classes.inviteCleanup.failed", {
                 error:
                   err instanceof Error
                     ? err.message
                     : t("classes.somethingWentWrong"),
               }),
-            })
+            )
           }
         }}
         onClose={() => setOpen(false)}

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -23,7 +23,9 @@ import {
   FormField,
   Input,
   Heading,
+  OutcomeAlert,
 } from "@/components/ui"
+import type { AlertOutcome } from "@/components/ui"
 
 export type EditClassroomFormValues = {
   name: string
@@ -40,7 +42,7 @@ type EditClassroomFormProps = {
   cl?: Classroom
   // The host page's save outcome, rendered inline above the actions (Primer:
   // post-submit feedback near the save button, not a corner toast).
-  saveOutcome?: { tone: "success" | "error"; message: string } | null
+  saveOutcome?: AlertOutcome | null
   // Fires on any edit so the host can clear a stale saveOutcome.
   onEdit?: () => void
 }
@@ -529,13 +531,7 @@ const EditClassroomForm = ({
             {t("classes.form.noChangesToSave")}
           </AnimatedAlert>
           {/* Save outcome from the host page, in the same near-actions slot. */}
-          <AnimatedAlert
-            tone={saveOutcome?.tone ?? "success"}
-            show={saveOutcome != null}
-            className="text-sm"
-          >
-            {saveOutcome?.message}
-          </AnimatedAlert>
+          <OutcomeAlert outcome={saveOutcome} className="text-sm" />
           <Card.Actions className="justify-end p-2">
             <form.Subscribe selector={(state) => [state.isSubmitting]}>
               {([isSubmitting]) => (

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -102,7 +102,9 @@ const MemberDetailModal = ({
   }
 
   const handleClose = () => {
-    if (working) return
+    // Both writes route failures into the in-dialog banner, which
+    // reset-on-open wipes — so dismissal mid-flight would lose them.
+    if (working || inviting) return
     onClose()
   }
 
@@ -127,18 +129,17 @@ const MemberDetailModal = ({
     setInviting(true)
     setActionError(null)
     try {
-      // Route the helper's error tone into the in-dialog banner; the success
-      // toast passes through (it must outlive the closing dialog).
       await runInviteMember(
         client,
         org,
         row,
-        (input) => {
-          if (input.tone === "error" && typeof input.message === "string") {
-            setActionError(input.message)
-          } else {
-            notify(input)
-          }
+        {
+          // Kept as a toast: the pending badge lags the eventually-consistent
+          // refetch, and this dialog is closing.
+          onSuccess: (message) =>
+            notify({ tone: "success", durationMs: 6000, message }),
+          // The dialog stays open on failure, so the error belongs inside it.
+          onError: setActionError,
         },
         onInvited,
         t,
@@ -199,7 +200,7 @@ const MemberDetailModal = ({
     <Modal
       open={open}
       onClose={handleClose}
-      closeDisabled={working}
+      closeDisabled={working || inviting}
       size="2xl"
       title={t("orgMembers.detailTitle")}
       footer={

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -10,6 +10,7 @@ import {
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import {
+  AnimatedAlert,
   Badge,
   Button,
   EmphasisLtr,
@@ -64,11 +65,13 @@ const MemberDetailModal = ({
 }) => {
   const { t } = useTranslation()
   const client = useGitHubClient()
-  const { notify } = useToast()
+  const { notify, announce } = useToast()
   const [confirming, setConfirming] = useState(false)
   const [confirmingInvite, setConfirmingInvite] = useState(false)
   const [working, setWorking] = useState(false)
   const [inviting, setInviting] = useState(false)
+  // Failure of the in-dialog remove action, rendered as an in-dialog banner.
+  const [removeError, setRemoveError] = useState<string | null>(null)
 
   // Retain the last non-null row so the fading dialog keeps its content after
   // the parent clears the selection (close-animation note in ui/Modal).
@@ -84,6 +87,7 @@ const MemberDetailModal = ({
     setConfirming(false)
     setConfirmingInvite(false)
     setInviting(false)
+    setRemoveError(null)
   }, [open])
 
   // Disarm the confirm panels during render when the row identity changes
@@ -132,37 +136,39 @@ const MemberDetailModal = ({
   const handleRemove = async () => {
     if (working) return
     setWorking(true)
+    setRemoveError(null)
     try {
       const result = await removeMemberFromOrg(client, { org, row }, t)
       if (result.warnings.length > 0) {
+        // Kept as a toast: it outlives the closing dialog, and the partial
+        // outcome isn't evident from the row update alone.
         notify({
           tone: "warning",
           durationMs: 8000,
           message: result.warnings.join(" "),
         })
       } else {
-        notify({
-          tone: "success",
-          durationMs: 6000,
-          message: result.unenrolledClassrooms.length
+        // The member row disappears from the list — SR announcement only.
+        announce(
+          result.unenrolledClassrooms.length
             ? t("orgMembers.removedWithUnenroll", {
                 label,
                 org,
                 count: result.unenrolledClassrooms.length,
               })
             : t("orgMembers.removed", { label, org }),
-        })
+        )
       }
       onRemoved(result.removed, result.unenrolledClassrooms)
     } catch (err) {
-      notify({
-        tone: "error",
-        message: t("orgMembers.removeFailed", {
+      // The dialog stays open on failure, so the error belongs inside it.
+      setRemoveError(
+        t("orgMembers.removeFailed", {
           label,
           reason:
             err instanceof Error ? err.message : t("orgMembers.somethingWrong"),
         }),
-      })
+      )
     } finally {
       setWorking(false)
       setConfirming(false)
@@ -206,6 +212,13 @@ const MemberDetailModal = ({
       }
     >
       <div className="mt-4 flex flex-col gap-4">
+        <AnimatedAlert
+          tone="error"
+          show={removeError != null}
+          className="text-sm"
+        >
+          {removeError}
+        </AnimatedAlert>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <Avatar
             name={row.name || label}

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -71,7 +71,7 @@ const MemberDetailModal = ({
   const [working, setWorking] = useState(false)
   const [inviting, setInviting] = useState(false)
   // Failure of the in-dialog remove action, rendered as an in-dialog banner.
-  const [removeError, setRemoveError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
 
   // Retain the last non-null row so the fading dialog keeps its content after
   // the parent clears the selection (close-animation note in ui/Modal).
@@ -87,7 +87,7 @@ const MemberDetailModal = ({
     setConfirming(false)
     setConfirmingInvite(false)
     setInviting(false)
-    setRemoveError(null)
+    setActionError(null)
   }, [open])
 
   // Disarm the confirm panels during render when the row identity changes
@@ -125,8 +125,24 @@ const MemberDetailModal = ({
   const handleInvite = async () => {
     if (inviting) return
     setInviting(true)
+    setActionError(null)
     try {
-      await runInviteMember(client, org, row, notify, onInvited, t)
+      // Route the helper's error tone into the in-dialog banner; the success
+      // toast passes through (it must outlive the closing dialog).
+      await runInviteMember(
+        client,
+        org,
+        row,
+        (input) => {
+          if (input.tone === "error" && typeof input.message === "string") {
+            setActionError(input.message)
+          } else {
+            notify(input)
+          }
+        },
+        onInvited,
+        t,
+      )
     } finally {
       setInviting(false)
       setConfirmingInvite(false)
@@ -136,7 +152,7 @@ const MemberDetailModal = ({
   const handleRemove = async () => {
     if (working) return
     setWorking(true)
-    setRemoveError(null)
+    setActionError(null)
     try {
       const result = await removeMemberFromOrg(client, { org, row }, t)
       if (result.warnings.length > 0) {
@@ -162,7 +178,7 @@ const MemberDetailModal = ({
       onRemoved(result.removed, result.unenrolledClassrooms)
     } catch (err) {
       // The dialog stays open on failure, so the error belongs inside it.
-      setRemoveError(
+      setActionError(
         t("orgMembers.removeFailed", {
           label,
           reason:
@@ -214,10 +230,10 @@ const MemberDetailModal = ({
       <div className="mt-4 flex flex-col gap-4">
         <AnimatedAlert
           tone="error"
-          show={removeError != null}
+          show={actionError != null}
           className="text-sm"
         >
-          {removeError}
+          {actionError}
         </AnimatedAlert>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <Avatar

--- a/web/src/pages/orgMembers/memberPresentation.tsx
+++ b/web/src/pages/orgMembers/memberPresentation.tsx
@@ -150,6 +150,8 @@ export const runInviteMember = async (
   try {
     const result = await inviteMemberToOrg(client, { org, row })
     const who = result.currentUsername ? `@${result.currentUsername}` : label
+    // Kept as a toast: the pending badge lags the eventually-consistent
+    // refetch, so the outcome isn't immediately evident in the list.
     notify({
       tone: "success",
       durationMs: 6000,

--- a/web/src/pages/orgMembers/memberPresentation.tsx
+++ b/web/src/pages/orgMembers/memberPresentation.tsx
@@ -10,7 +10,6 @@ import {
 import { Badge } from "@/components/ui"
 import { CellPlaceholder } from "@/components/memberList/memberPresentation"
 import type { GitHubClient } from "@/github-core/client"
-import type { NotifyInput } from "@/context/notifications/NotificationProvider"
 import { inviteMemberToOrg } from "@/domain/orgMembers/inviteMemberToOrg"
 import type { OrgMemberRow } from "@/util/orgMembers"
 
@@ -136,13 +135,19 @@ export const ClassificationBadge = ({
   return <Badge tone="success">{t("orgMembers.badgeMember")}</Badge>
 }
 
-// Shared invite flow for the inline row button and the detail modal. Errors are
-// toasted here so both call sites only track their own in-flight flag.
+// Shared invite flow for the inline row button and the detail modal. It
+// resolves the localized outcome copy and hands it to explicit callbacks so
+// each call site owns its own surface (the page toasts both; the modal
+// routes failures into its in-dialog banner) — routing is compiler-checked
+// instead of inferred from a notify payload's tone.
 export const runInviteMember = async (
   client: GitHubClient,
   org: string,
   row: OrgMemberRow,
-  notify: (input: NotifyInput) => void,
+  handlers: {
+    onSuccess: (message: string) => void
+    onError: (message: string) => void
+  },
   onDone: () => void,
   t: TFunction,
 ) => {
@@ -150,22 +155,15 @@ export const runInviteMember = async (
   try {
     const result = await inviteMemberToOrg(client, { org, row })
     const who = result.currentUsername ? `@${result.currentUsername}` : label
-    // Kept as a toast: the pending badge lags the eventually-consistent
-    // refetch, so the outcome isn't immediately evident in the list.
-    notify({
-      tone: "success",
-      durationMs: 6000,
-      message: t("toasts.invited", { who, org }),
-    })
+    handlers.onSuccess(t("toasts.invited", { who, org }))
     onDone()
   } catch (err) {
-    notify({
-      tone: "error",
-      message: t("orgMembers.inviteFailed", {
+    handlers.onError(
+      t("orgMembers.inviteFailed", {
         label,
         reason:
           err instanceof Error ? err.message : t("orgMembers.somethingWrong"),
       }),
-    })
+    )
   }
 }

--- a/web/src/pages/orgSettings/OrgActionsSection.tsx
+++ b/web/src/pages/orgSettings/OrgActionsSection.tsx
@@ -2,7 +2,8 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { LinkExternalIcon } from "@/components/ui/icons"
 
-import { AnimatedAlert, Badge, Spinner, Toggle } from "@/components/ui"
+import { Badge, OutcomeAlert, Spinner, Toggle } from "@/components/ui"
+import type { AlertOutcome } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import { CalloutDiv } from "@/lib/motionComponents"
 import { useToast } from "@/context/notifications/NotificationProvider"
@@ -134,10 +135,7 @@ const OrgActionsSection = ({
   // Partial/failed toggle outcome, rendered as a banner in this section
   // (Primer: feedback next to the control). A clean flip is evident from the
   // toggle itself and only announces to SR.
-  const [outcome, setOutcome] = useState<{
-    tone: "warning" | "error"
-    message: string
-  } | null>(null)
+  const [outcome, setOutcome] = useState<AlertOutcome | null>(null)
 
   const { data: mode, isLoading } = useGetOrgActionsMode(org)
   const mutation = useSetOrgActionsMode(org)
@@ -208,14 +206,11 @@ const OrgActionsSection = ({
         </div>
       ) : (
         <div className="space-y-4">
-          <AnimatedAlert
-            tone={outcome?.tone ?? "warning"}
-            show={outcome != null}
+          <OutcomeAlert
+            outcome={outcome}
             className="text-sm"
             onDismiss={() => setOutcome(null)}
-          >
-            {outcome?.message}
-          </AnimatedAlert>
+          />
           <ActionsUsagePanel org={org} />
 
           <label
@@ -283,7 +278,10 @@ const OrgActionsSection = ({
         description={t("orgSettings.actions.confirmBody")}
         confirmLabel={t("orgSettings.actions.confirmButton")}
         cancelLabel={t("common.cancel")}
-        onConfirm={() => applyMode("paused").then(() => undefined)}
+        // Through runToggle like the unpause path: it swallows the rejection
+        // after applyMode's onError has set the section banner, so the
+        // failure renders exactly once (ConfirmModal must not also catch it).
+        onConfirm={() => runToggle(() => applyMode("paused"))}
         onClose={() => setConfirmPause(false)}
       />
     </SettingsSection>

--- a/web/src/pages/orgSettings/OrgActionsSection.tsx
+++ b/web/src/pages/orgSettings/OrgActionsSection.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { LinkExternalIcon } from "@/components/ui/icons"
 
-import { Badge, Spinner, Toggle } from "@/components/ui"
+import { AnimatedAlert, Badge, Spinner, Toggle } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import { CalloutDiv } from "@/lib/motionComponents"
 import { useToast } from "@/context/notifications/NotificationProvider"
@@ -128,9 +128,16 @@ const OrgActionsSection = ({
   highlighted?: boolean
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const { announce } = useToast()
   const runToggle = useSafeSubmit()
   const [confirmPause, setConfirmPause] = useState(false)
+  // Partial/failed toggle outcome, rendered as a banner in this section
+  // (Primer: feedback next to the control). A clean flip is evident from the
+  // toggle itself and only announces to SR.
+  const [outcome, setOutcome] = useState<{
+    tone: "warning" | "error"
+    message: string
+  } | null>(null)
 
   const { data: mode, isLoading } = useGetOrgActionsMode(org)
   const mutation = useSetOrgActionsMode(org)
@@ -142,16 +149,18 @@ const OrgActionsSection = ({
   // when Actions are off org-wide (disabled) — neither is a pause we own.
   const toggleDisabled = mutation.isPending || unknown || disabled
 
-  const applyMode = (next: "paused" | "active") =>
-    mutation.mutateAsync(next, {
+  const applyMode = (next: "paused" | "active") => {
+    setOutcome(null)
+    return mutation.mutateAsync(next, {
       onSuccess: (result) => {
-        notify({
-          tone: result.status === "complete" ? "success" : "warning",
-          message: result.message,
-        })
+        if (result.status === "complete") {
+          announce(result.message)
+        } else {
+          setOutcome({ tone: "warning", message: result.message })
+        }
       },
       onError: (err) => {
-        notify({
+        setOutcome({
           tone: "error",
           message: t("orgSettings.actions.toggleFailed", {
             message: err instanceof Error ? err.message : String(err),
@@ -159,6 +168,7 @@ const OrgActionsSection = ({
         })
       },
     })
+  }
 
   return (
     <SettingsSection
@@ -198,6 +208,14 @@ const OrgActionsSection = ({
         </div>
       ) : (
         <div className="space-y-4">
+          <AnimatedAlert
+            tone={outcome?.tone ?? "warning"}
+            show={outcome != null}
+            className="text-sm"
+            onDismiss={() => setOutcome(null)}
+          >
+            {outcome?.message}
+          </AnimatedAlert>
           <ActionsUsagePanel org={org} />
 
           <label

--- a/web/src/pages/students/AddStudent.test.tsx
+++ b/web/src/pages/students/AddStudent.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/hooks/useEnsureTeam", () => ({
 
 const notify = vi.fn()
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify }),
+  useToast: () => ({ notify, announce: vi.fn() }),
 }))
 
 // Both mutation hooks are stubbed so the test asserts which backend a role

--- a/web/src/pages/students/AddStudent.test.tsx
+++ b/web/src/pages/students/AddStudent.test.tsx
@@ -134,9 +134,8 @@ describe("AddStudent — role routing", () => {
       username: "prof",
       role: "teacher",
     })
-    expect(notify).toHaveBeenCalledWith(
-      expect.objectContaining({ tone: "success" }),
-    )
+    // Success confirms in-modal (matching the student branch), not as a toast.
+    expect(await screen.findByText(/toasts\.staffAdded/)).toBeTruthy()
   })
 
   it("routes a TA selection to the staff backend", async () => {

--- a/web/src/pages/students/AddStudent.tsx
+++ b/web/src/pages/students/AddStudent.tsx
@@ -5,7 +5,6 @@ import { focusFirstInvalidField } from "@/util/focusFirstInvalidField"
 import useEnsureTeam from "@/hooks/useEnsureTeam"
 import { useEnrollOrInviteStudent } from "@/hooks/mutations/useEnrollOrInviteStudent"
 import { useAddStaffMember } from "@/hooks/mutations/useAddStaffMember"
-import { useToast } from "@/context/notifications/NotificationProvider"
 import { GitHubAPIError } from "@/github-core/errors"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import { StudentAlreadyEnrolledError } from "@/domain/students"
@@ -60,7 +59,6 @@ const AddStudent = ({
 }: AddStudentProps) => {
   const { team } = useEnsureTeam(org, classroom)
   const { t } = useTranslation()
-  const { notify } = useToast()
   // Ties the footer's submit button (outside the <form> element) to the form.
   const formId = useId()
   const roleId = useId()
@@ -155,8 +153,9 @@ const AddStudent = ({
   })
 
   // Staff branch: delegate to the staff-team backend (config-repo write). A
-  // successful add toasts and clears the username; failures stay in-modal as a
-  // warning so the teacher can correct and retry.
+  // successful add confirms in-modal (matching the student branch) and clears
+  // the form; failures stay in-modal as a warning so the teacher can correct
+  // and retry.
   const submitStaff = async (username: string, staffRole: StaffRole) => {
     await addStaffMutation
       .mutateAsync(
@@ -164,14 +163,12 @@ const AddStudent = ({
         {
           onSuccess: ({ trimmed, role: addedRole }) => {
             form.reset()
-            notify({
-              tone: "success",
-              durationMs: 5000,
-              message: t("toasts.staffAdded", {
+            setSuccess(
+              t("toasts.staffAdded", {
                 username: trimmed,
                 role: t(ROLE_LABEL_KEY[addedRole]),
               }),
-            })
+            )
           },
           onError: (err) => {
             setSuccess("")

--- a/web/src/pages/students/EnrolledStudents.smoke.test.tsx
+++ b/web/src/pages/students/EnrolledStudents.smoke.test.tsx
@@ -59,7 +59,7 @@ vi.mock("@/context/github/GitHubProvider", () => ({
   useGitHubClient: () => ({}),
 }))
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify: vi.fn() }),
+  useToast: () => ({ notify: vi.fn(), announce: vi.fn() }),
 }))
 vi.mock("@/hooks/useGitHubResources", () => ({
   useGitHubViewer: () => ({ data: null }),

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -149,6 +149,15 @@ const EnrolledStudents = ({
 
   // Keyed by row.key so a clean action can't clobber another's warning.
   const [warnings, setWarnings] = useState<Record<string, string>>({})
+  // Failed-invite action (re-invite/dismiss) failure, rendered inline in the
+  // failed-invitations list (Primer: feedback next to its actions).
+  const [inviteActionError, setInviteActionError] = useState<string | null>(
+    null,
+  )
+  // Manual/auto roster-sync failure, rendered as a banner above the table.
+  const [syncError, setSyncError] = useState<string | null>(null)
+  // Explains a no-op select-all (visible rows exist but none are selectable).
+  const [noneSelectableNotice, setNoneSelectableNotice] = useState(false)
   const [grouping, setGrouping] = useState<RosterGrouping>("none")
   const [query, setQuery] = useState("")
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all")
@@ -206,16 +215,17 @@ const EnrolledStudents = ({
     rateLimited: (who) => t("students.failedInviteRateLimited", { who }),
     notSent: (who) => t("students.failedInviteNotSent", { who }),
   })
-  const reinvite = (inv: GitHubOrgInvitation) =>
+  const reinvite = (inv: GitHubOrgInvitation) => {
+    setInviteActionError(null)
     reinviteFailedInvite.mutate(inv, {
       onError: (err) =>
-        notify({
-          tone: "error",
-          message: t("students.failedInviteReinviteError", {
+        setInviteActionError(
+          t("students.failedInviteReinviteError", {
             error: getErrorMessage(err),
           }),
-        }),
+        ),
     })
+  }
 
   // A row is selectable unless it's the signed-in teacher (can't bulk-unenroll
   // yourself), mirroring Org Members' self-exclusion. A pure staff row (no
@@ -370,13 +380,10 @@ const EnrolledStudents = ({
     // current view has rows but none are selectable — e.g., filtered to staff —
     // the click would silently no-op, so explain why instead.
     if (shouldWarnNoneSelectable(filtered.length, selectableFiltered.length)) {
-      notify({
-        tone: "info",
-        durationMs: 6000,
-        message: t("students.bulk.noneSelectable"),
-      })
+      setNoneSelectableNotice(true)
       return
     }
+    setNoneSelectableNotice(false)
     if (selectableFiltered.length === 0) return
     setSelectedKeys((prev) => toggleSelectAll(selectableFiltered, prev))
   }
@@ -424,10 +431,13 @@ const EnrolledStudents = ({
   // owns the roster-file invalidation that must always run; the toasts live
   // here so they skip when unmounted.
   const syncMutation = useSyncRoster(org, classroom)
-  const runSync = () =>
+  const runSync = () => {
+    setSyncError(null)
     syncMutation.mutate(undefined, {
       onSuccess: (result) => {
         const parts = rosterSyncMessageKeys(result)
+        // Kept as a toast: the recovered/added counts aren't evident from
+        // the table alone.
         notify({
           tone: "success",
           durationMs: 5000,
@@ -439,12 +449,10 @@ const EnrolledStudents = ({
         })
       },
       onError: (err) => {
-        notify({
-          tone: "error",
-          message: t("students.syncFailed", { error: getErrorMessage(err) }),
-        })
+        setSyncError(t("students.syncFailed", { error: getErrorMessage(err) }))
       },
     })
+  }
 
   // A roster synchronization is underway — the on-entry classroom reconcile,
   // the drift auto-sync, or the manual Sync button. While true the sync button
@@ -668,7 +676,9 @@ const EnrolledStudents = ({
             dismissFailedInvite.isPending
           }
           onReinvite={reinvite}
-          onDismiss={(inv) =>
+          actionError={inviteActionError}
+          onDismiss={(inv) => {
+            setInviteActionError(null)
             dismissFailedInvite.mutate(
               {
                 invitationId: inv.id,
@@ -677,15 +687,14 @@ const EnrolledStudents = ({
               },
               {
                 onError: (err) =>
-                  notify({
-                    tone: "error",
-                    message: t("students.failedInviteDismissError", {
+                  setInviteActionError(
+                    t("students.failedInviteDismissError", {
                       error: getErrorMessage(err),
                     }),
-                  }),
+                  ),
               },
             )
-          }
+          }}
         />
       ) : null}
 
@@ -733,6 +742,27 @@ const EnrolledStudents = ({
           addActions={addActions ?? null}
         />
       ) : null}
+
+      {/* Roster-sync failure: a banner above the table it degrades, with the
+          retry being the Sync control itself. */}
+      <AnimatedAlert
+        tone="error"
+        show={syncError != null}
+        className="mb-3 text-sm"
+        onDismiss={() => setSyncError(null)}
+      >
+        {syncError}
+      </AnimatedAlert>
+      {/* Select-all explanation: inline above the table (Primer: feedback
+          near the control), cleared on the next selection interaction. */}
+      <AnimatedAlert
+        tone="info"
+        show={noneSelectableNotice}
+        className="mb-3 text-sm"
+        onDismiss={() => setNoneSelectableNotice(false)}
+      >
+        {t("students.bulk.noneSelectable")}
+      </AnimatedAlert>
 
       {/* The roster table: Primer DataTable treatment via the shared
           TableShell frame (matching the assignments/submissions tables);

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -754,10 +754,15 @@ const EnrolledStudents = ({
         {syncError}
       </AnimatedAlert>
       {/* Select-all explanation: inline above the table (Primer: feedback
-          near the control), cleared on the next selection interaction. */}
+          near the control). `show` re-derives against the current view so
+          the notice self-clears the moment a filter/search change makes
+          rows selectable again — a latch alone would turn stale. */}
       <AnimatedAlert
         tone="info"
-        show={noneSelectableNotice}
+        show={
+          noneSelectableNotice &&
+          shouldWarnNoneSelectable(filtered.length, selectableFiltered.length)
+        }
         className="mb-3 text-sm"
         onDismiss={() => setNoneSelectableNotice(false)}
       >

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -651,7 +651,7 @@ const EnrolledStudents = ({
 
       {/* Non-owner: pending invites are owner-only. */}
       {!isLoading && !isError && pendingHidden ? (
-        <Alert tone="error">
+        <Alert tone="unavailable">
           <span className="text-sm">{t("students.pendingOwnerOnly")}</span>
         </Alert>
       ) : null}

--- a/web/src/pages/students/FailedInvitationsList.tsx
+++ b/web/src/pages/students/FailedInvitationsList.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { Alert, Button } from "@/components/ui"
+import { Alert, Button, InlineMessage } from "@/components/ui"
 import type { GitHubOrgInvitation } from "@/github-core/types"
 
 // Failed/expired invitations (owner-only). GitHub couldn't deliver these, so
@@ -8,11 +8,15 @@ import type { GitHubOrgInvitation } from "@/github-core/types"
 export const FailedInvitationsList = ({
   failedInvitations,
   actionsDisabled,
+  actionError,
   onReinvite,
   onDismiss,
 }: {
   failedInvitations: GitHubOrgInvitation[]
   actionsDisabled: boolean
+  // The last re-invite/dismiss failure, rendered inline in this list
+  // (Primer: feedback next to the actions that caused it).
+  actionError?: string | null
   onReinvite: (inv: GitHubOrgInvitation) => void
   onDismiss: (inv: GitHubOrgInvitation) => void
 }) => {
@@ -22,6 +26,9 @@ export const FailedInvitationsList = ({
       <span className="text-sm font-medium">
         {t("students.failedInvitesTitle", { count: failedInvitations.length })}
       </span>
+      {actionError != null && (
+        <InlineMessage tone="error">{actionError}</InlineMessage>
+      )}
       <ul className="flex flex-col divide-y divide-warning/20">
         {failedInvitations.map((inv) => {
           const who = inv.login || inv.email || String(inv.id)

--- a/web/src/pages/submissions/ManageSubmissionModal.test.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { cleanup, render, screen } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 vi.mock("react-i18next", async (importOriginal) => {
@@ -49,14 +49,19 @@ vi.mock("@/hooks/mutations/useRepairFeedbackPr", () => ({
   default: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify: vi.fn(), announce: vi.fn() }),
+  useToast: () => ({ notify: notifyMock, announce: vi.fn() }),
 }))
 vi.mock("@/hooks/useTriggerRegrade", () => ({
   default: () => ({ regrade: vi.fn(), phase: "idle", anyRegrading: false }),
 }))
 vi.mock("@/hooks/mutations/useDownloadSubmission", () => ({
-  default: () => ({ mutate: vi.fn(), isPending: false }),
+  default: () => ({ mutate: downloadMutate, isPending: false }),
 }))
+
+const notifyMock = vi.fn()
+// Configurable so tests can drive the download row's onError into the hub
+// feedback channel.
+const downloadMutate = vi.fn()
 
 import { ManageSubmissionModal } from "./ManageSubmissionModal"
 
@@ -74,6 +79,8 @@ const individualAction = {
 
 afterEach(() => {
   cleanup()
+  notifyMock.mockClear()
+  downloadMutate.mockReset()
   repoData.mockReturnValue({ data: undefined })
   collaboratorsData.mockReturnValue({ data: undefined })
   autogradeStateData.mockReturnValue({
@@ -422,5 +429,64 @@ describe("ManageSubmissionModal", () => {
         .getByRole("button", { name: "submissions.table.reviewAria" })
         .hasAttribute("disabled"),
     ).toBe(true)
+  })
+})
+
+// The hub feedback channel: an action row's outcome renders as a banner
+// inside the open hub; an outcome landing after the hub unmounts (closed
+// mid-action) falls back to a toast instead of vanishing.
+describe("ManageSubmissionModal — action feedback channel", () => {
+  const renderHub = () =>
+    render(
+      <ManageSubmissionModal
+        onClose={vi.fn()}
+        title="Alice"
+        repo="cs101-hw1-alice"
+        isGroup={false}
+        students={[]}
+        action={individualAction}
+      />,
+    )
+
+  it("renders an action failure as an in-hub banner, not a toast", () => {
+    // The download row reports failures through its mutate onError callback.
+    downloadMutate.mockImplementation(
+      (_vars: unknown, opts?: { onError?: (err: Error) => void }) => {
+        opts?.onError?.(new Error("boom"))
+      },
+    )
+    renderHub()
+    fireEvent.click(
+      screen.getByRole("button", { name: "submissions.rowDownload.aria" }),
+    )
+
+    expect(screen.getByText("submissions.rowDownload.error")).toBeTruthy()
+    expect(notifyMock).not.toHaveBeenCalled()
+  })
+
+  it("falls back to a toast when the outcome lands after the hub unmounted", () => {
+    // Capture the onError callback so it can fire post-unmount (a slow write
+    // settling after the teacher closed the hub).
+    let lateError: ((err: Error) => void) | undefined
+    downloadMutate.mockImplementation(
+      (_vars: unknown, opts?: { onError?: (err: Error) => void }) => {
+        lateError = opts?.onError
+      },
+    )
+    const view = renderHub()
+    fireEvent.click(
+      screen.getByRole("button", { name: "submissions.rowDownload.aria" }),
+    )
+    view.unmount()
+
+    act(() => {
+      lateError?.(new Error("boom"))
+    })
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tone: "error",
+        message: "submissions.rowDownload.error",
+      }),
+    )
   })
 })

--- a/web/src/pages/submissions/ManageSubmissionModal.test.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.test.tsx
@@ -49,7 +49,7 @@ vi.mock("@/hooks/mutations/useRepairFeedbackPr", () => ({
   default: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify: vi.fn() }),
+  useToast: () => ({ notify: vi.fn(), announce: vi.fn() }),
 }))
 vi.mock("@/hooks/useTriggerRegrade", () => ({
   default: () => ({ regrade: vi.fn(), phase: "idle", anyRegrading: false }),

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useRef } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { PeopleIcon, RepoIcon } from "@/components/ui/icons"
 
-import { Badge, Modal, MonoLtr } from "@/components/ui"
+import { AnimatedAlert, Badge, Modal, MonoLtr } from "@/components/ui"
 import useGetRepo from "@/hooks/useGetRepo"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
 import useGetAutogradeState from "@/hooks/useGetAutogradeState"
@@ -13,7 +13,9 @@ import {
 } from "@/components/modals/collaboratorHelpers"
 import {
   SubmissionActionList,
+  SubmissionHubFeedbackContext,
   type SubmissionActionListProps,
+  type SubmissionHubFeedback,
 } from "@/pages/submissions/SubmissionsRowActions"
 import { ActionListRow } from "@/pages/submissions/actionLayout"
 import { formatSubmissionDateTime as formatDateTime } from "@/util/formatDate"
@@ -285,6 +287,9 @@ export const ManageSubmissionModal = ({
 }) => {
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const { t } = useTranslation()
+  // Outcome of the last action row, rendered as a banner at the top of the
+  // hub (Primer: feedback for a dialog action stays in the dialog).
+  const [feedback, setFeedback] = useState<SubmissionHubFeedback | null>(null)
 
   // Lifted here (not in SubmissionDetails) so the repo's default-branch tip can
   // link both the "Last push" row and the "View latest commit" action. Only
@@ -334,6 +339,14 @@ export const ManageSubmissionModal = ({
         ) : undefined
       }
     >
+      <AnimatedAlert
+        tone={feedback?.tone ?? "info"}
+        show={feedback != null}
+        className="mt-3 text-sm"
+        onDismiss={() => setFeedback(null)}
+      >
+        {feedback?.message}
+      </AnimatedAlert>
       {repoHref ? (
         <a
           className="link link-hover mt-2 inline-flex w-fit max-w-full items-center gap-1.5"
@@ -366,14 +379,16 @@ export const ManageSubmissionModal = ({
       ) : null}
 
       <div className="mt-4 divide-y divide-base-200">
-        <SubmissionActionList
-          {...action}
-          latestCommitHref={latestCommitHref}
-          repoPrivate={repoData?.private}
-          onManageAccess={
-            action.onManageAccess ? handleManageAccess : undefined
-          }
-        />
+        <SubmissionHubFeedbackContext.Provider value={setFeedback}>
+          <SubmissionActionList
+            {...action}
+            latestCommitHref={latestCommitHref}
+            repoPrivate={repoData?.private}
+            onManageAccess={
+              action.onManageAccess ? handleManageAccess : undefined
+            }
+          />
+        </SubmissionHubFeedbackContext.Provider>
         {isGroup && onManageMembers ? (
           <ActionListRow
             icon={PeopleIcon}

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { PeopleIcon, RepoIcon } from "@/components/ui/icons"
 
-import { AnimatedAlert, Badge, Modal, MonoLtr } from "@/components/ui"
+import { Badge, Modal, MonoLtr, OutcomeAlert } from "@/components/ui"
+import { useToast } from "@/context/notifications/NotificationProvider"
 import useGetRepo from "@/hooks/useGetRepo"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
 import useGetAutogradeState from "@/hooks/useGetAutogradeState"
@@ -287,9 +288,28 @@ export const ManageSubmissionModal = ({
 }) => {
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const { t } = useTranslation()
+  const { notify } = useToast()
   // Outcome of the last action row, rendered as a banner at the top of the
   // hub (Primer: feedback for a dialog action stays in the dialog).
   const [feedback, setFeedback] = useState<SubmissionHubFeedback | null>(null)
+  // Unmount-safe sink: a row action awaited past the hub's close would call
+  // setFeedback on an unmounted dialog (a silent no-op — e.g. a failed
+  // "make private" leaving the repo public with zero indication), so once
+  // this instance is gone the outcome falls back to a toast.
+  const mountedRef = useRef(true)
+  useEffect(
+    () => () => {
+      mountedRef.current = false
+    },
+    [],
+  )
+  const publishFeedback = useCallback(
+    (outcome: SubmissionHubFeedback) => {
+      if (mountedRef.current) setFeedback(outcome)
+      else notify(outcome)
+    },
+    [notify],
+  )
 
   // Lifted here (not in SubmissionDetails) so the repo's default-branch tip can
   // link both the "Last push" row and the "View latest commit" action. Only
@@ -339,14 +359,11 @@ export const ManageSubmissionModal = ({
         ) : undefined
       }
     >
-      <AnimatedAlert
-        tone={feedback?.tone ?? "info"}
-        show={feedback != null}
+      <OutcomeAlert
+        outcome={feedback}
         className="mt-3 text-sm"
         onDismiss={() => setFeedback(null)}
-      >
-        {feedback?.message}
-      </AnimatedAlert>
+      />
       {repoHref ? (
         <a
           className="link link-hover mt-2 inline-flex w-fit max-w-full items-center gap-1.5"
@@ -379,7 +396,7 @@ export const ManageSubmissionModal = ({
       ) : null}
 
       <div className="mt-4 divide-y divide-base-200">
-        <SubmissionHubFeedbackContext.Provider value={setFeedback}>
+        <SubmissionHubFeedbackContext.Provider value={publishFeedback}>
           <SubmissionActionList
             {...action}
             latestCommitHref={latestCommitHref}

--- a/web/src/pages/submissions/ReviewButton.test.tsx
+++ b/web/src/pages/submissions/ReviewButton.test.tsx
@@ -31,7 +31,7 @@ vi.mock("@/hooks/mutations/useRepairFeedbackPr", () => ({
   default: () => ({ mutate, isPending: false }),
 }))
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify }),
+  useToast: () => ({ notify, announce: vi.fn() }),
 }))
 
 import { ReviewButton } from "./ReviewButton"

--- a/web/src/pages/submissions/ReviewButton.tsx
+++ b/web/src/pages/submissions/ReviewButton.tsx
@@ -98,6 +98,8 @@ export const FeedbackPrAction = ({
       {
         onSuccess: async (result) => {
           if (result.ok) {
+            // Kept as a toast: the repaired PR opens in another tab and this
+            // dialog closes, so nothing on the page evidences the outcome.
             notify({
               tone: "success",
               durationMs: 5000,

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -12,7 +12,7 @@ import {
   SlidersIcon,
   SyncIcon,
 } from "@/components/ui/icons"
-import { useState } from "react"
+import { createContext, useCallback, useContext, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 
 import { safeHttpUrl } from "@/util/url"
@@ -31,6 +31,32 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { updateShimSubmissionMode } from "@/domain/assignments/submissionTrigger"
 import type { AssignmentMode, SubmissionMode } from "@/types/classroom"
+
+// Feedback channel for actions running inside the submission hub: outcomes
+// render as a banner at the top of the hub dialog (Primer: feedback for a
+// dialog action stays in the dialog) rather than as page-corner toasts.
+// Outside a provider the hook falls back to a toast, so the action rows keep
+// working if ever rendered standalone.
+export type SubmissionHubFeedback = {
+  tone: "info" | "success" | "warning" | "error"
+  message: string
+}
+
+export const SubmissionHubFeedbackContext = createContext<
+  ((feedback: SubmissionHubFeedback) => void) | null
+>(null)
+
+const useSubmissionFeedback = () => {
+  const inHub = useContext(SubmissionHubFeedbackContext)
+  const { notify } = useToast()
+  return useCallback(
+    (feedback: SubmissionHubFeedback) => {
+      if (inHub) inHub(feedback)
+      else notify(feedback)
+    },
+    [inHub, notify],
+  )
+}
 
 // Per-row regrade: dispatches regrade.yaml scoped to one owner, tracked via
 // useTriggerRegrade (icon shows progress; disabled while any regrade is in
@@ -191,7 +217,7 @@ export const DownloadButton = ({
   noRepo?: boolean
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const feedback = useSubmissionFeedback()
   const download = useDownloadSubmission()
 
   const start = () => {
@@ -204,7 +230,7 @@ export const DownloadButton = ({
           // not an error.
           const nothing =
             err instanceof Error && err.message === "no-submission"
-          notify({
+          feedback({
             tone: nothing ? "info" : "error",
             message: nothing
               ? t("submissions.rowDownload.nothingToDownload", { owner })
@@ -489,7 +515,7 @@ const UpdateTriggerButton = ({
   noRepo: boolean
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const feedback = useSubmissionFeedback()
   const client = useGitHubClient()
   // `pending` drives the disabled state; the synchronous useSafeSubmit latch is
   // the real re-entrancy guard (React state updates a render tick late, so two
@@ -509,7 +535,7 @@ const UpdateTriggerButton = ({
         mode: submissionMode,
         tags: submissionTags,
       })
-      notify({
+      feedback({
         tone:
           outcome.status === "updated" || outcome.status === "current"
             ? "success"
@@ -517,7 +543,7 @@ const UpdateTriggerButton = ({
         message: t(`submissions.rowTrigger.outcome.${outcome.status}`),
       })
     } catch (err) {
-      notify({
+      feedback({
         tone: "error",
         message:
           err instanceof Error
@@ -562,7 +588,7 @@ const ChangeVisibilityButton = ({
   noRepo: boolean
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const feedback = useSubmissionFeedback()
   const run = useSafeSubmit()
   const mutation = useSetRepoVisibility()
   const [confirmOpen, setConfirmOpen] = useState(false)
@@ -577,7 +603,7 @@ const ChangeVisibilityButton = ({
         repo,
         visibility: makePublic ? "public" : "private",
       })
-      notify({
+      feedback({
         tone: "success",
         message: t(
           makePublic
@@ -587,7 +613,7 @@ const ChangeVisibilityButton = ({
         ),
       })
     } catch (err) {
-      notify({
+      feedback({
         tone: "error",
         message:
           err instanceof Error
@@ -670,7 +696,7 @@ const PauseAutogradingButton = ({
   noRepo: boolean
 }) => {
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const feedback = useSubmissionFeedback()
   const run = useSafeSubmit()
   const {
     data: state,
@@ -697,7 +723,7 @@ const PauseAutogradingButton = ({
     if (noRepo) return
     try {
       const result = await mutation.mutateAsync({ org, repo, action })
-      notify({
+      feedback({
         tone: result.status === "notGradable" ? "warning" : "success",
         message: t(
           result.status === "notGradable"
@@ -708,7 +734,7 @@ const PauseAutogradingButton = ({
         ),
       })
     } catch (err) {
-      notify({
+      feedback({
         tone: "error",
         message:
           err instanceof Error

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -27,6 +27,7 @@ import useGetAutogradeState from "@/hooks/useGetAutogradeState"
 import useSetAutogradeState from "@/hooks/mutations/useSetAutogradeState"
 import useSetRepoVisibility from "@/hooks/mutations/useSetRepoVisibility"
 import { useToast } from "@/context/notifications/NotificationProvider"
+import type { ToastTone } from "@/context/notifications/NotificationProvider"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { updateShimSubmissionMode } from "@/domain/assignments/submissionTrigger"
@@ -36,9 +37,10 @@ import type { AssignmentMode, SubmissionMode } from "@/types/classroom"
 // render as a banner at the top of the hub dialog (Primer: feedback for a
 // dialog action stays in the dialog) rather than as page-corner toasts.
 // Outside a provider the hook falls back to a toast, so the action rows keep
-// working if ever rendered standalone.
+// working if ever rendered standalone. The hub's sink is itself unmount-safe
+// (falls back to a toast once the hub closes) — see ManageSubmissionModal.
 export type SubmissionHubFeedback = {
-  tone: "info" | "success" | "warning" | "error"
+  tone: ToastTone
   message: string
 }
 

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -42,7 +42,7 @@ vi.mock("@/hooks/mutations/useSetScoreOverride", () => ({
   }),
 }))
 vi.mock("@/context/notifications/NotificationProvider", () => ({
-  useToast: () => ({ notify: vi.fn() }),
+  useToast: () => ({ notify: vi.fn(), announce: vi.fn() }),
 }))
 vi.mock("@/hooks/useTriggerRegrade", () => ({
   default: () => ({ regrade: vi.fn(), phase: "idle", anyRegrading: false }),

--- a/web/src/test/a11yStructural.test.tsx
+++ b/web/src/test/a11yStructural.test.tsx
@@ -114,8 +114,12 @@ describe("structural a11y — 4.1.3 status-message live region", () => {
         </NotificationProvider>,
       )
       await userEvent.click(screen.getByText("fire"))
-      const status = screen.getByRole("status")
-      expect(status.getAttribute("aria-live")).toBe("polite")
+      // Two status regions exist: the always-mounted sr-only announce()
+      // region and the toast itself — assert on the toast (it has content).
+      const statuses = screen.getAllByRole("status")
+      const toast = statuses.find((el) => el.textContent?.includes("Status."))
+      expect(toast).toBeTruthy()
+      expect(toast?.getAttribute("aria-live")).toBe("polite")
     },
   )
 


### PR DESCRIPTION
## Summary

- Aligns every feedback surface with [Primer's notification-messaging guidance](https://primer.style/product/ui-patterns/notification-messaging/), from a full inventory of all 66 `notify()` sites plus alert tones and dismissal timing.
- **New `unavailable` Alert tone** (neutral chrome, circle-slash icon, polite `status` role) for permission gates and degraded reads; locked/closed assignment notices retone warning -> info.
- **Dialog feedback stays in the dialog:** ConfirmModal-driven flows rethrow localized errors into its error slot instead of toasting (which double-showed), custom modals render in-modal banners, and the submission hub gains a feedback context its action rows publish to — with an unmount-safe sink that falls back to a toast if the hub closes mid-action. Dialogs whose banner is the error's only home block dismissal while the write is pending.
- **Page and row outcomes move next to their source:** classroom settings save results render by the Save button, create failures by the Create button, staff/invite failures on their field or row (with `role="alert"` so screen readers still hear them), roster-sync failures as a banner above the table.
- **Success messaging used sparingly:** 12 toasts for visually evident outcomes (row disappears, badge flips) replaced by a new sr-only `announce()` polite live region on the notification provider, which joins burst announcements instead of dropping them. Every surviving toast carries a documented rationale (Undo, post-navigation, or no page anchor).
- **No more timed dismissals:** the access modals' "saved" note and the assignment-settings success banner persist until the next edit clears them.
- Shared `AlertOutcome` type + `OutcomeAlert` primitive replace six hand-rolled outcome shapes; `runInviteMember` takes explicit outcome callbacks instead of a tone-sniffed notify sink.
- New tests pin the contracts: ConfirmModal rejection rendering, hub banner + unmount fallback, staff-remove in-dialog failure, save-failure banners, and the announce() live region.

## Test plan

- [x] `npm run check` green (tsc, eslint, prettier, arch:validate, vitest — 4,671 tests)
- [x] Multi-reviewer code review pass; all validated findings fixed on-branch
- [ ] Manual QA: trigger a failing archive/delete/staff-remove and confirm the error renders inside the confirm dialog and the dialog stays open
- [ ] Manual QA: close the submission hub while an action is running and confirm the outcome arrives as a toast
- [ ] Screen reader spot-check: archive a classroom (announcement, no toast) and drop a reserved-path file in the upload dialog (alert announced)