### PR TITLE
fix(web): a11y mechanics sweep — focus, announcements, and error copy

### DIFF
--- a/web/src/components/RoleResolvingFallback.tsx
+++ b/web/src/components/RoleResolvingFallback.tsx
@@ -1,15 +1,21 @@
+import { useTranslation } from "react-i18next"
+
 import { Spinner } from "@/components/Spinner"
 
 // Shared pending state for the role-gated surfaces (RequireRole, the
-// assignment index redirect, the SubmissionsPage self-guard).
+// assignment index redirect, the SubmissionsPage self-guard). Labeled with
+// what is actually resolving (Primer: name the load when known).
 const RoleResolvingFallback = ({
   className = "min-h-[60vh]",
 }: {
   className?: string
-}) => (
-  <div className={`flex items-center justify-center ${className}`}>
-    <Spinner size="lg" />
-  </div>
-)
+}) => {
+  const { t } = useTranslation()
+  return (
+    <div className={`flex items-center justify-center ${className}`}>
+      <Spinner size="lg" label={t("common.resolvingRole")} />
+    </div>
+  )
+}
 
 export default RoleResolvingFallback

--- a/web/src/components/SubmitUpload.tsx
+++ b/web/src/components/SubmitUpload.tsx
@@ -16,6 +16,7 @@ import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { useSubmitAssignment } from "@/hooks/mutations/useSubmitAssignment"
 import type { SubmissionMode } from "@/types/classroom"
+import { errorText } from "@/types/localizedMessage"
 import {
   normalizeRepoPath,
   isReservedUploadPath,
@@ -312,9 +313,7 @@ export function SubmitUpload({
             <Alert tone="error">
               <div>
                 {t("submissions.student.upload.error")}
-                {mutation.error instanceof Error
-                  ? ` ${mutation.error.message}`
-                  : ""}
+                {` ${errorText(t, mutation.error)}`}
               </div>
             </Alert>
           )}

--- a/web/src/components/breadcrumb/index.tsx
+++ b/web/src/components/breadcrumb/index.tsx
@@ -17,8 +17,15 @@ import { useDismissOnOutsidePointerDown } from "@/hooks/useDismissOnOutsidePoint
 import { Link, useParams } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 
-import { Button, cx, Input, popoverPanelClass } from "@/components/ui"
+import {
+  Button,
+  cx,
+  Input,
+  InlineMessage,
+  popoverPanelClass,
+} from "@/components/ui"
 import { CheckIcon, ChevronDownIcon, SearchIcon } from "@/components/ui/icons"
+import { GitHubAPIError } from "@/github-core/errors"
 
 // GitHub-style leaf switcher (like the repo picker in github.com's header):
 // the current segment's name in default ink plus a caret that opens a titled
@@ -35,6 +42,7 @@ const CrumbSwitcher = <T,>({
   searchPlaceholder,
   items,
   getLabel,
+  loadError = false,
   children,
 }: {
   name: ReactNode
@@ -46,6 +54,10 @@ const CrumbSwitcher = <T,>({
   items: T[]
   // Plain-text form of an item, used for search filtering.
   getLabel: (item: T) => string
+  // The source list failed to load (a real failure, not the expected
+  // role-based 404): the panel says so instead of showing an empty list a
+  // user would misread as "nothing to switch to".
+  loadError?: boolean
   // Renders the filtered items as menu rows; `close` dismisses the panel on
   // selection.
   children: (visible: T[], close: () => void) => ReactNode
@@ -134,7 +146,11 @@ const CrumbSwitcher = <T,>({
                 onChange={(event) => setQuery(event.target.value)}
               />
             </div>
-            {visible.length > 0 ? (
+            {loadError ? (
+              <InlineMessage tone="error" className="px-3 py-3">
+                {t("components.breadcrumb.loadError")}
+              </InlineMessage>
+            ) : visible.length > 0 ? (
               // text-base-content: rows are actions, not trail links, so they
               // opt out of the nav's [&_a] accent-blue. The --menu-active-*
               // vars tone daisyUI's pressed-item feedback down from the
@@ -182,11 +198,21 @@ const Breadcrumb = ({
   // Switcher menu data. Each source stays idle (disabled query / empty list)
   // unless its switcher is requested. Both read the staff config repo, so for
   // a student the list resolves empty and the leaf degrades to plain text.
-  const { classes } = useGetClasses(switcher === "classroom" ? org : undefined)
+  const { classes, isError: classesError } = useGetClasses(
+    switcher === "classroom" ? org : undefined,
+  )
   const classroomSummaries = useClassroomSummaries(org, classes)
   const assignmentsQuery = useGetClassroomAssignments(org, classroom, {
     enabled: switcher === "assignment",
   })
+  // A student's 404 on the staff-only assignments.json is the expected
+  // degrade-to-plain-text path, not a load failure.
+  const assignmentsError =
+    assignmentsQuery.isError &&
+    !(
+      assignmentsQuery.error instanceof GitHubAPIError &&
+      assignmentsQuery.error.status === 404
+    )
 
   if (!org && !classroom) return <div></div>
 
@@ -221,13 +247,14 @@ const Breadcrumb = ({
         )}
         {org && classroom && switcher === "classroom" && (
           <li aria-current="page">
-            {switchableClassrooms.length > 1 ? (
+            {switchableClassrooms.length > 1 || classesError ? (
               <CrumbSwitcher
                 name={classroomName}
                 title={t("components.breadcrumb.switchClassroom")}
                 searchPlaceholder={t("components.breadcrumb.findClassroom")}
                 items={switchableClassrooms}
                 getLabel={(s) => classroomDisplayName(s, s.path)}
+                loadError={classesError}
               >
                 {(visible, close) =>
                   visible.map((s) => (
@@ -275,7 +302,7 @@ const Breadcrumb = ({
             </li>
             {switcher === "assignment" ? (
               <li aria-current="page">
-                {assignments.length > 1 ? (
+                {assignments.length > 1 || assignmentsError ? (
                   <CrumbSwitcher
                     name={assignmentName || assignment}
                     title={t("components.breadcrumb.switchAssignment")}
@@ -284,6 +311,7 @@ const Breadcrumb = ({
                     )}
                     items={assignments}
                     getLabel={(a) => a.name || a.slug}
+                    loadError={assignmentsError}
                   >
                     {/* Straight to each assignment's submissions gradebook:
                         the switcher only materializes from the staff-only

--- a/web/src/components/bulk/resultView.tsx
+++ b/web/src/components/bulk/resultView.tsx
@@ -6,7 +6,7 @@
 
 import { useTranslation } from "react-i18next"
 
-import { Button, Spinner, TableShell } from "@/components/ui"
+import { Button, InlineSpinner, Spinner, TableShell } from "@/components/ui"
 
 // The lifecycle of a bulk run's modal: idle (closed) -> working (progress) ->
 // complete/error (results).
@@ -106,14 +106,17 @@ export const bulkProgressPct = (
     ? Math.round((progress.processed / progress.total) * 100)
     : 0
 
-// Shared <progress> props. With `indeterminateUntilFirst`, `value` is omitted
-// until the first item lands so a slow first write animates as an
-// indeterminate track instead of sitting at 0%.
+// Shared <progress> props — including the accessible name (a bare <progress>
+// is announced as an unlabeled progressbar). With `indeterminateUntilFirst`,
+// `value` is omitted until the first item lands so a slow first write
+// animates as an indeterminate track instead of sitting at 0%.
 export const bulkProgressBarProps = (
   progress: Pick<BulkProgress, "processed" | "total">,
+  label: string,
   indeterminateUntilFirst = false,
 ) => ({
   className: "progress progress-primary w-full",
+  "aria-label": label,
   ...(indeterminateUntilFirst && progress.processed === 0
     ? {}
     : { value: bulkProgressPct(progress) }),
@@ -134,7 +137,9 @@ export const BulkProgressBlock = ({
 }) => (
   <div className="mt-6 flex flex-col items-center gap-3 py-6">
     <Spinner label={workingLabel} />
-    <progress {...bulkProgressBarProps(progress, indeterminateUntilFirst)} />
+    <progress
+      {...bulkProgressBarProps(progress, workingLabel, indeterminateUntilFirst)}
+    />
     <p className="break-all text-center text-sm text-base-content/70">
       {caption}
     </p>
@@ -157,7 +162,7 @@ export const BulkProgressRow = ({
 }) => (
   <div className="mt-6">
     <p className="mb-2 font-medium">{progress.message}</p>
-    <progress {...bulkProgressBarProps(progress)} />
+    <progress {...bulkProgressBarProps(progress, progress.message)} />
     <div className="mt-2 flex justify-between text-sm opacity-70">
       <span>{processedCaption}</span>
       <span>{percentCaption}</span>
@@ -172,14 +177,17 @@ export const BulkProgressInline = ({
   label,
   progress,
 }: {
-  label: React.ReactNode
+  label: string
   progress: Pick<BulkProgress, "processed" | "total">
 }) => (
   <div className="mt-4 space-y-3">
-    <p className="flex items-center gap-2 text-sm text-base-content/70">
-      <Spinner size="xs" />
+    <p
+      role="status"
+      className="flex items-center gap-2 text-sm text-base-content/70"
+    >
+      <InlineSpinner />
       {label}
     </p>
-    <progress {...bulkProgressBarProps(progress)} />
+    <progress {...bulkProgressBarProps(progress, label)} />
   </div>
 )

--- a/web/src/components/modals/NewOrgModal.tsx
+++ b/web/src/components/modals/NewOrgModal.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next"
 import PlanBadge from "@/components/PlanBadge"
 import MissingOrgNotice from "@/components/MissingOrgNotice"
 import FreePlanInfoModal from "@/components/modals/FreePlanInfoModal"
-import { Badge, Button, Modal, Spinner, cx } from "@/components/ui"
+import { Badge, Button, Modal, InlineSpinner, cx } from "@/components/ui"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
 import useNeedsSetupPlans from "@/hooks/useNeedsSetupPlans"
 import { useLingeringOpen } from "@/hooks/useLingeringOpen"
@@ -127,7 +127,7 @@ function OrgPicker({
                     />
                   )}
                   {planLoading ? (
-                    <Spinner size="sm" className="shrink-0" />
+                    <InlineSpinner size="sm" className="shrink-0" />
                   ) : isFree ? (
                     <>
                       <Badge tone="warning" size="sm" className="shrink-0">

--- a/web/src/components/modals/OrgDetailsModal.tsx
+++ b/web/src/components/modals/OrgDetailsModal.tsx
@@ -20,6 +20,7 @@ import { isOwnerGitHubOrgRole } from "@/authz"
 import type { Classroom50OrgSummary } from "@/github-core/queries"
 import { githubOrgSettingsUrl } from "@/util/orgUrl"
 import { normalizeWebsiteUrl, safeHttpUrl } from "@/util/url"
+import { errorText } from "@/types/localizedMessage"
 
 type ProfileFormValues = {
   name: string
@@ -105,7 +106,7 @@ function OrgDetailsModal({
         // A dialog-action failure belongs inside the dialog, not a page toast.
         setSaveError(
           t("orgs.detailsModal.saveError", {
-            error: err instanceof Error ? err.message : "",
+            error: errorText(t, err),
           }),
         )
       }

--- a/web/src/components/modals/TemplateAccessModal.tsx
+++ b/web/src/components/modals/TemplateAccessModal.tsx
@@ -13,7 +13,7 @@ import {
   Modal,
   ModalIcon,
   OutcomeAlert,
-  Spinner,
+  InlineSpinner,
 } from "@/components/ui"
 import type { AlertOutcome } from "@/components/ui"
 import type { Assignment } from "@/types/classroom"
@@ -262,8 +262,11 @@ const TeamsList = ({
 
   if (loading) {
     return (
-      <p className="mt-2 flex items-center gap-2 text-sm text-base-content/60">
-        <Spinner size="xs" />
+      <p
+        role="status"
+        className="mt-2 flex items-center gap-2 text-sm text-base-content/60"
+      >
+        <InlineSpinner />
         {t("assignments.template.accessModal.teamsLoading")}
       </p>
     )

--- a/web/src/components/settings/LanguageSwitcher.tsx
+++ b/web/src/components/settings/LanguageSwitcher.tsx
@@ -14,6 +14,7 @@ import { AnimatedAlert, Badge, Button, rtlFlip } from "@/components/ui"
 import { useLanguage } from "@/hooks/useLanguage"
 import { useLanguageRegistry } from "@/hooks/useLanguageRegistry"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
+import { errorText } from "@/types/localizedMessage"
 import {
   BASE_LANG,
   LanguagePackError,
@@ -76,7 +77,7 @@ export const LanguageSwitcher = ({
       setNeedsCode(true)
       setError(t("language.errorCodeUndetectable"))
     } else if (err instanceof LanguagePackError) {
-      setError(err.message)
+      setError(errorText(t, err))
     } else {
       setError(t("language.errorGeneric"))
     }

--- a/web/src/components/ui/Button.test.tsx
+++ b/web/src/components/ui/Button.test.tsx
@@ -55,12 +55,22 @@ describe("Button", () => {
     expect(cls.endsWith("w-full join-item")).toBe(true)
   })
 
-  it("disables and marks aria-busy while loading", () => {
-    render(<Button loading>Save</Button>)
+  it("stays focusable but inert while loading (aria-disabled, click swallowed)", async () => {
+    const onClick = vi.fn()
+    render(
+      <Button loading onClick={onClick}>
+        Save
+      </Button>,
+    )
     const btn = screen.getByRole("button", { name: /Save/ })
-    expect(btn.hasAttribute("disabled")).toBe(true)
+    // Not semantically disabled — a native `disabled` would drop keyboard
+    // focus mid-action (Primer loading guidance).
+    expect(btn.hasAttribute("disabled")).toBe(false)
+    expect(btn.getAttribute("aria-disabled")).toBe("true")
     expect(btn.getAttribute("aria-busy")).toBe("true")
     expect(btn.querySelector(".loading")).not.toBeNull()
+    await userEvent.click(btn)
+    expect(onClick).not.toHaveBeenCalled()
   })
 
   it("does not fire onClick when disabled", async () => {

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -12,11 +12,12 @@ import { cx } from "./cx"
 // The canonical button. Wraps daisyUI `btn` so the ~160 inline sites share one
 // prop->class mapping instead of hand-ordered modifier strings. Color/size are
 // props; icon-only buttons pick a `shape`; `loading` renders the accessible
-// Spinner inside and disables the button (replacing the hand-placed inner
-// spinners the audit found). A trailing `className` escape hatch stays for the
-// per-site layout utilities (`w-full`, `join-item`, `self-start`, ...). `ref`
-// is a plain prop (React 19) so sites that manage focus can still reach the
-// underlying element.
+// Spinner inside and makes the button inert WITHOUT semantically disabling it
+// (aria-disabled + click guard — a native `disabled` would drop keyboard focus
+// mid-action, per Primer's loading guidance). A trailing `className` escape
+// hatch stays for the per-site layout utilities (`w-full`, `join-item`,
+// `self-start`, ...). `ref` is a plain prop (React 19) so sites that manage
+// focus can still reach the underlying element.
 //
 // Passing `href` (or `as="a"`) renders an <a> that reuses the same recipe, so
 // link-shaped actions (open a repo/commit in a new tab) share the button look
@@ -114,6 +115,7 @@ export function Button({
   disabled,
   type,
   ref,
+  onClick,
   ...rest
 }: ButtonProps) {
   const classes = cx(
@@ -147,6 +149,11 @@ export function Button({
         download={download}
         aria-disabled={inert || undefined}
         aria-busy={loading || undefined}
+        onClick={
+          inert
+            ? (event) => event.preventDefault()
+            : (onClick as AnchorHTMLAttributes<HTMLAnchorElement>["onClick"])
+        }
         {...(rest as AnchorHTMLAttributes<HTMLAnchorElement>)}
       >
         {inner}
@@ -159,8 +166,22 @@ export function Button({
       ref={ref as Ref<HTMLButtonElement>}
       type={type ?? "button"}
       className={classes}
-      disabled={disabled || loading}
+      // Loading does NOT semantically disable (Primer: a disabled initiating
+      // button drops keyboard focus mid-action). aria-disabled + the click
+      // guard keep it inert but focusable; aria-busy carries the state.
+      disabled={disabled}
+      aria-disabled={disabled || loading || undefined}
       aria-busy={loading || undefined}
+      onClick={(event) => {
+        if (loading) {
+          // Swallow activation (including a submit re-fire) mid-action; the
+          // per-site re-entrancy latches stay the real guard.
+          event.preventDefault()
+          event.stopPropagation()
+          return
+        }
+        onClick?.(event)
+      }}
       {...rest}
     >
       {inner}

--- a/web/src/hooks/useRovingTabList.test.tsx
+++ b/web/src/hooks/useRovingTabList.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { useState } from "react"
+
+import { useRovingTabList } from "./useRovingTabList"
+
+const TABS = ["one", "two", "three"] as const
+
+function Probe() {
+  const [active, setActive] = useState(0)
+  const tabProps = useRovingTabList(TABS.length, active)
+  return (
+    <div role="tablist">
+      {TABS.map((label, index) => (
+        <button
+          key={label}
+          type="button"
+          role="tab"
+          aria-selected={index === active}
+          onClick={() => setActive(index)}
+          {...tabProps(index)}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+describe("useRovingTabList", () => {
+  it("keeps only the active tab in the page tab order", () => {
+    render(<Probe />)
+    const tabs = screen.getAllByRole("tab")
+    expect(tabs.map((tab) => tab.tabIndex)).toEqual([0, -1, -1])
+  })
+
+  it("moves focus with arrow keys, wrapping at the ends", () => {
+    render(<Probe />)
+    const tabs = screen.getAllByRole("tab")
+    tabs[0].focus()
+
+    fireEvent.keyDown(tabs[0], { key: "ArrowRight" })
+    expect(document.activeElement).toBe(tabs[1])
+
+    // Wrap backward from the first tab to the last.
+    fireEvent.keyDown(tabs[1], { key: "ArrowLeft" })
+    fireEvent.keyDown(tabs[0], { key: "ArrowLeft" })
+    expect(document.activeElement).toBe(tabs[2])
+  })
+
+  it("jumps to the ends with Home and End", () => {
+    render(<Probe />)
+    const tabs = screen.getAllByRole("tab")
+    tabs[0].focus()
+
+    fireEvent.keyDown(tabs[0], { key: "End" })
+    expect(document.activeElement).toBe(tabs[2])
+    fireEvent.keyDown(tabs[2], { key: "Home" })
+    expect(document.activeElement).toBe(tabs[0])
+  })
+
+  it("moves focus without activating (manual activation)", () => {
+    render(<Probe />)
+    const tabs = screen.getAllByRole("tab")
+    tabs[0].focus()
+    fireEvent.keyDown(tabs[0], { key: "ArrowRight" })
+    // Focus moved but selection stayed — activation needs a click/Enter.
+    expect(tabs[0].getAttribute("aria-selected")).toBe("true")
+    expect(tabs[1].getAttribute("aria-selected")).toBe("false")
+  })
+})

--- a/web/src/hooks/useRovingTabList.ts
+++ b/web/src/hooks/useRovingTabList.ts
@@ -1,0 +1,43 @@
+import { useRef } from "react"
+import type { KeyboardEvent } from "react"
+
+// Roving-tabindex keyboard wiring for a manual-activation `role="tablist"`
+// (ARIA APG tabs pattern): arrow keys move focus between tabs (wrapping,
+// direction-aware for RTL), Home/End jump to the ends, and only the active
+// tab sits in the page tab order. Activation stays on click/Enter/Space —
+// the native button behavior — so arrowing through tabs never loads panels
+// the user didn't ask for. Returns a per-tab props factory to spread onto
+// each `role="tab"` button.
+export function useRovingTabList(count: number, activeIndex: number) {
+  const refs = useRef<(HTMLButtonElement | null)[]>([])
+
+  const handleKeyDown = (index: number) => (e: KeyboardEvent) => {
+    const last = count - 1
+    const rtl = getComputedStyle(e.currentTarget).direction === "rtl"
+    const forward = rtl ? "ArrowLeft" : "ArrowRight"
+    const backward = rtl ? "ArrowRight" : "ArrowLeft"
+    let next: number | null = null
+    if (e.key === forward || e.key === "ArrowDown") {
+      next = index === last ? 0 : index + 1
+    } else if (e.key === backward || e.key === "ArrowUp") {
+      next = index === 0 ? last : index - 1
+    } else if (e.key === "Home") {
+      next = 0
+    } else if (e.key === "End") {
+      next = last
+    }
+    if (next === null) return
+    e.preventDefault()
+    refs.current[next]?.focus()
+  }
+
+  return (index: number) => ({
+    ref: (el: HTMLButtonElement | null) => {
+      refs.current[index] = el
+    },
+    tabIndex: index === activeIndex ? 0 : -1,
+    onKeyDown: handleKeyDown(index),
+  })
+}
+
+export default useRovingTabList

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1593,6 +1593,8 @@
       "sortByName": "Sort by name",
       "sortByDue": "Sort by due date",
       "empty": "No assignments created.",
+      "emptyTitle": "Create your first assignment",
+      "emptyBody": "Assignments you create or reuse from another classroom will show up here.",
       "loadError": "Couldn't load assignments from GitHub. This is a load error — your assignments aren't gone.",
       "retry": "Retry",
       "individual": "Individual",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -148,6 +148,8 @@
     }
   },
   "common": {
+    "checkingOrgAccess": "Checking your access to this organization…",
+    "resolvingRole": "Checking your role…",
     "goToDashboard": "Go to dashboard",
     "close": "Close",
     "cancel": "Cancel",
@@ -3551,7 +3553,8 @@
       "switchAssignment": "Switch assignment",
       "findClassroom": "Find a classroom…",
       "findAssignment": "Find an assignment…",
-      "noMatches": "No matches."
+      "noMatches": "No matches.",
+      "loadError": "Couldn't load the list. It's a load error — nothing is gone."
     },
     "planBadge": {
       "label": "{{name}} plan"

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -238,7 +238,6 @@
       "suffix": "Template repo suffix",
       "suffixHelp": "Optional text appended to every copied template repo name (e.g. hw1 becomes hw1-f26). Use it only if a repo with the assignment's name already exists in this organization and the import would otherwise collide. Leave blank in most cases.",
       "suffixPlaceholder": "optional",
-      "preflightError": "Couldn't build the import preview.",
       "loading": "Retrieving classroom data…",
       "updating": "Updating preview…",
       "selectAll": "Select all assignments",
@@ -822,7 +821,6 @@
     "githubIdentityNoId": "GitHub: <username>@{{username}}</username>",
     "saving": "Saving...",
     "saveChanges": "Save changes",
-    "couldNotReadFile": "Could not read file",
     "startingImport": "Starting import...",
     "importFailed": "Import failed",
     "uploadTitle": "Upload roster",
@@ -2023,7 +2021,6 @@
       "placeholder": "github_pat_…",
       "validating": "Validating…",
       "saveButton": "Save token",
-      "saveError": "Could not validate or save the token.",
       "saved": "Service token saved.",
       "savedNoMetadata": "Service token saved, but its expiry and name couldn't be recorded — the health chip may show “expiry not tracked” until you save again."
     },
@@ -2123,7 +2120,6 @@
     "teardown": {
       "title": "Danger zone",
       "description": "Tear down this organization by deleting <strong>every</strong> repository in it, including the <repo>classroom50</repo> repository, and removing the GitHub team of every classroom. This is irreversible.",
-      "prepareError": "Couldn't prepare the teardown plan.",
       "preparing": "Preparing…",
       "button": "Tear down organization",
       "confirmText": "delete {{org}}",
@@ -3153,8 +3149,7 @@
       "outcome": {
         "paused": "Autograding paused for this repository.",
         "resumed": "Autograding resumed for this repository.",
-        "notGradable": "This repository has no autograding workflow — nothing to change.",
-        "failed": "Could not change the autograding state — try again."
+        "notGradable": "This repository has no autograding workflow — nothing to change."
       }
     },
     "rowVisibility": {
@@ -3169,8 +3164,7 @@
       "confirmLabel": "Make public",
       "outcome": {
         "public": "Repository is now public.",
-        "private": "Repository is now private.",
-        "failed": "Could not change the repository's visibility — try again."
+        "private": "Repository is now private."
       }
     },
     "bulkAutograde": {

--- a/web/src/pages/AssessmentPage.tsx
+++ b/web/src/pages/AssessmentPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
 
 import {
   Alert,
@@ -19,6 +20,7 @@ import {
   type ManualVerdict,
 } from "@/util/a11y/vpatModel"
 import type { Guidance } from "@/util/a11y/assessmentGuidance"
+import { errorText } from "@/types/localizedMessage"
 
 // Dev-only interactive WCAG assessment tool (route: /assess). It pulls in the
 // full VPAT report: the manually-assessed criteria are editable (record, then
@@ -56,6 +58,7 @@ const isManual = (c: Criterion, verdicts: Record<string, ManualVerdict>) =>
 
 export default function AssessmentPage() {
   useDocumentTitle("Assessment mode — WCAG 2.2 AA")
+  const { t } = useTranslation()
   const [data, setData] = useState<AssessData | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -66,8 +69,8 @@ export default function AssessmentPage() {
         return res.json() as Promise<AssessData>
       })
       .then(setData)
-      .catch((e) => setError(e instanceof Error ? e.message : "load failed"))
-  }, [])
+      .catch((e) => setError(errorText(t, e)))
+  }, [t])
 
   useEffect(load, [load])
 
@@ -97,24 +100,27 @@ export default function AssessmentPage() {
     [criteria, verdicts],
   )
 
-  const save = useCallback(async (body: SavePayload) => {
-    setError(null)
-    try {
-      const res = await fetch("/_assess/save", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      })
-      const next = (await res.json()) as AssessData & { error?: string }
-      if (next.error) {
-        setError(next.error)
-        return
+  const save = useCallback(
+    async (body: SavePayload) => {
+      setError(null)
+      try {
+        const res = await fetch("/_assess/save", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        })
+        const next = (await res.json()) as AssessData & { error?: string }
+        if (next.error) {
+          setError(next.error)
+          return
+        }
+        setData(next)
+      } catch (e) {
+        setError(errorText(t, e))
       }
-      setData(next)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "save failed")
-    }
-  }, [])
+    },
+    [t],
+  )
 
   if (error && !data) {
     return (

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -169,11 +169,11 @@ export const TeacherAssignmentsView = ({
   )
 
   const hasAssignments = (sourceAssignments?.length ?? 0) > 0
-  // The toolbar owns the primary action now (New assignment / archived badge),
-  // so it renders whenever the list has loaded — with only the trailing action
-  // when there are no assignments yet (actionsOnly), and the full search/filter/
-  // sort bar once there are.
-  const showToolbar = !assignmentsLoading
+  // The toolbar renders only once assignments exist: on a first-use empty
+  // list the table's blankslate carries the New-assignment action instead
+  // (Primer: the empty state owns its resolving action, and a view gets one
+  // primary button — a toolbar copy would duplicate it).
+  const showToolbar = !assignmentsLoading && hasAssignments
   const showNoResults = hasAssignments && visible.length === 0
 
   // Right-aligned toolbar action: the New assignment split button for an author,
@@ -262,7 +262,6 @@ export const TeacherAssignmentsView = ({
           onFiltersChange={setFilters}
           sort={sort}
           onSortChange={setSort}
-          actionsOnly={!hasAssignments}
           leading={collectAction}
           trailing={primaryAction}
         />
@@ -292,6 +291,14 @@ export const TeacherAssignmentsView = ({
           loading={assignmentsLoading}
           loadError={assignmentsError}
           onRetryLoad={() => void refetchAssignments()}
+          // The first-use blankslate's action — the same split button
+          // (create + reuse) the toolbar shows once assignments exist. A TA
+          // or an archived classroom gets no action (plain empty statement).
+          emptyAction={
+            canAuthor && !archived ? (
+              <NewAssignmentButton org={org} classroom={classroom} />
+            ) : undefined
+          }
           archived={archived}
           canAuthor={canAuthor}
           sort={sort}

--- a/web/src/pages/ClassroomSettingsPage.tsx
+++ b/web/src/pages/ClassroomSettingsPage.tsx
@@ -19,6 +19,7 @@ import RequireRole from "@/components/RequireRole"
 import { LoadingSwap } from "@/lib/LoadingSwap"
 import { Alert, EmphasisLtr } from "@/components/ui"
 import type { AlertOutcome } from "@/components/ui"
+import { errorText } from "@/types/localizedMessage"
 
 const EditClassroomContent = ({
   org,
@@ -92,7 +93,7 @@ const EditClassroomContent = ({
                           err instanceof GitHubAPIError && err.status === 409
                             ? t("toasts.classroomSaveConflict")
                             : t("toasts.classroomSaveFailed", {
-                                message: err.message,
+                                message: errorText(t, err),
                               }),
                       })
                     },

--- a/web/src/pages/CreateClassroomPage.tsx
+++ b/web/src/pages/CreateClassroomPage.tsx
@@ -14,6 +14,7 @@ import MissingParams from "@/components/MissingParams"
 import { logger } from "@/lib/logger"
 import { logWriteFailure } from "@/lib/logWriteFailure"
 import RequireRole from "@/components/RequireRole"
+import { errorText } from "@/types/localizedMessage"
 import CreateClassroomForm from "./classes/CreateClassroomForm"
 
 const log = logger.scope("CreateClassroomPage")
@@ -72,7 +73,7 @@ const CreateClassroomPage = () => {
                   // the create button rather than as a corner toast.
                   setCreateError(
                     t("toasts.classroomCreateFailed", {
-                      message: err.message,
+                      message: errorText(t, err),
                     }),
                   )
                 },

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -862,7 +862,11 @@ const OrgMembersPage = () => {
                                   label: row.username || row.email || row.name,
                                 })
                           }
-                          disabled={isSelf(row)}
+                          // aria-disabled + click guard instead of `disabled`:
+                          // the checkbox stays focusable so the "you can't
+                          // select yourself" reason reaches keyboard and
+                          // screen-reader users.
+                          aria-disabled={isSelf(row) || undefined}
                           title={
                             isSelf(row)
                               ? t("orgMembers.bulk.selfNotSelectable")
@@ -871,9 +875,16 @@ const OrgMembersPage = () => {
                           checked={selectedKeys.has(row.key)}
                           onClick={(e) => {
                             e.stopPropagation()
+                            if (isSelf(row)) {
+                              e.preventDefault()
+                              return
+                            }
                             handleRowCheckboxClick(e, row.key)
                           }}
-                          onChange={() => handleToggleRow(row.key)}
+                          onChange={() => {
+                            if (isSelf(row)) return
+                            handleToggleRow(row.key)
+                          }}
                         />
                       </td>
                       <td className="min-w-0">

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -32,6 +32,7 @@ import TeardownSection from "@/pages/orgSettings/TeardownSection"
 import SettingsSection from "@/pages/orgSettings/SettingsSection"
 import { githubOrgSettingsUrl } from "@/util/orgUrl"
 import { WIKI_URL } from "@/version"
+import { errorText } from "@/types/localizedMessage"
 import {
   AlertIcon,
   CalendarIcon,
@@ -168,9 +169,7 @@ function TokenNameRow({
       </Button>
       {renameMutation.isError && (
         <span className="text-xs text-error">
-          {renameMutation.error instanceof Error
-            ? renameMutation.error.message
-            : t("orgSettings.serviceToken.saveError")}
+          {errorText(t, renameMutation.error)}
         </span>
       )}
     </form>
@@ -374,9 +373,7 @@ function SetTokenModal({
             hint={t("orgSettings.serviceToken.pasteHelp")}
             error={
               saveMutation.isError
-                ? saveMutation.error instanceof Error
-                  ? saveMutation.error.message
-                  : t("orgSettings.serviceToken.saveError")
+                ? errorText(t, saveMutation.error)
                 : undefined
             }
           >

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -53,6 +53,7 @@ import {
 } from "@/components/submissions/SubmissionRowCells"
 import { StudentRowActions } from "@/pages/submissions/StudentRowActions"
 import SubmitGuidance from "@/components/SubmitGuidance"
+import { errorText } from "@/types/localizedMessage"
 
 // A submit/<UTC-ts>-<short-sha> release tag → its trailing short sha, so a
 // push submission can link the graded release published at its commit. Returns
@@ -247,7 +248,7 @@ const SubmissionBody = ({
     const firstError = [releasesErrorObj, repoError].find(
       (e) => e instanceof Error,
     )
-    const message = firstError instanceof Error ? firstError.message : ""
+    const message = firstError ? errorText(t, firstError) : ""
     return (
       <Alert tone="error">
         {t("submissions.student.loadError")}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -22,7 +22,7 @@ import {
   EmphasisLtr,
   HelpTooltip,
   MetricBar,
-  Spinner,
+  InlineSpinner,
 } from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import SubmissionsTable from "@/pages/submissions/SubmissionsTable"
@@ -1200,7 +1200,7 @@ const SubmissionsPageContent = () => {
           )}
           {collectScores.phase === "running" && (
             <Alert tone="info" role="status">
-              <Spinner size="xs" />
+              <InlineSpinner />
               {t("submissions.collect.statusRunning")}
             </Alert>
           )}
@@ -1241,7 +1241,7 @@ const SubmissionsPageContent = () => {
           )}
           {regradeAll.phase === "running" && (
             <Alert tone="info" role="status">
-              <Spinner size="xs" />
+              <InlineSpinner />
               {t("submissions.regradeAll.statusRunning")}
             </Alert>
           )}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -101,6 +101,7 @@ import { downloadBlob } from "@/util/downloadBlob"
 import { hasStudentEnrollment } from "@/util/classroomRoleUI"
 import type { Student } from "@/types/classroom"
 import { isClassroomArchived } from "@/types/classroom"
+import { errorText } from "@/types/localizedMessage"
 import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
 import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
 import useAcceptShareSummary from "@/hooks/useAcceptShareSummary"
@@ -1060,7 +1061,7 @@ const SubmissionsPageContent = () => {
             <>
               {scoresErrorObj instanceof Error
                 ? t("submissions.errors.gradebookLoadWithReason", {
-                    reason: scoresErrorObj.message,
+                    reason: errorText(t, scoresErrorObj),
                   })
                 : t("submissions.errors.gradebookLoad")}{" "}
               {t("submissions.errors.gradebookLoadHint")}
@@ -1217,7 +1218,7 @@ const SubmissionsPageContent = () => {
                 <>
                   {collectScores.error instanceof Error
                     ? t("submissions.collect.statusFailedWithReason", {
-                        reason: collectScores.error.message,
+                        reason: errorText(t, collectScores.error),
                       })
                     : t("submissions.collect.statusFailed")}{" "}
                   {t("submissions.collect.statusFailedHint")}
@@ -1260,7 +1261,7 @@ const SubmissionsPageContent = () => {
             <Alert tone="error" role="status">
               {regradeAll.error instanceof Error
                 ? t("submissions.regradeAll.statusFailedWithReason", {
-                    reason: regradeAll.error.message,
+                    reason: errorText(t, regradeAll.error),
                   })
                 : t("submissions.regradeAll.statusFailed")}{" "}
               {t("submissions.regradeAll.statusFailedHint")}

--- a/web/src/pages/accessibility/ContrastSection.tsx
+++ b/web/src/pages/accessibility/ContrastSection.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useId, useRef, useState } from "react"
 import { SkeletonRegion } from "@/components/list"
 import { useTranslation } from "react-i18next"
 import { InfoIcon } from "@/components/ui/icons"
 
 import { Alert, Badge, Card, Modal } from "@/components/ui"
+import { useRovingTabList } from "@/hooks/useRovingTabList"
 
 import {
   STATUS_TONE,
@@ -219,6 +220,11 @@ export function ContrastSection() {
 
   const activeTheme = pickedTheme ?? audit?.themes[0]?.theme ?? null
   const shownTheme = audit?.themes.find((th) => th.theme === activeTheme)
+  const tabsId = useId()
+  const tabProps = useRovingTabList(
+    audit?.themes.length ?? 0,
+    audit?.themes.findIndex((th) => th.theme === activeTheme) ?? 0,
+  )
   const marginCount = audit?.summary.marginMisses ?? 0
 
   return (
@@ -254,14 +260,17 @@ export function ContrastSection() {
 
           <div className="flex flex-wrap items-center gap-3">
             <div role="tablist" className="tabs-boxed tabs w-fit">
-              {audit.themes.map((th) => (
+              {audit.themes.map((th, index) => (
                 <button
                   key={th.theme}
                   type="button"
                   role="tab"
+                  id={`${tabsId}-tab-${th.theme}`}
                   aria-selected={th.theme === activeTheme}
+                  aria-controls={`${tabsId}-panel`}
                   className={tabClass(th.theme === activeTheme)}
                   onClick={() => setPickedTheme(th.theme)}
+                  {...tabProps(index)}
                 >
                   {th.label}
                 </button>
@@ -270,7 +279,13 @@ export function ContrastSection() {
           </div>
 
           {shownTheme && (
-            <ThemeTable theme={shownTheme} onOpenRow={setSelectedRow} />
+            <div
+              role="tabpanel"
+              id={`${tabsId}-panel`}
+              aria-labelledby={`${tabsId}-tab-${shownTheme.theme}`}
+            >
+              <ThemeTable theme={shownTheme} onOpenRow={setSelectedRow} />
+            </div>
           )}
 
           <details className="collapse-arrow collapse rounded-box border border-base-300 bg-base-100">

--- a/web/src/pages/accessibility/VpatSection.tsx
+++ b/web/src/pages/accessibility/VpatSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useId, useMemo, useState } from "react"
 import { SkeletonRegion } from "@/components/list"
 import { useTranslation } from "react-i18next"
 import {
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/icons"
 
 import { Alert, Badge, Card, Toolbar, cx } from "@/components/ui"
+import { useRovingTabList } from "@/hooks/useRovingTabList"
 import {
   CONFORMANCE_TONE,
   hasGenericRemark,
@@ -45,6 +46,11 @@ function VpatConformanceTable({
   const { t } = useTranslation()
   const [activePrinciple, setActivePrinciple] =
     useState<WcagPrinciple>("Perceivable")
+  const tabsId = useId()
+  const tabProps = useRovingTabList(
+    PRINCIPLE_ORDER.length,
+    PRINCIPLE_ORDER.indexOf(activePrinciple),
+  )
 
   // Counts per principle reflect the current search/filter so a tab shows how
   // many rows it holds (and an emptied tab reads 0 rather than looking broken).
@@ -65,14 +71,17 @@ function VpatConformanceTable({
           aria-label={t("accessibility.vpat.principleTabsAria")}
           className="tabs-boxed tabs w-fit"
         >
-          {PRINCIPLE_ORDER.map((principle) => (
+          {PRINCIPLE_ORDER.map((principle, index) => (
             <button
               key={principle}
               type="button"
               role="tab"
+              id={`${tabsId}-tab-${principle}`}
               aria-selected={principle === activePrinciple}
+              aria-controls={`${tabsId}-panel`}
               className={tabClass(principle === activePrinciple)}
               onClick={() => setActivePrinciple(principle)}
+              {...tabProps(index)}
             >
               {principle}
               <span
@@ -89,65 +98,73 @@ function VpatConformanceTable({
           ))}
         </div>
 
-        {rows.length === 0 ? (
-          <div className="flex flex-col items-center gap-2 p-8 text-center text-sm text-base-content/60">
-            <IssueDraftIcon aria-hidden="true" className="size-4" />
-            {t("accessibility.vpat.empty")}
-          </div>
-        ) : (
-          // Deliberately not TableShell: the VPAT matrix is long-form document
-          // content on the public accessibility statement, where the boxed
-          // list-frame treatment would read as UI chrome.
-          <div className="overflow-x-auto">
-            <table className="table w-full">
-              <thead>
-                <tr>
-                  <th className="w-64">
-                    {t("accessibility.vpat.col.criterion")}
-                  </th>
-                  <th className="w-14">{t("accessibility.vpat.col.level")}</th>
-                  <th className="w-40">
-                    {t("accessibility.vpat.col.conformance")}
-                  </th>
-                  <th className="w-28">
-                    {t("accessibility.vpat.col.assessed")}
-                  </th>
-                  <th className="min-w-[24rem]">
-                    {t("accessibility.vpat.col.remarks")}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((c) => (
-                  <tr key={c.id}>
-                    <td className="align-top">
-                      <span className="font-mono text-xs text-base-content/60">
-                        {c.id}
-                      </span>{" "}
-                      {c.name}
-                    </td>
-                    <td className="align-top font-mono text-xs">{c.level}</td>
-                    <td className="align-top">
-                      <Badge tone={CONFORMANCE_TONE[c.status]}>
-                        {t(`accessibility.vpat.status.${c.status}`)}
-                      </Badge>
-                    </td>
-                    <td className="align-top font-mono text-xs whitespace-nowrap text-base-content/60">
-                      {c.assessed ?? generated}
-                    </td>
-                    <td className="align-top text-sm text-base-content/70">
-                      {hasGenericRemark(c) ? (
-                        <span className="text-base-content/40">—</span>
-                      ) : (
-                        c.remark
-                      )}
-                    </td>
+        <div
+          role="tabpanel"
+          id={`${tabsId}-panel`}
+          aria-labelledby={`${tabsId}-tab-${activePrinciple}`}
+        >
+          {rows.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 p-8 text-center text-sm text-base-content/60">
+              <IssueDraftIcon aria-hidden="true" className="size-4" />
+              {t("accessibility.vpat.empty")}
+            </div>
+          ) : (
+            // Deliberately not TableShell: the VPAT matrix is long-form document
+            // content on the public accessibility statement, where the boxed
+            // list-frame treatment would read as UI chrome.
+            <div className="overflow-x-auto">
+              <table className="table w-full">
+                <thead>
+                  <tr>
+                    <th className="w-64">
+                      {t("accessibility.vpat.col.criterion")}
+                    </th>
+                    <th className="w-14">
+                      {t("accessibility.vpat.col.level")}
+                    </th>
+                    <th className="w-40">
+                      {t("accessibility.vpat.col.conformance")}
+                    </th>
+                    <th className="w-28">
+                      {t("accessibility.vpat.col.assessed")}
+                    </th>
+                    <th className="min-w-[24rem]">
+                      {t("accessibility.vpat.col.remarks")}
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+                </thead>
+                <tbody>
+                  {rows.map((c) => (
+                    <tr key={c.id}>
+                      <td className="align-top">
+                        <span className="font-mono text-xs text-base-content/60">
+                          {c.id}
+                        </span>{" "}
+                        {c.name}
+                      </td>
+                      <td className="align-top font-mono text-xs">{c.level}</td>
+                      <td className="align-top">
+                        <Badge tone={CONFORMANCE_TONE[c.status]}>
+                          {t(`accessibility.vpat.status.${c.status}`)}
+                        </Badge>
+                      </td>
+                      <td className="align-top font-mono text-xs whitespace-nowrap text-base-content/60">
+                        {c.assessed ?? generated}
+                      </td>
+                      <td className="align-top text-sm text-base-content/70">
+                        {hasGenericRemark(c) ? (
+                          <span className="text-base-content/40">—</span>
+                        ) : (
+                          c.remark
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
       </Card.Body>
     </Card>
   )

--- a/web/src/pages/assignments/AssignmentRowActions.tsx
+++ b/web/src/pages/assignments/AssignmentRowActions.tsx
@@ -99,13 +99,18 @@ export const CopyAcceptLinkAction = ({
       variant="ghost"
       size="sm"
       shape="circle"
-      disabled={secretPending}
+      // aria-disabled + click guard instead of `disabled`: the button stays
+      // focusable so the title/aria-label reason ("secret still loading" /
+      // "load failed") is reachable by keyboard and screen readers.
+      aria-disabled={secretPending || undefined}
+      className={secretPending ? "opacity-50" : undefined}
       title={state ?? t("assignments.table.copyLinkTitle")}
       aria-label={t("assignments.table.copyLinkAria", {
         name: assignmentName(assignment),
       })}
       onClick={(e) => {
         e.stopPropagation()
+        if (secretPending) return
         void copy()
       }}
     >

--- a/web/src/pages/assignments/AssignmentsTable.test.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.test.tsx
@@ -104,6 +104,37 @@ describe("AssignmentsTable load error vs empty state", () => {
     expect(screen.getByText("assignments.table.empty")).toBeTruthy()
     expect(screen.queryByText("assignments.table.loadError")).toBeNull()
   })
+
+  it("renders the first-use blankslate with the action when emptyAction is given", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[]}
+        canAuthor
+        emptyAction={<button type="button">new assignment</button>}
+      />,
+    )
+    // Rich blankslate (title + body + action), not the plain statement.
+    expect(screen.getByText("assignments.table.emptyTitle")).toBeTruthy()
+    expect(screen.getByText("assignments.table.emptyBody")).toBeTruthy()
+    expect(screen.getByRole("button", { name: "new assignment" })).toBeTruthy()
+    expect(screen.queryByText("assignments.table.empty")).toBeNull()
+  })
+
+  it("never renders the blankslate action on a load error", () => {
+    wrap(
+      <AssignmentsTable
+        org="acme"
+        classroom="cs101"
+        assignments={[]}
+        loadError
+        emptyAction={<button type="button">new assignment</button>}
+      />,
+    )
+    expect(screen.queryByRole("button", { name: "new assignment" })).toBeNull()
+    expect(screen.getByText("assignments.table.loadError")).toBeTruthy()
+  })
 })
 const ACCESS_ARIA = "assignments.template.accessModal.triggerAria"
 const MANAGE_ARIA = "assignments.manageModal.openAria"

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -6,6 +6,7 @@ import {
   EyeIcon,
   LockIcon,
   PencilIcon,
+  PlusIcon,
   SlidersIcon,
 } from "@/components/ui/icons"
 
@@ -17,6 +18,7 @@ import { formatDueDate, formatDueDateTime, isPastDue } from "@/util/formatDate"
 import { composedRepoNameFits } from "@/util/repoNameBudget"
 import { Link } from "@tanstack/react-router"
 import { useState } from "react"
+import type { ReactNode } from "react"
 import { githubKeys } from "@/github-core/queries"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { useQueryClient } from "@tanstack/react-query"
@@ -109,6 +111,7 @@ const AssignmentsTable = ({
   loading = false,
   loadError = false,
   onRetryLoad,
+  emptyAction,
   archived = false,
   canAuthor = false,
   sort,
@@ -141,6 +144,11 @@ const AssignmentsTable = ({
   // tell a teacher their assignments are gone.
   loadError?: boolean
   onRetryLoad?: () => void
+  // The "New assignment" affordance rendered inside the first-use empty
+  // state (Primer blankslate: the resolving action lives in the empty state;
+  // the page hides its toolbar so the view has one primary action). Omit for
+  // read-only viewers — the empty state then shows the plain statement.
+  emptyAction?: ReactNode
   // When archived, hide per-row mutating actions (edit/reuse/delete); viewing
   // stays available.
   archived?: boolean
@@ -292,10 +300,27 @@ const AssignmentsTable = ({
           {!loading && !loadError && !assignments?.length && (
             <tr>
               <td colSpan={7}>
-                <EmptyState
-                  variant="bare"
-                  body={t("assignments.table.empty")}
-                />
+                {emptyAction ? (
+                  // First-use blankslate (Primer): the resolving action lives
+                  // here, and the page hides its toolbar so the view carries
+                  // a single primary action.
+                  <EmptyState
+                    variant="bare"
+                    className="py-12"
+                    icon={PlusIcon}
+                    titleAs="h3"
+                    title={t("assignments.table.emptyTitle")}
+                    body={t("assignments.table.emptyBody")}
+                    action={emptyAction}
+                  />
+                ) : (
+                  // Read-only viewers (TA, archived classroom) get the plain
+                  // statement — there is no action they could take.
+                  <EmptyState
+                    variant="bare"
+                    body={t("assignments.table.empty")}
+                  />
+                )}
               </td>
             </tr>
           )}

--- a/web/src/pages/assignments/AssignmentsToolbar.tsx
+++ b/web/src/pages/assignments/AssignmentsToolbar.tsx
@@ -15,9 +15,8 @@ import {
 // classroom-wide action (Collect all), while search + filters + sort + the
 // trailing actions (the New assignment split button or the archived badge)
 // sit on the right — so the primary action lives in the bar, not the page
-// header. When `actionsOnly` is set (no assignments exist yet) only the
-// leading/trailing actions render — the search/filter/sort controls would
-// have nothing to act on.
+// header. The bar renders only once assignments exist: on a first-use empty
+// list the table's blankslate owns the New-assignment action instead.
 const AssignmentsToolbar = ({
   query,
   onQueryChange,
@@ -25,7 +24,6 @@ const AssignmentsToolbar = ({
   onFiltersChange,
   sort,
   onSortChange,
-  actionsOnly = false,
   leading,
   trailing,
 }: {
@@ -35,7 +33,6 @@ const AssignmentsToolbar = ({
   onFiltersChange: (filters: AssignmentFilters) => void
   sort: AssignmentSort
   onSortChange: (sort: AssignmentSort) => void
-  actionsOnly?: boolean
   // Left-aligned lead content (the Collect all button), as on the submissions
   // toolbar where DataFreshness leads. Search + filters + sort + actions sit
   // on the right.
@@ -49,15 +46,6 @@ const AssignmentsToolbar = ({
   const clearAll = () => {
     onQueryChange("")
     onFiltersChange({ ...DEFAULT_FILTERS })
-  }
-
-  if (actionsOnly) {
-    return leading || trailing ? (
-      <Toolbar>
-        {leading}
-        <Toolbar.Trailing>{trailing}</Toolbar.Trailing>
-      </Toolbar>
-    ) : null
   }
 
   return (

--- a/web/src/pages/assignments/ClassroomCollectButton.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.tsx
@@ -18,6 +18,7 @@ import {
   latestCollectedAt,
 } from "@/pages/submissions/dashboard"
 import { formatRelativeToNow } from "@/util/formatDate"
+import { errorText } from "@/types/localizedMessage"
 
 // Classroom-wide "Collect all", presented as the assignments toolbar's
 // freshness widget — a passive "Submission data collected x ago" line, an
@@ -190,7 +191,7 @@ export function ClassroomCollectButton({
       message:
         collect.error instanceof Error
           ? `${t("submissions.collect.statusFailedWithReason", {
-              reason: collect.error.message,
+              reason: errorText(t, collect.error),
             })} ${t("submissions.collect.statusFailedHint")}`
           : `${t("submissions.collect.statusFailed")} ${t(
               "submissions.collect.statusFailedHint",

--- a/web/src/pages/classes/ClaimTeacherNotice.tsx
+++ b/web/src/pages/classes/ClaimTeacherNotice.tsx
@@ -8,6 +8,7 @@ import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRolePr
 import { can } from "@/authz"
 import { useClaimTeacher } from "@/hooks/mutations/useClaimTeacher"
 import { Alert, Button, InlineMessage } from "@/components/ui"
+import { errorText } from "@/types/localizedMessage"
 import { logger } from "@/lib/logger"
 
 const log = logger.scope("classroom:claim-teacher")
@@ -50,10 +51,7 @@ export function ClaimTeacherNotice({
         // that caused it).
         setClaimError(
           t("classes.claimTeacher.failed", {
-            message:
-              err instanceof Error
-                ? err.message
-                : t("classes.somethingWentWrong"),
+            message: errorText(t, err),
           }),
         )
       },

--- a/web/src/pages/classes/ClassroomCard.tsx
+++ b/web/src/pages/classes/ClassroomCard.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/ui/icons"
 import { useEffect, useId, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
+import { errorText } from "@/types/localizedMessage"
 
 type ClassroomCardProps = {
   summary: ClassroomSummary
@@ -347,10 +348,7 @@ function ClassroomMenu({
                 archived ? "classes.unarchiveFailed" : "classes.archiveFailed",
                 {
                   classroom: slug,
-                  error:
-                    err instanceof Error
-                      ? err.message
-                      : t("classes.somethingWentWrong"),
+                  error: errorText(t, err),
                 },
               ),
               { cause: err },
@@ -414,10 +412,7 @@ function ClassroomMenu({
             throw new Error(
               t("classes.deleteFailed", {
                 classroom: slug,
-                error:
-                  err instanceof Error
-                    ? err.message
-                    : t("classes.somethingWentWrong"),
+                error: errorText(t, err),
               }),
               { cause: err },
             )

--- a/web/src/pages/classes/ClassroomStaffSection.tsx
+++ b/web/src/pages/classes/ClassroomStaffSection.tsx
@@ -28,6 +28,7 @@ import useCancelClassroomInvite from "@/hooks/mutations/useCancelClassroomInvite
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { GitHubAPIError } from "@/github-core/errors"
 import { STAFF_ROLES, type StaffRole } from "@/types/classroom"
+import { errorText } from "@/types/localizedMessage"
 import {
   ROLE_LABEL_KEY,
   ROLE_PLURAL_KEY,
@@ -165,9 +166,7 @@ const AddStaff = ({
               const message =
                 err instanceof GitHubAPIError && err.status === 404
                   ? t("classes.staff.noSuchUser")
-                  : err instanceof Error
-                    ? err.message
-                    : t("classes.somethingWentWrong")
+                  : errorText(t, err)
               setAddError(t("classes.staff.addFailed", { message }))
               usernameInputRef.current?.focus()
             },
@@ -449,10 +448,7 @@ const StaffMemberRow = ({
             throw new Error(
               t("classes.staff.removeFailed", {
                 login: member.login,
-                error:
-                  err instanceof Error
-                    ? err.message
-                    : t("classes.somethingWentWrong"),
+                error: errorText(t, err),
               }),
               { cause: err },
             )
@@ -547,10 +543,7 @@ const PendingStaffRow = ({
                         setRowError(
                           t("classes.staff.resendFailed", {
                             who,
-                            error:
-                              err instanceof Error
-                                ? err.message
-                                : t("classes.somethingWentWrong"),
+                            error: errorText(t, err),
                           }),
                         ),
                     },
@@ -589,10 +582,7 @@ const PendingStaffRow = ({
                       setRowError(
                         t("classes.staff.cancelFailed", {
                           who,
-                          error:
-                            err instanceof Error
-                              ? err.message
-                              : t("classes.somethingWentWrong"),
+                          error: errorText(t, err),
                         }),
                       ),
                   },

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -13,6 +13,7 @@ import { useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { focusFirstInvalidField } from "@/util/focusFirstInvalidField"
 import { isClassroomArchived, type Classroom } from "@/types/classroom"
+import { errorText } from "@/types/localizedMessage"
 import { normalizePagesBaseUrl } from "@/util/pagesBaseUrl"
 import { CollapsibleAdvanced } from "@/pages/assignments/sections/CollapsibleAdvanced"
 import {
@@ -193,10 +194,7 @@ const ArchiveClassroomButton = ({
                 archived ? "classes.unarchiveFailed" : "classes.archiveFailed",
                 {
                   classroom,
-                  error:
-                    err instanceof Error
-                      ? err.message
-                      : t("classes.somethingWentWrong"),
+                  error: errorText(t, err),
                 },
               ),
               { cause: err },
@@ -275,10 +273,7 @@ const CleanupInviteDataButton = ({
             // Surfaces inside the confirm dialog rather than a corner toast.
             throw new Error(
               t("classes.inviteCleanup.failed", {
-                error:
-                  err instanceof Error
-                    ? err.message
-                    : t("classes.somethingWentWrong"),
+                error: errorText(t, err),
               }),
               { cause: err },
             )

--- a/web/src/pages/migration/ConfirmStep.tsx
+++ b/web/src/pages/migration/ConfirmStep.tsx
@@ -22,7 +22,7 @@ import {
   Modal,
   ModalIcon,
   RouterButton,
-  Spinner,
+  InlineSpinner,
   Toolbar,
 } from "@/components/ui"
 import { useDebouncedValue } from "@/hooks/useDebouncedValue"
@@ -481,8 +481,11 @@ export const ConfirmStep = ({
         </p>
 
         {isLoading && !plan && (
-          <div className="mt-6 flex items-center gap-2 text-base-content/70">
-            <Spinner size="sm" />
+          <div
+            role="status"
+            className="mt-6 flex items-center gap-2 text-base-content/70"
+          >
+            <InlineSpinner size="sm" />
             {t("migration.confirm.loading")}
           </div>
         )}
@@ -597,8 +600,11 @@ export const ConfirmStep = ({
               ))}
 
             {(isFetching || pendingEdit) && !controlsDisabled && (
-              <div className="mt-4 flex items-center gap-1 text-sm text-base-content/50">
-                <Spinner size="xs" />
+              <div
+                role="status"
+                className="mt-4 flex items-center gap-1 text-sm text-base-content/50"
+              >
+                <InlineSpinner />
                 {t("migration.confirm.updating")}
               </div>
             )}

--- a/web/src/pages/migration/ConfirmStep.tsx
+++ b/web/src/pages/migration/ConfirmStep.tsx
@@ -26,10 +26,7 @@ import {
   Toolbar,
 } from "@/components/ui"
 import { useDebouncedValue } from "@/hooks/useDebouncedValue"
-import {
-  localizedMessageOf,
-  resolveLocalizedMessage,
-} from "@/types/localizedMessage"
+import { errorText } from "@/types/localizedMessage"
 import { useGitHubViewer } from "@/hooks/useGitHubResources"
 import { useMigrateClassroom } from "@/hooks/mutations/useMigrateClassroom"
 import { buildPreflight } from "@/migration/preflight"
@@ -62,14 +59,6 @@ export const ConfirmStep = ({
   const client = useGitHubClient()
   const { data: viewer } = useGitHubViewer()
   const mutation = useMigrateClassroom(targetOrg)
-
-  // Prefer a translatable { key, params } payload the migration layer attached
-  // over a raw English Error.message (which is a diagnostic fallback only).
-  const renderError = (err: unknown, fallbackKey: string): string => {
-    const localized = localizedMessageOf(err)
-    if (localized) return resolveLocalizedMessage(t, localized)
-    return err instanceof Error ? err.message : t(fallbackKey)
-  }
 
   // Tunables. `shortName` and `templateSuffix` change the PLAN (target repo
   // names, collision checks), so they key the preflight query. `name` and
@@ -492,9 +481,7 @@ export const ConfirmStep = ({
 
         {isError && !plan && (
           <Alert tone="error" className="mt-4 items-start">
-            <span className="text-sm">
-              {renderError(error, "migration.confirm.preflightError")}
-            </span>
+            <span className="text-sm">{errorText(t, error)}</span>
             <Button variant="ghost" size="sm" onClick={() => refetch()}>
               {t("migration.select.retry")}
             </Button>
@@ -573,9 +560,7 @@ export const ConfirmStep = ({
               <Alert tone="error" className="mt-4 items-start">
                 <div>
                   <p className="font-medium">{t("migration.execute.error")}</p>
-                  <p className="mt-1 text-sm">
-                    {renderError(mutation.error, "migration.execute.error")}
-                  </p>
+                  <p className="mt-1 text-sm">{errorText(t, mutation.error)}</p>
                 </div>
               </Alert>
             )}
@@ -585,9 +570,7 @@ export const ConfirmStep = ({
                 inline — the stale plan stays visible but Import is disabled. */}
             {isError && !controlsDisabled && (
               <Alert tone="error" className="mt-4 items-start">
-                <span className="text-sm">
-                  {renderError(error, "migration.confirm.preflightError")}
-                </span>
+                <span className="text-sm">{errorText(t, error)}</span>
               </Alert>
             )}
 

--- a/web/src/pages/migration/ImportClassroomPage.tsx
+++ b/web/src/pages/migration/ImportClassroomPage.tsx
@@ -11,7 +11,14 @@ import { CheckIcon } from "@/components/ui/icons"
 import PageShell from "@/components/PageShell"
 import PageHeader from "@/components/PageHeader"
 import MissingParams from "@/components/MissingParams"
-import { Alert, Button, Card, RouterButton, Spinner, cx } from "@/components/ui"
+import {
+  Alert,
+  Button,
+  Card,
+  RouterButton,
+  InlineSpinner,
+  cx,
+} from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useOrgClassroom50Status } from "@/hooks/useOrgClassroom50Status"
 import { githubOrgOAuthPolicyUrl } from "@/auth/constants"
@@ -141,8 +148,11 @@ export const ImportClassroomPage = () => {
       />
 
       {status.isLoading && (
-        <div className="flex items-center gap-2 text-base-content/70">
-          <Spinner size="sm" />
+        <div
+          role="status"
+          className="flex items-center gap-2 text-base-content/70"
+        >
+          <InlineSpinner size="sm" />
           {t("migration.gate.checking")}
         </div>
       )}

--- a/web/src/pages/migration/migrationItemCard.tsx
+++ b/web/src/pages/migration/migrationItemCard.tsx
@@ -21,7 +21,7 @@ import {
   Checkbox,
   InlineMessage,
   Input,
-  Spinner,
+  InlineSpinner,
   cx,
   rtlFlip,
   type BadgeTone,
@@ -91,7 +91,7 @@ const STATUS_BADGE: Record<
 }
 
 const StatusIcon = ({ icon }: { icon: string }) => {
-  if (icon === "running") return <Spinner size="xs" className="size-4" />
+  if (icon === "running") return <InlineSpinner className="size-4" />
   if (icon === "done")
     return <CheckCircleIcon aria-hidden="true" className="size-4" />
   if (icon === "skip")

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/pages/orgMembers/bulkResults"
 import PreviewPanel from "@/pages/orgMembers/PreviewPanel"
 import RemoveConfirmDialog from "@/pages/orgMembers/RemoveConfirmDialog"
+import { errorText } from "@/types/localizedMessage"
 
 const log = logger.scope("orgMembers:BulkActionsBar")
 
@@ -222,9 +223,7 @@ const BulkActionsBar = ({
       setPhase("complete")
     } catch (err) {
       log.error("bulk action failed", { err, record: true })
-      setError(
-        err instanceof Error ? err.message : t("orgMembers.somethingWrong"),
-      )
+      setError(errorText(t, err))
       setPhase("error")
     }
   }

--- a/web/src/pages/orgMembers/MemberDetailModal.tsx
+++ b/web/src/pages/orgMembers/MemberDetailModal.tsx
@@ -31,6 +31,7 @@ import {
   runInviteMember,
 } from "@/pages/orgMembers/memberPresentation"
 import type { OrgMemberRow } from "@/util/orgMembers"
+import { errorText } from "@/types/localizedMessage"
 
 // Centered modal showing one org member's details: identity, classification,
 // per-classroom access, and member-level actions (invite an on-roster
@@ -182,8 +183,7 @@ const MemberDetailModal = ({
       setActionError(
         t("orgMembers.removeFailed", {
           label,
-          reason:
-            err instanceof Error ? err.message : t("orgMembers.somethingWrong"),
+          reason: errorText(t, err),
         }),
       )
     } finally {

--- a/web/src/pages/orgMembers/memberPresentation.tsx
+++ b/web/src/pages/orgMembers/memberPresentation.tsx
@@ -12,6 +12,7 @@ import { CellPlaceholder } from "@/components/memberList/memberPresentation"
 import type { GitHubClient } from "@/github-core/client"
 import { inviteMemberToOrg } from "@/domain/orgMembers/inviteMemberToOrg"
 import type { OrgMemberRow } from "@/util/orgMembers"
+import { errorText } from "@/types/localizedMessage"
 
 // Org-specific member presentation. The view-agnostic primitives (initialsFor,
 // GitHubIdentity) moved down to components/memberList/memberPresentation so a
@@ -161,8 +162,7 @@ export const runInviteMember = async (
     handlers.onError(
       t("orgMembers.inviteFailed", {
         label,
-        reason:
-          err instanceof Error ? err.message : t("orgMembers.somethingWrong"),
+        reason: errorText(t, err),
       }),
     )
   }

--- a/web/src/pages/orgSettings/OrgActionsSection.tsx
+++ b/web/src/pages/orgSettings/OrgActionsSection.tsx
@@ -17,6 +17,7 @@ import useGetOrgActionsBudget from "@/hooks/useGetOrgActionsBudget"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
 import { useSetOrgActionsMode } from "@/hooks/mutations/useSetOrgActionsMode"
 import { sectionHighlightClass } from "@/hooks/useHashSectionHighlight"
+import { errorText } from "@/types/localizedMessage"
 import SettingsSection from "./SettingsSection"
 
 const ACTIONS_ANCHOR = "github-actions"
@@ -161,7 +162,7 @@ const OrgActionsSection = ({
         setOutcome({
           tone: "error",
           message: t("orgSettings.actions.toggleFailed", {
-            message: err instanceof Error ? err.message : String(err),
+            message: errorText(t, err),
           }),
         })
       },

--- a/web/src/pages/orgSettings/OrgActionsSection.tsx
+++ b/web/src/pages/orgSettings/OrgActionsSection.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { LinkExternalIcon } from "@/components/ui/icons"
 
-import { Badge, OutcomeAlert, Spinner, Toggle } from "@/components/ui"
+import { Badge, OutcomeAlert, InlineSpinner, Toggle } from "@/components/ui"
 import type { AlertOutcome } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import { CalloutDiv } from "@/lib/motionComponents"
@@ -201,8 +201,11 @@ const OrgActionsSection = ({
       }
     >
       {isLoading ? (
-        <div className="flex items-center gap-2 text-sm text-base-content/70">
-          <Spinner /> {t("orgSettings.actions.loading")}
+        <div
+          role="status"
+          className="flex items-center gap-2 text-sm text-base-content/70"
+        >
+          <InlineSpinner size="md" /> {t("orgSettings.actions.loading")}
         </div>
       ) : (
         <div className="space-y-4">
@@ -245,8 +248,11 @@ const OrgActionsSection = ({
           </label>
 
           {mutation.isPending && (
-            <div className="flex items-center gap-2 text-sm text-base-content/70">
-              <Spinner /> {t("orgSettings.actions.applying")}
+            <div
+              role="status"
+              className="flex items-center gap-2 text-sm text-base-content/70"
+            >
+              <InlineSpinner size="md" /> {t("orgSettings.actions.applying")}
             </div>
           )}
 

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -16,7 +16,7 @@ import useRepairOrgPolicyConcern from "@/hooks/mutations/useRepairOrgPolicyConce
 import {
   Badge,
   Button,
-  Spinner,
+  InlineSpinner,
   rtlFlip,
   type BadgeTone,
 } from "@/components/ui"
@@ -592,8 +592,11 @@ const OrgPolicyAuditPane = ({
       }
     >
       {isLoading && (
-        <div className="flex items-center gap-2 text-sm text-base-content/70">
-          <Spinner size="sm" />
+        <div
+          role="status"
+          className="flex items-center gap-2 text-sm text-base-content/70"
+        >
+          <InlineSpinner size="sm" />
           {t("orgSettings.audit.auditing")}
         </div>
       )}

--- a/web/src/pages/orgSettings/TeardownSection.tsx
+++ b/web/src/pages/orgSettings/TeardownSection.tsx
@@ -8,11 +8,11 @@ import { Button, HelpTooltip, MonoLtr, cx } from "@/components/ui"
 import {
   formatTeardownResult,
   TeardownAbortError,
-  TeardownMarkerError,
   TeardownScopeError,
   type TeardownPlan,
 } from "@/domain/teardown"
 import {
+  errorText,
   localizedMessageOf,
   resolveLocalizedMessage,
 } from "@/types/localizedMessage"
@@ -72,10 +72,7 @@ const TeardownSection = ({
       onError: (err) => {
         log.warn("teardown plan failed", { org, err })
         setError({
-          message:
-            err instanceof TeardownMarkerError
-              ? err.message
-              : t("orgSettings.teardown.prepareError"),
+          message: errorText(t, err),
           canElevate: false,
         })
       },

--- a/web/src/pages/orgSettings/initStepBoard.tsx
+++ b/web/src/pages/orgSettings/initStepBoard.tsx
@@ -19,7 +19,7 @@ import {
   isOrgDefaultsStepData,
   unenforcedDefaultItems,
 } from "./orgDefaultsStepData"
-import { Badge, Spinner, rtlFlip, type BadgeTone } from "@/components/ui"
+import { Badge, InlineSpinner, rtlFlip, type BadgeTone } from "@/components/ui"
 import { CONFIG_REPO } from "@/util/configRepo"
 
 // Shared init "badge board" used by the org setup wizard (OrgSetupPage) and the
@@ -216,7 +216,7 @@ const STATUS_ICON: Record<InitStepStatus, ReactNode> = {
   complete: <CheckCircleFillIcon aria-hidden="true" className="size-4" />,
   warning: <AlertFillIcon aria-hidden="true" className="size-4" />,
   error: <XCircleFillIcon aria-hidden="true" className="size-4" />,
-  running: <Spinner size="xs" className="size-4" />,
+  running: <InlineSpinner className="size-4" />,
   pending: null,
   skipped: null,
 }

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -9,6 +9,7 @@ import {
 import {
   Alert,
   AnimatedAlert,
+  OutcomeAlert,
   Badge,
   Button,
   SelectAllCheckbox,
@@ -141,7 +142,7 @@ const EnrolledStudents = ({
   const client = useGitHubClient()
   const queryClient = useQueryClient()
   const { t } = useTranslation()
-  const { notify } = useToast()
+  const { notify, announce } = useToast()
   const { data: viewer } = useGitHubViewer()
   // Roster invite / unenroll / role-change all hit owner-only org APIs
   // (createOrgInvitation, removeOrgMembership, setOrgMembershipRole). Gate the
@@ -165,6 +166,9 @@ const EnrolledStudents = ({
   )
   // Manual/auto roster-sync failure, rendered as a banner above the table.
   const [syncError, setSyncError] = useState<string | null>(null)
+  // Batch-edit partial outcome (stale-view misses, failed team adds),
+  // rendered as a warning banner above the refreshed table.
+  const [editWarning, setEditWarning] = useState<string | null>(null)
   // Explains a no-op select-all (visible rows exist but none are selectable).
   const [noneSelectableNotice, setNoneSelectableNotice] = useState(false)
   const [grouping, setGrouping] = useState<RosterGrouping>("none")
@@ -592,25 +596,26 @@ const EnrolledStudents = ({
       suppressedLogins.remember(removed.map((r) => r.username))
   }
 
-  // Batch Edit mode saved: toast the outcome (applied count, plus any misses
-  // or failed team adds as warnings), refresh every cache the commit touched,
+  // Batch Edit mode saved: announce the applied count (the refreshed table
+  // itself shows the outcome), surface any misses or failed team adds as a
+  // warning banner above the table (Primer: feedback near the rows it
+  // describes, not a corner toast), refresh every cache the commit touched,
   // and exit the mode. Misses are stale-view skips the domain reported, not
   // errors — the refreshed table is the retry surface.
   const onEditSaved = (result: ApplyRosterEditsResult) => {
     setEditing(false)
+    setEditWarning(null)
     if (result.applied > 0) {
-      notify({
-        tone: "success",
-        durationMs: 5000,
-        message: t("students.editRoster.savedToast", {
+      announce(
+        t("students.editRoster.savedToast", {
           count: result.applied,
         }),
-      })
+      )
     }
+    const warnings: string[] = []
     if (result.missed.length > 0) {
-      notify({
-        tone: "warning",
-        message: t("students.editRoster.missedToast", {
+      warnings.push(
+        t("students.editRoster.missedToast", {
           count: result.missed.length,
           details: result.missed
             .map((m) =>
@@ -624,17 +629,17 @@ const EnrolledStudents = ({
             )
             .join("; "),
         }),
-      })
+      )
     }
     if (result.teamAddFailedLogins.length > 0) {
-      notify({
-        tone: "warning",
-        message: t("students.editRoster.teamAddFailed", {
+      warnings.push(
+        t("students.editRoster.teamAddFailed", {
           count: result.teamAddFailedLogins.length,
           logins: result.teamAddFailedLogins.join(", "),
         }),
-      })
+      )
     }
+    if (warnings.length > 0) setEditWarning(warnings.join(" "))
     invalidateInviteQueries()
     invalidateTeamRoster()
     refetchRoster()
@@ -891,6 +896,13 @@ const EnrolledStudents = ({
       >
         {syncError}
       </AnimatedAlert>
+      {/* Batch-edit partial outcome: the refreshed table is the retry
+          surface, so the detail banner sits right above it. */}
+      <OutcomeAlert
+        outcome={editWarning ? { tone: "warning", message: editWarning } : null}
+        className="mb-3 text-sm"
+        onDismiss={() => setEditWarning(null)}
+      />
       {/* Select-all explanation: inline above the table (Primer: feedback
           near the control). `show` re-derives against the current view so
           the notice self-clears the moment a filter/search change makes

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/domain/students"
 import { cancelOrgInvitation } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
+import { errorText } from "@/types/localizedMessage"
 import {
   isMalformedGitHubId,
   nameFromParts,
@@ -531,10 +532,7 @@ const RosterMemberModal = ({
       onUnenrolled(row.key, result.teamWarning)
       onClose()
     } catch (err) {
-      onError(
-        row.key,
-        err instanceof Error ? err.message : t("students.somethingWentWrong"),
-      )
+      onError(row.key, errorText(t, err))
     } finally {
       setWorking(false)
       setConfirmingUnenroll(false)

--- a/web/src/pages/students/UploadRoster.tsx
+++ b/web/src/pages/students/UploadRoster.tsx
@@ -19,6 +19,7 @@ import {
   type PreflightResult,
 } from "@/util/rosterUploadPreflight"
 import { logger } from "@/lib/logger"
+import { errorText } from "@/types/localizedMessage"
 import { decodeTextFile } from "@/util/fileBytes"
 import { downloadBlob } from "@/util/downloadBlob"
 import { isTeacherRole } from "@/authz"
@@ -317,9 +318,7 @@ const UploadRoster = ({
         log.warn("roster upload preflight failed", { err, record: true })
         setPreflightContext(null)
         setResolved(null)
-        setPreflightError(
-          err instanceof Error ? err.message : t("students.somethingWentWrong"),
-        )
+        setPreflightError(errorText(t, err))
       })
       .finally(() => {
         if (preflightToken.current === token) setPreflighting(false)
@@ -619,9 +618,7 @@ const UploadRoster = ({
     } catch (err) {
       if (ingestToken.current !== token) return
       log.warn("upload file read/parse failed", { err, record: true })
-      setError(
-        err instanceof Error ? err.message : t("students.couldNotReadFile"),
-      )
+      setError(errorText(t, err))
       setPhase("error")
     }
   }

--- a/web/src/pages/submissions/ReviewButton.tsx
+++ b/web/src/pages/submissions/ReviewButton.tsx
@@ -7,6 +7,7 @@ import { useToast } from "@/context/notifications/NotificationProvider"
 import useGetFeedbackPr from "@/hooks/useGetFeedbackPr"
 import useRepairFeedbackPr from "@/hooks/mutations/useRepairFeedbackPr"
 import { ActionListRow } from "@/pages/submissions/actionLayout"
+import { errorText } from "@/types/localizedMessage"
 import type { AssignmentMode } from "@/types/classroom"
 
 // The Feedback-PR action: links to the open Feedback PR (opened at accept
@@ -57,7 +58,7 @@ export const FeedbackPrAction = ({
       // `error`; show it rather than the misleading "no PR yet" message.
       const { data: pr, error } = await refetch()
       if (error) {
-        setErrorMsg(error instanceof Error ? error.message : String(error))
+        setErrorMsg(errorText(t, error))
         setModalOpen(true)
       } else if (pr) {
         window.open(pr.html_url, "_blank", "noopener,noreferrer")
@@ -116,7 +117,7 @@ export const FeedbackPrAction = ({
           setErrorMsg(repairReasonMessage(result))
         },
         onError: (err) => {
-          setErrorMsg(err instanceof Error ? err.message : String(err))
+          setErrorMsg(errorText(t, err))
         },
       },
     )

--- a/web/src/pages/submissions/ScoreOverrideModal.tsx
+++ b/web/src/pages/submissions/ScoreOverrideModal.tsx
@@ -1,14 +1,7 @@
 import { useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import {
-  Alert,
-  Button,
-  FormField,
-  Input,
-  Modal,
-  Spinner,
-} from "@/components/ui"
+import { Alert, Button, FormField, Input, Modal } from "@/components/ui"
 import { ScoreBadge } from "@/pages/submissions/ScoreBadge"
 import { useSetScoreOverride } from "@/hooks/mutations/useSetScoreOverride"
 
@@ -225,7 +218,6 @@ export function ScoreOverrideModal({
               </Button>
             ) : null}
           </div>
-          {saving ? <Spinner size="xs" className="self-center" /> : null}
           <Button
             type="button"
             variant="ghost"
@@ -240,8 +232,9 @@ export function ScoreOverrideModal({
             variant="primary"
             size="sm"
             // Enabled while invalid (Primer): the validation errors already
-            // render live below the inputs; save() guards re-entry.
-            disabled={saving}
+            // render live below the inputs; save() guards re-entry. `loading`
+            // keeps it focusable-but-inert and announces busy.
+            loading={saving}
             onClick={save}
           >
             {t("submissions.scoreOverride.save")}

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -32,6 +32,7 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { updateShimSubmissionMode } from "@/domain/assignments/submissionTrigger"
 import type { AssignmentMode, SubmissionMode } from "@/types/classroom"
+import { errorText } from "@/types/localizedMessage"
 
 // Feedback channel for actions running inside the submission hub: outcomes
 // render as a banner at the top of the hub dialog (Primer: feedback for a
@@ -547,10 +548,7 @@ const UpdateTriggerButton = ({
     } catch (err) {
       feedback({
         tone: "error",
-        message:
-          err instanceof Error
-            ? err.message
-            : t("submissions.rowTrigger.outcome.failed"),
+        message: errorText(t, err),
       })
     } finally {
       setPending(false)
@@ -617,10 +615,7 @@ const ChangeVisibilityButton = ({
     } catch (err) {
       feedback({
         tone: "error",
-        message:
-          err instanceof Error
-            ? err.message
-            : t("submissions.rowVisibility.outcome.failed"),
+        message: errorText(t, err),
       })
     }
   }
@@ -738,10 +733,7 @@ const PauseAutogradingButton = ({
     } catch (err) {
       feedback({
         tone: "error",
-        message:
-          err instanceof Error
-            ? err.message
-            : t("submissions.rowAutograde.outcome.failed"),
+        message: errorText(t, err),
       })
     }
   }

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -19,7 +19,7 @@ import {
   Button,
   SkeletonRows,
   SortableTh,
-  Spinner,
+  InlineSpinner,
   TablePagination,
   TableShell,
 } from "@/components/ui"
@@ -985,8 +985,8 @@ const SubmissionsTable = ({
                 colSpan={5}
                 className="py-4 text-center text-sm text-base-content/60"
               >
-                <span className="inline-flex items-center gap-2">
-                  <Spinner size="xs" />
+                <span role="status" className="inline-flex items-center gap-2">
+                  <InlineSpinner />
                   {t("submissions.table.resolvingNonSubmitters")}
                 </span>
               </td>

--- a/web/src/routes/_authed/$org/route.tsx
+++ b/web/src/routes/_authed/$org/route.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router"
 
 import { Spinner } from "@/components/Spinner"
+import { useTranslation } from "react-i18next"
 import useGetOwnOrgMembership from "@/hooks/useGetOwnOrgMembership"
 import { useOrgClassroom50Status } from "@/hooks/useOrgClassroom50Status"
 import { useGitHubOrgRole } from "@/context/githubOrgRole/GitHubOrgRoleProvider"
@@ -24,6 +25,7 @@ export const Route = createFileRoute("/_authed/$org")({
 // The org role provider now wraps the `_authed` shell above this route, so this
 // layout reads the role directly (no local provider needed).
 function OrgLayout() {
+  const { t } = useTranslation()
   const { org } = useParams({ from: "/_authed/$org" })
   // Match the setup route by matched-route id, not a pathname suffix: a suffix
   // check (endsWith("/setup")) both collides with any path segment named
@@ -48,7 +50,8 @@ function OrgLayout() {
   if (loadingMembership || loadingRepo) {
     return (
       <div className="min-h-screen grid place-items-center">
-        <Spinner size="lg" />
+        {/* Contextual label (Primer: name what is loading when known). */}
+        <Spinner size="lg" label={t("common.checkingOrgAccess")} />
       </div>
     )
   }


### PR DESCRIPTION
## Summary

Slice 4 of the Primer UI-patterns audit (after #801/#803/#804), plus the follow-up gaps the audit recalibration found in #806/#807 surfaces.

- **Loading buttons keep focus:** `Button`'s loading state now uses `aria-disabled` + a click guard instead of a semantic disable, which dropped keyboard focus mid-action (Primer loading guidance). Applies to both the button and anchor variants.
- **One announcement per busy state:** 14 sites rendered the `role="status"` Spinner beside visible status text (worst: nested inside `Alert role="status"`), double-announcing. They now use the presentational `InlineSpinner` with the visible text as the single announcement; `ScoreOverrideModal`'s loose spinner became the Save button's own loading state.
- **Named progress bars:** the bulk `<progress>` elements get accessible names through the shared `bulkProgressBarProps` recipe.
- **Reachable "why" on disabled controls:** the copy-invite-link button and the self-row checkbox swap `disabled`+`title` (unreachable by keyboard/SR) for focusable `aria-disabled` + click guard.
- **Keyboard-complete tabs:** the accessibility page's VPAT and contrast tab sets gain APG wiring — roving tabindex, RTL-aware arrow keys, Home/End, `tabpanel`/`aria-controls` — via a new `useRovingTabList` hook (4 tests).
- **Localized error copy:** 39 view-layer sites interpolated raw `err.message` into user copy, so domain errors carrying a `{ key, params }` localized message rendered diagnostic key text; all now route through `errorText(t, err)`, and migration's duplicate `renderError` helper is deleted.
- **Contextual load labels:** the org-access gate and role fallback announce what is loading instead of generic "Loading…".
- **#807 follow-up:** the breadcrumb switcher panel reports a failed list read instead of degrading to an empty list indistinguishable from "no classes" (the student 404 path keeps degrading to plain text).
- **#806 follow-up:** batch-edit outcomes leave the toast corner — the applied count announces to screen readers (the refreshed table shows it) and partial failures render as a warning banner above the rows.
- **First-use blankslate for assignments:** an empty list now shows a proper empty state owning the create+reuse split button, and the toolbar renders only once assignments exist — one primary action per view (mirrors the ClassesPage precedent). TA/archived viewers keep the plain statement; a load error never shows the create action.

## Test plan

- [x] `npm run check` green (tsc, eslint, prettier, arch:validate, vitest — 4,763 tests, +10 new)
- [ ] Manual QA: keyboard-walk the VPAT/contrast tabs (arrows, Home/End, panel updates on Enter/click)
- [ ] Manual QA: empty classroom shows the assignments blankslate with the split button; creating the first assignment brings the toolbar back
- [ ] Screen reader spot-check: a saving button announces busy without dropping focus; a bulk run announces its status text once