### PR TITLE
fix(web): adopt Primer conventions — carets, save placement, banners, URL pagination

### DIFF
--- a/web/src/auth/ScopeWarningBanner.tsx
+++ b/web/src/auth/ScopeWarningBanner.tsx
@@ -7,6 +7,7 @@ import { useGithubAuth } from "./useGithubAuth"
 import { AppBanner } from "@/components/AppBanner"
 import { useMissingScopes } from "@/context/github/GitHubProvider"
 import { Button } from "@/components/ui"
+import { useBannerSlot } from "@/context/bannerStack/BannerStackProvider"
 
 // Surfaces missing required scopes detected from live API responses:
 // best-effort, non-blocking, with a re-authorize action. A revoked/expired
@@ -19,11 +20,12 @@ export function ScopeWarningBanner() {
   const { t } = useTranslation()
 
   const show = missing.length > 0 && !dismissed
+  const granted = useBannerSlot("scope-warning", show)
   const scopeCount = missing.length
 
   return (
     <AnimatePresence initial={false}>
-      {show ? (
+      {granted ? (
         <AppBanner
           key="missing-scopes"
           tone="warning"

--- a/web/src/components/BudgetCreatedBanner.tsx
+++ b/web/src/components/BudgetCreatedBanner.tsx
@@ -12,6 +12,7 @@ import {
   dismissBudgetNotice,
   readBudgetNotice,
 } from "@/orgPolicy/budgetNoticeStore"
+import { useBannerSlot } from "@/context/bannerStack/BannerStackProvider"
 
 export type BudgetBannerView = "success" | "hidden"
 
@@ -69,6 +70,10 @@ export function BudgetCreatedBanner() {
     created: notice.created,
     dismissed: notice.dismissed,
   })
+  const granted = useBannerSlot(
+    "budget-created",
+    view !== "hidden" && Boolean(org),
+  )
 
   const dismiss = () => {
     if (org) dismissBudgetNotice(org)
@@ -76,7 +81,7 @@ export function BudgetCreatedBanner() {
 
   return (
     <AnimatePresence initial={false}>
-      {view !== "hidden" && org ? (
+      {granted && org ? (
         <AppBanner
           key="budget-created"
           tone="success"

--- a/web/src/components/GitHubStatusBanner.tsx
+++ b/web/src/components/GitHubStatusBanner.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next"
 import { AppBanner } from "@/components/AppBanner"
 import { GitHubStatusNote } from "@/components/GitHubStatusNote"
 import { useGitHubHealth } from "@/lib/githubHealth"
+import { useBannerSlot } from "@/context/bannerStack/BannerStackProvider"
 
 // Global warning banner shown when the app suspects GitHub is having trouble
 // (repeated outage-shaped API failures), optionally enriched with the
@@ -23,10 +24,11 @@ export function GitHubStatusBanner() {
   if (!suspected && dismissed) setDismissed(false)
 
   const show = suspected && !dismissed
+  const granted = useBannerSlot("github-status", show)
 
   return (
     <AnimatePresence initial={false}>
-      {show ? (
+      {granted ? (
         <AppBanner
           key="github-status"
           tone="warning"

--- a/web/src/components/OfflineBanner.tsx
+++ b/web/src/components/OfflineBanner.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { AppBanner } from "@/components/AppBanner"
 import { useOnlineStatus } from "@/hooks/useOnlineStatus"
+import { useBannerSlot } from "@/context/bannerStack/BannerStackProvider"
 
 // Global banner shown while the browser reports no network. Non-dismissible: it
 // reflects live connectivity, so it clears itself the moment the `online` event
@@ -11,10 +12,11 @@ import { useOnlineStatus } from "@/hooks/useOnlineStatus"
 export function OfflineBanner() {
   const isOnline = useOnlineStatus()
   const { t } = useTranslation()
+  const show = useBannerSlot("offline", !isOnline)
 
   return (
     <AnimatePresence initial={false}>
-      {!isOnline ? (
+      {show ? (
         <AppBanner
           key="offline"
           tone="warning"

--- a/web/src/components/SkeletonDriftBanner.tsx
+++ b/web/src/components/SkeletonDriftBanner.tsx
@@ -16,6 +16,7 @@ import {
   useSkeletonOverwriteConfirm,
 } from "@/components/skeletonOverwrite/skeletonOverwriteUi"
 import { Button } from "@/components/ui"
+import { useBannerSlot } from "@/context/bannerStack/BannerStackProvider"
 
 export type DriftBannerView = "warning" | "success" | "hidden"
 
@@ -110,13 +111,15 @@ export function SkeletonDriftBanner() {
     isPending: pendingOrg === org,
     fixResolvedClean: fixedCleanOrg === org,
   })
+  const granted = useBannerSlot("skeleton-drift", view !== "hidden")
 
   const isSuccess = view === "success"
 
   return (
     <>
       <AnimatePresence initial={false}>
-        {view !== "hidden" ? (
+        {/* view !== "hidden" repeats the claim only for TS narrowing of `tone`. */}
+        {view !== "hidden" && granted ? (
           // key stays view-scoped so AnimatePresence animates the warning->success swap.
           <AppBanner
             key={isSuccess ? "skeleton-drift-success" : "skeleton-drift"}

--- a/web/src/components/UpdateAvailableBanner.tsx
+++ b/web/src/components/UpdateAvailableBanner.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next"
 import { AppBanner } from "@/components/AppBanner"
 import { Button } from "@/components/ui"
 import { useVersionCheck } from "@/hooks/useVersionCheck"
+import { useBannerSlot } from "@/context/bannerStack/BannerStackProvider"
 
 // State the banner depends on — structural so the decision stays a pure,
 // testable function (mirrors resolveDriftBannerView).
@@ -39,10 +40,11 @@ export function UpdateAvailableBanner() {
     dismissedCommit,
     deployedCommit: data?.commit,
   })
+  const granted = useBannerSlot("update-available", visible)
 
   return (
     <AnimatePresence initial={false}>
-      {visible ? (
+      {granted ? (
         <AppBanner
           key="app-update"
           tone="success"

--- a/web/src/components/breadcrumb/index.tsx
+++ b/web/src/components/breadcrumb/index.tsx
@@ -24,7 +24,7 @@ import {
   InlineMessage,
   popoverPanelClass,
 } from "@/components/ui"
-import { CheckIcon, ChevronDownIcon, SearchIcon } from "@/components/ui/icons"
+import { CheckIcon, TriangleDownIcon, SearchIcon } from "@/components/ui/icons"
 import { GitHubAPIError } from "@/github-core/errors"
 
 // GitHub-style leaf switcher (like the repo picker in github.com's header):
@@ -113,7 +113,7 @@ const CrumbSwitcher = <T,>({
             setOpen((wasOpen) => !wasOpen)
           }}
         >
-          <ChevronDownIcon aria-hidden="true" className="size-4" />
+          <TriangleDownIcon aria-hidden="true" className="size-4" />
         </Button>
         {open && (
           <div

--- a/web/src/context/bannerStack/BannerStackProvider.test.tsx
+++ b/web/src/context/bannerStack/BannerStackProvider.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import { afterEach } from "vitest"
+
+import {
+  BannerStackProvider,
+  useBannerSlot,
+  type BannerId,
+} from "./BannerStackProvider"
+
+afterEach(cleanup)
+
+function FakeBanner({ id, visible }: { id: BannerId; visible: boolean }) {
+  const granted = useBannerSlot(id, visible)
+  return granted ? <div data-testid={`banner-${id}`} /> : null
+}
+
+describe("BannerStackProvider", () => {
+  it("caps visible banners at two, by priority", () => {
+    render(
+      <BannerStackProvider>
+        <FakeBanner id="offline" visible />
+        <FakeBanner id="scope-warning" visible />
+        <FakeBanner id="budget-created" visible />
+      </BannerStackProvider>,
+    )
+    expect(screen.getByTestId("banner-offline")).toBeTruthy()
+    expect(screen.getByTestId("banner-scope-warning")).toBeTruthy()
+    // Third claimant waits for a slot.
+    expect(screen.queryByTestId("banner-budget-created")).toBeNull()
+  })
+
+  it("slides the next claimant in when a higher-priority banner clears", () => {
+    const view = render(
+      <BannerStackProvider>
+        <FakeBanner id="offline" visible />
+        <FakeBanner id="scope-warning" visible />
+        <FakeBanner id="budget-created" visible />
+      </BannerStackProvider>,
+    )
+    view.rerender(
+      <BannerStackProvider>
+        <FakeBanner id="offline" visible={false} />
+        <FakeBanner id="scope-warning" visible />
+        <FakeBanner id="budget-created" visible />
+      </BannerStackProvider>,
+    )
+    expect(screen.queryByTestId("banner-offline")).toBeNull()
+    expect(screen.getByTestId("banner-scope-warning")).toBeTruthy()
+    expect(screen.getByTestId("banner-budget-created")).toBeTruthy()
+  })
+
+  it("grants the wish outside a provider (isolated banner tests)", () => {
+    render(<FakeBanner id="budget-created" visible />)
+    expect(screen.getByTestId("banner-budget-created")).toBeTruthy()
+  })
+})

--- a/web/src/context/bannerStack/BannerStackProvider.tsx
+++ b/web/src/context/bannerStack/BannerStackProvider.tsx
@@ -1,0 +1,90 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+  type PropsWithChildren,
+} from "react"
+
+// Global app banners in priority order — offline first, since it explains
+// every other degraded read. Primer (notification messaging): show at most
+// two banners at once; anything lower-priority waits for a slot.
+export const BANNER_PRIORITY = [
+  "offline",
+  "github-status",
+  "scope-warning",
+  "update-available",
+  "skeleton-drift",
+  "budget-created",
+] as const
+
+export type BannerId = (typeof BANNER_PRIORITY)[number]
+
+const MAX_VISIBLE = 2
+
+type BannerStore = {
+  claim: (id: BannerId, visible: boolean) => void
+  subscribe: (listener: () => void) => () => void
+  getGranted: () => ReadonlySet<BannerId>
+}
+
+// External store (not React state) so banners can register visibility from
+// effects without setState-in-effect cascades; consumers subscribe via
+// useSyncExternalStore.
+function createBannerStore(): BannerStore {
+  const claims = new Map<BannerId, boolean>()
+  const listeners = new Set<() => void>()
+  let granted: ReadonlySet<BannerId> = new Set()
+  return {
+    claim(id, visible) {
+      if ((claims.get(id) ?? false) === visible) return
+      claims.set(id, visible)
+      granted = new Set(
+        BANNER_PRIORITY.filter((b) => claims.get(b)).slice(0, MAX_VISIBLE),
+      )
+      listeners.forEach((listener) => listener())
+    },
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    getGranted: () => granted,
+  }
+}
+
+const BannerStackContext = createContext<BannerStore | null>(null)
+
+export function BannerStackProvider({ children }: PropsWithChildren) {
+  // Lazy useState (not a ref) so the store is created once without touching
+  // a ref during render.
+  const [store] = useState(createBannerStore)
+  return (
+    <BannerStackContext.Provider value={store}>
+      {children}
+    </BannerStackContext.Provider>
+  )
+}
+
+const noopSubscribe = () => () => {}
+const emptyGranted: ReadonlySet<BannerId> = new Set()
+const getEmptyGranted = () => emptyGranted
+
+// A banner's slot gate: pass whether the banner WANTS to show; the return is
+// whether it MAY (it holds one of the two visible slots). When a
+// higher-priority banner clears, the next claimant slides in. Outside a
+// provider (isolated tests) the cap is off and the wish is granted.
+export function useBannerSlot(id: BannerId, visible: boolean): boolean {
+  const store = useContext(BannerStackContext)
+  useEffect(() => {
+    if (!store) return
+    store.claim(id, visible)
+    return () => store.claim(id, false)
+  }, [store, id, visible])
+  const granted = useSyncExternalStore(
+    store ? store.subscribe : noopSubscribe,
+    store ? store.getGranted : getEmptyGranted,
+  )
+  if (!store) return visible
+  return visible && granted.has(id)
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1135,6 +1135,7 @@
     }
   },
   "settings": {
+    "noChangesToSave": "No changes to save.",
     "page": {
       "heading": "Settings",
       "subheading": "Preferences for this browser. Nothing here is shared with your organizations."
@@ -1179,7 +1180,8 @@
       "onHint": "Always animate.",
       "off": "Off",
       "offHint": "Turn off all animations.",
-      "groupAria": "Animation preference"
+      "groupAria": "Animation preference",
+      "saved": "Animation preference saved."
     },
     "appearance": {
       "heading": "Appearance",
@@ -1190,7 +1192,8 @@
       "lightHint": "Always use the light theme.",
       "dark": "Dark",
       "darkHint": "Always use the dark theme.",
-      "groupAria": "Theme preference"
+      "groupAria": "Theme preference",
+      "saved": "Theme preference saved."
     },
     "language": {
       "heading": "Language",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2688,6 +2688,7 @@
     },
     "downloadCsv": "Download scores (CSV)",
     "viewSourceRepo": "View template",
+    "skipPastTable": "Skip past the submissions table",
     "lockedNotice": "This assignment is locked. Students can't accept or open it, and if it uses a private template the student team's access to that template has been removed. Existing repositories and their submissions are unaffected. Unlock it from the Actions menu (or the assignments list) to reopen it.",
     "closedNotice": "Submissions are closed. New students can't accept this assignment. When you close from here, accepted students' repositories are set to read-only; existing work is preserved. Reopen it from the Actions menu to allow submissions again.",
     "lock": {

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -1,5 +1,5 @@
 import { Link, useParams } from "@tanstack/react-router"
-import { ChevronDownIcon, CopyIcon, PlusIcon } from "@/components/ui/icons"
+import { TriangleDownIcon, CopyIcon, PlusIcon } from "@/components/ui/icons"
 import { useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 
@@ -78,7 +78,7 @@ const NewAssignmentButton = ({
             className="join-item h-full border-s border-primary-content/20 px-2"
             aria-label={t("assignments.newButton.moreOptions")}
           >
-            <ChevronDownIcon aria-hidden="true" className="size-4" />
+            <TriangleDownIcon aria-hidden="true" className="size-4" />
           </Button>
           <DropdownMenu className="w-max">
             <li>

--- a/web/src/pages/ClassesPage.tsx
+++ b/web/src/pages/ClassesPage.tsx
@@ -1,7 +1,7 @@
 import { useParams, Link } from "@tanstack/react-router"
 import { Trans, useTranslation } from "react-i18next"
 import {
-  ChevronDownIcon,
+  TriangleDownIcon,
   MarkGithubIcon,
   PlusIcon,
 } from "@/components/ui/icons"
@@ -65,7 +65,7 @@ const NewClassroomButton = ({ org }: { org: string }) => {
           className="join-item h-full border-s border-primary-content/20 px-2"
           aria-label={t("classes.newButton.moreOptions")}
         >
-          <ChevronDownIcon aria-hidden="true" className="size-4" />
+          <TriangleDownIcon aria-hidden="true" className="size-4" />
         </Button>
         <DropdownMenu className="w-max">
           {/* FEATURE: github-classroom-migration — removable entry point (#312) */}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -3,6 +3,7 @@ import PageHeader from "@/components/PageHeader"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useHiddenOrgs } from "@/context/hiddenOrgs/HiddenOrgsProvider"
 import {
+  AnimatedAlert,
   Button,
   Card,
   Radio,
@@ -12,6 +13,7 @@ import {
   Heading,
   headingVariantClass,
 } from "@/components/ui"
+import { useOptionalToast } from "@/context/notifications/NotificationProvider"
 import { useTranslation } from "react-i18next"
 import { useMemo, useState } from "react"
 import useGetOrgs from "@/hooks/useGetOrgs"
@@ -265,6 +267,85 @@ function PreferenceRadioGroup<T extends string>({
   )
 }
 
+// Draft-and-save wrapper around PreferenceRadioGroup (Primer settings
+// guidance: an explicit Save, not save-on-click). Selection edits a local
+// draft; Save commits it through the pref hook. An unchanged save is a no-op
+// with a notice (the house form pattern), a real save confirms inline and
+// announces to SR. An external pref change (another tab, the OS) re-syncs a
+// pristine draft but never clobbers in-progress edits.
+function PreferenceForm<T extends string>({
+  name,
+  legend,
+  value,
+  onSave,
+  options,
+  savedMessage,
+}: {
+  name: string
+  legend: string
+  value: T
+  onSave: (next: T) => void
+  options: { value: T; label: string; hint: string }[]
+  savedMessage: string
+}) {
+  const { t } = useTranslation()
+  // Optional: the settings page also renders in provider-less tests.
+  const announce = useOptionalToast()?.announce
+  const [draft, setDraft] = useState<T>(value)
+  const [lastValue, setLastValue] = useState(value)
+  if (value !== lastValue) {
+    setLastValue(value)
+    setDraft((current) => (current === lastValue ? value : current))
+  }
+  const [notice, setNotice] = useState<"saved" | "noChanges" | null>(null)
+
+  return (
+    <form
+      noValidate
+      onSubmit={(event) => {
+        event.preventDefault()
+        if (draft === value) {
+          setNotice("noChanges")
+          return
+        }
+        onSave(draft)
+        setNotice("saved")
+        announce?.(savedMessage)
+      }}
+    >
+      <PreferenceRadioGroup
+        name={name}
+        legend={legend}
+        value={draft}
+        onChange={(next) => {
+          setDraft(next)
+          setNotice(null)
+        }}
+        options={options}
+      />
+      <AnimatedAlert
+        tone="info"
+        show={notice === "noChanges"}
+        className="mt-3 text-sm"
+      >
+        {t("settings.noChangesToSave")}
+      </AnimatedAlert>
+      <AnimatedAlert
+        tone="success"
+        show={notice === "saved"}
+        className="mt-3 text-sm"
+      >
+        {savedMessage}
+      </AnimatedAlert>
+      <div className="mt-4">
+        <Button type="submit" variant="primary" size="sm">
+          {t("common.save")}
+        </Button>
+      </div>
+    </form>
+  )
+}
+
 // Card shell for a settings section: an anchor heading + subheading over its
 // body. Matches the Service-tokens / Hidden-orgs sections.
 function SettingsSectionCard({
@@ -358,12 +439,13 @@ function AppearanceSection({ highlighted }: { highlighted?: boolean }) {
       subheading={t("settings.appearance.subheading")}
       highlighted={highlighted}
     >
-      <PreferenceRadioGroup
+      <PreferenceForm
         name="theme-pref"
         legend={t("settings.appearance.groupAria")}
         value={pref}
-        onChange={setThemePref}
+        onSave={setThemePref}
         options={options}
+        savedMessage={t("settings.appearance.saved")}
       />
     </SettingsSectionCard>
   )
@@ -417,12 +499,13 @@ function MotionSection({ highlighted }: { highlighted?: boolean }) {
       subheading={t("settings.motion.subheading")}
       highlighted={highlighted}
     >
-      <PreferenceRadioGroup
+      <PreferenceForm
         name="motion-pref"
         legend={t("settings.motion.groupAria")}
         value={pref}
-        onChange={setPref}
+        onSave={setPref}
         options={options}
+        savedMessage={t("settings.motion.saved")}
       />
     </SettingsSectionCard>
   )

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { AlertIcon, CalendarIcon, DownloadIcon } from "@/components/ui/icons"
 import Papa from "papaparse"
@@ -381,23 +381,65 @@ const SubmissionsPageContent = () => {
       setFilters((current) => applyStatusSelection(current, statusParam))
     }
   }
-  // Client-side table pagination over the display list. `page` is 0-based;
-  // clamped at render (pageBounds) so a filter that shrinks the list can't
-  // strand the view on an empty page.
-  const [page, setPage] = useState(0)
-  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
+  // Client-side table pagination over the display list, held in the URL
+  // (Primer: pagination is URL state — reload/back keep the page and a view
+  // is sharable). 1-based `?page=` in the URL, 0-based internally; page 1 and
+  // the default size never travel. Clamped at render (pageBounds) so a
+  // filter that shrinks the list can't strand the view on an empty page.
+  const { page: pageParam, pageSize: pageSizeParam } = useSearch({
+    strict: false,
+  })
+  const page = (pageParam ?? 1) - 1
+  const pageSize = pageSizeParam ?? DEFAULT_PAGE_SIZE
+  const setPage = useCallback(
+    (next: number) => {
+      void navigate({
+        to: ".",
+        // Paging is a navigation step: pushed, so Back walks pages.
+        search: (prev) => ({
+          ...prev,
+          page: next >= 1 ? next + 1 : undefined,
+        }),
+        resetScroll: false,
+      })
+    },
+    [navigate],
+  )
+  const setPageSize = useCallback(
+    (next: number) => {
+      void navigate({
+        to: ".",
+        search: (prev) => ({
+          ...prev,
+          pageSize: next === DEFAULT_PAGE_SIZE ? undefined : next,
+          page: undefined,
+        }),
+        resetScroll: false,
+      })
+    },
+    [navigate],
+  )
   // Reset to the first page whenever the visible set changes (new search,
-  // filter, sort, page size, or a different assignment). Done render-purely via
-  // a stored view signature (setState-during-render, not an effect) so the reset
-  // lands in the same commit as the change — no extra render, and no
-  // setState-in-effect. React bails out of the re-render once the signature
-  // matches.
+  // filter, sort, or a different assignment). The URL page param is cleared
+  // via a replace so the reset doesn't pollute history; the render-time
+  // clamp covers the frame until the navigation lands.
   const viewSignature = `${query}|${JSON.stringify(filters)}|${sort}|${pageSize}|${assignment ?? ""}`
-  const [lastViewSignature, setLastViewSignature] = useState(viewSignature)
-  if (viewSignature !== lastViewSignature) {
-    setLastViewSignature(viewSignature)
-    setPage(0)
-  }
+  const lastViewSignatureRef = useRef(viewSignature)
+  useEffect(() => {
+    if (viewSignature === lastViewSignatureRef.current) return
+    lastViewSignatureRef.current = viewSignature
+    if (pageParam !== undefined) {
+      void navigate({
+        to: ".",
+        search: (prev) => ({
+          ...prev,
+          page: undefined,
+        }),
+        replace: true,
+        resetScroll: false,
+      })
+    }
+  }, [viewSignature, pageParam, navigate])
   // The animation signature drops the search text: re-keying the rows on every
   // keystroke would remount and replay the whole tbody entrance while typing.
   // Filter/sort/size/assignment changes still re-stagger.
@@ -1484,6 +1526,18 @@ const SubmissionsPageContent = () => {
             </>
           }
         />
+        {/* Dense-content skip (Primer): keyboard users can jump past the
+            whole submissions table instead of tabbing through every row's
+            links and actions. Mirrors the global skip-to-main recipe. */}
+        <Button
+          as="a"
+          href="#after-submissions-table"
+          variant="primary"
+          size="sm"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:start-3 focus:z-50"
+        >
+          {t("submissions.skipPastTable")}
+        </Button>
         <SubmissionsTable
           scores={visibleRows}
           students={students}
@@ -1594,6 +1648,8 @@ const SubmissionsPageContent = () => {
           // is enabled, so a detection-only view (no_autograder) still shimmers.
           settling={overlayCapable && (livePending || detectedPending)}
         />
+        {/* The skip link's landing point, focusable so focus actually moves. */}
+        <span id="after-submissions-table" tabIndex={-1} />
       </div>
       <ConfirmModal
         open={regradeConfirmOpen}

--- a/web/src/pages/assignments/AdvancedRuntimeFields.tsx
+++ b/web/src/pages/assignments/AdvancedRuntimeFields.tsx
@@ -5,7 +5,7 @@ import {
   AlertIcon,
   CheckCircleIcon,
   CheckIcon,
-  ChevronDownIcon,
+  TriangleDownIcon,
   QuestionIcon,
   ServerIcon,
 } from "@/components/ui/icons"
@@ -121,7 +121,7 @@ export const LanguageVersionField = ({
                     language: meta.label,
                   })}
                 >
-                  <ChevronDownIcon aria-hidden="true" className="size-4" />
+                  <TriangleDownIcon aria-hidden="true" className="size-4" />
                 </Button>
               </div>
               {!disabled && (

--- a/web/src/pages/assignments/CreateAssignmentForm.tsx
+++ b/web/src/pages/assignments/CreateAssignmentForm.tsx
@@ -262,17 +262,9 @@ const CreateAssignmentForm = ({
       <AnimatedAlert tone="info" show={noChangesNotice} className="text-sm">
         {t("assignments.form.noChangesToSave")}
       </AnimatedAlert>
-      <div className="card-actions justify-end p-2">
-        {onCancel && (
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={onCancel}
-            disabled={loading}
-          >
-            {readOnly ? t("assignments.form.back") : t("common.cancel")}
-          </Button>
-        )}
+      {/* Primer page-form convention: actions bottom-LEFT, primary leftmost
+          (right alignment is for dialog footers). */}
+      <div className="card-actions justify-start p-2">
         {!readOnly && (
           <form.Subscribe
             selector={(state) => [
@@ -283,18 +275,6 @@ const CreateAssignmentForm = ({
           >
             {([, isSubmitting, isDefaultValue]) => (
               <>
-                {/* Edit mode: revert all unsaved edits back to the stored
-                    assignment. Shown only while the form is dirty. */}
-                {edit && !isDefaultValue ? (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    onClick={discardChanges}
-                    disabled={isSubmitting || loading}
-                  >
-                    {t("assignments.form.discardChanges")}
-                  </Button>
-                ) : null}
                 <Button
                   variant="primary"
                   type="submit"
@@ -310,9 +290,31 @@ const CreateAssignmentForm = ({
                       ? t("assignments.form.saveChanges")
                       : t("assignments.form.createButton")}
                 </Button>
+                {/* Edit mode: revert all unsaved edits back to the stored
+                    assignment. Shown only while the form is dirty. */}
+                {edit && !isDefaultValue ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={discardChanges}
+                    disabled={isSubmitting || loading}
+                  >
+                    {t("assignments.form.discardChanges")}
+                  </Button>
+                ) : null}
               </>
             )}
           </form.Subscribe>
+        )}
+        {onCancel && (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onCancel}
+            disabled={loading}
+          >
+            {readOnly ? t("assignments.form.back") : t("common.cancel")}
+          </Button>
         )}
       </div>
     </form>

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router"
 import {
   ArrowSwitchIcon,
-  ChevronDownIcon,
+  TriangleDownIcon,
   FilterIcon,
   MarkGithubIcon,
   PlusIcon,
@@ -278,7 +278,7 @@ const ClassroomList = ({
               className="join-item h-full border-s border-primary-content/20 px-1.5"
               aria-label={t("classes.newButton.moreOptions")}
             >
-              <ChevronDownIcon aria-hidden="true" className="size-4" />
+              <TriangleDownIcon aria-hidden="true" className="size-4" />
             </Button>
             <DropdownMenu className="w-max">
               {/* FEATURE: github-classroom-migration — removable entry point (#312) */}

--- a/web/src/pages/classes/CreateClassroomForm.tsx
+++ b/web/src/pages/classes/CreateClassroomForm.tsx
@@ -385,7 +385,9 @@ const CreateClassroomForm = ({
         >
           {submitError}
         </AnimatedAlert>
-        <Card.Actions className="justify-end p-2">
+        {/* Primer page-form convention: actions bottom-LEFT (right alignment
+              is for dialog footers). */}
+        <Card.Actions className="justify-start p-2">
           <form.Subscribe selector={(state) => [state.isSubmitting]}>
             {([isSubmitting]) => {
               // Hold the loading state through post-create navigation so the

--- a/web/src/pages/classes/EditClassroomForm.tsx
+++ b/web/src/pages/classes/EditClassroomForm.tsx
@@ -527,7 +527,9 @@ const EditClassroomForm = ({
           </AnimatedAlert>
           {/* Save outcome from the host page, in the same near-actions slot. */}
           <OutcomeAlert outcome={saveOutcome} className="text-sm" />
-          <Card.Actions className="justify-end p-2">
+          {/* Primer page-form convention: actions bottom-LEFT (right alignment
+              is for dialog footers). */}
+          <Card.Actions className="justify-start p-2">
             <form.Subscribe selector={(state) => [state.isSubmitting]}>
               {([isSubmitting]) => (
                 <Button

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
-  ChevronDownIcon,
+  TriangleDownIcon,
   PlusIcon,
   SignOutIcon,
   XCircleIcon,
@@ -245,7 +245,7 @@ const BulkActionsBar = ({
           <div className="dropdown dropdown-start">
             <Button variant="primary" size="sm">
               {t("orgMembers.bulk.actions")}
-              <ChevronDownIcon aria-hidden="true" className="size-4" />
+              <TriangleDownIcon aria-hidden="true" className="size-4" />
             </Button>
             <DropdownMenu className="w-64">
               <li>

--- a/web/src/pages/students/AddStudentButtons.tsx
+++ b/web/src/pages/students/AddStudentButtons.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next"
 import {
-  ChevronDownIcon,
+  TriangleDownIcon,
   PencilIcon,
   PlusIcon,
   ShareAndroidIcon,
@@ -71,7 +71,7 @@ export function AddStudentButtons({
             className="join-item h-full border-s border-primary-content/20 px-2"
             aria-label={t("students.addMoreOptions")}
           >
-            <ChevronDownIcon aria-hidden="true" className="size-4" />
+            <TriangleDownIcon aria-hidden="true" className="size-4" />
           </Button>
           <DropdownMenu className="w-max">
             <li>

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
-  ChevronDownIcon,
+  TriangleDownIcon,
   PaperAirplaneIcon,
   SignOutIcon,
   TrashIcon,
@@ -477,7 +477,7 @@ const RosterBulkActionsBar = ({
           <div className="dropdown dropdown-start">
             <Button variant="primary" size="sm">
               {t("students.bulk.actions")}
-              <ChevronDownIcon aria-hidden="true" className="size-4" />
+              <TriangleDownIcon aria-hidden="true" className="size-4" />
             </Button>
             <DropdownMenu className="w-64">
               <li>

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -1,6 +1,6 @@
 import {
   CalendarIcon,
-  ChevronDownIcon,
+  TriangleDownIcon,
   DownloadIcon,
   FileZipIcon,
   GitBranchIcon,
@@ -162,7 +162,7 @@ export function SubmissionsActionsMenu({
             ? t("submissions.collect.active")
             : t("submissions.regradeAll.active")
           : t("submissions.menu.actions")}
-        {!busy && <ChevronDownIcon aria-hidden="true" className="size-4" />}
+        {!busy && <TriangleDownIcon aria-hidden="true" className="size-4" />}
       </Button>
       <DropdownMenu className="w-64">
         {/* Metrics — graded-snapshot stats; hidden in live view (onMetrics

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, redirect, useParams } from "@tanstack/react-router"
 import { type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 import { ScopeWarningBanner } from "@/auth/ScopeWarningBanner"
+import { BannerStackProvider } from "@/context/bannerStack/BannerStackProvider"
 import { SkeletonDriftBanner } from "@/components/SkeletonDriftBanner"
 import { BudgetCreatedBanner } from "@/components/BudgetCreatedBanner"
 import { OfflineBanner } from "@/components/OfflineBanner"
@@ -60,14 +61,16 @@ function AuthedLayout() {
   return (
     <AuthedShell
       topSlot={
-        <>
+        // Priority-capped stack (Primer: at most two banners at once);
+        // order here is cosmetic — BANNER_PRIORITY owns precedence.
+        <BannerStackProvider>
           <OfflineBanner />
           <GitHubStatusBanner />
           <ScopeWarningBanner />
           <SkeletonDriftBanner />
           <BudgetCreatedBanner />
           <UpdateAvailableBanner />
-        </>
+        </BannerStackProvider>
       }
     />
   )

--- a/web/src/routes/_authed/$org/$classroom/assignments/$assignment/submissions/index.tsx
+++ b/web/src/routes/_authed/$org/$classroom/assignments/$assignment/submissions/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router"
 import SubmissionsPage from "@/pages/SubmissionsPage"
 import {
+  DEFAULT_PAGE_SIZE,
+  PAGE_SIZE_OPTIONS,
   STATUS_SELECT_VALUES,
   type StatusSelectValue,
 } from "@/pages/submissions/dashboard"
@@ -16,13 +18,32 @@ const parseStatus = (value: unknown): StatusSelectValue | undefined =>
     ? (value as StatusSelectValue)
     : undefined
 
+// Pagination is URL state (Primer): reload/back keep the page, and a row's
+// location is sharable. 1-based in the URL for humans; page 1 and the
+// default size never travel. Invalid values degrade to the defaults.
+const parsePage = (value: unknown): number | undefined => {
+  const n = typeof value === "string" ? Number(value) : value
+  return typeof n === "number" && Number.isInteger(n) && n >= 2 ? n : undefined
+}
+
+const parsePageSize = (value: unknown): number | undefined => {
+  const n = typeof value === "string" ? Number(value) : value
+  return typeof n === "number" &&
+    n !== DEFAULT_PAGE_SIZE &&
+    (PAGE_SIZE_OPTIONS as readonly number[]).includes(n)
+    ? n
+    : undefined
+}
+
 export const Route = createFileRoute(
   "/_authed/$org/$classroom/assignments/$assignment/submissions/",
 )({
   validateSearch: (
     search: Record<string, unknown>,
-  ): { status?: StatusSelectValue } => ({
+  ): { status?: StatusSelectValue; page?: number; pageSize?: number } => ({
     status: parseStatus(search.status),
+    page: parsePage(search.page),
+    pageSize: parsePageSize(search.pageSize),
   }),
   component: SubmissionsPage,
 })

--- a/web/src/util/a11y/contrastModel.ts
+++ b/web/src/util/a11y/contrastModel.ts
@@ -366,6 +366,29 @@ function buildTheme(theme: Theme): Pair[] {
     true,
   )
 
+  // Progress fill vs its own track (MetricBar funnel bars, the bulk progress
+  // bars): daisyUI's track is currentColor at 20% over the surface, so the
+  // filled-vs-unfilled distinction is a 1.4.11 non-text pair on base-100.
+  const progressTrack = (token: string) =>
+    flattenOver(
+      mixColor("oklab", token, 20, "transparent"),
+      parseColor(T.base100),
+    )
+  for (const [name, token] of [
+    ["primary", T.primary],
+    ["info", T.info],
+    ["success", T.success],
+  ] as const) {
+    add(
+      `progress-${name}`,
+      `progress ${name} fill vs its own track on base-100`,
+      opaque(token),
+      progressTrack(token),
+      "body",
+      "nonText",
+    )
+  }
+
   return pairs
 }
 


### PR DESCRIPTION
## Summary

Slice 5 — the final slice of the Primer UI-patterns audit (after #801/#803/#804/#808). Six convention decisions, all resolved in favor of Primer's letter:

- **Carets for menus:** the nine menu-opening triggers (split buttons, actions menus, the breadcrumb switcher, the runtime-version menu) swap ChevronDownIcon -> TriangleDownIcon; the eight collapse/expand chevrons stay chevrons, per Primer's split.
- **Page-form saves bottom-left:** Create/EditClassroom and CreateAssignment left-align their actions with the primary leftmost (right alignment stays dialog-only); CreateAssignment's order becomes Save -> Discard -> Cancel.
- **Explicit Save for settings:** the Appearance and Motion preference groups no longer commit on click — a shared draft-state form with a Save button, unchanged-save no-op notice, persistent inline confirmation, and SR announcement. Note the intentional UX change: picking a theme applies on Save, not on click.
- **Banner priority policy:** the six global banners register with a priority-ordered stack (offline first) that shows at most two at once; the next claimant slides in as a higher-priority banner clears. External-store implementation, pinned by tests.
- **Pagination in the URL:** submissions `?page=`/`?pageSize=` join `?status=` — validated in the route schema, defaults never travel, page changes push history so Back walks pages, filter changes clear the page via replace.
- **Skip-past-table link:** a focus-revealed link jumps keyboard users over the dense submissions table to a focusable anchor below it.
- **Progress contrast pinned:** the fill-vs-track pairs (primary/info/success, both themes) joined the contrast audit at 3.86-5.42:1 against the 3:1 non-text floor, so the test suite now guards them.

## Test plan

- [x] `npm run check` green (tsc, eslint, prettier, arch:validate, vitest — 4,766 tests) plus the strict i18n audit locally
- [ ] Manual QA: settings — change a preference without saving (nothing applies), save (confirmation + applies), save again unchanged (no-op notice)
- [ ] Manual QA: submissions — page to 3, reload (page kept), change a filter (back to page 1), Back button (walks pages)
- [ ] Manual QA: go offline while another banner is up — offline banner takes a slot, at most two visible
- [ ] Visual sweep of the caret swaps and left-aligned form actions