### PR TITLE
fix(cli): rewrite user-facing copy in GitHub's voice

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -117,49 +117,43 @@ func acceptCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "accept <org> <classroom> <assignment>",
 		Short: "Accept an assignment from an organization's classroom",
-		Long: "Accept an assignment by creating a repo at\n" +
-			"<org>/<classroom>-<assignment>-<username> (lowercased). The\n" +
-			"assignment is looked up in the published assignments.json on the\n" +
-			"classroom's GitHub Pages site (no token required). The repo is\n" +
-			"private unless the assignment opts into public repos\n" +
-			"(repo_visibility: public — for peer-review or showcase work), in\n" +
-			"which case it is created PUBLIC and you are told before it is\n" +
-			"created.\n\n" +
-			"If the classroom uses an unlisted URL, your teacher will give\n" +
-			"you an access key; pass it with `--key <key>`. The key is part\n" +
-			"of the published URL (`<classroom>/<key>/...`); without it the\n" +
-			"classroom's assignments can't be found. Normal classrooms need\n" +
-			"no key.\n\n" +
-			"If the assignment has a template repo (which may live outside\n" +
-			"<org>), the new repo is a copy generated from it. If it\n" +
-			"has no template, an empty repo is created carrying only\n" +
-			"the autograder workflow shim.\n\n" +
-			"The autograder workflow shim is dropped at\n" +
-			"`.github/workflows/autograde.yaml` in the new repo. For the\n" +
-			"default autograder it's the universal shim embedded in this\n" +
-			"CLI; for a non-default `--autograder <name>` (registered via\n" +
-			"`gh teacher assignment add --autograder <name>`) the shim is\n" +
-			"fetched from Pages instead. The shim is intentionally inert —\n" +
-			"it `uses:` the reusable autograde-runner workflow in the\n" +
-			"teacher's classroom50 repository, and that workflow fetches the\n" +
-			"runner-side bootstrap and the autograder at workflow runtime.\n" +
-			"Teacher edits to runtime, dependencies, or grading logic\n" +
-			"propagate on the next submission without ever touching the\n" +
-			"student repo.\n\n" +
-			"If the student has a pending org invite it is auto-accepted first.\n" +
-			"After creating the repo, the student is added as a collaborator on\n" +
-			"their own repo (`push` for an individual assignment; `admin` for a\n" +
-			"group assignment, so the founder can add teammates), and\n" +
-			"`.classroom50.yaml` and the autograde workflow are written in a\n" +
-			"single Tree commit, then verified.\n\n" +
-			"Re-running is safe and self-healing: an already-accepted repo\n" +
-			"that is fully provisioned is left in place (its founder role is\n" +
-			"updated best-effort), but one whose setup never finished (a\n" +
-			"prior run interrupted after the repo was created but before the\n" +
-			"control files landed) is repaired by re-running the idempotent\n" +
-			"provisioning. accept only reports\n" +
-			"success once both control files are confirmed present, so an\n" +
-			"\"accepted\" repo always autogrades.",
+		Long: "Accept an assignment by creating your own repository for it at\n" +
+			"<org>/<classroom>-<assignment>-<username> (all lowercase). The\n" +
+			"assignment is looked up in the classroom's published assignment list,\n" +
+			"which is public, so the lookup needs no special access.\n\n" +
+			"What accept does:\n\n" +
+			"  - Accepts any pending invitation to the organization first.\n" +
+			"  - Creates the repository. If the assignment has starter code (a\n" +
+			"    template repository, which may live outside <org>), your\n" +
+			"    repository starts as a copy of it; with no starter code, it\n" +
+			"    starts empty with only the autograding setup.\n" +
+			"  - Adds the autograding workflow at .github/workflows/autograde.yaml.\n" +
+			"    This CLI carries the standard one; if your teacher registered a\n" +
+			"    custom autograder for the assignment, that one is downloaded from\n" +
+			"    the classroom's published site instead. Either way the file only\n" +
+			"    points at the grading logic your teacher manages, so grading\n" +
+			"    updates apply on your next submission without ever changing your\n" +
+			"    repository.\n" +
+			"  - Adds you as a collaborator on your own repository: push access\n" +
+			"    for an individual assignment, admin for a group assignment so\n" +
+			"    you can add teammates with `gh student invite`.\n" +
+			"  - Writes the classroom marker file (.classroom50.yaml) and the\n" +
+			"    autograding workflow in a single commit, then verifies both are\n" +
+			"    in place before reporting success, so an accepted repository\n" +
+			"    always autogrades.\n\n" +
+			"Visibility and access:\n\n" +
+			"  - The repository is private unless the assignment opts into public\n" +
+			"    repositories (for peer review or showcase work). You are warned\n" +
+			"    before a public repository is created.\n" +
+			"  - If the classroom uses an unlisted URL, your teacher will give\n" +
+			"    you an access key; pass it with `--key <key>`. The key is part\n" +
+			"    of the published URL (`<classroom>/<key>/...`); without it the\n" +
+			"    classroom's assignments can't be found. Normal classrooms need\n" +
+			"    no key.\n\n" +
+			"Running accept again is safe:\n\n" +
+			"  - A repository that is fully set up is left in place (your access\n" +
+			"    level is refreshed when possible).\n" +
+			"  - A repository whose setup was interrupted partway is repaired.",
 		Example: "  gh student accept cs50 cs50-fall-2026 hello\n" +
 			"  gh student accept cs50 cs50-fall-2026 hello --key dhkrm4ih\n",
 		Args: cobra.ExactArgs(3),
@@ -213,28 +207,28 @@ func acceptCmd() *cobra.Command {
 					case http.StatusOK:
 						return acceptAssignment(cmd, client, u, out, org, classroom, assignment, secret, isOwner)
 					case http.StatusNotFound:
-						return fmt.Errorf("%s: no membership found for accept", org)
+						return fmt.Errorf("%s: couldn't find your invitation to this organization; ask your teacher to invite you again", org)
 					case http.StatusForbidden:
-						return fmt.Errorf("%s: blocked from accepting invite", org)
+						return fmt.Errorf("%s: GitHub blocked accepting the organization invitation; ask your teacher for help", org)
 					case http.StatusUnprocessableEntity:
-						return fmt.Errorf("%s: spam detection (422) triggered for accept", org)
+						return fmt.Errorf("%s: GitHub's spam detection (status 422) blocked accepting the invitation; ask your teacher for help", org)
 					default:
-						return fmt.Errorf("%s: unknown accept status received (%d)", org, acceptStatus.StatusCode)
+						return fmt.Errorf("%s: unexpected response (status %d) while accepting the organization invitation", org, acceptStatus.StatusCode)
 					}
 				}
 			case http.StatusNotFound:
-				return fmt.Errorf("%s: no membership found", org)
+				return fmt.Errorf("%s: you're not a member of this organization; ask your teacher for an invitation", org)
 			case http.StatusForbidden:
-				return fmt.Errorf("%s: forbidden", org)
+				return fmt.Errorf("%s: GitHub denied the membership check (status 403); ask your teacher for help", org)
 			default:
-				return fmt.Errorf("%s: unknown status received (%d)", org, status.StatusCode)
+				return fmt.Errorf("%s: unexpected response (status %d) while checking your organization membership", org, status.StatusCode)
 			}
 
 			return acceptAssignment(cmd, client, u, out, org, classroom, assignment, secret, isOwner)
 		},
 	}
 
-	cmd.Flags().StringVar(&key, "key", "", "Access key for a classroom that uses an unlisted URL (provided by your teacher); omit for normal classrooms")
+	cmd.Flags().StringVar(&key, "key", "", "Access key from your teacher for a classroom that uses an unlisted URL; omit for normal classrooms")
 	return cmd
 }
 
@@ -350,10 +344,10 @@ func checkAcceptableMode(assignment, mode string) error {
 // enforceable boundary is the teacher's template/collaborator changes.
 func assertAssignmentAcceptable(entry assignments.Entry, assignment string) error {
 	if entry.Locked {
-		return fmt.Errorf("assignment %q is locked by your teacher and can't be accepted right now — ask them to unlock it", assignment)
+		return fmt.Errorf("assignment %q is locked by your teacher and can't be accepted right now; ask them to unlock it", assignment)
 	}
 	if entry.Closed {
-		return fmt.Errorf("assignment %q is closed to new submissions — ask your teacher to reopen it", assignment)
+		return fmt.Errorf("assignment %q is closed to new submissions; ask your teacher to reopen it", assignment)
 	}
 	return nil
 }
@@ -364,7 +358,7 @@ func assertAssignmentAcceptable(entry assignments.Entry, assignment string) erro
 // still reconcile even if a later-published entry drifted incoherent.
 func assertModeCoherentForCreate(assignment, mode string, maxGroupSize int) error {
 	if maxGroupSize > 0 && mode != contract.ModeGroup {
-		return fmt.Errorf("assignment %q has max_group_size %d but mode %q (want %q) — its published metadata is inconsistent; ask your teacher to re-run `gh teacher assignment add`",
+		return fmt.Errorf("assignment %q has max_group_size %d but mode %q (want %q): its published details are inconsistent; ask your teacher to re-run `gh teacher assignment add`",
 			assignment, maxGroupSize, mode, contract.ModeGroup)
 	}
 	return nil
@@ -377,7 +371,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	// accept time alongside the login (rename-safe github_id identity).
 	username, ownerID, err := githubapi.CurrentUser(client)
 	if err != nil {
-		return fmt.Errorf("retrieving authed user: %w", err)
+		return fmt.Errorf("looking up the signed-in GitHub user: %w", err)
 	}
 
 	// Enrollment gate: a plain org member who isn't on this classroom's student
@@ -420,7 +414,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	// autograder shim — see the hasTemplate fork below.
 	hasTemplate := entry.HasTemplate()
 	if entry.Template != nil && !hasTemplate {
-		return fmt.Errorf("assignment %q has an incomplete template ref (owner=%q repo=%q branch=%q) — ask your teacher to re-run `gh teacher assignment add`",
+		return fmt.Errorf("assignment %q has an incomplete template reference (owner=%q repo=%q branch=%q); ask your teacher to re-run `gh teacher assignment add`",
 			assignment, entry.Template.Owner, entry.Template.Repo, entry.Template.Branch)
 	}
 	// empty_repo and template are mutually exclusive at write time, but
@@ -429,13 +423,13 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	// fork would generate starter content, then the bare fork would skip every
 	// control file — a templated repo the grading pipeline ignores).
 	if entry.EmptyRepo && entry.Template != nil {
-		return fmt.Errorf("assignment %q sets both empty_repo and a template — the entry is invalid; ask your teacher to re-run `gh teacher assignment add`", assignment)
+		return fmt.Errorf("assignment %q sets both empty_repo and a template, which is invalid; ask your teacher to re-run `gh teacher assignment add`", assignment)
 	}
 	// no_autograder is a templated, shim-less state; empty_repo is a bare
 	// shim-less state. Both being set is an invalid hand-edited entry — fail
 	// closed rather than pick one. (Mirrors the empty_repo+template guard.)
 	if entry.NoAutograder && entry.EmptyRepo {
-		return fmt.Errorf("assignment %q sets both no_autograder and empty_repo — the entry is invalid; ask your teacher to re-run `gh teacher assignment add`", assignment)
+		return fmt.Errorf("assignment %q sets both no_autograder and empty_repo, which is invalid; ask your teacher to re-run `gh teacher assignment add`", assignment)
 	}
 	// no_autograder is the TEMPLATED teacher-supplied-CI state: the template
 	// carries its own workflows. A template-less no_autograder entry (only
@@ -443,20 +437,20 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	// template) would produce a bare marker-only repo with no CI at all — use
 	// empty_repo for that. Fail closed rather than silently contradict the docs.
 	if entry.NoAutograder && !hasTemplate {
-		return fmt.Errorf("assignment %q sets no_autograder without a template — teacher-supplied CI needs a template that carries the workflows; the entry is invalid, ask your teacher to re-run `gh teacher assignment add`", assignment)
+		return fmt.Errorf("assignment %q sets no_autograder without a template: teacher-supplied CI needs a template that carries the workflows, so the entry is invalid; ask your teacher to re-run `gh teacher assignment add`", assignment)
 	}
 	// init_shim is the built-in-autograder-on-an-empty-repo state: template-less,
 	// commits the default shim onto an initialized repo. A hand-edited manifest
 	// could contradict that; fail closed rather than half-apply (mirrors the
 	// empty_repo+template and no_autograder+empty_repo guards above).
 	if entry.InitShim && entry.Template != nil {
-		return fmt.Errorf("assignment %q sets both init_shim and a template — init_shim is the template-less shim-only state; the entry is invalid, ask your teacher to re-run `gh teacher assignment add`", assignment)
+		return fmt.Errorf("assignment %q sets both init_shim and a template: init_shim is the template-less shim-only state, so the entry is invalid; ask your teacher to re-run `gh teacher assignment add`", assignment)
 	}
 	if entry.InitShim && entry.EmptyRepo {
-		return fmt.Errorf("assignment %q sets both init_shim and empty_repo — init_shim commits the shim, empty_repo commits nothing; the entry is invalid, ask your teacher to re-run `gh teacher assignment add`", assignment)
+		return fmt.Errorf("assignment %q sets both init_shim and empty_repo: init_shim commits the shim, empty_repo commits nothing, so the entry is invalid; ask your teacher to re-run `gh teacher assignment add`", assignment)
 	}
 	if entry.InitShim && entry.NoAutograder {
-		return fmt.Errorf("assignment %q sets both init_shim and no_autograder — one commits the default shim, the other commits none; the entry is invalid, ask your teacher to re-run `gh teacher assignment add`", assignment)
+		return fmt.Errorf("assignment %q sets both init_shim and no_autograder: one commits the default shim, the other commits none, so the entry is invalid; ask your teacher to re-run `gh teacher assignment add`", assignment)
 	}
 
 	// 2) Resolve the autograder shim. A non-default (Pages-fetched) autograder
@@ -500,9 +494,9 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	visibilityWord := "private"
 	if wantPublic {
 		visibilityWord = "public"
-		u.Warn("this assignment creates a PUBLIC repository — your work (code, commits, name) will be visible to anyone on the internet")
+		u.Warn("this assignment creates a PUBLIC repository: your work (code, commits, name) will be visible to anyone on the internet")
 	}
-	createMsg := fmt.Sprintf("Creating %s repo for %s", visibilityWord, assignment)
+	createMsg := fmt.Sprintf("Creating %s repository for %s", visibilityWord, assignment)
 	createSp := u.Spinner(createMsg)
 	createSp.Start()
 	createRepo := func(public bool) (htmlURL, fullName, branch string, alreadyExisted bool, err error) {
@@ -516,7 +510,7 @@ func acceptAssignment(cmd *cobra.Command, client githubapi.Client, u *ui.UI, out
 	}
 	htmlURL, fullName, commitBranch, alreadyExisted, err = createRepo(wantPublic)
 	if err != nil && wantPublic && isPublicRepoCreationDenied(err) {
-		u.Warn("`%s` does not allow you to create public repositories; creating a private repository instead — your teacher can make it public later", org)
+		u.Warn("`%s` does not allow you to create public repositories; creating a private repository instead. Your teacher can make it public later", org)
 		htmlURL, fullName, commitBranch, alreadyExisted, err = createRepo(false)
 	}
 	if err != nil {
@@ -658,7 +652,7 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 			if err := inviteFounder(client, u, verbose, p.username, p.org, p.repoName, founderPermission(p.mode, p.studentPermission)); err != nil && verbose {
 				u.Detail("could not update %s's role on %s/%s (repo already accepted; leaving as-is): %v", p.username, p.org, p.repoName, err)
 			}
-			p.createSp.Stop(fmt.Sprintf("Repo already exists: %s", p.fullName))
+			p.createSp.Stop(fmt.Sprintf("Repository already exists: %s", p.fullName))
 			// Ensure the Feedback PR exists even on the healthy path: repos
 			// accepted before the accept-time-PR feature (issue #228) get
 			// their PR by re-accepting — the only Actions-free route. The
@@ -721,7 +715,7 @@ func acceptIntoRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writ
 // asserts mode/size coherence.
 func acceptIntoBareRepo(client githubapi.Client, u *ui.UI, verbose bool, out io.Writer, p acceptRepoParams) error {
 	if p.alreadyExisted {
-		p.createSp.Stop(fmt.Sprintf("Repo already exists: %s", p.fullName))
+		p.createSp.Stop(fmt.Sprintf("Repository already exists: %s", p.fullName))
 
 		// Already accepted: reconcile the role best-effort, matching the
 		// templated already-accepted path. The bare repo is already healthy
@@ -844,7 +838,7 @@ func verifyProvisioned(client githubapi.Client, org, repoName string) error {
 		if ok {
 			return nil
 		}
-		lastErr = fmt.Errorf("%s/%s was created but %s is missing after setup — re-run `gh student accept %s %s %s` to finish provisioning (it is safe to re-run)",
+		lastErr = fmt.Errorf("%s/%s was created but %s is missing after setup; run `gh student accept %s %s %s` again to finish the setup (running it again is safe)",
 			org, repoName, classroomcfg.MetadataPath, org, classroomFromRepo(repoName), repoName)
 		if attempt < verifyProvisionAttempts-1 {
 			time.Sleep(time.Duration(attempt+1) * verifyProvisionBackoff)
@@ -894,8 +888,8 @@ func is422NameTooLong(httpErr *githubapi.HTTPError) bool {
 // assignment slug) rather than surfacing GitHub's raw validation error.
 func repoNameTooLongError(repoName string, cause error) error {
 	return fmt.Errorf("the repository name %q is %d characters, over GitHub's 100-character "+
-		"limit, so it couldn't be created. Ask your teacher to shorten the classroom or "+
-		"assignment slug, then run accept again: %w", repoName, len(repoName), cause)
+		"limit, so it couldn't be created. Ask your teacher to shorten the classroom "+
+		"short-name or assignment slug, then run accept again: %w", repoName, len(repoName), cause)
 }
 
 // has422Message gates httpErrorMentions on a 422 status, so a caller that isn't
@@ -1072,8 +1066,8 @@ func printCloneInstructions(u *ui.UI, out io.Writer, htmlURL string) error {
 		return err
 	}
 	if insideRepo {
-		u.Warn("you are currently inside a Git repository (%s) — clone from a parent/workspace directory to avoid nesting repositories", root)
-		_, _ = fmt.Fprintln(out, "Clone from a parent/workspace directory to avoid nesting repositories:")
+		u.Warn("you are currently inside a Git repository (%s); clone from a parent or workspace directory to avoid nesting repositories", root)
+		_, _ = fmt.Fprintln(out, "Clone from a parent or workspace directory to avoid nesting repositories:")
 	} else {
 		_, _ = fmt.Fprintln(out, "Clone it with:")
 	}
@@ -1280,7 +1274,7 @@ func createTemplatedAssignmentRepoInOrg(client githubapi.Client, u *ui.UI, verbo
 						return "", "", "", false, forkParentRestrictedError(parent, tmpl, err)
 					}
 				}
-				return "", "", "", false, fmt.Errorf("template `%s/%s` is not accessible to you — ask your teacher to make it public or grant your account access",
+				return "", "", "", false, fmt.Errorf("template `%s/%s` is not accessible to you; ask your teacher to make it public or grant your account access",
 					tmpl.Owner, tmpl.Repo)
 			case http.StatusForbidden:
 				// The refusal is about the destination org, not the template, so

--- a/cli/gh-student/accept_orchestration_test.go
+++ b/cli/gh-student/accept_orchestration_test.go
@@ -631,7 +631,7 @@ func TestVerifyProvisioned(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected an error when the accept marker is persistently missing, got nil")
 		}
-		if !strings.Contains(err.Error(), "re-run") {
+		if !strings.Contains(err.Error(), "run `gh student accept") || !strings.Contains(err.Error(), "again") {
 			t.Errorf("error should carry a re-run hint, got: %v", err)
 		}
 	})

--- a/cli/gh-student/feedback_pr.go
+++ b/cli/gh-student/feedback_pr.go
@@ -204,7 +204,7 @@ func openFeedbackPRStep(client githubapi.Client, u *ui.UI, verbose bool, p accep
 // Pointing only at "your first submission" would be false in exactly the
 // Actions-disabled classroom this feature exists for — the runner never runs
 // there, so re-accepting is the only route. Mirrors the GUI's deferred message.
-const feedbackPRDeferredHint = "could not open the Feedback PR now; run accept again to retry (or it opens on your first submission if autograding is enabled)"
+const feedbackPRDeferredHint = "could not open the feedback pull request now; run accept again to retry (or it opens on your first submission if autograding is enabled)"
 
 // acceptCommitSHA recovers the accept commit — the earliest commit touching
 // the .classroom50.yaml marker — for a repo provisioned by an earlier accept.
@@ -287,7 +287,7 @@ func verifyFeedbackBaseRef(client githubapi.Client, org, repoName, acceptSHA str
 		return err
 	}
 	if sha != acceptSHA {
-		return fmt.Errorf("%s branch is at %s, not the expected baseline %s — an org admin must delete it so it can be re-frozen correctly",
+		return fmt.Errorf("%s branch is at %s, not the expected baseline %s; an org admin must delete it so it can be re-frozen correctly",
 			contract.FeedbackBaseBranch, sha, acceptSHA)
 	}
 	return nil

--- a/cli/gh-student/internal/assignments/assignments.go
+++ b/cli/gh-student/internal/assignments/assignments.go
@@ -266,7 +266,7 @@ func FetchEntry(ctx context.Context, org, classroom, secret, assignment string) 
 	// scope.
 	if errors.Is(err, errManifestNotFound) {
 		if secret != "" {
-			return entry, fmt.Errorf("%w; the access key (--key) may be wrong — double-check the key your teacher gave you", err)
+			return entry, fmt.Errorf("%w; the access key (--key) may be wrong, so double-check the key your teacher gave you", err)
 		}
 		return entry, fmt.Errorf("%w; if this is an unlisted classroom, you must pass the access key your teacher gave you with `--key <key>`", err)
 	}
@@ -286,12 +286,12 @@ func fetchEntryFromURL(ctx context.Context, rawURL, assignment string) (Entry, e
 	client := &http.Client{Timeout: PagesFetchTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		return Entry{}, fmt.Errorf("GET %s: %w (the classroom50 Pages site may not be deployed yet — ask your teacher to verify `publish-pages.yaml` has run successfully)", rawURL, err)
+		return Entry{}, fmt.Errorf("GET %s: %w (the classroom's published site may not be live yet; ask your teacher to check that the publish-pages workflow has run)", rawURL, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return Entry{}, fmt.Errorf("%s returned 404 — the classroom may not exist yet, or `publish-pages.yaml` may not have run; ask your teacher to confirm the Pages site has deployed: %w", rawURL, errManifestNotFound)
+		return Entry{}, fmt.Errorf("%s returned 404: the classroom may not exist yet, or its publish-pages workflow may not have run; ask your teacher to confirm the classroom is published: %w", rawURL, errManifestNotFound)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return Entry{}, fmt.Errorf("GET %s: unexpected status %d", rawURL, resp.StatusCode)
@@ -307,7 +307,7 @@ func fetchEntryFromURL(ctx context.Context, rawURL, assignment string) (Entry, e
 		return Entry{}, fmt.Errorf("parse %s: %w", rawURL, err)
 	}
 	if file.Schema != assignmentsSchemaV1 {
-		return Entry{}, fmt.Errorf("%s: schema = %q, want %q — this gh-student version is older than the assignments.json shape; update gh-student and try again",
+		return Entry{}, fmt.Errorf("%s: schema = %q, want %q; this version of gh-student is too old to read the classroom's assignment list, so update gh-student and try again",
 			rawURL, file.Schema, assignmentsSchemaV1)
 	}
 
@@ -338,10 +338,10 @@ type NotFoundError struct {
 
 func (e *NotFoundError) Error() string {
 	if e.Org != "" && e.Classroom != "" {
-		return fmt.Sprintf("assignment %q is not registered in %s — ask your teacher to run `gh teacher assignment add %s %s %s`",
+		return fmt.Sprintf("assignment %q isn't in the classroom's published assignment list (%s); check the assignment name, or ask your teacher to run `gh teacher assignment add %s %s %s`",
 			e.Assignment, e.URL, e.Org, e.Classroom, e.Assignment)
 	}
-	return fmt.Sprintf("assignment %q is not registered in %s — ask your teacher to run `gh teacher assignment add`",
+	return fmt.Sprintf("assignment %q isn't in the classroom's published assignment list (%s); check the assignment name, or ask your teacher to run `gh teacher assignment add`",
 		e.Assignment, e.URL)
 }
 
@@ -382,12 +382,12 @@ func fetchAutograderWorkflowFromURL(ctx context.Context, rawURL, name string) (A
 	client := &http.Client{Timeout: PagesFetchTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		return AutogradeWorkflow{}, fmt.Errorf("GET %s: %w (the classroom50 Pages site may not be deployed yet — ask your teacher to verify `publish-pages.yaml` has run successfully)", rawURL, err)
+		return AutogradeWorkflow{}, fmt.Errorf("GET %s: %w (the classroom's published site may not be live yet; ask your teacher to check that the publish-pages workflow has run)", rawURL, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return AutogradeWorkflow{}, fmt.Errorf("autograder %q not published yet (%s returned 404) — ask your teacher to confirm that file exists in the classroom50 repository and that `publish-pages.yaml` has run", name, rawURL)
+		return AutogradeWorkflow{}, fmt.Errorf("autograder %q not published yet (%s returned 404); ask your teacher to confirm the file exists in the classroom50 repository and that the publish-pages workflow has run", name, rawURL)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return AutogradeWorkflow{}, fmt.Errorf("GET %s: unexpected status %d", rawURL, resp.StatusCode)
@@ -398,7 +398,7 @@ func fetchAutograderWorkflowFromURL(ctx context.Context, rawURL, name string) (A
 		return AutogradeWorkflow{}, fmt.Errorf("read %s: %w", rawURL, err)
 	}
 	if len(bytes.TrimSpace(body)) == 0 {
-		return AutogradeWorkflow{}, fmt.Errorf("GET %s: empty body — the Pages deployment may still be in flight; retry in a minute", rawURL)
+		return AutogradeWorkflow{}, fmt.Errorf("GET %s: empty body; the site may still be deploying, so retry in a minute", rawURL)
 	}
 
 	// Decode into `any` to validate YAML well-formedness without imposing
@@ -407,7 +407,7 @@ func fetchAutograderWorkflowFromURL(ctx context.Context, rawURL, name string) (A
 	// release asset, `classroom50/autograde` commit status).
 	var sink any
 	if err := yaml.Unmarshal(body, &sink); err != nil {
-		return AutogradeWorkflow{}, fmt.Errorf("autograder %q is malformed YAML (parsed from %s) — ask your teacher to check the file in the classroom50 repository: %w", name, rawURL, err)
+		return AutogradeWorkflow{}, fmt.Errorf("autograder %q is malformed YAML (fetched from %s); ask your teacher to check the file in the classroom50 repository: %w", name, rawURL, err)
 	}
 
 	return AutogradeWorkflow{Content: string(body)}, nil

--- a/cli/gh-student/internal/auth/logout.go
+++ b/cli/gh-student/internal/auth/logout.go
@@ -13,8 +13,8 @@ func NewLogoutCmd() *cobra.Command {
 		Use:   "logout",
 		Short: "Log out of GitHub",
 		Long: "Wrapper around `gh auth logout`. Removes the local gh\n" +
-			"authentication so subsequent classroom50 commands require a\n" +
-			"fresh `gh student login`.",
+			"authentication, so later commands need a fresh\n" +
+			"`gh student login`.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true

--- a/cli/gh-student/internal/invitecmd/group_membership.go
+++ b/cli/gh-student/internal/invitecmd/group_membership.go
@@ -106,7 +106,7 @@ func checkGroupSizeBeforeInvite(ctx context.Context, client githubapi.Client, or
 		}
 	}
 	if len(members) >= maxGroupSize {
-		return fmt.Errorf("group is full: %s/%s already has %d member(s), at the max of %d for this assignment — ask your teacher to raise the assignment's max group size if you need more",
+		return fmt.Errorf("group is full: %s/%s already has %d member(s), the maximum of %d for this assignment; ask your teacher to raise the assignment's maximum group size if you need more",
 			org, repo, len(members), maxGroupSize)
 	}
 	return nil

--- a/cli/gh-student/internal/invitecmd/invite.go
+++ b/cli/gh-student/internal/invitecmd/invite.go
@@ -27,19 +27,18 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "invite <org>/<repo> <username>",
 		Short: "Invite a classmate or TA to push to your assignment repo",
-		Long: "Add <username> as a `push`-level collaborator on <org>/<repo>. The\n" +
-			"invitee receives a GitHub invitation they must accept before they can\n" +
-			"push. Re-running on an existing collaborator is a no-op (GitHub upserts\n" +
-			"the permission).\n\n" +
-			"When run from inside a group-assignment repo (one with a\n" +
-			".classroom50.yaml for a `mode: group` assignment), invite checks the\n" +
-			"assignment's configured maximum group size (read from the teacher's\n" +
-			"published assignments.json) and refuses to add a new teammate once the\n" +
-			"group is full. This is an advisory guardrail for the honest case — it\n" +
-			"can be bypassed (e.g., via the GitHub UI), and the authoritative\n" +
-			"size/credit boundary is collection time. Run outside such a repo (or\n" +
-			"for an individual assignment / a TA invite), it just adds the\n" +
-			"collaborator.",
+		Long: "Add <username> as a collaborator with push access on <org>/<repo>.\n" +
+			"They receive a GitHub invitation and can push once they accept it.\n\n" +
+			"  - Inviting someone who is already a collaborator is safe and\n" +
+			"    changes nothing.\n" +
+			"  - Run from inside a group-assignment repository, invite checks the\n" +
+			"    assignment's maximum group size (from the classroom's published\n" +
+			"    assignment list) and refuses to add a new teammate once the\n" +
+			"    group is full. The limit is advisory: it can be bypassed, for\n" +
+			"    example via the GitHub UI, and the group size that counts is\n" +
+			"    checked again when your teacher collects the work.\n" +
+			"  - Run anywhere else (or for an individual assignment or a TA\n" +
+			"    invite), it just adds the collaborator.",
 		Example: "  gh student invite cs50/cs50-fall-2026-hello-alice cs50-duck\n",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -47,7 +46,7 @@ func NewCmd() *cobra.Command {
 			target := strings.TrimSpace(args[0])
 			username := strings.TrimSpace(args[1])
 			if target == "" {
-				return errors.New("target must not be empty")
+				return errors.New("repository must not be empty; expected <org>/<repo>")
 			}
 			if username == "" {
 				return errors.New("username must not be empty")
@@ -56,7 +55,7 @@ func NewCmd() *cobra.Command {
 			// Exactly two non-empty components.
 			parts := strings.SplitN(target, "/", 3)
 			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-				return fmt.Errorf("invalid target %q: expected <org>/<repo>", target)
+				return fmt.Errorf("invalid repository %q: expected <org>/<repo>", target)
 			}
 			org, repo := parts[0], parts[1]
 
@@ -136,7 +135,7 @@ func enforceGroupSize(cmd *cobra.Command, client githubapi.Client, org, repo, in
 		var nf *assignments.NotFoundError
 		if !errors.As(err, &nf) {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-				"Warning: couldn't check the group size for %s/%s (%v); proceeding with the invite — the size limit is advisory and enforced again at collection time.\n",
+				"Warning: couldn't check the group size for %s/%s (%v); proceeding with the invite. The size limit is advisory and is checked again when your teacher collects the work.\n",
 				org, repo, err)
 		}
 		return nil
@@ -177,7 +176,7 @@ func inviteUserToPush(client githubapi.Client, out io.Writer, org, repo, usernam
 		return err
 	}
 
-	_, _ = fmt.Fprintf(out, "invited %s to %s/%s with push permission\n", username, org, repo)
+	_, _ = fmt.Fprintf(out, "Invited %s to %s/%s with push access\n", username, org, repo)
 
 	return nil
 }

--- a/cli/gh-student/internal/submitcmd/finish_submission_test.go
+++ b/cli/gh-student/internal/submitcmd/finish_submission_test.go
@@ -214,7 +214,7 @@ func TestFinishSubmission_TagPushFailureIsFatal(t *testing.T) {
 	if err == nil {
 		t.Fatal("want the wrapped tag-push error")
 	}
-	if !strings.Contains(err.Error(), "re-run `gh student submit`") {
+	if !strings.Contains(err.Error(), "run `gh student submit` again") {
 		t.Errorf("error missing the re-run guidance: %v", err)
 	}
 	if out := h.buf.String(); strings.Contains(out, "CONFIRM") {
@@ -238,7 +238,7 @@ func TestFinishSubmission_RetryThenTagPushFailure(t *testing.T) {
 	if h.retryCalls != 1 {
 		t.Errorf("retryCalls = %d, want 1", h.retryCalls)
 	}
-	if !strings.Contains(err.Error(), "re-run `gh student submit`") {
+	if !strings.Contains(err.Error(), "run `gh student submit` again") {
 		t.Errorf("error missing the re-run guidance: %v", err)
 	}
 	if out := h.buf.String(); strings.Contains(out, "CONFIRM") {

--- a/cli/gh-student/internal/submitcmd/submit.go
+++ b/cli/gh-student/internal/submitcmd/submit.go
@@ -37,30 +37,30 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "submit",
-		Short: "Submit the current assignment to its remote",
-		Long: "Snapshot the current branch and push it as a new commit on top\n" +
-			"of the assignment repo's default branch. For an every-push\n" +
-			"assignment (the default) the autograde workflow listens for\n" +
-			"pushes to that branch and (a) creates its own\n" +
-			"`submit/<UTC-timestamp>-<short-sha>` tag at the pushed commit\n" +
-			"and (b) publishes a scored Release at that tag a minute or two\n" +
-			"later.\n\n" +
-			"For a tag-mode assignment (submission_mode: tag) plain pushes\n" +
-			"are not graded; this command additionally pushes the\n" +
-			"`submit/<UTC-timestamp>-<short-sha>` tag itself, which is what\n" +
-			"triggers grading. (Pushing your own `submit/*` tag by hand\n" +
-			"works too.)\n\n" +
-			"Before snapshotting, the latest teacher `.gitignore` and\n" +
-			"`.github/` (both optional) are fetched from the template repo\n" +
-			"recorded in `.classroom50.yaml` so any teacher-side updates\n" +
-			"flow through. The autograder workflow shim itself is set\n" +
-			"once at accept time and never refreshed — runtime, dependency,\n" +
-			"and grading-logic changes propagate via the runner workflow\n" +
-			"and assignments.json on the teacher's side, both fetched\n" +
-			"fresh by the runner on every submission.\n\n" +
+		Short: "Submit your work on the current assignment",
+		Long: "Snapshot your work and push it as a new commit on top of the\n" +
+			"assignment repository's default branch. Run it from inside your\n" +
+			"assignment repository clone.\n\n" +
+			"How grading is triggered:\n\n" +
+			"  - Most assignments grade every push: the autograding workflow\n" +
+			"    creates its own `submit/<UTC-timestamp>-<short-sha>` tag at the\n" +
+			"    pushed commit and publishes a scored release at that tag a\n" +
+			"    minute or two later.\n" +
+			"  - Some assignments grade only on submission tags (your teacher\n" +
+			"    configures this). Plain pushes aren't graded there, so this\n" +
+			"    command also pushes the `submit/...` tag itself, which is what\n" +
+			"    triggers grading. Pushing your own `submit/*` tag by hand works\n" +
+			"    too.\n\n" +
+			"Before the snapshot:\n\n" +
+			"  - The latest teacher `.gitignore` and `.github/` files (both\n" +
+			"    optional) are fetched from the starter-code repository recorded\n" +
+			"    in `.classroom50.yaml`, so teacher-side updates flow through.\n" +
+			"  - The autograding workflow itself is set once at accept time and\n" +
+			"    never refreshed: changes to the grading logic, runtime, or\n" +
+			"    dependencies reach you through the teacher-side setup, fetched\n" +
+			"    fresh on every submission.\n\n" +
 			"Functionally equivalent to `git commit -am 'Submit' && git push`,\n" +
-			"with the template `.gitignore`/`.github/` refresh as the only\n" +
-			"delta.",
+			"plus the teacher file refresh.",
 		Example: "  gh student submit",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
@@ -88,7 +88,7 @@ func NewCmd() *cobra.Command {
 // through unchanged.
 func annotateMissingConfig(err error) error {
 	if errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("%w — if this is an empty-repository assignment, autograding is disabled and `gh student submit` is not used; commit and `git push` directly", err)
+		return fmt.Errorf("%w; if this is an empty-repository assignment, autograding is disabled and `gh student submit` isn't used, so commit and `git push` directly", err)
 	}
 	return err
 }
@@ -103,7 +103,7 @@ func submitAssignment(ctx context.Context, client githubapi.Client, verbose bool
 		return err
 	}
 	if !inside {
-		return fmt.Errorf("not inside a Git repository")
+		return fmt.Errorf("not inside a Git repository; run this from your assignment repository clone")
 	}
 
 	config, err := classroomcfg.ReadConfig(filepath.Join(root, classroomcfg.MetadataPath))
@@ -301,7 +301,7 @@ func finishSubmission(
 		if err != nil {
 			return fmt.Errorf(
 				"submission pushed (%s/commit/%s) but the submit tag failed: %w\n"+
-					"this assignment grades only on submit/* tags — re-run `gh student submit` to retry (the pushed work is safe)",
+					"this assignment grades only on submit/* tags, so run `gh student submit` again to retry (the pushed work is safe)",
 				repoHTMLURL, sha, err,
 			)
 		}
@@ -313,7 +313,7 @@ func finishSubmission(
 	announce()
 
 	if entry == nil && entryErr != nil {
-		u.Warn("could not determine the assignment's submission mode (%v); if this assignment grades on submit tags, re-run `gh student submit`", entryErr)
+		u.Warn("could not determine the assignment's submission mode (%v); if this assignment grades on submit tags, run `gh student submit` again", entryErr)
 	}
 
 	return nil
@@ -337,7 +337,7 @@ func fetchSubmitEntry(ctx context.Context, org string, config *classroomcfg.Conf
 	entry, err := fetchEntryFn(ctx, org, config.Classroom, config.Secret, config.Assignment)
 	if err != nil {
 		if verbose {
-			u.Detail("Could not resolve the assignment entry (%v); submitting all files — the autograder enforces allowed_files", err)
+			u.Detail("Could not resolve the assignment entry (%v); submitting all files (the autograder enforces allowed_files)", err)
 		}
 		return nil, err
 	}

--- a/cli/gh-student/main.go
+++ b/cli/gh-student/main.go
@@ -28,7 +28,7 @@ var (
 func main() {
 	root := &cobra.Command{
 		Use:     "gh-student",
-		Short:   "Student-facing GitHub CLI extension",
+		Short:   "Accept and submit Classroom 50 assignments",
 		Version: versionString(),
 	}
 	root.SetErrPrefix("gh-student:")

--- a/cli/gh-teacher/autograder_cmd.go
+++ b/cli/gh-teacher/autograder_cmd.go
@@ -39,22 +39,21 @@ var diagnosticStub []byte
 func autograderCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "autograder",
-		Short: "Manage the classroom default autograder.py",
-		Long: "Manage the default autograder for a classroom. The default\n" +
-			"runs for every assignment in the classroom that has no\n" +
-			"per-assignment override at\n" +
-			"<classroom>/autograders/<slug>/autograder.py — replacing it\n" +
-			"lets you grade every assignment in the classroom with one\n" +
-			"script (e.g., a slug-driven dispatcher to a third-party\n" +
-			"grader).\n\n" +
-			"  set-default  install/replace <classroom>/autograder.py\n" +
+		Short: "Manage the classroom default autograder",
+		Long: "Manage the default autograder for a classroom. The default runs\n" +
+			"for every assignment in the classroom that has no per-assignment\n" +
+			"override at <classroom>/autograders/<slug>/autograder.py, so\n" +
+			"replacing it lets you grade every assignment with one script\n" +
+			"(for example, a slug-driven dispatcher to a third-party grader).\n\n" +
+			"Subcommands:\n" +
+			"  set-default  install or replace <classroom>/autograder.py\n" +
 			"  show         print it (or report none); --json for metadata\n" +
 			"  remove       delete it (distinct from the stub overwrite)\n" +
-			"  list         list named shims + per-assignment overrides\n\n" +
+			"  list         list named shims and per-assignment overrides\n\n" +
 			"Named shims (<classroom>/autograders/<name>.yaml) and\n" +
 			"per-assignment overrides (<classroom>/autograders/<slug>/\n" +
-			"autograder.py) are read-only from the CLI — `list` shows what\n" +
-			"is present; author or delete them via ordinary git operations\n" +
+			"autograder.py) are read-only from the CLI: `list` shows what is\n" +
+			"present; author or delete them via ordinary git operations\n" +
 			"against the classroom50 repository.",
 	}
 	cmd.AddCommand(autograderSetDefaultCmd())
@@ -71,20 +70,21 @@ func autograderSetDefaultCmd() *cobra.Command {
 	var fromPath string
 	cmd := &cobra.Command{
 		Use:   "set-default <org> <classroom>",
-		Short: "Replace <classroom>/autograder.py with --from (or the diagnostic stub when omitted)",
-		Long: "Replace `<classroom>/autograder.py` in <org>/classroom50\n" +
-			"with the contents of --from <path>. Pass `--from -` to\n" +
-			"read from stdin (one-shot agent flows). Lands as a single\n" +
-			"Tree commit on the classroom50 repository's default branch and is\n" +
-			"picked up by every subsequent submission once the next\n" +
-			"`publish-pages.yaml` run deploys (~30s).\n\n" +
-			"When --from is omitted, writes the diagnostic stub shipped\n" +
-			"with this CLI — it echoes every env var the runner exposed\n" +
-			"and emits a vacuous-pass result.json, so teachers can verify\n" +
-			"the runner pipeline before authoring real grading logic.\n\n" +
-			"Re-running with the same content is a no-op — the commit\n" +
-			"is skipped if the proposed body matches the file already\n" +
-			"in the repo.",
+		Short: "Replace the classroom's default autograder",
+		Long: "Replace `<classroom>/autograder.py` in <org>/classroom50 with the\n" +
+			"contents of --from <path>.\n\n" +
+			"  - Pass `--from -` to read from stdin (one-shot agent flows).\n" +
+			"  - Omit --from to install the diagnostic stub shipped with this\n" +
+			"    CLI: it echoes every env var the runner exposed and emits a\n" +
+			"    vacuous-pass result.json, so you can verify the runner\n" +
+			"    pipeline before authoring real grading logic.\n" +
+			"  - The change lands as a single commit on the classroom50\n" +
+			"    repository's default branch and applies to every subsequent\n" +
+			"    submission once the next `publish-pages.yaml` run deploys\n" +
+			"    (about 30 seconds).\n" +
+			"  - Re-running with the same content is a no-op: the commit is\n" +
+			"    skipped when the proposed body matches the file already in\n" +
+			"    the repository.",
 		Example: "  gh teacher autograder set-default cs50-fall-2026 cs-principles --from ./autograder.py\n" +
 			"  cat my-autograder.py | gh teacher autograder set-default cs50-fall-2026 cs-principles --from -\n" +
 			"  gh teacher autograder set-default cs50-fall-2026 cs-principles\n" +
@@ -110,7 +110,7 @@ func autograderSetDefaultCmd() *cobra.Command {
 			return setClassroomDefaultAutograder(client, cmd.OutOrStdout(), cmd.ErrOrStderr(), org, classroom, label, content)
 		},
 	}
-	cmd.Flags().StringVar(&fromPath, "from", "", "Path to the autograder.py to upload, or `-` to read from stdin. Omit to install the shipped diagnostic stub.")
+	cmd.Flags().StringVar(&fromPath, "from", "", "Path to the autograder.py to upload, or `-` to read from stdin; omit to install the shipped diagnostic stub")
 	return cmd
 }
 
@@ -172,13 +172,13 @@ func setClassroomDefaultAutograder(client githubapi.Client, out, errOut io.Write
 		return err
 	}
 	if commitSHA == "" {
-		_, _ = fmt.Fprintf(out, "%s/%s: %s already matches —\u00a0no commit\n", org, configrepo.ConfigRepoName, repoPath)
+		_, _ = fmt.Fprintf(out, "%s/%s: %s already matches, no commit\n", org, configrepo.ConfigRepoName, repoPath)
 		return nil
 	}
 
 	_, _ = fmt.Fprintf(out, "%s/%s: updated %s (commit %s)\n", org, configrepo.ConfigRepoName, repoPath, commitSHA[:8])
 	_, _ = fmt.Fprintf(errOut, "View at https://github.com/%s/%s/blob/%s/%s\n", org, configrepo.ConfigRepoName, branch, repoPath)
-	_, _ = fmt.Fprintf(errOut, "Next: wait ~30s for publish-pages.yaml to redeploy, then push a submission to test\n")
+	_, _ = fmt.Fprintf(errOut, "Next: wait about 30 seconds for publish-pages.yaml to redeploy, then push a submission to test\n")
 	return nil
 }
 

--- a/cli/gh-teacher/autograder_crud.go
+++ b/cli/gh-teacher/autograder_crud.go
@@ -30,7 +30,7 @@ func requireClassroomExists(client githubapi.Client, org, classroom, branch stri
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("classroom %q not found in %s/%s (no %s) -- run `gh teacher classroom add %s %s` first",
+		return fmt.Errorf("classroom %q not found in %s/%s (no %s): run `gh teacher classroom add %s %s` first",
 			classroom, org, configrepo.ConfigRepoName, marker, org, classroom)
 	}
 	return nil
@@ -65,20 +65,21 @@ func autograderShowCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "show <org> <classroom>",
-		Short: "Print the classroom's default autograder.py (or report none)",
+		Short: "Print the classroom's default autograder",
 		Long: "Print the current default autograder at\n" +
 			"<org>/classroom50/<classroom>/autograder.py.\n\n" +
-			"Default output writes the file body to stdout -- pipe it to a\n" +
-			"file or a pager. A one-line summary (whether it's the shipped\n" +
-			"diagnostic stub or a custom autograder, plus its size) goes to\n" +
-			"stderr unless --quiet.\n\n" +
-			"Pass --json for metadata only -- {path, exists, is_stub, size,\n" +
-			"sha} -- without the body, so a script can branch on whether a\n" +
-			"real autograder is installed.\n\n" +
-			"When the classroom has no default autograder.py, stdout stays\n" +
-			"empty and stderr says so; the command still exits 0 (an unset\n" +
-			"default is a valid mid-setup state, graded as a vacuous pass).\n" +
-			"This is a read-only command; no commit lands on the repo.",
+			"  - Default output writes the file body to stdout; pipe it to a\n" +
+			"    file or a pager.\n" +
+			"  - A one-line summary (whether it's the shipped diagnostic stub\n" +
+			"    or a custom autograder, plus its size) goes to stderr unless\n" +
+			"    --quiet.\n" +
+			"  - Pass --json for metadata only ({path, exists, is_stub, size,\n" +
+			"    sha}) without the body, so a script can branch on whether a\n" +
+			"    real autograder is installed.\n" +
+			"  - When the classroom has no default autograder, stdout stays\n" +
+			"    empty and stderr says so; the command still exits 0 (an unset\n" +
+			"    default is a valid mid-setup state, graded as a vacuous pass).\n\n" +
+			"This is a read-only command; no commit lands on the repository.",
 		Example: "  gh teacher autograder show cs50-fall-2026 cs-principles\n" +
 			"  gh teacher autograder show cs50-fall-2026 cs-principles --json\n" +
 			"  gh teacher autograder show cs50-fall-2026 cs-principles > autograder.py",
@@ -136,7 +137,7 @@ func runAutograderShow(client githubapi.Client, out, errOut io.Writer, org, clas
 
 	if !ok {
 		if !quiet {
-			_, _ = fmt.Fprintf(errOut, "%s/%s/%s: no default autograder set — use `gh teacher autograder set-default %s %s` to install one\n",
+			_, _ = fmt.Fprintf(errOut, "%s/%s/%s: no default autograder set. Install one with `gh teacher autograder set-default %s %s`\n",
 				org, configrepo.ConfigRepoName, repoPath, org, classroom)
 		}
 		return nil
@@ -181,7 +182,7 @@ func autograderListCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "list <org> <classroom>",
-		Short: "List named and per-assignment autograders under <classroom>/autograders/",
+		Short: "List named and per-assignment autograders",
 		Long: "List every entry under\n" +
 			"<org>/classroom50/<classroom>/autograders/:\n\n" +
 			"  - named shims (`<name>.yaml`) opted into with\n" +
@@ -193,10 +194,10 @@ func autograderListCmd() *cobra.Command {
 			"A one-line `<path>: N autograder(s)` summary goes to stderr\n" +
 			"unless --quiet. Pass --json for the full array of\n" +
 			"{name, kind, path} objects.\n\n" +
-			"The classroom DEFAULT autograder (<classroom>/autograder.py)\n" +
-			"is not listed here -- inspect it with `gh teacher autograder\n" +
-			"show`. Named shims and per-assignment overrides are authored\n" +
-			"via ordinary git operations against the classroom50 repository; this\n" +
+			"The classroom default autograder (<classroom>/autograder.py) is\n" +
+			"not listed here; inspect it with `gh teacher autograder show`.\n" +
+			"Named shims and per-assignment overrides are authored via\n" +
+			"ordinary git operations against the classroom50 repository; this\n" +
 			"command is read-only and lists what is present.",
 		Example: "  gh teacher autograder list cs50-fall-2026 cs-principles\n" +
 			"  gh teacher autograder list cs50-fall-2026 cs-principles --json",
@@ -290,7 +291,7 @@ func runAutograderList(client githubapi.Client, out, errOut io.Writer, org, clas
 func summarizeAutograderList(org, classroom string, entries []autograderListEntry) string {
 	path := fmt.Sprintf("%s/%s/%s/autograders", org, configrepo.ConfigRepoName, classroom)
 	if len(entries) == 0 {
-		return fmt.Sprintf("%s: no named or per-assignment autograders — the classroom default (autograder.py) covers every assignment", path)
+		return fmt.Sprintf("%s: no named or per-assignment autograders; the classroom default (autograder.py) covers every assignment", path)
 	}
 	var named, perAssignment int
 	for _, e := range entries {
@@ -309,17 +310,17 @@ func autograderRemoveCmd() *cobra.Command {
 	var skipConfirm bool
 	cmd := &cobra.Command{
 		Use:   "remove <org> <classroom>",
-		Short: "Delete the classroom's default autograder.py",
+		Short: "Delete the classroom's default autograder",
 		Long: "Delete <classroom>/autograder.py from <org>/classroom50 in a\n" +
 			"single commit. This is distinct from `set-default` with no\n" +
-			"--from, which OVERWRITES the file with the diagnostic stub --\n" +
+			"--from, which overwrites the file with the diagnostic stub;\n" +
 			"remove deletes it outright.\n\n" +
-			"Grading impact: once removed, any assignment in the classroom\n" +
-			"that has no per-assignment override\n" +
-			"(<classroom>/autograders/<slug>/autograder.py) and no\n" +
-			"declarative tests falls back to a vacuous pass (0/0) on the\n" +
-			"next submission, until you set a new default. Per-assignment\n" +
-			"overrides and named shims are NOT touched.\n\n" +
+			"Grading impact:\n" +
+			"  - Once removed, any assignment with no per-assignment override\n" +
+			"    (<classroom>/autograders/<slug>/autograder.py) and no\n" +
+			"    declarative tests falls back to a vacuous pass (0/0) on the\n" +
+			"    next submission, until you set a new default.\n" +
+			"  - Per-assignment overrides and named shims are not touched.\n\n" +
 			"You'll be asked to confirm; pass --yes to skip the prompt\n" +
 			"(scripted runs only). Idempotent: removing a classroom that\n" +
 			"has no default autograder is a no-op.",
@@ -373,7 +374,7 @@ func removeClassroomDefaultAutograder(client githubapi.Client, in io.Reader, out
 			return err
 		}
 		if !proceed {
-			return errors.New("aborted — default autograder not removed")
+			return errors.New("aborted: default autograder not removed")
 		}
 	}
 

--- a/cli/gh-teacher/init.go
+++ b/cli/gh-teacher/init.go
@@ -27,16 +27,17 @@ func initCmd() *cobra.Command {
 		Use:   "init <org>",
 		Short: "Bootstrap the classroom50 repository in an organization",
 		Long: "Bootstrap the classroom50 repository for a teaching organization.\n" +
-			"Run once per org; safe to re-run (idempotent).\n\n" +
-			"What it sets up (in order):\n" +
-			"  1.  Org member-privilege lockdown (least-privilege: the only\n" +
-			"      enabled member capabilities are private-repo creation and\n" +
-			"      public Pages creation).\n" +
+			"Run once per organization; re-running is safe and picks up where a\n" +
+			"prior run left off.\n\n" +
+			"What it sets up, in order:\n" +
+			"  1.  Org member-privilege lockdown (least-privilege: members keep\n" +
+			"      only private-repo creation and public Pages creation).\n" +
 			"  2.  GitHub Actions enabled for the org.\n" +
 			"  3.  A $0 GitHub Actions spending cap (created only if none exists;\n" +
 			"      an existing teacher-set budget is left untouched).\n" +
 			"  4.  Actions allowed to create pull requests (for Feedback PRs).\n" +
-			"  5.  Branch rulesets protecting submission history + Feedback base.\n" +
+			"  5.  Branch rulesets protecting submission history and the\n" +
+			"      Feedback base.\n" +
 			"  6.  The private classroom50 repository (auto-initialized).\n" +
 			"  7.  Repo-level Actions re-enabled.\n" +
 			"  8.  The embedded workflow and script files (single commit).\n" +
@@ -45,39 +46,40 @@ func initCmd() *cobra.Command {
 			"  11. Workflow GITHUB_TOKEN permissions.\n" +
 			"  12. Reusable-workflow access for the org.\n" +
 			"  13. The repo-level CLASSROOM50_SERVICE_TOKEN secret.\n\n" +
-			"Setup checks: before any change, init verifies your OAuth scopes,\n" +
-			"org access and ownership, the org plan, and that a service token\n" +
-			"is available — and stops without mutating if a hard check fails.\n\n" +
-			"Service token: read from the CLASSROOM50_SERVICE_TOKEN environment\n" +
-			"variable, else a hidden interactive prompt on first setup. There\n" +
-			"is no --token flag (PATs on the command line leak via shell\n" +
-			"history, process listings, and CI logs). Create a fine-grained PAT\n" +
-			"with Resource owner = your org, Repository access = All\n" +
-			"repositories, Contents: Read and write, Actions: Read and\n" +
-			"write, and Organization permissions -> Members: Read AND\n" +
-			"Administration: Read and write — student repos are created on\n" +
-			"demand, so an \"Only select repositories\" scope silently misses\n" +
-			"them. Contents read is needed to collect scores; Contents write\n" +
-			"pushes submit/* tags and Actions write re-runs autograde workflows\n" +
-			"when regrading; Members: Read is needed to list the classroom team\n" +
-			"(collection is team-driven); Organization Administration is needed\n" +
-			"to set the $0 Actions spending cap. Since init requires you to be\n" +
-			"an org owner, your own PAT is auto-approved.\n" +
-			"init validates the token before storing it (and a re-run leaves\n" +
-			"an already-configured token untouched; replace it with\n" +
-			"`gh teacher rotate-service-token <org>`).\n\n" +
-			"Re-running is safe: init picks up where a prior run left off and\n" +
-			"refreshes workflow and script files that differ from this CLI's\n" +
-			"embedded version (so orgs gain new features) after a confirmation\n" +
-			"prompt; --yes skips that prompt for scripted runs.\n\n" +
+			"Setup checks run first: init verifies your OAuth scopes, your\n" +
+			"organization access and ownership, the organization plan, and that\n" +
+			"a service token is available. If a hard check fails, init stops\n" +
+			"before changing anything.\n\n" +
+			"Service token:\n" +
+			"  - Read from the CLASSROOM50_SERVICE_TOKEN environment variable,\n" +
+			"    or a hidden interactive prompt on first setup. There is no\n" +
+			"    --token flag: a token on the command line leaks via shell\n" +
+			"    history, process listings, and CI logs.\n" +
+			"  - Create a fine-grained personal access token with Resource\n" +
+			"    owner = your organization, Repository access = All repositories,\n" +
+			"    Contents: Read and write, Actions: Read and write, and\n" +
+			"    Organization permissions -> Members: Read and Administration:\n" +
+			"    Read and write. Student repos are created on demand, so an\n" +
+			"    \"Only select repositories\" scope silently misses them.\n" +
+			"  - Why each permission: Contents read collects scores; Contents\n" +
+			"    write pushes submit/* tags; Actions write re-runs autograde\n" +
+			"    workflows when regrading; Members read lists the classroom\n" +
+			"    team (collection is team-driven); Organization Administration\n" +
+			"    sets the $0 Actions spending cap.\n" +
+			"  - init validates the token before storing it. A re-run leaves an\n" +
+			"    already-configured token untouched; replace it with\n" +
+			"    `gh teacher rotate-service-token <org>`.\n" +
+			"  - Since init requires you to be an org owner, your own token is\n" +
+			"    auto-approved.\n\n" +
+			"Re-running:\n" +
+			"  - init picks up where a prior run left off.\n" +
+			"  - Workflow and script files that differ from this CLI's embedded\n" +
+			"    version are refreshed (so orgs gain new features) after a\n" +
+			"    confirmation prompt; --yes skips that prompt for scripted runs.\n\n" +
 			"Four org member-privilege settings have no REST API; init reports\n" +
 			"them as a manual checklist (and in --json's\n" +
 			"manual_hardening_required). See the CLI Teacher Guide for the full\n" +
-			"hardening context.\n\n" +
-			"Flags: --dry-run (setup checks + planned steps, no changes),\n" +
-			"--json (machine-readable summary on stdout, implies --quiet),\n" +
-			"--quiet/-q (suppress progress chatter), --yes (skip the refresh\n" +
-			"prompt).",
+			"hardening context.",
 		Example: "  CLASSROOM50_SERVICE_TOKEN=github_pat_xxx gh teacher init cs50-fall-2026\n" +
 			"  gh teacher init cs50-fall-2026              # interactive prompt for the token\n" +
 			"  gh teacher init cs50-fall-2026 --dry-run    # preview without changes\n" +
@@ -189,7 +191,7 @@ func initCmd() *cobra.Command {
 				// The org-level locks defang the repo-admin `student accept`
 				// grants each founder. Record the warning; the checklist is
 				// rendered at the end so it isn't lost above the progress line.
-				summary.addWarning("%s: org member-privilege lockdown INCOMPLETE — %d setting(s) need to be set by hand at %s (see the summary checklist). Until then, the repo-admin that `gh student accept` grants founders is not fully defanged org-wide.", org, len(unenforced), settingsURL)
+				summary.addWarning("%s: org member-privilege lockdown is incomplete: %d setting(s) must be set by hand at %s (see the summary checklist). Until then, the repo admin access that `gh student accept` grants founders is not fully contained org-wide.", org, len(unenforced), settingsURL)
 			}
 
 			// On Team/Free, "private repos only" doesn't exist: GitHub couples
@@ -319,7 +321,7 @@ func initCmd() *cobra.Command {
 				if !rulesetsReady {
 					missing = append(missing, "the submission-history / feedback-base rulesets")
 				}
-				summary.addWarning("%s: Feedback PR prerequisites incomplete — %s could not be applied. Assignments created with `--feedback-pr` may not open PRs or may leave submissions unprotected until you apply these at https://github.com/organizations/%s/settings, then re-run `gh teacher init`.",
+				summary.addWarning("%s: Feedback PR prerequisites are incomplete: %s could not be applied. Assignments created with `--feedback-pr` may not open PRs or may leave submissions unprotected until you apply these at https://github.com/organizations/%s/settings, then re-run `gh teacher init`.",
 					org, strings.Join(missing, " and "), org)
 			}
 

--- a/cli/gh-teacher/init_preflight.go
+++ b/cli/gh-teacher/init_preflight.go
@@ -106,7 +106,7 @@ func checkScopes(client githubapi.Client) (check preflightCheck, scopes, login s
 	resp, err := client.Request(http.MethodGet, "user", nil)
 	if err != nil {
 		c.Status = preflightWarn
-		c.Detail = fmt.Sprintf("couldn't verify OAuth scopes (%v); proceeding — operations needing the classroom scopes will fail with guidance if a scope is missing", err)
+		c.Detail = fmt.Sprintf("couldn't verify OAuth scopes (%v); proceeding, but operations needing the classroom scopes will fail with guidance if a scope is missing", err)
 		return c, "", ""
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -146,7 +146,7 @@ func checkOrgAccess(client githubapi.Client, org string) (preflightCheck, string
 	if err != nil {
 		c.Status = preflightFail
 		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
-			c.Detail = fmt.Sprintf("organization %q not found, or your token can't see it — check the name and that you're a member", org)
+			c.Detail = fmt.Sprintf("organization %q not found, or your token can't see it; check the name and that you're a member", org)
 		} else {
 			c.Detail = fmt.Sprintf("couldn't read organization %q (%v)", org, err)
 		}
@@ -194,7 +194,7 @@ func checkOwnership(client githubapi.Client, org, login string) preflightCheck {
 	}
 	if err := client.Get(path, &resp); err != nil {
 		c.Status = preflightWarn
-		c.Detail = fmt.Sprintf("couldn't read your org membership (%v); proceeding — owner-only steps will fail with guidance if you aren't an owner", err)
+		c.Detail = fmt.Sprintf("couldn't read your org membership (%v); proceeding, but owner-only steps will fail with guidance if you aren't an owner", err)
 		return c
 	}
 	if resp.Role != "admin" {
@@ -275,7 +275,7 @@ func preflightFailError(res preflightResult) error {
 			failed = append(failed, fmt.Sprintf("%s (%s)", c.Name, c.Detail))
 		}
 	}
-	return fmt.Errorf("setup checks failed — fix before re-running: %s", strings.Join(failed, "; "))
+	return fmt.Errorf("setup checks failed. Fix these before re-running: %s", strings.Join(failed, "; "))
 }
 
 // initStepLabels are init's phase labels in order — used by --dry-run and the
@@ -298,7 +298,7 @@ var initStepLabels = []string{
 
 // renderDryRunSteps prints the ordered steps init would perform, for --dry-run.
 func renderDryRunSteps(w io.Writer) {
-	_, _ = fmt.Fprintln(w, "Dry run — init would perform these steps (no changes made):")
+	_, _ = fmt.Fprintln(w, "Dry run: init would perform these steps (no changes made):")
 	for i, label := range initStepLabels {
 		_, _ = fmt.Fprintf(w, "  %d. %s\n", i+1, label)
 	}

--- a/cli/gh-teacher/init_repo.go
+++ b/cli/gh-teacher/init_repo.go
@@ -127,7 +127,7 @@ func verifyOrgDefaults(client githubapi.Client, errOut io.Writer, org, plan stri
 func unenforcedCause(plan string) string {
 	switch plan {
 	case "enterprise":
-		return "These are likely pinned at the enterprise level; an org owner can't change them from org settings — ask an enterprise owner, or set them by hand below."
+		return "These are likely pinned at the enterprise level; an org owner can't change them from org settings. Ask an enterprise owner, or set them by hand below."
 	case "team", "free", "":
 		return "GitHub doesn't expose these settings via the API on your plan, so set them by hand below."
 	default:
@@ -239,7 +239,7 @@ func reportPartialMemberDefaults(errOut io.Writer, org string, settings []orgpol
 		appliedList = strings.Join(applied, ", ")
 	}
 	_, _ = fmt.Fprintf(errOut,
-		"Warning: %s: org member-privilege lockdown was left PARTIALLY APPLIED by a transient error. Applied: %s. Not yet attempted (including the field that errored): %s. The org is in a half-locked state — re-run `gh teacher init` to finish, or set the remaining policies at %s.\n",
+		"Warning: %s: org member-privilege lockdown was left partially applied by a transient error. Applied: %s. Not yet attempted (including the field that errored): %s. The org is in a half-locked state: re-run `gh teacher init` to finish, or set the remaining policies at %s.\n",
 		org, appliedList, strings.Join(notAttempted, ", "), settingsURL)
 }
 
@@ -267,7 +267,7 @@ func ensureOrgActionsBudgetCap(client githubapi.Client, out, errOut io.Writer, o
 		_, _ = fmt.Fprintf(out, "%s: Actions budget cap already in place ($%d)\n", org, v.Amount)
 		return "present"
 	case orgpolicy.BudgetWarn:
-		_, _ = fmt.Fprintf(errOut, "Warning: %s: an Actions budget over $%d ($%d) is set; leaving it untouched — lower it to $0 at %s to hard-stop paid Actions minutes.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: an Actions budget over $%d ($%d) is set; leaving it untouched. Lower it to $0 at %s to hard-stop paid Actions minutes.\n",
 			org, orgpolicy.BudgetWarnThreshold, v.Amount, settingsURL)
 		return "warn"
 	case orgpolicy.BudgetMissing:
@@ -309,7 +309,7 @@ func ensureOrgActionsEnabled(client githubapi.Client, out, errOut io.Writer, org
 
 	var perms orgActionsPermissions
 	if err := client.Get(path, &perms); err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: %s: couldn't read Actions permissions (%v); make sure GitHub Actions is enabled for the org at https://github.com/organizations/%s/settings/actions — Classroom50's autograde, publish-pages, and collect-scores workflows won't run without it.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: couldn't read Actions permissions (%v); make sure GitHub Actions is enabled for the org at https://github.com/organizations/%s/settings/actions. Classroom50's autograde, publish-pages, and collect-scores workflows won't run without it.\n",
 			org, err, org)
 		return nil
 	}
@@ -319,14 +319,14 @@ func ensureOrgActionsEnabled(client githubapi.Client, out, errOut io.Writer, org
 		_, _ = fmt.Fprintf(out, "%s: Actions already enabled (all repositories)\n", org)
 		return nil
 	case "selected":
-		_, _ = fmt.Fprintf(errOut, "Warning: %s: Actions is enabled only for selected repositories; ensure the classroom50 repository and the <classroom>-* student repos are included (or switch to All repositories) at https://github.com/organizations/%s/settings/actions — Classroom50's autograde, publish-pages, and collect-scores workflows won't run in any repo left out.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: Actions is enabled only for selected repositories; ensure the classroom50 repository and the <classroom>-* student repos are included (or switch to All repositories) at https://github.com/organizations/%s/settings/actions. Classroom50's autograde, publish-pages, and collect-scores workflows won't run in any repo left out.\n",
 			org, org)
 		return nil
 	case "none":
 		// Off org-wide — enable below.
 	default:
 		// Empty/unknown: warn, don't touch the policy.
-		_, _ = fmt.Fprintf(errOut, "Warning: %s: unexpected Actions enabled_repositories value %q; leaving it unchanged — verify GitHub Actions is enabled for the org at https://github.com/organizations/%s/settings/actions, or Classroom50's workflows may not run.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: unexpected Actions enabled_repositories value %q; leaving it unchanged. Verify GitHub Actions is enabled for the org at https://github.com/organizations/%s/settings/actions, or Classroom50's workflows may not run.\n",
 			org, perms.EnabledRepositories, org)
 		return nil
 	}
@@ -340,7 +340,7 @@ func ensureOrgActionsEnabled(client githubapi.Client, out, errOut io.Writer, org
 	resp, err := client.Request(http.MethodPut, path, bytes.NewReader(body))
 	if err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusForbidden) || cliutil.IsHTTPStatus(err, http.StatusConflict) || cliutil.IsHTTPStatus(err, http.StatusUnprocessableEntity) {
-			_, _ = fmt.Fprintf(errOut, "Warning: %s: couldn't enable GitHub Actions (%v); this is often an enterprise-level policy an org admin can't override — ask an enterprise admin to enable Actions for the org at https://github.com/organizations/%s/settings/actions. Classroom50 workflows won't run until then.\n",
+			_, _ = fmt.Fprintf(errOut, "Warning: %s: couldn't enable GitHub Actions (%v); this is often an enterprise-level policy an org admin can't override. Ask an enterprise admin to enable Actions for the org at https://github.com/organizations/%s/settings/actions. Classroom50 workflows won't run until then.\n",
 				org, err, org)
 			return nil
 		}
@@ -433,7 +433,7 @@ func ensureRepoActionsEnabled(client githubapi.Client, out, errOut io.Writer, ow
 
 	var perms repoActionsPermissions
 	if err := client.Get(path, &perms); err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: couldn't read Actions permissions (%v); make sure Actions is enabled at https://github.com/%s/%s/settings/actions — Classroom50's publish-pages and collect-scores workflows won't run without it.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: couldn't read Actions permissions (%v); make sure Actions is enabled at https://github.com/%s/%s/settings/actions. Classroom50's publish-pages and collect-scores workflows won't run without it.\n",
 			owner, repo, err, owner, repo)
 		return nil
 	}
@@ -451,7 +451,7 @@ func ensureRepoActionsEnabled(client githubapi.Client, out, errOut io.Writer, ow
 	resp, err := client.Request(http.MethodPut, path, bytes.NewReader(body))
 	if err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusForbidden) || cliutil.IsHTTPStatus(err, http.StatusConflict) || cliutil.IsHTTPStatus(err, http.StatusUnprocessableEntity) {
-			_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: couldn't enable Actions (%v); this is often an org or enterprise policy — enable it at https://github.com/%s/%s/settings/actions. Classroom50's publish-pages and collect-scores workflows won't run until then.\n",
+			_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: couldn't enable Actions (%v); this is often an org or enterprise policy. Enable it at https://github.com/%s/%s/settings/actions. Classroom50's publish-pages and collect-scores workflows won't run until then.\n",
 				owner, repo, err, owner, repo)
 			return nil
 		}
@@ -558,14 +558,14 @@ func setPagesPublic(client githubapi.Client, out, errOut io.Writer, owner, repo 
 				owner, repo)
 			return nil
 		}
-		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: couldn't set Pages visibility to public (%v); toggle it manually at https://github.com/%s/%s/settings/pages → Visibility if students see 404s on the Pages URL\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: couldn't set Pages visibility to public (%v); toggle it manually at https://github.com/%s/%s/settings/pages -> Visibility if students see 404s on the Pages URL\n",
 			owner, repo, err, owner, repo)
 		return nil
 	}
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode != http.StatusNoContent {
-		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: PUT /pages returned HTTP %d while setting visibility; toggle it manually at https://github.com/%s/%s/settings/pages → Visibility if students see 404s on the Pages URL\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: PUT /pages returned HTTP %d while setting visibility; toggle it manually at https://github.com/%s/%s/settings/pages -> Visibility if students see 404s on the Pages URL\n",
 			owner, repo, resp.StatusCode, owner, repo)
 		return nil
 	}
@@ -574,7 +574,7 @@ func setPagesPublic(client githubapi.Client, out, errOut io.Writer, owner, repo 
 	// and a read failure is silent (the PUT reported success), mirroring the
 	// org-lockdown read-back.
 	if public, known := readPagesPublic(client, owner, repo); known && !public {
-		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: set Pages visibility to public but a read-back shows it still private — likely pinned by an org or enterprise policy. Students fetch assignments.json unauthenticated, so a private Pages site breaks `gh student accept`. Set it manually at https://github.com/%s/%s/settings/pages → Visibility.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: set Pages visibility to public but a read-back shows it still private, likely pinned by an org or enterprise policy. Students fetch assignments.json unauthenticated, so a private Pages site breaks `gh student accept`. Set it manually at https://github.com/%s/%s/settings/pages -> Visibility.\n",
 			owner, repo, owner, repo)
 		return nil
 	}
@@ -746,7 +746,7 @@ func ensureClassroomRulesets(client githubapi.Client, out, errOut io.Writer, org
 			// Reconcile: PUT the current definition so a re-run picks up a
 			// changed branch pattern/rules instead of skipping it.
 			if err := updateOrgRuleset(client, org, id, rs); err != nil {
-				_, _ = fmt.Fprintf(errOut, "Warning: %s: could not update org ruleset %q (%v); review it at https://github.com/organizations/%s/settings/rules — a stale ruleset may %s.\n",
+				_, _ = fmt.Fprintf(errOut, "Warning: %s: could not update org ruleset %q (%v); review it at https://github.com/organizations/%s/settings/rules. A stale ruleset may %s.\n",
 					org, rs.Name, err, org, rulesetMissDescription(rs.Name))
 				allReady = false
 				continue
@@ -755,7 +755,7 @@ func ensureClassroomRulesets(client githubapi.Client, out, errOut io.Writer, org
 			continue
 		}
 		if err := createOrgRuleset(client, org, rs); err != nil {
-			_, _ = fmt.Fprintf(errOut, "Warning: %s: could not create org ruleset %q (%v); apply it manually at https://github.com/organizations/%s/settings/rules — without it students could %s.\n",
+			_, _ = fmt.Fprintf(errOut, "Warning: %s: could not create org ruleset %q (%v); apply it manually at https://github.com/organizations/%s/settings/rules. Without it students could %s.\n",
 				org, rs.Name, err, org, rulesetMissDescription(rs.Name))
 			allReady = false
 			continue
@@ -912,7 +912,7 @@ func enableReusableWorkflowAccess(client githubapi.Client, out, errOut io.Writer
 	resp, err := client.Request(http.MethodPut, path, bytes.NewReader(body))
 	if err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusForbidden) || cliutil.IsHTTPStatus(err, http.StatusConflict) {
-			_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: couldn't enable reusable-workflow access for the org (%v); student-repo autograde workflows may 403 on `uses:`. Retry with an org-admin token: gh api -X PUT /repos/%s/%s/actions/permissions/access -f access_level=organization — or toggle manually at https://github.com/%s/%s/settings/actions → Access if students see workflow-resolution errors.\n",
+			_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: couldn't enable reusable-workflow access for the org (%v); student-repo autograde workflows may 403 on `uses:`. Retry with an org-admin token: gh api -X PUT /repos/%s/%s/actions/permissions/access -f access_level=organization. Or toggle it manually at https://github.com/%s/%s/settings/actions -> Access if students see workflow-resolution errors.\n",
 				owner, repo, err, owner, repo, owner, repo)
 			return nil
 		}
@@ -921,7 +921,7 @@ func enableReusableWorkflowAccess(client githubapi.Client, out, errOut io.Writer
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode != http.StatusNoContent {
-		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: PUT /actions/permissions/access returned HTTP %d while enabling reusable-workflow access; retry with an org-admin token: gh api -X PUT /repos/%s/%s/actions/permissions/access -f access_level=organization — or toggle manually at https://github.com/%s/%s/settings/actions → Access if students see `uses:` errors.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s/%s: PUT /actions/permissions/access returned HTTP %d while enabling reusable-workflow access; retry with an org-admin token: gh api -X PUT /repos/%s/%s/actions/permissions/access -f access_level=organization. Or toggle it manually at https://github.com/%s/%s/settings/actions -> Access if students see `uses:` errors.\n",
 			owner, repo, resp.StatusCode, owner, repo, owner, repo)
 		return nil
 	}

--- a/cli/gh-teacher/init_repo_test.go
+++ b/cli/gh-teacher/init_repo_test.go
@@ -620,7 +620,7 @@ func TestApplyOrgMemberDefaults_FallbackTransportFailurePropagates(t *testing.T)
 	}
 	// #8: a transient mid-loop failure must surface the partial state
 	// (what landed / what was never attempted), not just a bare error.
-	if !strings.Contains(errOut.String(), "PARTIALLY APPLIED") {
+	if !strings.Contains(errOut.String(), "partially applied") {
 		t.Errorf("expected a partial-state warning on transient mid-loop failure, got: %q", errOut.String())
 	}
 

--- a/cli/gh-teacher/init_summary.go
+++ b/cli/gh-teacher/init_summary.go
@@ -107,7 +107,7 @@ func (s *initSummary) renderHuman(u *ui.UI) {
 	case s.LockdownComplete:
 		u.Result(preflightWarn, "%s: init finished with warnings", s.Org)
 	default:
-		u.Result(preflightFail, "%s: init INCOMPLETE — action needed", s.Org)
+		u.Result(preflightFail, "%s: init incomplete, action needed", s.Org)
 	}
 
 	// 2. Terse setup summary.
@@ -128,7 +128,7 @@ func (s *initSummary) renderHuman(u *ui.UI) {
 	if s.FeedbackPRReady {
 		u.Item("feedback PR prerequisites: ready")
 	} else {
-		u.Item("feedback PR prerequisites: incomplete — assignments using --feedback-pr may not open PRs")
+		u.Item("feedback PR prerequisites: incomplete; assignments using --feedback-pr may not open PRs")
 	}
 	switch s.BudgetCap {
 	case "created":
@@ -136,7 +136,7 @@ func (s *initSummary) renderHuman(u *ui.UI) {
 	case "present":
 		u.Item("actions budget cap: in place")
 	case "warn":
-		u.Item("actions budget cap: a budget over $%d is set — left as-is; lower it to $0 to hard-stop paid Actions minutes", orgpolicy.BudgetWarnThreshold)
+		u.Item("actions budget cap: a budget over $%d is set and was left as-is; lower it to $0 to hard-stop paid Actions minutes", orgpolicy.BudgetWarnThreshold)
 	case "unreadable":
 		u.Item("actions budget cap: couldn't verify (token lacks Organization Administration: Read); set a $0 Actions budget by hand")
 	case "failed":
@@ -157,7 +157,7 @@ func (s *initSummary) renderHuman(u *ui.UI) {
 	settingsURL := manualSettingsURL(s)
 	manual := s.manualActions()
 	if len(manual) > 0 {
-		u.Heading("Action required — set these by hand (org owner)")
+		u.Heading("Action required: set these by hand (org owner)")
 		// When incomplete, lead with the plan-aware reason.
 		if !s.LockdownComplete {
 			u.Detail("%s", unenforcedCause(s.Plan))

--- a/cli/gh-teacher/init_summary_test.go
+++ b/cli/gh-teacher/init_summary_test.go
@@ -150,8 +150,10 @@ func TestInitSummary_RenderHuman_IncompleteListsActions(t *testing.T) {
 	var buf bytes.Buffer
 	s.renderHuman(ui.NewForced(&buf, false))
 	out := buf.String()
-	if !strings.Contains(out, "INCOMPLETE") {
-		t.Errorf("incomplete run should banner INCOMPLETE:\n%s", out)
+	// Assert on the banner line specifically: a bare "incomplete" also matches
+	// the always-rendered feedback-PR checklist item.
+	if !strings.Contains(out, "init incomplete, action needed") {
+		t.Errorf("incomplete run should banner incomplete:\n%s", out)
 	}
 	// The lockdown manual fix is merged into the action checklist as a
 	// checkbox, ahead of the always-manual hardening steps.

--- a/cli/gh-teacher/internal/assignment/assignments_json.go
+++ b/cli/gh-teacher/internal/assignment/assignments_json.go
@@ -537,7 +537,7 @@ func validateRFC3339Field(field, value, example string) error {
 		return nil
 	}
 	if _, err := time.Parse(time.RFC3339, value); err != nil {
-		return fmt.Errorf("%s %q is not an RFC 3339 timestamp with timezone (e.g., %s)", field, value, example)
+		return fmt.Errorf("%s %q is not an RFC 3339 timestamp with timezone (for example %s)", field, value, example)
 	}
 	return nil
 }
@@ -880,14 +880,14 @@ func NextAvailableSlug(entries []AssignmentEntry, slug string, maxLen int) (stri
 		maxLen = slugMaxLen
 	}
 	if maxLen < 2 {
-		return "", fmt.Errorf("cannot derive a slug for %q: the target classroom leaves %d characters for a slug (student repo names are capped at %d by GitHub) — reuse into a classroom with a shorter short-name",
+		return "", fmt.Errorf("cannot derive a slug for %q: the target classroom leaves %d characters for a slug (student repo names are capped at %d by GitHub); reuse into a classroom with a shorter short-name",
 			slug, maxLen, slugMaxLen)
 	}
 	base := trimSlugTo(slug, maxLen)
 	if len(base) < 2 {
 		// A hyphen just inside the cut can trim the base below ShortName's
 		// 2-char minimum even when maxLen >= 2 (e.g. "a-..." at budget 2).
-		return "", fmt.Errorf("cannot derive a slug for %q within the %d-character budget (trimming leaves less than the 2-character minimum) — pass an explicit, shorter --slug",
+		return "", fmt.Errorf("cannot derive a slug for %q within the %d-character budget (trimming leaves less than the 2-character minimum); pass an explicit, shorter --slug",
 			slug, maxLen)
 	}
 	if !taken(base) {
@@ -907,7 +907,7 @@ func NextAvailableSlug(entries []AssignmentEntry, slug string, maxLen int) (stri
 		suffix := fmt.Sprintf("-%d", n)
 		room := maxLen - len(suffix)
 		if room < 1 || len(trimSlugTo(stem, room)) < 1 {
-			return "", fmt.Errorf("cannot auto-suffix slug %q within the %d-character budget — pass an explicit, shorter --slug", slug, maxLen)
+			return "", fmt.Errorf("cannot auto-suffix slug %q within the %d-character budget; pass an explicit, shorter --slug", slug, maxLen)
 		}
 		candidate := trimSlugTo(stem, room) + suffix
 		if !taken(candidate) {
@@ -1099,7 +1099,7 @@ func validateEmptyRepoExclusions(entry AssignmentEntry) error {
 // --no-autograder flag; the parse path wraps with the entry context.
 func validateNoAutograderExclusions(entry AssignmentEntry) error {
 	if entry.Template == nil {
-		return errors.New("no_autograder requires a template: it marks a TEMPLATED assignment as teacher-supplied CI (the template carries its own workflows); a template-less repo has no CI to run — use empty_repo for a bare repo instead")
+		return errors.New("no_autograder requires a template: it marks a templated assignment as teacher-supplied CI (the template carries its own workflows), and a template-less repo has no CI to run; use empty_repo for a bare repo instead")
 	}
 	if entry.EmptyRepo {
 		return errors.New("no_autograder is mutually exclusive with empty_repo: a bare repo already commits no shim")

--- a/cli/gh-teacher/internal/assignment/runtime.go
+++ b/cli/gh-teacher/internal/assignment/runtime.go
@@ -123,7 +123,7 @@ func ValidateRuntime(r RuntimeRef) error {
 			continue
 		}
 		if !LanguageVersionPattern.MatchString(pair.value) {
-			return fmt.Errorf("%s %q must match %s (e.g., \"3.14\", \"20\", \"1.23.4\")", pair.field, pair.value, LanguageVersionPattern.String())
+			return fmt.Errorf("%s %q must match %s (for example \"3.14\", \"20\", \"1.23.4\")", pair.field, pair.value, LanguageVersionPattern.String())
 		}
 	}
 
@@ -171,7 +171,7 @@ func ValidateContainer(c ContainerSpec) error {
 		return fmt.Errorf("runtime.container.image %q contains characters other than [A-Za-z0-9._:/@+-]", c.Image)
 	}
 	if c.User != "" && !ContainerUserPattern.MatchString(c.User) {
-		return fmt.Errorf("runtime.container.user %q must match %s (e.g., \"root\", \"0\", \"1000:1000\")", c.User, ContainerUserPattern.String())
+		return fmt.Errorf("runtime.container.user %q must match %s (for example \"root\", \"0\", \"1000:1000\")", c.User, ContainerUserPattern.String())
 	}
 	return nil
 }

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -37,18 +37,21 @@ func NewCmd() *cobra.Command {
 			"  add     register or upsert an assignment\n" +
 			"  remove  drop an assignment entry (does not touch existing student repos)\n" +
 			"  list    print every assignment slug registered in a classroom\n\n" +
-			"Writes use a single Tree commit on <org>/classroom50's default\n" +
-			"branch with the same optimistic-update-with-rebase loop the roster\n" +
-			"commands use, so concurrent edits don't silently lose each other's\n" +
-			"work. Each entry carries an immutable `slug` (the same name used in\n" +
-			"student repo names like `<classroom>-<slug>-<username>`), a\n" +
-			"template ref pointing at the starter-code repo, and the autograder\n" +
-			"name that picks which shim YAML (`<classroom>/autograders/<name>.yaml`)\n" +
-			"— and thus which reusable runner — handles submissions for this\n" +
-			"assignment. Per-assignment grading lives separately at\n" +
-			"`<classroom>/autograders/<slug>/autograder.py` (entrypoint),\n" +
-			"with optional sibling fixtures alongside (see the\n" +
-			"Advanced-Autograding wiki page).",
+			"Writes use a single commit on <org>/classroom50's default branch\n" +
+			"with the same optimistic-update-with-rebase loop the roster\n" +
+			"commands use, so concurrent edits don't silently lose each\n" +
+			"other's work.\n\n" +
+			"Each entry carries:\n" +
+			"  - an immutable `slug`, the same name used in student repo names\n" +
+			"    like `<classroom>-<slug>-<username>`\n" +
+			"  - a template ref pointing at the starter-code repository\n" +
+			"  - the autograder name, which picks the shim YAML\n" +
+			"    (`<classroom>/autograders/<name>.yaml`) and thus the reusable\n" +
+			"    runner that handles submissions for this assignment\n\n" +
+			"Per-assignment grading lives separately at\n" +
+			"`<classroom>/autograders/<slug>/autograder.py` (entrypoint), with\n" +
+			"optional sibling fixtures alongside (see the Advanced-Autograding\n" +
+			"wiki page).",
 	}
 	cmd.AddCommand(assignmentAddCmd())
 	cmd.AddCommand(assignmentReuseCmd())
@@ -90,63 +93,69 @@ func assignmentAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add <org> <classroom> <slug>",
 		Short: "Add or upsert an assignment in assignments.json",
-		Long: "Register an assignment — its template repo and the autograder it\n" +
-			"runs against — in <org>/classroom50/<classroom>/assignments.json.\n\n" +
-			"`<slug>` must match ^[a-z0-9][a-z0-9-]{1,99}$ (the same shape as\n" +
-			"classroom short-names) because student repos are named\n" +
-			"`<classroom>-<slug>-<username>`. Only --name is required;\n" +
-			"--template is optional (omit it for a template-less assignment).\n" +
-			"If the assignment slug already exists in assignments.json, this\n" +
-			"command replaces the entry in place (idempotent for repeated\n" +
-			"edits to the same assignment).\n\n" +
-			"--empty-repo creates truly bare student repos: no README, no\n" +
-			".classroom50.yaml marker, no autograde workflow — for assignments\n" +
-			"where students build everything (including their own GitHub\n" +
-			"Actions) from scratch. Autograding and the Feedback PR are\n" +
-			"disabled. The setting can be changed on a same-slug re-add, but\n" +
-			"repositories students already accepted are not retrofitted, so the\n" +
-			"change applies only to accepts from now on (a warning is printed).\n" +
-			"Mutually exclusive with --template, --tests, --feedback-pr,\n" +
-			"--allowed-files, --pass-threshold, --submission-mode, and\n" +
-			"--submission-tag.\n\n" +
-			"--template parses `<owner>/<repo>` (or `<owner>/<repo>@<branch>`).\n" +
-			"A custom source branch is tolerated but IGNORED — the assignment\n" +
-			"uses the template repo's default branch. To use a different branch,\n" +
-			"change the template repository's default branch first. The template\n" +
-			"repo must be marked `is_template: true` (set in Settings →\n" +
-			"\"Template repository\"); if your account can't see the repo, the CLI\n" +
-			"returns the cross-org visibility message.\n\n" +
-			"--runtime points at a JSON file describing the runtime\n" +
-			"environment for this assignment's autograde job: which\n" +
-			"runner label(s), optional language toolchains\n" +
-			"(python/node/java/go/rust), optional apt packages, or a custom\n" +
-			"container image. `runs-on` mirrors GitHub Actions itself —\n" +
-			"a single label (\"ubuntu-latest\") or an array of labels\n" +
-			"([\"self-hosted\", \"gpu\"]) for a custom / self-hosted runner.\n" +
-			"Pass `-` to read the JSON from stdin instead of a file\n" +
-			"(one-shot agent flows).\n" +
-			"Omit for the defaults (ubuntu-latest + Python 3.14).\n" +
-			"See the Advanced-Autograding wiki page for the JSON schema and\n" +
-			"worked examples.\n\n" +
-			"--autograder is reserved for the rare case where you need to\n" +
-			"call a *different reusable workflow* entirely (not just\n" +
-			"different language toolchains — for that, use --runtime). The\n" +
-			"name resolves to <classroom>/autograders/<name>.yaml; the\n" +
-			"referenced file must exist at write time. The default is\n" +
-			"`default`, which uses the universal shim embedded in\n" +
-			"gh-student — that shim `uses:` the autograde-runner workflow\n" +
-			"in the classroom50 repository.\n\n" +
-			"There are three ways to grade. (1) Declarative tests: pass\n" +
-			"--tests <file.json> here (or use `gh teacher assignment test\n" +
-			"add`) to describe io/run/python checks that the runner grades\n" +
-			"with no autograder.py. (2) A per-assignment autograder.py: drop\n" +
-			"an entrypoint plus any sibling fixtures at\n" +
-			"<classroom>/autograders/<slug>/ in the classroom50 repository (mutually\n" +
-			"exclusive with --tests). (3) A classroom default: run\n" +
-			"`gh teacher autograder set-default <org> <classroom>` to install\n" +
-			"<classroom>/autograder.py for every assignment. See the\n" +
-			"Advanced-Autograding wiki page for the result.json contract and\n" +
-			"templates (pytest, custom).",
+		Long: "Register an assignment (its template repository and the autograder\n" +
+			"it runs against) in <org>/classroom50/<classroom>/assignments.json.\n\n" +
+			"  - `<slug>` must match ^[a-z0-9][a-z0-9-]{1,99}$ (the same shape\n" +
+			"    as classroom short-names) because student repos are named\n" +
+			"    `<classroom>-<slug>-<username>`.\n" +
+			"  - Only --name is required; --template is optional (omit it for\n" +
+			"    a template-less assignment).\n" +
+			"  - If the slug already exists in assignments.json, the entry is\n" +
+			"    replaced in place (idempotent for repeated edits to the same\n" +
+			"    assignment).\n\n" +
+			"--empty-repo creates truly bare student repos:\n" +
+			"  - No README, no .classroom50.yaml marker, no autograde workflow:\n" +
+			"    for assignments where students build everything (including\n" +
+			"    their own GitHub Actions) from scratch.\n" +
+			"  - Autograding and the Feedback PR are disabled.\n" +
+			"  - Changing this on a same-slug re-add applies only to accepts\n" +
+			"    from now on; repositories students already accepted are not\n" +
+			"    retrofitted (a warning is printed).\n" +
+			"  - Mutually exclusive with --template, --tests, --feedback-pr,\n" +
+			"    --allowed-files, --pass-threshold, --submission-mode, and\n" +
+			"    --submission-tag.\n\n" +
+			"--template parses `<owner>/<repo>` (or `<owner>/<repo>@<branch>`):\n" +
+			"  - A custom source branch is tolerated but ignored; the\n" +
+			"    assignment uses the template repository's default branch. To\n" +
+			"    use a different branch, change the template repository's\n" +
+			"    default branch first.\n" +
+			"  - The template repository must be marked `is_template: true`\n" +
+			"    (set in Settings -> \"Template repository\").\n" +
+			"  - If your account can't see the repository, the CLI returns the\n" +
+			"    cross-org visibility message.\n\n" +
+			"--runtime points at a JSON file describing the runtime environment\n" +
+			"for this assignment's autograde job:\n" +
+			"  - Which runner label(s), optional language toolchains\n" +
+			"    (python/node/java/go/rust), optional apt packages, or a custom\n" +
+			"    container image.\n" +
+			"  - `runs-on` mirrors GitHub Actions itself: a single label\n" +
+			"    (\"ubuntu-latest\") or an array of labels\n" +
+			"    ([\"self-hosted\", \"gpu\"]) for a custom or self-hosted runner.\n" +
+			"  - Pass `-` to read the JSON from stdin instead of a file\n" +
+			"    (one-shot agent flows).\n" +
+			"  - Omit for the defaults (ubuntu-latest and Python 3.14). See the\n" +
+			"    Advanced-Autograding wiki page for the JSON schema and worked\n" +
+			"    examples.\n\n" +
+			"--autograder is reserved for the rare case where you need to call\n" +
+			"a different reusable workflow entirely (for different language\n" +
+			"toolchains, use --runtime instead):\n" +
+			"  - The name resolves to <classroom>/autograders/<name>.yaml; the\n" +
+			"    referenced file must exist at write time.\n" +
+			"  - The default is `default`, the universal shim embedded in\n" +
+			"    gh-student, which `uses:` the autograde-runner workflow in the\n" +
+			"    classroom50 repository.\n\n" +
+			"There are three ways to grade:\n" +
+			"  1. Declarative tests: pass --tests <file.json> here (or use\n" +
+			"     `gh teacher assignment test add`) to describe io/run/python\n" +
+			"     checks that the runner grades with no autograder script.\n" +
+			"  2. A per-assignment autograder: drop an entrypoint plus any\n" +
+			"     sibling fixtures at <classroom>/autograders/<slug>/ in the\n" +
+			"     classroom50 repository (mutually exclusive with --tests).\n" +
+			"  3. A classroom default: run\n" +
+			"     `gh teacher autograder set-default <org> <classroom>` to\n" +
+			"     install <classroom>/autograder.py for every assignment.\n\n" +
+			"See the Advanced-Autograding wiki page for the result.json\n" +
+			"contract and templates (pytest, custom).",
 		Example: "  gh teacher assignment add cs50-fall-2026 cs-principles hello \\\n" +
 			"      --name \"Hello\" --template cs50/hello-template \\\n" +
 			"      --due 2026-09-15T23:59:00-04:00\n" +
@@ -265,7 +274,7 @@ func assignmentAddCmd() *cobra.Command {
 				// surprised the branch had no effect.
 				if parsed.IgnoredBranch != "" {
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-						"warning: --template branch %q is ignored — the assignment uses %s/%s's default branch. To use a different branch, change the template repository's default branch.\n",
+						"warning: --template branch %q is ignored; the assignment uses %s/%s's default branch. To use a different branch, change the template repository's default branch.\n",
 						parsed.IgnoredBranch, parsed.Owner, parsed.Repo)
 				}
 				tmplArg = &parsed
@@ -315,24 +324,24 @@ func assignmentAddCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&name, "name", "", `Display name written into the assignment entry (e.g., "Hello") (required)`)
-	cmd.Flags().StringVar(&template, "template", "", "Optional template repo as <owner>/<repo> (or <owner>/<repo>@<branch>). Omit for a template-less assignment (students get an initialized repo: a README plus the autograding setup). A custom source branch (@<branch>) is tolerated but ignored — the assignment uses the template's default branch; change the template repo's default branch to use a different one.")
+	cmd.Flags().StringVar(&name, "name", "", `Display name written into the assignment entry, for example "Hello" (required)`)
+	cmd.Flags().StringVar(&template, "template", "", "Optional template repository as <owner>/<repo> (or <owner>/<repo>@<branch>). Omit for a template-less assignment (students get an initialized repo: a README plus the autograding setup). A custom source branch (@<branch>) is tolerated but ignored; the assignment uses the template's default branch, so change that to use a different one")
 	cmd.Flags().StringVar(&description, "description", "", "Optional one-line description")
-	cmd.Flags().StringVar(&due, "due", "", "Optional due date (e.g., 2026-09-15T23:59:00-04:00); stored as UTC. Omit the offset to use the machine's local timezone")
-	cmd.Flags().StringVar(&availableFrom, "available-from", "", "Optional release date (e.g., 2026-09-15T00:00:00-04:00); stored as UTC. Assignments are hidden from the student list by default (invite-link accept only); set this to list it for everyone once the date passes. Students who already accepted always see it (listing-only, not access control). Omit the offset to use the machine's local timezone.")
-	cmd.Flags().StringVar(&mode, "mode", assignment.ModeIndividual, "Assignment mode: `individual` (default) or `group`. Group mode requires --max-group-size.")
-	cmd.Flags().IntVar(&maxGroupSize, "max-group-size", 0, "Maximum collaborators on a group repo (>= 2; required with --mode group). Enforced within the CLI when students join; direct GitHub-UI invites can bypass it.")
+	cmd.Flags().StringVar(&due, "due", "", "Optional due date, for example 2026-09-15T23:59:00-04:00; stored as UTC. Omit the offset to use the machine's local timezone")
+	cmd.Flags().StringVar(&availableFrom, "available-from", "", "Optional release date, for example 2026-09-15T00:00:00-04:00; stored as UTC. Assignments are hidden from the student list by default (invite-link accept only); set this to list it for everyone once the date passes. Students who already accepted always see it (listing-only, not access control). Omit the offset to use the machine's local timezone")
+	cmd.Flags().StringVar(&mode, "mode", assignment.ModeIndividual, "Assignment mode: `individual` (default) or `group`. Group mode requires --max-group-size")
+	cmd.Flags().IntVar(&maxGroupSize, "max-group-size", 0, "Maximum collaborators on a group repo (>= 2; required with --mode group). Enforced within the CLI when students join; direct GitHub-UI invites can bypass it")
 	cmd.Flags().StringVar(&autograder, "autograder", contract.DefaultAutograderName, "Autograder workflow shim this assignment opts into; resolves to <classroom>/autograders/<name>.yaml in the classroom50 repository")
-	cmd.Flags().StringVar(&runtimeFile, "runtime", "", "Path to a JSON file describing the runtime environment (runs-on as a single label or an array of labels for self-hosted runners, python/node/java/go/rust versions, apt packages, or container image), or `-` to read from stdin. Omit for ubuntu-latest + Python 3.14.")
-	cmd.Flags().StringVar(&testsFile, "tests", "", "Path to a JSON file with a bare array of declarative test specs (io/run/python), or `-` to read from stdin. Sets the assignment's `tests` block; mutually exclusive with a per-assignment autograder.py. See `gh teacher assignment test --help`.")
-	cmd.Flags().BoolVar(&feedbackPR, "feedback-pr", true, "Open one long-lived Feedback pull request per student repo so you can leave inline review comments on the full starter→submission diff. Accept freezes a base branch at the baseline commit and opens the PR right away, so it exists even with GitHub Actions disabled; the autograde runner then adopts and maintains it (and opens it on the first submission if accept could not). Default on; pass --feedback-pr=false to disable. Requires `gh teacher init` to have set up the org prerequisites.")
-	cmd.Flags().BoolVar(&emptyRepo, "empty-repo", false, "Create truly bare student repos: no README/initial commit, no .classroom50.yaml marker, no autograde workflow — for assignments where students build the repo (including their own GitHub Actions) from scratch. Autograding and the Feedback PR are disabled. Changing this on a same-slug re-add applies only to accepts from now on (repositories students already accepted are not retrofitted; a warning is printed). Mutually exclusive with --template, --tests, --feedback-pr, --allowed-files, --pass-threshold, --submission-mode, and --submission-tag.")
-	cmd.Flags().StringArrayVar(&allowedFiles, "allowed-files", nil, "Ordered .gitignore-style pattern (repeatable, order preserved) defining which files belong to the submission. Last match wins; `!` re-includes. Pass `--allowed-files '*' --allowed-files '!hello.py'` to allow only hello.py. The autograde runner removes disallowed files before grading (control files are always kept); `gh student submit` filters them too. Omit to allow every file.")
-	cmd.Flags().IntVar(&passThreshold, "pass-threshold", 0, "Opt-in passing bar as a percentage of max score (0–100): at/above it the submissions page shows a submission as passing. Advisory/display-only — it does not change a student's score. Omit to leave it off (no passing concept); pass --pass-threshold 0 for an explicit 0%.")
-	cmd.Flags().StringVar(&studentPerm, "student-permission", "", "Optional collaborator role each student gets on their OWN assignment repo at accept time: one of pull, triage, push, maintain, admin. Omit for the default (push for individual, admin for group). Choose admin to let students manage repo settings and enable GitHub Pages. Applies to students who accept from now on; existing repos are unchanged. Caution: admin lets the student manage the repo's settings and collaborators; the org lockdown from `gh teacher init` still blocks members from changing repo visibility (verify with `gh teacher audit`).")
-	cmd.Flags().StringVar(&submissionMd, "submission-mode", contract.SubmissionModeEveryPush, "When the autograder fires: `every-push` (default; every push to the default branch grades) or `tag` (only submit/* tag pushes grade — `gh student submit` pushes the tag, or push any submit/* tag by hand; plain `git push` costs no Actions minutes). Baked into each student repo's shim at accept time; change it later with `gh teacher assignment submission-mode`, which also retrofits existing repos. Mutually exclusive with --empty-repo.")
-	cmd.Flags().StringArrayVar(&submissionTags, "submission-tag", nil, "Milestone tag pattern (repeatable) that ALSO triggers grading — e.g. --submission-tag phase1 --submission-tag phase2, or a glob like 'v*'. A student pushing a matching tag (`git tag phase1 && git push origin phase1`) gets that commit graded; the grading record still lives at the canonical submit/* tag the runner mints, so history and collection are unchanged. The canonical submit/* namespace always triggers too. Baked into the shim at accept time like --submission-mode (same retrofit to change later). Caution: a broad glob like 'v*' grades every matching tag a student pushes. Mutually exclusive with --empty-repo.")
-	cmd.Flags().StringVar(&repoVisibility, "repo-visibility", contract.RepoVisibilityPrivate, "Visibility each student repo is CREATED with at accept time: `private` (default) or `public` (for peer-review, portfolio, or showcase assignments — students are told upfront their work will be publicly visible). Applies to students who accept from now on; existing repos are unchanged (flip those from the gradebook's visibility actions). Caution with public: student work — names, emails, commit history — is visible to anyone on the internet from the moment the repo is created. If org policy blocks members from creating public repos, accept falls back to a private repo and tells the student.")
+	cmd.Flags().StringVar(&runtimeFile, "runtime", "", "Path to a JSON file describing the runtime environment (runs-on as a single label or an array of labels for self-hosted runners, python/node/java/go/rust versions, apt packages, or container image), or `-` to read from stdin. Omit for ubuntu-latest and Python 3.14")
+	cmd.Flags().StringVar(&testsFile, "tests", "", "Path to a JSON file with a bare array of declarative test specs (io/run/python), or `-` to read from stdin. Sets the assignment's `tests` block; mutually exclusive with a per-assignment autograder. See `gh teacher assignment test --help`")
+	cmd.Flags().BoolVar(&feedbackPR, "feedback-pr", true, "Open one long-lived Feedback pull request per student repo so you can leave inline review comments on the full starter-to-submission diff. Accept freezes a base branch at the baseline commit and opens the PR right away, so it exists even with GitHub Actions disabled; the autograde runner then adopts and maintains it (and opens it on the first submission if accept could not). Default on; pass --feedback-pr=false to disable. Requires `gh teacher init` to have set up the org prerequisites")
+	cmd.Flags().BoolVar(&emptyRepo, "empty-repo", false, "Create truly bare student repos (no README or initial commit, no .classroom50.yaml marker, no autograde workflow) for assignments where students build the repo, including their own GitHub Actions, from scratch. Autograding and the Feedback PR are disabled. Changing this on a same-slug re-add applies only to accepts from now on (repositories students already accepted are not retrofitted; a warning is printed). Mutually exclusive with --template, --tests, --feedback-pr, --allowed-files, --pass-threshold, --submission-mode, and --submission-tag")
+	cmd.Flags().StringArrayVar(&allowedFiles, "allowed-files", nil, "Ordered .gitignore-style pattern (repeatable, order preserved) defining which files belong to the submission. Last match wins; `!` re-includes. Pass `--allowed-files '*' --allowed-files '!hello.py'` to allow only hello.py. The autograde runner removes disallowed files before grading (control files are always kept); `gh student submit` filters them too. Omit to allow every file")
+	cmd.Flags().IntVar(&passThreshold, "pass-threshold", 0, "Opt-in passing bar as a percentage of max score (0-100): at or above it the submissions page shows a submission as passing. Advisory and display-only: it does not change a student's score. Omit to leave it off (no passing concept); pass --pass-threshold 0 for an explicit 0%")
+	cmd.Flags().StringVar(&studentPerm, "student-permission", "", "Optional collaborator role each student gets on their own assignment repo at accept time: one of pull, triage, push, maintain, admin. Omit for the default (push for individual, admin for group). Choose admin to let students manage repo settings and enable GitHub Pages. Applies to students who accept from now on; existing repos are unchanged. Caution: admin lets the student manage the repo's settings and collaborators; the org lockdown from `gh teacher init` still blocks members from changing repo visibility (verify with `gh teacher audit`)")
+	cmd.Flags().StringVar(&submissionMd, "submission-mode", contract.SubmissionModeEveryPush, "When the autograder fires: `every-push` (default; every push to the default branch grades) or `tag` (only submit/* tag pushes grade: `gh student submit` pushes the tag, or push any submit/* tag by hand; plain `git push` costs no Actions minutes). Baked into each student repo's shim at accept time; change it later with `gh teacher assignment submission-mode`, which also retrofits existing repos. Mutually exclusive with --empty-repo")
+	cmd.Flags().StringArrayVar(&submissionTags, "submission-tag", nil, "Milestone tag pattern (repeatable) that also triggers grading, for example --submission-tag phase1 --submission-tag phase2, or a glob like 'v*'. A student pushing a matching tag (`git tag phase1 && git push origin phase1`) gets that commit graded; the grading record still lives at the canonical submit/* tag the runner mints, so history and collection are unchanged. The canonical submit/* namespace always triggers too. Baked into the shim at accept time like --submission-mode (same retrofit to change later). Caution: a broad glob like 'v*' grades every matching tag a student pushes. Mutually exclusive with --empty-repo")
+	cmd.Flags().StringVar(&repoVisibility, "repo-visibility", contract.RepoVisibilityPrivate, "Visibility each student repo is created with at accept time: `private` (default) or `public` (for peer-review, portfolio, or showcase assignments; students are told upfront their work will be publicly visible). Applies to students who accept from now on; existing repos are unchanged (flip those from the gradebook's visibility actions). Caution with public: student work (names, emails, commit history) is visible to anyone on the internet from the moment the repo is created. If org policy blocks members from creating public repos, accept falls back to a private repo and tells the student")
 	return cmd
 }
 
@@ -346,15 +355,14 @@ func assignmentRemoveCmd() *cobra.Command {
 		Long: "Drop the assignment entry with matching slug from\n" +
 			"<org>/classroom50/<classroom>/assignments.json. Idempotent:\n" +
 			"if the slug is already absent, exits 0 with a note.\n\n" +
-			"Does NOT touch any existing student repos that were created\n" +
-			"against this assignment. The starter code and submission\n" +
-			"history stay intact; only new `gh student accept` invocations\n" +
-			"stop finding the slug.\n\n" +
-			"Because the repos survive, re-adding the SAME slug is not a\n" +
+			"Existing student repos created against this assignment are not\n" +
+			"touched. The starter code and submission history stay intact;\n" +
+			"only new `gh student accept` invocations stop finding the slug.\n\n" +
+			"Because the repos survive, re-adding the same slug is not a\n" +
 			"clean reset: an --empty-repo flag that differs from the removed\n" +
-			"entry leaves already-accepted repos on the old behavior — the\n" +
-			"change applies only to accepts from now on (a warning is printed;\n" +
-			"update existing repositories yourself).",
+			"entry leaves already-accepted repos on the old behavior. The\n" +
+			"change applies only to accepts from now on (a warning is\n" +
+			"printed; update existing repositories yourself).",
 		Example: "  gh teacher assignment remove cs50-fall-2026 cs-principles hello",
 		Args:    cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -394,17 +402,17 @@ func assignmentListCmd() *cobra.Command {
 		Short: "Print every assignment slug registered in a classroom",
 		Long: "List the slugs of every assignment registered in\n" +
 			"<org>/classroom50/<classroom>/assignments.json.\n\n" +
-			"Default output is one slug per line on stdout — pipeable\n" +
-			"directly into `xargs gh teacher download`, `grep`, or an\n" +
-			"agent loop. Pass --json to emit the full JSON array of\n" +
-			"assignment entries instead; that form preserves every field\n" +
-			"(template ref, due, mode, tests) so an agent can introspect\n" +
-			"the manifest without a second API call.\n\n" +
-			"A one-line summary (`<repo-path>: N assignment(s)`) is\n" +
-			"printed to stderr by default; pass --quiet to suppress it\n" +
-			"so stdout is the only output stream a capturing script has\n" +
-			"to parse.\n\n" +
-			"This is a read-only command; no commit lands on the repo.",
+			"  - Default output is one slug per line on stdout, pipeable\n" +
+			"    directly into `xargs gh teacher download`, `grep`, or an\n" +
+			"    agent loop.\n" +
+			"  - Pass --json to emit the full JSON array of assignment entries\n" +
+			"    instead; that form preserves every field (template ref, due,\n" +
+			"    mode, tests) so an agent can introspect the manifest without\n" +
+			"    a second API call.\n" +
+			"  - A one-line summary (`<repo-path>: N assignment(s)`) is printed\n" +
+			"    to stderr by default; pass --quiet to suppress it so stdout is\n" +
+			"    the only output stream a capturing script has to parse.\n\n" +
+			"This is a read-only command; no commit lands on the repository.",
 		Example: "  gh teacher assignment list cs50-fall-2026 cs-principles\n" +
 			"  gh teacher assignment list cs50-fall-2026 cs-principles --json\n" +
 			"  gh teacher assignment list -q cs50-fall-2026 cs-principles | xargs -I{} gh teacher download cs50-fall-2026 cs-principles {}",
@@ -485,7 +493,7 @@ func summarizeAssignmentList(org, classroom string, count int) string {
 	path := fmt.Sprintf("%s/%s/%s", org, configrepo.ConfigRepoName, assignmentsFilePath(classroom))
 	switch count {
 	case 0:
-		return fmt.Sprintf("%s: no assignments registered yet — use `gh teacher assignment add %s %s <slug>` to create one", path, org, classroom)
+		return fmt.Sprintf("%s: no assignments registered yet. Create one with `gh teacher assignment add %s %s <slug>`", path, org, classroom)
 	case 1:
 		return fmt.Sprintf("%s: 1 assignment", path)
 	default:
@@ -665,7 +673,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		// than letting every `student accept` 404 later.
 		inOrg = templateInOrg(ref.Owner, org)
 		if templatePrivate && !inOrg {
-			return fmt.Errorf("template `%s/%s` is private and outside the org %s — students can't be granted access to it, so `gh student accept` would fail. Copy it into %s and reference the copy, or make the template public",
+			return fmt.Errorf("template `%s/%s` is private and outside the org %s, so students can't be granted access to it and `gh student accept` would fail. Copy it into %s and reference the copy, or make the template public",
 				ref.Owner, ref.Repo, org, org)
 		}
 		// A cross-org fork works only while its upstream org keeps Classroom 50
@@ -758,7 +766,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 					org, configrepo.ConfigRepoName, autograderseam.FilePath(classroom, entry.Autograder), err)
 			}
 			if !exists {
-				return nil, fmt.Errorf("autograder %q does not exist at %s/%s/%s — create it (or pass --autograder default) before registering this assignment",
+				return nil, fmt.Errorf("autograder %q does not exist at %s/%s/%s: create it (or pass --autograder default) before registering this assignment",
 					entry.Autograder, org, configrepo.ConfigRepoName, autograderseam.FilePath(classroom, entry.Autograder))
 			}
 		}
@@ -797,7 +805,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 			// there would mint repos at renamed student repos' old names,
 			// permanently severing GitHub's redirects for every student clone.
 			if current, reserved := assignment.SlugReservedFold(file.Assignments, slug); reserved {
-				return nil, fmt.Errorf("slug %q is reserved: it is the pre-rename slug of assignment %q, and reusing it would permanently break GitHub's redirects for that assignment's renamed student repos — choose a different slug",
+				return nil, fmt.Errorf("slug %q is reserved: it is the pre-rename slug of assignment %q, and reusing it would permanently break GitHub's redirects for that assignment's renamed student repos. Choose a different slug",
 					slug, current)
 			}
 		}
@@ -997,33 +1005,33 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		}
 	}
 	if resolved != nil && templatePrivate && inOrg && committedLocked {
-		_, _ = fmt.Fprintf(errOut, "Note: %q is locked, so the classroom student team was NOT granted read on the private template %s/%s — unlock it with `gh teacher assignment lock %s %s %s --unlock` when you want students to accept again.\n",
+		_, _ = fmt.Fprintf(errOut, "Note: %q is locked, so the classroom student team was not granted read on the private template %s/%s. Unlock it with `gh teacher assignment lock %s %s %s --unlock` when you want students to accept again.\n",
 			slug, resolved.Owner, resolved.Repo, org, classroom, slug)
 	}
 	if droppedTests > 0 {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q dropped its %d declarative test(s) — `assignment add` rewrites the whole entry. Pass --tests to keep them, or re-add with `gh teacher assignment test add`.\n",
+			"Warning: replacing %q dropped its %d declarative test(s): `assignment add` rewrites the whole entry. Pass --tests to keep them, or re-add with `gh teacher assignment test add`.\n",
 			slug, droppedTests)
 	}
 	if droppedTemplate != nil {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q dropped its template %s/%s@%s — `assignment add` rewrites the whole entry, and you re-ran it without --template. The assignment is now template-less (students get an empty shim-only repo). Pass --template %s/%s@%s to keep it.\n",
+			"Warning: replacing %q dropped its template %s/%s@%s: `assignment add` rewrites the whole entry, and you re-ran it without --template. The assignment is now template-less (students get an empty shim-only repo). Pass --template %s/%s@%s to keep it.\n",
 			slug, droppedTemplate.Owner, droppedTemplate.Repo, droppedTemplate.Branch,
 			droppedTemplate.Owner, droppedTemplate.Repo, droppedTemplate.Branch)
 	}
 	if droppedAllowedCnt > 0 {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q dropped its %d allowed_files pattern(s) — `assignment add` rewrites the whole entry, and you re-ran it without --allowed-files. Submissions are now unrestricted. Pass --allowed-files to keep the allowlist.\n",
+			"Warning: replacing %q dropped its %d allowed_files pattern(s): `assignment add` rewrites the whole entry, and you re-ran it without --allowed-files. Submissions are now unrestricted. Pass --allowed-files to keep the allowlist.\n",
 			slug, droppedAllowedCnt)
 	}
 	if droppedPassThreshold != nil {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q dropped its pass_threshold (%d%%) — `assignment add` rewrites the whole entry, and you re-ran it without --pass-threshold. The passing bar (often set in the web app) is now off. Pass --pass-threshold %d to keep it.\n",
+			"Warning: replacing %q dropped its pass_threshold (%d%%): `assignment add` rewrites the whole entry, and you re-ran it without --pass-threshold. The passing bar (often set in the web app) is now off. Pass --pass-threshold %d to keep it.\n",
 			slug, *droppedPassThreshold, *droppedPassThreshold)
 	}
 	if droppedStudentPerm != "" {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q dropped its student_permission (%s) — `assignment add` rewrites the whole entry, and you re-ran it without --student-permission. New accepters revert to the mode default. Pass --student-permission %s to keep it.\n",
+			"Warning: replacing %q dropped its student_permission (%s): `assignment add` rewrites the whole entry, and you re-ran it without --student-permission. New accepters revert to the mode default. Pass --student-permission %s to keep it.\n",
 			slug, droppedStudentPerm, droppedStudentPerm)
 	}
 	// Provisioning-class changes only affect repos accepted from now on;
@@ -1032,7 +1040,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 	// reconciling any resulting inconsistency (mirrors the web app's confirm).
 	if changedEmptyRepo {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q changed its empty_repo setting. Repositories students already accepted are not retrofitted — they keep their original setup, and if autograding is now off their autograde runs start failing and drop out of the collected scores. The new setting applies only to accepts from now on; update existing repositories yourself.\n",
+			"Warning: replacing %q changed its empty_repo setting. Repositories students already accepted are not retrofitted: they keep their original setup, and if autograding is now off their autograde runs start failing and drop out of the collected scores. The new setting applies only to accepts from now on; update existing repositories yourself.\n",
 			slug)
 	}
 	// Heads-up if the encoded file nears GitHub's ~1 MiB contents-API limit
@@ -1040,7 +1048,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 	// Diagnostic only. See assignment.LargeAssignmentsWarnBytes.
 	if lastEncodedSize > assignment.LargeAssignmentsWarnBytes {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: %s/%s/%s is %d bytes — approaching GitHub's ~1 MiB contents-API ceiling. Past that, the API returns encoding:\"none\" and future `gh teacher assignment add/remove` calls will fail to read the file. Consider splitting the classroom or shrinking per-entry fields.\n",
+			"Warning: %s/%s/%s is %d bytes, approaching GitHub's ~1 MiB contents-API ceiling. Past that, the API returns encoding:\"none\" and future `gh teacher assignment add/remove` calls will fail to read the file. Consider splitting the classroom or shrinking per-entry fields.\n",
 			org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), lastEncodedSize)
 	}
 	// #691: a NEW over-budget slug is blocked in the build above, so reaching
@@ -1114,7 +1122,7 @@ func ensureClassroomActive(client githubapi.Client, org, classroom, ref string) 
 		return err
 	}
 	if ok && c.IsArchived() {
-		return fmt.Errorf("classroom %q is archived (classroom.json active:false) — new assignments are refused; run `gh teacher classroom unarchive %s %s` to re-activate it first",
+		return fmt.Errorf("classroom %q is archived (classroom.json active:false), so new assignments are refused. Run `gh teacher classroom unarchive %s %s` to re-activate it first",
 			classroom, org, classroom)
 	}
 	return nil
@@ -1258,7 +1266,7 @@ func validateTemplateRepo(client githubapi.Client, t templateArg, org string) (r
 	}
 	if err := client.Get(path, &resp); err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
-			return assignment.TemplateRef{}, false, "", fmt.Errorf("template `%s/%s` is not visible to your account — either make it public, or copy it into your org and reference the copy",
+			return assignment.TemplateRef{}, false, "", fmt.Errorf("template `%s/%s` is not visible to your account: either make it public, or copy it into your org and reference the copy",
 				t.Owner, t.Repo)
 		}
 		return assignment.TemplateRef{}, false, "", fmt.Errorf("GET %s: %w", path, err)
@@ -1302,7 +1310,7 @@ func templateInOrg(templateOwner, org string) bool {
 // branches probe) so this stays a pure, unit-testable function.
 func resolveTemplateBranch(t templateArg, isTemplate, hasCommits bool, defaultBranch string) (assignment.TemplateRef, error) {
 	if !isTemplate {
-		return assignment.TemplateRef{}, fmt.Errorf("`%s/%s` is not a template repository — toggle Settings → \"Template repository\" on the repo, then re-run", t.Owner, t.Repo)
+		return assignment.TemplateRef{}, fmt.Errorf("`%s/%s` is not a template repository: toggle Settings -> \"Template repository\" on the repo, then re-run", t.Owner, t.Repo)
 	}
 	// Caught before the empty-branch guard below (which a commitless repo's
 	// phantom default_branch would slip past). `hasCommits` is resolved by the
@@ -1311,13 +1319,13 @@ func resolveTemplateBranch(t templateArg, isTemplate, hasCommits bool, defaultBr
 	// when size is 0 (size is async and lags a fresh repo's real commits —
 	// issue #544).
 	if !hasCommits {
-		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no commits — add at least one commit (e.g. a README) so students can generate from it, then re-run", t.Owner, t.Repo)
+		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no commits: add at least one commit (a README is enough) so students can generate from it, then re-run", t.Owner, t.Repo)
 	}
 	branch := defaultBranch
 	if branch == "" {
 		// Not expected once size > 0, but a blank on-disk Branch would trip
 		// `student accept`, so guard it anyway.
-		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no default branch — push a commit to it, then re-run", t.Owner, t.Repo)
+		return assignment.TemplateRef{}, fmt.Errorf("template `%s/%s` has no default branch: push a commit to it, then re-run", t.Owner, t.Repo)
 	}
 	return assignment.TemplateRef{Owner: t.Owner, Repo: t.Repo, Branch: branch}, nil
 }

--- a/cli/gh-teacher/internal/assignmentcmd/lock.go
+++ b/cli/gh-teacher/internal/assignmentcmd/lock.go
@@ -27,16 +27,16 @@ func assignmentLockCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lock <org> <classroom> <slug>",
 		Short: "Lock (or --unlock) an assignment against student access",
-		Long: "Lock an assignment so students can no longer access it — the web\n" +
+		Long: "Lock an assignment so students can no longer access it: the web\n" +
 			"accept page, the student assignments list, the submission view, and\n" +
-			"`gh student accept` all refuse a locked assignment for EVERY student,\n" +
+			"`gh student accept` all refuse a locked assignment for every student,\n" +
 			"including ones who already accepted.\n\n" +
 			"Because assignments.json is published publicly to GitHub Pages, the\n" +
-			"client-side gates are best-effort UX. The ENFORCEABLE boundary applies\n" +
-			"only to a PRIVATE, in-org template: locking also removes the classroom\n" +
-			"STUDENT team's read on that template repo, so no new student can\n" +
+			"client-side gates are best-effort UX. The enforceable boundary applies\n" +
+			"only to a private, in-org template: locking also removes the classroom\n" +
+			"student team's read on that template repository, so no new student can\n" +
 			"generate a repo from it while locked. The teacher, head-TA, and TA\n" +
-			"teams are left untouched. Existing student repos are NOT deleted.\n\n" +
+			"teams are left untouched. Existing student repos are not deleted.\n\n" +
 			"Pass --unlock to reverse it: the flag is cleared and, for a private\n" +
 			"in-org template, the student team's read is re-granted so students\n" +
 			"can accept again.",
@@ -124,7 +124,7 @@ func runAssignmentLock(client githubapi.Client, out, errOut io.Writer, org, clas
 	}
 
 	if !found {
-		return fmt.Errorf("assignment %q not found in %s/%s/%s — nothing to %s",
+		return fmt.Errorf("assignment %q not found in %s/%s/%s: nothing to %s",
 			slug, org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), verb)
 	}
 
@@ -186,7 +186,7 @@ func revokeClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Wri
 	}
 	if err := configrepo.RemoveTeamRepo(client, org, team.Slug, tmplOwner, tmplRepo); err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusForbidden) && !cliutil.IsRateLimited(err) {
-			_, _ = fmt.Fprintf(errOut, "Warning: locked %q, but removing the student team %s read on the private template %s/%s needs an organization owner. Students may still be able to accept until an owner revokes it — re-run as an owner, use the web app, or remove the %s team from %s/%s in GitHub (Settings -> Collaborators and teams).\n",
+			_, _ = fmt.Fprintf(errOut, "Warning: locked %q, but removing the student team %s read on the private template %s/%s needs an organization owner. Students may still be able to accept until an owner revokes it: re-run as an owner, use the web app, or remove the %s team from %s/%s in GitHub (Settings -> Collaborators and teams).\n",
 				slug, team.Slug, tmplOwner, tmplRepo, team.Slug, tmplOwner, tmplRepo)
 			return nil
 		}

--- a/cli/gh-teacher/internal/assignmentcmd/rename.go
+++ b/cli/gh-teacher/internal/assignmentcmd/rename.go
@@ -40,10 +40,10 @@ func assignmentRenameCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "rename <org> <classroom> <old-slug> <new-slug>",
-		Short: "Rename an over-budget assignment slug and its student repos (one-shot)",
+		Short: "Rename an over-budget assignment slug and its repos (one-shot)",
 		Long: "Rename an assignment whose composed student-repo name\n" +
 			"`<classroom>-<slug>-<username>` can exceed GitHub's 100-character\n" +
-			"limit, renaming EVERY existing student repo to match. Offered only\n" +
+			"limit, renaming every existing student repo to match. Offered only\n" +
 			"for that remediation, and only once per assignment: the old slug is\n" +
 			"recorded as renamed_from and permanently reserved, because creating\n" +
 			"a new repo at a renamed repo's old name would sever the automatic\n" +
@@ -52,18 +52,18 @@ func assignmentRenameCmd() *cobra.Command {
 			"  1. One config commit: the slug changes, renamed_from records the\n" +
 			"     old slug, the scores.json bucket is re-keyed, a per-assignment\n" +
 			"     autograders/<slug>/ directory moves, and the assignment is\n" +
-			"     LOCKED so nobody accepts mid-rename.\n" +
-			"  2. Each student repo (matched by prefix AND verified by its\n" +
+			"     locked so nobody accepts mid-rename.\n" +
+			"  2. Each student repo (matched by prefix and verified by its\n" +
 			"     .classroom50.yaml marker): the marker's `assignment` field is\n" +
 			"     rewritten ([skip ci]), then the repo is renamed. GitHub\n" +
 			"     redirects git/web/API traffic from the old name indefinitely,\n" +
 			"     so student clones keep working; grading picks up the new slug\n" +
 			"     on the next run.\n" +
 			"  3. The lock is restored to its pre-rename state.\n\n" +
-			"Per-repo failures never abort the batch — they're reported with\n" +
-			"fixes, and RE-RUNNING THE SAME COMMAND resumes: already-renamed\n" +
+			"Per-repo failures never abort the batch: they're reported with\n" +
+			"fixes, and re-running the same command resumes. Already-renamed\n" +
 			"repos are skipped, stragglers are healed. Historical submissions\n" +
-			"keep their grades (collection accepts the pre-rename slug embedded\n" +
+			"keep their scores (collection accepts the pre-rename slug embedded\n" +
 			"in old result.json payloads via renamed_from).\n\n" +
 			"Students only need `git pull` once before their next\n" +
 			"`gh student submit` (the local marker must catch up); plain pushes\n" +
@@ -91,7 +91,7 @@ func assignmentRenameCmd() *cobra.Command {
 				return err
 			}
 			if strings.EqualFold(oldSlug, newSlug) {
-				return errors.New("old-slug and new-slug are the same — nothing to rename")
+				return errors.New("old-slug and new-slug are the same: nothing to rename")
 			}
 			if err := validate.ComposedRepoNameBudget(classroom, newSlug); err != nil {
 				return err
@@ -169,16 +169,16 @@ func runAssignmentRename(client githubapi.Client, in io.Reader, out, errOut io.W
 	if idx, ok := assignment.FindAssignment(preFile.Assignments, p.oldSlug); ok {
 		entry := preFile.Assignments[idx]
 		if entry.RenamedFrom != "" {
-			return fmt.Errorf("assignment %q was already renamed once (from %q) — a rename is one-shot, so it can't be renamed again", p.oldSlug, entry.RenamedFrom)
+			return fmt.Errorf("assignment %q was already renamed once (from %q); a rename is one-shot, so it can't be renamed again", p.oldSlug, entry.RenamedFrom)
 		}
 		if _, fits := contract.ComposedRepoNameFits(p.classroom, p.oldSlug); fits {
-			return fmt.Errorf("assignment %q fits the composed repo-name budget — rename is offered only to remediate a slug whose `<classroom>-<slug>-<username>` student-repo names can exceed GitHub's %d-character limit", p.oldSlug, contract.GitHubRepoNameMaxLen)
+			return fmt.Errorf("assignment %q fits the composed repo-name budget: rename is offered only to remediate a slug whose `<classroom>-<slug>-<username>` student-repo names can exceed GitHub's %d-character limit", p.oldSlug, contract.GitHubRepoNameMaxLen)
 		}
 		if assignment.SlugExistsFold(preFile.Assignments, p.newSlug) {
-			return fmt.Errorf("slug %q already exists in classroom %q — choose a different new-slug", p.newSlug, p.classroom)
+			return fmt.Errorf("slug %q already exists in classroom %q: choose a different new-slug", p.newSlug, p.classroom)
 		}
 		if current, reserved := assignment.SlugReservedFold(preFile.Assignments, p.newSlug); reserved {
-			return fmt.Errorf("slug %q is reserved: it is the pre-rename slug of assignment %q — choose a different new-slug", p.newSlug, current)
+			return fmt.Errorf("slug %q is reserved: it is the pre-rename slug of assignment %q. Choose a different new-slug", p.newSlug, current)
 		}
 		prevLocked = entry.Locked
 	} else if idx, ok := assignment.FindAssignment(preFile.Assignments, p.newSlug); ok &&
@@ -187,7 +187,7 @@ func runAssignmentRename(client githubapi.Client, in io.Reader, out, errOut io.W
 		// this is a deliberate re-run to heal stragglers).
 		resume = true
 	} else {
-		return fmt.Errorf("assignment %q not found in %s/%s/%s — run `gh teacher assignment list %s %s` to see available slugs",
+		return fmt.Errorf("assignment %q not found in %s/%s/%s: run `gh teacher assignment list %s %s` to see available slugs",
 			p.oldSlug, p.org, configrepo.ConfigRepoName, assignmentsFilePath(p.classroom), p.org, p.classroom)
 	}
 
@@ -218,7 +218,7 @@ func runAssignmentRename(client githubapi.Client, in io.Reader, out, errOut io.W
 		if resume {
 			mode = "resume"
 		}
-		_, _ = fmt.Fprintf(out, "%s %s/%s: %s %q -> %q — %d repo(s) to rename, %d to re-check\n",
+		_, _ = fmt.Fprintf(out, "%s %s/%s: %s %q -> %q: %d repo(s) to rename, %d to re-check\n",
 			p.org, configrepo.ConfigRepoName, p.classroom, mode, p.oldSlug, p.newSlug, len(toRename), len(toHeal))
 	}
 	if p.dryRun {
@@ -229,7 +229,7 @@ func runAssignmentRename(client githubapi.Client, in io.Reader, out, errOut io.W
 		for _, repo := range toHeal {
 			_, _ = fmt.Fprintf(out, "  would re-check the marker of %s\n", repo)
 		}
-		_, _ = fmt.Fprintln(errOut, "Dry-run complete — no API writes performed.")
+		_, _ = fmt.Fprintln(errOut, "Dry run complete. No API writes performed.")
 		return nil
 	}
 
@@ -242,7 +242,7 @@ func runAssignmentRename(client githubapi.Client, in io.Reader, out, errOut io.W
 			return fmt.Errorf("read confirmation: %w", err)
 		}
 		if strings.TrimSpace(line) != p.newSlug {
-			return errors.New("confirmation did not match the new slug — aborted with nothing written")
+			return errors.New("confirmation did not match the new slug: aborted with nothing written")
 		}
 	}
 
@@ -280,19 +280,19 @@ func runAssignmentRename(client githubapi.Client, in io.Reader, out, errOut io.W
 	// unknowable, so it is left alone with a note rather than guessed.
 	if !resume && !prevLocked {
 		if failed > 0 {
-			_, _ = fmt.Fprintf(errOut, "Note: %q stays LOCKED while %d repo(s) are unrenamed — an accept now would occupy a new repo name and strand a student's work. Re-run to heal them; the lock is restored when everything lands.\n",
+			_, _ = fmt.Fprintf(errOut, "Note: %q stays locked while %d repo(s) are unrenamed: an accept now would occupy a new repo name and strand a student's work. Re-run to heal them; the lock is restored when everything lands.\n",
 				p.newSlug, failed)
 		} else if err := setRenamedEntryLocked(client, p, branch, false); err != nil {
-			_, _ = fmt.Fprintf(errOut, "Warning: restoring the lock failed (%v) — unlock manually: gh teacher assignment lock %s %s %s --unlock\n",
+			_, _ = fmt.Fprintf(errOut, "Warning: restoring the lock failed (%v). Unlock manually: gh teacher assignment lock %s %s %s --unlock\n",
 				err, p.org, p.classroom, p.newSlug)
 		}
 	}
 	if resume {
 		if failed == 0 {
-			_, _ = fmt.Fprintf(errOut, "Note: resumed run complete — if the original rename locked %q, unlock it with `gh teacher assignment lock %s %s %s --unlock`.\n",
+			_, _ = fmt.Fprintf(errOut, "Note: resumed run complete. If the original rename locked %q, unlock it with `gh teacher assignment lock %s %s %s --unlock`.\n",
 				p.newSlug, p.org, p.classroom, p.newSlug)
 		} else {
-			_, _ = fmt.Fprintf(errOut, "Note: %q should stay locked while %d repo(s) are unrenamed — re-run to heal them before unlocking.\n",
+			_, _ = fmt.Fprintf(errOut, "Note: %q should stay locked while %d repo(s) are unrenamed. Re-run to heal them before unlocking.\n",
 				p.newSlug, failed)
 		}
 	}
@@ -317,18 +317,18 @@ func commitRenameConfig(client githubapi.Client, p renameParams, branch string) 
 		}
 		idx, ok := assignment.FindAssignment(file.Assignments, p.oldSlug)
 		if !ok {
-			return change, fmt.Errorf("assignment %q disappeared from %s during the rename — retry", p.oldSlug, assignmentsFilePath(p.classroom))
+			return change, fmt.Errorf("assignment %q disappeared from %s during the rename: retry", p.oldSlug, assignmentsFilePath(p.classroom))
 		}
 		// Re-assert the preflight invariants against this attempt's parent:
 		// a concurrent write must lose cleanly, never half-apply.
 		if file.Assignments[idx].RenamedFrom != "" {
-			return change, fmt.Errorf("assignment %q was renamed concurrently — nothing written", p.oldSlug)
+			return change, fmt.Errorf("assignment %q was renamed concurrently: nothing written", p.oldSlug)
 		}
 		if assignment.SlugExistsFold(file.Assignments, p.newSlug) {
-			return change, fmt.Errorf("slug %q was taken concurrently — nothing written", p.newSlug)
+			return change, fmt.Errorf("slug %q was taken concurrently: nothing written", p.newSlug)
 		}
 		if current, reserved := assignment.SlugReservedFold(file.Assignments, p.newSlug); reserved {
-			return change, fmt.Errorf("slug %q is reserved (pre-rename slug of %q) — nothing written", p.newSlug, current)
+			return change, fmt.Errorf("slug %q is reserved (pre-rename slug of %q): nothing written", p.newSlug, current)
 		}
 		file.Assignments[idx].Slug = p.newSlug
 		file.Assignments[idx].RenamedFrom = p.oldSlug
@@ -372,7 +372,7 @@ func commitRenameConfig(client githubapi.Client, p renameParams, branch string) 
 				return change, err
 			}
 			if !exists {
-				return change, fmt.Errorf("%s: listed but unreadable — retry", path)
+				return change, fmt.Errorf("%s: listed but unreadable, retry", path)
 			}
 			change.Upserts[newDir+strings.TrimPrefix(path, oldDir)] = string(content)
 			change.Deletes = append(change.Deletes, path)
@@ -401,7 +401,7 @@ func rekeyScoresBucket(raw []byte, oldSlug, newSlug string) ([]byte, bool, error
 		return nil, false, nil
 	}
 	if _, exists := buckets[newSlug]; exists {
-		return nil, false, fmt.Errorf("bucket %q already exists — refusing to overwrite it with the %q bucket", newSlug, oldSlug)
+		return nil, false, fmt.Errorf("bucket %q already exists: refusing to overwrite it with the %q bucket", newSlug, oldSlug)
 	}
 	buckets[newSlug] = bucket
 	delete(buckets, oldSlug)
@@ -428,7 +428,7 @@ func setRenamedEntryLocked(client githubapi.Client, p renameParams, branch strin
 		}
 		idx, ok := assignment.FindAssignment(file.Assignments, p.newSlug)
 		if !ok {
-			return nil, fmt.Errorf("assignment %q disappeared from %s — unlock manually", p.newSlug, assignmentsFilePath(p.classroom))
+			return nil, fmt.Errorf("assignment %q disappeared from %s: unlock manually", p.newSlug, assignmentsFilePath(p.classroom))
 		}
 		if file.Assignments[idx].Locked == locked {
 			return nil, nil
@@ -470,7 +470,7 @@ func renameOneRepo(client githubapi.Client, p renameParams, repo, oldPrefix, new
 	if notFound {
 		// The org listing said it exists; a 404 now means it was deleted (or
 		// renamed) concurrently — nothing to do, a re-run re-classifies.
-		res.outcome, res.reason = repoFailed, "repo disappeared during the rename — re-run to re-check"
+		res.outcome, res.reason = repoFailed, "repo disappeared during the rename; re-run to re-check"
 		return res
 	}
 
@@ -484,16 +484,16 @@ func renameOneRepo(client githubapi.Client, p renameParams, repo, oldPrefix, new
 			return nil, err
 		}
 		if !exists {
-			missing = "no " + contract.MetadataPath + " — ownership can't be verified, repo left untouched (re-accept heals the marker, then re-run)"
+			missing = "no " + contract.MetadataPath + ": ownership can't be verified, repo left untouched (re-accept heals the marker, then re-run)"
 			return nil, nil
 		}
 		rewritten, changed, current, err := rewriteMarkerAssignment(raw, p.oldSlug, p.newSlug)
 		if err != nil {
-			missing = fmt.Sprintf("unparseable %s (%v) — repo left untouched", contract.MetadataPath, err)
+			missing = fmt.Sprintf("unparseable %s (%v); repo left untouched", contract.MetadataPath, err)
 			return nil, nil
 		}
 		if current != "" {
-			foreign = fmt.Sprintf("marker names assignment %q — a sibling slug sharing the prefix, not %q; left untouched", current, p.oldSlug)
+			foreign = fmt.Sprintf("marker names assignment %q, a sibling slug sharing the prefix, not %q; left untouched", current, p.oldSlug)
 			return nil, nil
 		}
 		if !changed {
@@ -588,10 +588,10 @@ func renameRepoAPI(client githubapi.Client, org, repo, newName string) error {
 	resp, err := client.Request(http.MethodPatch, path, bytes.NewReader(body))
 	if err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusForbidden) {
-			return fmt.Errorf("rename to %q needs admin on the repo (or org ownership) — re-run as an owner: %w", newName, err)
+			return fmt.Errorf("rename to %q needs admin on the repo (or org ownership); re-run as an owner: %w", newName, err)
 		}
 		if cliutil.IsHTTPStatus(err, http.StatusUnprocessableEntity) {
-			return fmt.Errorf("rename to %q rejected — a repo may already exist at that name (https://github.com/%s/%s); resolve it and re-run: %w", newName, org, newName, err)
+			return fmt.Errorf("rename to %q rejected: a repo may already exist at that name (https://github.com/%s/%s); resolve it and re-run: %w", newName, org, newName, err)
 		}
 		return fmt.Errorf("PATCH %s: %w", path, err)
 	}
@@ -632,11 +632,11 @@ func summarizeRenameResults(out, errOut io.Writer, p renameParams, results []rep
 		}
 	}
 	if !p.quiet {
-		_, _ = fmt.Fprintf(out, "%s/%s: rename summary — %d renamed, %d marker(s) healed, %d already current, %d sibling(s) skipped, %d unverifiable, %d failed\n",
+		_, _ = fmt.Fprintf(out, "%s/%s: rename summary: %d renamed, %d marker(s) healed, %d already current, %d sibling(s) skipped, %d unverifiable, %d failed\n",
 			p.org, p.classroom, renamed, healed, current, foreign, noMarker, failed)
 	}
 	if failed > 0 {
-		return fmt.Errorf("%d repo(s) failed — the rename is idempotent, so fix the causes above and re-run the same command to heal them", failed)
+		return fmt.Errorf("%d repo(s) failed: the rename is idempotent, so fix the causes above and re-run the same command to heal them", failed)
 	}
 	return nil
 }

--- a/cli/gh-teacher/internal/assignmentcmd/rename_cmd_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/rename_cmd_test.go
@@ -416,7 +416,7 @@ func TestRunAssignmentRename_FailureKeepsLock(t *testing.T) {
 	if !strings.Contains(fix.assignments, `"locked": true`) {
 		t.Errorf("assignment must stay locked with a failed repo, final assignments.json:\n%s", fix.assignments)
 	}
-	if !strings.Contains(errOut.String(), "stays LOCKED") {
+	if !strings.Contains(errOut.String(), "stays locked") {
 		t.Errorf("errOut = %q, want the stays-locked note", errOut.String())
 	}
 }

--- a/cli/gh-teacher/internal/assignmentcmd/reuse.go
+++ b/cli/gh-teacher/internal/assignmentcmd/reuse.go
@@ -41,28 +41,32 @@ func assignmentReuseCmd() *cobra.Command {
 		Use:   "reuse <org> <source-slug> --from <source-classroom> --to <target-classroom>",
 		Short: "Copy an assignment from one classroom into another (same org)",
 		Long: "Duplicate an existing assignment record from one classroom's\n" +
-			"assignments.json into another classroom's, within the same org —\n" +
-			"the scriptable counterpart to the web's assignment reuse, ideal\n" +
-			"for rebuilding last term's assignments in a new classroom.\n\n" +
-			"The source record is copied verbatim (template, due/due_meta,\n" +
-			"mode, autograder, max_group_size, feedback_pr, runtime,\n" +
-			"allowed_files, release_assets, pass_threshold, student_permission,\n" +
-			"submission_mode, submission_tags, tests, description); only the\n" +
-			"slug and name change. By default the source slug/name are reused;\n" +
-			"pass --slug and/or --name to override.\n\n" +
+			"assignments.json into another classroom's, within the same\n" +
+			"organization: the scriptable counterpart to the web's assignment\n" +
+			"reuse, ideal for rebuilding last term's assignments in a new\n" +
+			"classroom.\n\n" +
+			"  - The source record is copied verbatim (template, due/due_meta,\n" +
+			"    mode, autograder, max_group_size, feedback_pr, runtime,\n" +
+			"    allowed_files, release_assets, pass_threshold,\n" +
+			"    student_permission, submission_mode, submission_tags, tests,\n" +
+			"    description); only the slug and name change.\n" +
+			"  - By default the source slug and name are reused; pass --slug\n" +
+			"    and/or --name to override.\n" +
+			"  - Slug collisions are refused case-insensitively (slugs become\n" +
+			"    GitHub repo path segments). Pass --slug to choose a free name,\n" +
+			"    or omit it to auto-suffix `-2`, `-3`, and so on off a\n" +
+			"    colliding slug.\n" +
+			"  - Refuses to write into an archived (active:false) target\n" +
+			"    classroom, mirroring `assignment add`.\n\n" +
 			"In-org only (v1): a private template can only be shared with the\n" +
-			"target classroom's team inside its own org, so cross-org reuse of\n" +
-			"a private template is out of scope. When the copied assignment\n" +
-			"references a private, org-owned template, the target classroom's\n" +
-			"team is re-granted read on it (the same grant `assignment add`\n" +
-			"performs) so rostered students can generate from it.\n\n" +
-			"Slug collisions are refused case-insensitively (slugs become\n" +
-			"GitHub repo path segments). Pass --slug to choose a free name, or\n" +
-			"omit it to auto-suffix `-2`, `-3`, … off a colliding slug.\n\n" +
-			"Refuses to write into an archived (active:false) target classroom,\n" +
-			"mirroring `assignment add`.\n\n" +
+			"target classroom's team inside its own organization, so cross-org\n" +
+			"reuse of a private template is out of scope. When the copied\n" +
+			"assignment references a private, org-owned template, the target\n" +
+			"classroom's team is re-granted read on it (the same grant\n" +
+			"`assignment add` performs) so rostered students can generate\n" +
+			"from it.\n\n" +
 			"Pass --json to emit the resolved copy ({org, classroom, slug,\n" +
-			"source_slug, auto_suffixed, template}) on stdout — scripts and\n" +
+			"source_slug, auto_suffixed, template}) on stdout. Scripts and\n" +
 			"agents should read the chosen slug from there rather than parsing\n" +
 			"the human summary, since an auto-suffixed slug isn't known until\n" +
 			"the write resolves the collision.",
@@ -101,7 +105,7 @@ func assignmentReuseCmd() *cobra.Command {
 				}
 			}
 			if fromClassroom == toClassroom && slugOverride == "" {
-				return errors.New("source and target classroom are the same — pass --slug to give the copy a distinct slug (an in-place reuse must rename)")
+				return errors.New("source and target classroom are the same: pass --slug to give the copy a distinct slug (an in-place reuse must rename)")
 			}
 			client, err := githubapi.RequireAuthClient(cmd)
 			if err != nil {
@@ -122,7 +126,7 @@ func assignmentReuseCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&from, "from", "", "Source classroom short-name to copy the assignment from (required)")
 	cmd.Flags().StringVar(&to, "to", "", "Target classroom short-name to copy the assignment into, same org (required)")
-	cmd.Flags().StringVar(&newSlug, "slug", "", "Slug for the copy in the target classroom (default: the source slug, auto-suffixed -2/-3/… on a case-insensitive collision)")
+	cmd.Flags().StringVar(&newSlug, "slug", "", "Slug for the copy in the target classroom (default: the source slug, auto-suffixed -2/-3/... on a case-insensitive collision)")
 	cmd.Flags().StringVar(&newName, "name", "", "Display name for the copy (default: the source name)")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit the resolved copy as JSON ({org, classroom, slug, source_slug, auto_suffixed, template}) on stdout instead of the human summary")
 	return cmd
@@ -183,7 +187,7 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 		}
 		idx, ok := assignment.FindAssignment(srcFile.Assignments, p.SourceSlug)
 		if !ok {
-			return nil, fmt.Errorf("assignment %q not found in source classroom %q (%s/%s/%s) — run `gh teacher assignment list %s %s` to see available slugs",
+			return nil, fmt.Errorf("assignment %q not found in source classroom %q (%s/%s/%s): run `gh teacher assignment list %s %s` to see available slugs",
 				p.SourceSlug, p.Org, configrepo.ConfigRepoName, p.From, assignmentsFilePath(p.From), p.Org, p.From)
 		}
 		// Copy verbatim through the typed entry; only slug/name are overridable.
@@ -211,13 +215,13 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 		autoSuffixed = false
 		if p.SlugWasSet {
 			if assignment.SlugExistsFold(dstFile.Assignments, p.SlugOverride) {
-				return nil, fmt.Errorf("slug %q already exists in target classroom %q (case-insensitive) — choose a different --slug",
+				return nil, fmt.Errorf("slug %q already exists in target classroom %q (case-insensitive): choose a different --slug",
 					p.SlugOverride, p.To)
 			}
 			// A renamed assignment's old slug is reserved (see SlugReservedFold):
 			// reusing it would sever GitHub's redirects for renamed student repos.
 			if current, reserved := assignment.SlugReservedFold(dstFile.Assignments, p.SlugOverride); reserved {
-				return nil, fmt.Errorf("slug %q is reserved in target classroom %q: it is the pre-rename slug of assignment %q — choose a different --slug",
+				return nil, fmt.Errorf("slug %q is reserved in target classroom %q: it is the pre-rename slug of assignment %q. Choose a different --slug",
 					p.SlugOverride, p.To, current)
 			}
 			finalSlug = p.SlugOverride
@@ -305,7 +309,7 @@ func runAssignmentReuse(client githubapi.Client, out, errOut io.Writer, p reuseA
 		// A locked copy has no student-team grant and can't be accepted yet, so
 		// skip the grant and point the teacher at unlock instead of the usual
 		// "students can now accept" hint.
-		_, _ = fmt.Fprintf(errOut, "Note: %q is locked, so the target classroom student team was NOT granted read on its private template.\n", finalSlug)
+		_, _ = fmt.Fprintf(errOut, "Note: %q is locked, so the target classroom student team was not granted read on its private template.\n", finalSlug)
 		_, _ = fmt.Fprintf(errOut, "Unlock it first: gh teacher assignment lock %s %s %s --unlock\n", p.Org, p.To, finalSlug)
 	} else {
 		if err := grantReusedTemplateAccess(client, grantOut, errOut, p.Org, p.To, branch, finalSlug, copied.Template); err != nil {
@@ -337,7 +341,7 @@ func grantReusedTemplateAccess(client githubapi.Client, out, errOut io.Writer, o
 		return nil // public template needs no grant
 	}
 	if !templateInOrg(tmpl.Owner, org) {
-		_, _ = fmt.Fprintf(errOut, "Warning: reused %q references the private out-of-org template %s/%s — it can't be team-granted to classroom %q (reuse is in-org only for private templates). Students won't be able to accept; copy the template into %s and re-add.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: reused %q references the private out-of-org template %s/%s, which can't be team-granted to classroom %q (reuse is in-org only for private templates). Students won't be able to accept; copy the template into %s and re-add.\n",
 			slug, tmpl.Owner, tmpl.Repo, classroom, org)
 		return nil
 	}
@@ -373,7 +377,7 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writ
 		return fmt.Errorf("assignment %s, but reading the %s team failed: %w", ctx.verb, ctx.classroomNoun, err)
 	}
 	if !ok {
-		return fmt.Errorf("assignment %q %s, but %s %q has no team to grant read on the private template %s/%s — run `gh teacher classroom add %s %s` to create the team%s (students can't accept until the team can read the template)",
+		return fmt.Errorf("assignment %q %s, but %s %q has no team to grant read on the private template %s/%s. Run `gh teacher classroom add %s %s` to create the team%s (students can't accept until the team can read the template)",
 			slug, ctx.verb, ctx.classroomNoun, classroom, tmplOwner, tmplRepo, org, classroom, ctx.rerunHint)
 	}
 	granted, err := configrepo.GrantTeamRepoRead(client, org, team.Slug, tmplOwner, tmplRepo)
@@ -384,7 +388,7 @@ func grantClassroomTeamTemplateRead(client githubapi.Client, out, errOut io.Writ
 		// denial — keep it fatal so a throttle stays a loud, non-zero-exit failure
 		// rather than misleading owner guidance. Only a non-rate-limited 403 is benign.
 		if cliutil.IsHTTPStatus(err, http.StatusForbidden) && !cliutil.IsRateLimited(err) {
-			_, _ = fmt.Fprintf(errOut, "Warning: assignment %s, but granting the %s team read on the private template %s/%s needs an organization owner (a non-owner can't grant repo access at GitHub). Students can't `gh student accept` until an owner grants it — re-run this command as an owner%s, open the classroom in the web app (which grants it automatically), or grant the %s team read on %s/%s directly in GitHub (Settings -> Collaborators and teams).\n",
+			_, _ = fmt.Fprintf(errOut, "Warning: assignment %s, but granting the %s team read on the private template %s/%s needs an organization owner (a non-owner can't grant repo access at GitHub). Students can't `gh student accept` until an owner grants it: re-run this command as an owner%s, open the classroom in the web app (which grants it automatically), or grant the %s team read on %s/%s directly in GitHub (Settings -> Collaborators and teams).\n",
 				ctx.verb, ctx.classroomNoun, tmplOwner, tmplRepo, ctx.rerunHint, team.Slug, tmplOwner, tmplRepo)
 			return nil
 		}

--- a/cli/gh-teacher/internal/assignmentcmd/submissionmode.go
+++ b/cli/gh-teacher/internal/assignmentcmd/submissionmode.go
@@ -54,33 +54,37 @@ func assignmentSubmissionModeCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "submission-mode <org> <classroom> <slug> (--every-push | --tag)",
-		Short: "Set when the autograder fires (every push vs. submit tags) and retrofit existing repos",
+		Short: "Set when the autograder fires and retrofit existing repos",
 		Long: "Set the assignment's submission mode and update the autograde shim in\n" +
 			"every existing student repo to match.\n\n" +
 			"Modes:\n" +
 			"  --every-push  every push to the default branch grades (the default\n" +
 			"                behavior); submit/* tag pushes grade too\n" +
-			"  --tag         ONLY submit/* tag pushes grade. `gh student submit`\n" +
+			"  --tag         only submit/* tag pushes grade. `gh student submit`\n" +
 			"                pushes the tag; a hand-pushed submit/* tag works too.\n" +
-			"                Plain `git push` costs no Actions minutes — the cost\n" +
-			"                lever for large cohorts.\n\n" +
+			"                Plain `git push` costs no Actions minutes, making\n" +
+			"                this the cost lever for large cohorts.\n\n" +
 			"The trigger lives in each student repo's shim (GitHub evaluates a\n" +
 			"workflow's `on:` block before any job runs), so changing the mode must\n" +
-			"rewrite `.github/workflows/autograde.yaml` across existing repos. That\n" +
-			"retrofit runs by default: enrollment comes from the classroom team, each\n" +
-			"member's <classroom>-<slug>-<user> repo is updated idempotently, and the\n" +
-			"commit carries `[skip ci]` so it never triggers grading. Repos whose shim\n" +
-			"doesn't match a known default-shim trigger shape (e.g., student-edited)\n" +
-			"are reported and left untouched. Students must `git pull` afterward —\n" +
-			"stale clones will conflict on their next push.\n\n" +
-			"Committing workflow files needs the `workflow` OAuth scope\n" +
-			"(`gh auth refresh -s workflow` if missing).\n\n" +
+			"rewrite `.github/workflows/autograde.yaml` across existing repos.\n\n" +
+			"The retrofit runs by default:\n" +
+			"  - Enrollment comes from the classroom team, and each member's\n" +
+			"    <classroom>-<slug>-<user> repo is updated idempotently.\n" +
+			"  - The commit carries `[skip ci]` so it never triggers grading.\n" +
+			"  - Repos whose shim doesn't match a known default-shim trigger\n" +
+			"    shape (student-edited, for example) are reported and left\n" +
+			"    untouched.\n" +
+			"  - Students must `git pull` afterward: stale clones will conflict\n" +
+			"    on their next push.\n" +
+			"  - Committing workflow files needs the `workflow` OAuth scope\n" +
+			"    (`gh auth refresh -s workflow` if missing).\n\n" +
 			"Custom-autograder assignments: the shim is teacher-authored, so this\n" +
 			"command refuses to rewrite it. Edit your autograder's `on:` block\n" +
 			"yourself, then re-run with --update-shims=false to flip only the field\n" +
 			"(which still controls whether submit clients push the tag).\n\n" +
-			"Pass --user to retrofit a single student's repo (e.g., one that was\n" +
-			"skipped or failed on a previous run); the field flip is idempotent.",
+			"Pass --user to retrofit a single student's repo (one that was\n" +
+			"skipped or failed on a previous run, say); the field flip is\n" +
+			"idempotent.",
 		Example: "  gh teacher assignment submission-mode cs50-fall-2026 cs-principles hello --tag\n" +
 			"  gh teacher assignment submission-mode cs50-fall-2026 cs-principles hello --every-push\n" +
 			"  gh teacher assignment submission-mode cs50-fall-2026 cs-principles hello --tag --user alice\n" +
@@ -194,13 +198,13 @@ func runSubmissionMode(client githubapi.Client, out, errOut io.Writer, p submiss
 	}
 	customAutograder := preEntry.Autograder != "" && preEntry.Autograder != contract.DefaultAutograderName
 	if customAutograder && p.updateShims {
-		return fmt.Errorf("assignment %q uses the custom autograder %q — its shim is teacher-authored and this command never rewrites it. Edit that autograder's `on:` trigger yourself, then re-run with --update-shims=false to flip only the field (which controls whether submit clients push the tag)",
+		return fmt.Errorf("assignment %q uses the custom autograder %q, whose shim is teacher-authored, and this command never rewrites it. Edit that autograder's `on:` trigger yourself, then re-run with --update-shims=false to flip only the field (which controls whether submit clients push the tag)",
 			p.slug, preEntry.Autograder)
 	}
 
 	if p.dryRun {
 		if preEntry.SubmissionMode == wireMode {
-			_, _ = fmt.Fprintf(out, "dry run: %s already has submission_mode %s — no field change\n", p.slug, p.mode)
+			_, _ = fmt.Fprintf(out, "dry run: %s already has submission_mode %s, no field change\n", p.slug, p.mode)
 		} else {
 			_, _ = fmt.Fprintf(out, "dry run: would set submission_mode of %s to %s\n", p.slug, p.mode)
 		}
@@ -212,7 +216,7 @@ func runSubmissionMode(client githubapi.Client, out, errOut io.Writer, p submiss
 			}
 			idx, ok := assignment.FindAssignment(file.Assignments, p.slug)
 			if !ok {
-				return nil, fmt.Errorf("assignment %q disappeared from %s during the update — retry",
+				return nil, fmt.Errorf("assignment %q disappeared from %s during the update: retry",
 					p.slug, assignmentsFilePath(p.classroom))
 			}
 			entry := file.Assignments[idx]
@@ -260,7 +264,7 @@ func runSubmissionMode(client githubapi.Client, out, errOut io.Writer, p submiss
 	}
 	if len(repos) == 0 {
 		if !p.quiet {
-			_, _ = fmt.Fprintf(out, "%s: no repos to process — the classroom's student team has no members (sync the roster, or target one repo with --user <login>)\n", p.org)
+			_, _ = fmt.Fprintf(out, "%s: no repos to process: the classroom's student team has no members (sync the roster, or target one repo with --user <login>)\n", p.org)
 		}
 		return nil
 	}
@@ -277,9 +281,9 @@ func runSubmissionMode(client githubapi.Client, out, errOut io.Writer, p submiss
 			// "0 repo(s)" — that looks like an enumeration failure).
 			notAccepted++
 			if p.user != "" {
-				_, _ = fmt.Fprintf(out, "%s does not exist — %s has not accepted %s yet\n", repo, p.user, p.slug)
+				_, _ = fmt.Fprintf(out, "%s does not exist: %s has not accepted %s yet\n", repo, p.user, p.slug)
 			} else if p.verbose && !p.quiet {
-				_, _ = fmt.Fprintf(out, "Skipped %s (no repo — not accepted yet?)\n", repo)
+				_, _ = fmt.Fprintf(out, "Skipped %s (no repo; not accepted yet?)\n", repo)
 			}
 			continue
 		}
@@ -343,7 +347,7 @@ func retrofitShim(client githubapi.Client, org, repo, mode string, tags []string
 			// Repo exists but the shim never landed (a mid-flow accept
 			// failure). Accept's self-heal owns that case; nothing safe to
 			// rewrite here.
-			unrecognized = errors.New("no " + autogradeShimPath + " — accept may not have completed; re-accept heals it")
+			unrecognized = errors.New("no " + autogradeShimPath + ": accept may not have completed; re-accept heals it")
 			return nil, nil
 		}
 		updated, changed, err := rewriteShimTrigger(string(current), mode, branch, tags)
@@ -375,7 +379,7 @@ func retrofitShim(client githubapi.Client, org, repo, mode string, tags []string
 	commitSHA, err := configwrite.CommitTree(client, org, repo, branch, contract.ShimUpdateCommitMessage(mode), build)
 	if err != nil {
 		if errors.Is(err, configwrite.ErrMissingWorkflowScope) {
-			return shimResult{repo: repo, outcome: shimFailed, reason: "token lacks the `workflow` OAuth scope — run `gh auth refresh -s workflow` and re-run"}
+			return shimResult{repo: repo, outcome: shimFailed, reason: "token lacks the `workflow` OAuth scope: run `gh auth refresh -s workflow` and re-run"}
 		}
 		return shimResult{repo: repo, outcome: shimFailed, reason: err.Error()}
 	}
@@ -404,7 +408,7 @@ func retrofitShim(client githubapi.Client, org, repo, mode string, tags []string
 func rewriteShimTrigger(content, mode string, branch string, tags []string) (string, bool, error) {
 	loc := shimTriggerBlock.FindStringSubmatchIndex(content)
 	if loc == nil {
-		return "", false, errors.New("shim does not carry a recognizable default trigger block — left untouched (student-edited?)")
+		return "", false, errors.New("shim does not carry a recognizable default trigger block; left untouched (student-edited?)")
 	}
 	hasBranches := loc[2] != -1
 
@@ -502,15 +506,15 @@ func summarizeShimResults(out, errOut io.Writer, p submissionModeParams, results
 		_, _ = fmt.Fprintf(out, "%s: %d %s, %d already current, %d skipped, %d failed (of %d repo(s))\n",
 			p.org, updated, verb, current, len(unrecognized), len(failed), len(results)+notAccepted)
 		if notAccepted > 0 {
-			_, _ = fmt.Fprintf(out, "%d enrolled student(s) have not accepted %s yet — their repos will get the new trigger at accept time\n", notAccepted, p.slug)
+			_, _ = fmt.Fprintf(out, "%d enrolled student(s) have not accepted %s yet; their repos will get the new trigger at accept time\n", notAccepted, p.slug)
 		}
 		if updated > 0 && !p.dryRun {
-			_, _ = fmt.Fprintln(out, "Tell students to `git pull` — clones made before this change will conflict on their next push.")
+			_, _ = fmt.Fprintln(out, "Tell students to `git pull`: clones made before this change will conflict on their next push.")
 		}
 	}
 
 	if len(unrecognized) > 0 {
-		_, _ = fmt.Fprintln(errOut, "Skipped (shim content not recognized — review and update by hand if intended):")
+		_, _ = fmt.Fprintln(errOut, "Skipped (shim content not recognized; review and update by hand if intended):")
 		for _, r := range unrecognized {
 			_, _ = fmt.Fprintf(errOut, "  %s: %s\n", r.repo, r.reason)
 		}

--- a/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
+++ b/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
@@ -26,10 +26,13 @@ func assignmentTestCmd() *cobra.Command {
 		Use:   "test",
 		Short: "Add, list, or remove declarative tests on an assignment",
 		Long: "Manage the declarative `tests` block on an assignment in\n" +
-			"<org>/classroom50/<classroom>/assignments.json. Each test is one\n" +
-			"of three types -- io (compare stdout), run (check exit code), or\n" +
-			"python (run pytest) -- mirroring GitHub Classroom's autograding.\n" +
-			"Describe tests here instead of writing an autograder.py: the\n" +
+			"<org>/classroom50/<classroom>/assignments.json.\n\n" +
+			"Each test is one of three types, mirroring GitHub Classroom's\n" +
+			"autograding:\n" +
+			"  - io      compare stdout\n" +
+			"  - run     check the exit code\n" +
+			"  - python  run pytest\n\n" +
+			"Describe tests here instead of writing an autograder script: the\n" +
 			"publish-pages workflow materializes them into the assignment's\n" +
 			"Pages bundle and runner.py grades them on every submission. See\n" +
 			"the Autograding-Basics wiki page for the field reference.\n\n" +
@@ -67,19 +70,21 @@ func assignmentTestAddCmd() *cobra.Command {
 		Long: "Add a test to the assignment's `tests` block, or replace the\n" +
 			"existing test with the same --name (names are unique within an\n" +
 			"assignment). Required: --name, --type, --run.\n\n" +
-			"--type io: feed --input (or --input-file) on stdin, compare the\n" +
-			"  command's stdout against --expected (or --expected-file) using\n" +
-			"  --comparison (included | exact | regex).\n" +
-			"--type run: pass iff the command's exit code matches --exit-code\n" +
-			"  (default 0).\n" +
-			"--type python: run pytest; points are split across discovered\n" +
-			"  cases at grade time.\n\n" +
+			"Types:\n" +
+			"  - io: feed --input (or --input-file) on stdin, compare the\n" +
+			"    command's stdout against --expected (or --expected-file)\n" +
+			"    using --comparison (included | exact | regex).\n" +
+			"  - run: pass only when the command's exit code matches\n" +
+			"    --exit-code (default 0).\n" +
+			"  - python: run pytest; points are split across discovered cases\n" +
+			"    at grade time.\n\n" +
 			"--input-file / --expected-file name a fixture file the teacher\n" +
 			"has committed alongside the assignment at\n" +
-			"<classroom>/autograders/<slug>/ in the classroom50 repository; it is bundled\n" +
-			"and read at grade time. Fails if the assignment slug isn't\n" +
-			"registered yet, or if the assignment already has a hand-written\n" +
-			"per-assignment autograder.py (the two are mutually exclusive).",
+			"<classroom>/autograders/<slug>/ in the classroom50 repository; it\n" +
+			"is bundled and read at grade time.\n\n" +
+			"Fails if the assignment slug isn't registered yet, or if the\n" +
+			"assignment already has a hand-written per-assignment autograder\n" +
+			"(the two are mutually exclusive).",
 		Example: "  gh teacher assignment test add cs50-fall-2026 cs-principles hello \\\n" +
 			"      --name compiles --type run --run \"gcc -o hello hello.c\" --points 1\n" +
 			"  gh teacher assignment test add cs50-fall-2026 cs-principles hello \\\n" +
@@ -142,7 +147,7 @@ func assignmentTestAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&name, "name", "", "Test name, unique within the assignment (required)")
 	cmd.Flags().StringVar(&ttype, "type", "", "Test type: io | run | python (required)")
 	cmd.Flags().StringVar(&run, "run", "", "Command to run (required)")
-	cmd.Flags().StringVar(&setup, "setup", "", "Optional command run before --run (e.g., compile)")
+	cmd.Flags().StringVar(&setup, "setup", "", "Optional command run before --run (a compile step, for example)")
 	cmd.Flags().StringVar(&input, "input", "", "io only: inline stdin for the run command")
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "io only: bundled fixture file fed on stdin")
 	cmd.Flags().StringVar(&expected, "expected", "", "io only: inline expected stdout")
@@ -180,7 +185,7 @@ func runAssignmentTestAdd(client githubapi.Client, out io.Writer, org, classroom
 		}
 		idx, ok := assignment.FindAssignment(file.Assignments, slug)
 		if !ok {
-			return nil, fmt.Errorf("assignment %q is not registered in %s/%s/%s — run `gh teacher assignment add %s %s %s ...` first",
+			return nil, fmt.Errorf("assignment %q is not registered in %s/%s/%s: run `gh teacher assignment add %s %s %s ...` first",
 				slug, org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), org, classroom, slug)
 		}
 		entry := file.Assignments[idx]
@@ -287,7 +292,7 @@ func runAssignmentTestList(client githubapi.Client, out, errOut io.Writer, org, 
 		path := fmt.Sprintf("%s/%s/%s [%s]", org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), slug)
 		switch len(tests) {
 		case 0:
-			_, _ = fmt.Fprintf(errOut, "%s: no declarative tests — add one with `gh teacher assignment test add %s %s %s ...`\n", path, org, classroom, slug)
+			_, _ = fmt.Fprintf(errOut, "%s: no declarative tests. Add one with `gh teacher assignment test add %s %s %s ...`\n", path, org, classroom, slug)
 		case 1:
 			_, _ = fmt.Fprintf(errOut, "%s: 1 test\n", path)
 		default:
@@ -398,7 +403,7 @@ func ensureDeclarativeTestsSupported(client githubapi.Client, org, ref string) e
 		return fmt.Errorf("check %s/%s/%s: %w", org, configrepo.ConfigRepoName, materializeScriptPath, err)
 	}
 	if !exists {
-		return fmt.Errorf("%s/%s is missing %s, so declarative tests would never run — re-run `gh teacher init %s` to update the workflow files, then retry",
+		return fmt.Errorf("%s/%s is missing %s, so declarative tests would never run: re-run `gh teacher init %s` to update the workflow files, then retry",
 			org, configrepo.ConfigRepoName, materializeScriptPath, org)
 	}
 	return nil
@@ -414,7 +419,7 @@ func ensureNoPerAssignmentAutograder(client githubapi.Client, org, classroom, sl
 		return fmt.Errorf("check %s/%s/%s: %w", org, configrepo.ConfigRepoName, path, err)
 	}
 	if exists {
-		return fmt.Errorf("assignment %q has a per-assignment autograder at %s/%s/%s — declarative tests and a hand-written autograder.py are mutually exclusive (the runner prefers autograder.py); remove it before adding tests",
+		return fmt.Errorf("assignment %q has a per-assignment autograder at %s/%s/%s: declarative tests and a hand-written autograder.py are mutually exclusive (the runner prefers autograder.py); remove it before adding tests",
 			slug, org, configrepo.ConfigRepoName, path)
 	}
 	return nil

--- a/cli/gh-teacher/internal/audit/audit.go
+++ b/cli/gh-teacher/internal/audit/audit.go
@@ -43,8 +43,8 @@ func NewCmd() *cobra.Command {
 		Long: "Re-read an organization and report whether the least-privilege\n" +
 			"member-privilege lockdown that `gh teacher init` applies is\n" +
 			"actually in effect. Read-only: makes no changes.\n\n" +
-			"Use it to confirm a manual fix took hold — e.g., after you\n" +
-			"unchecked the boxes from init's \"Action required\" list — without\n" +
+			"Use it to confirm a manual fix took hold (after you unchecked\n" +
+			"the boxes from init's \"Action required\" list, say) without\n" +
 			"re-running init.\n\n" +
 			"Reports two groups:\n" +
 			"  - API-readable settings: audit reads each live value and flags\n" +
@@ -52,11 +52,11 @@ func NewCmd() *cobra.Command {
 			"  - The four web-UI-only settings (app access requests, repo-admin\n" +
 			"    GitHub App installs, Projects base permissions, branch renames):\n" +
 			"    GitHub exposes no REST API to read these, so audit can't\n" +
-			"    confirm them — it lists them for you to eyeball by hand.\n\n" +
-			"Exit status is non-zero when ANY API-readable lockdown field\n" +
+			"    confirm them; it lists them for you to eyeball by hand.\n\n" +
+			"Exit status is non-zero when any API-readable lockdown field\n" +
 			"is unenforced (scriptable); the unreadable manual items\n" +
 			"never fail the command.\n\n" +
-			"Flags: --json (machine-readable report on stdout).",
+			"Pass --json for a machine-readable report on stdout.",
 		Example: "  gh teacher audit cs50-fall-2026\n" +
 			"  gh teacher audit cs50-fall-2026 --json",
 		Args: cobra.ExactArgs(1),
@@ -92,7 +92,7 @@ func NewCmd() *cobra.Command {
 				report.renderHuman(ui.New(cmd.ErrOrStderr()))
 			}
 			if !report.LockdownComplete {
-				return errors.New("org member-privilege lockdown INCOMPLETE — see the report above")
+				return errors.New("org member-privilege lockdown is incomplete: see the report above")
 			}
 			return nil
 		},
@@ -311,7 +311,7 @@ func (r *auditReport) renderHuman(u *ui.UI) {
 	}
 
 	if len(r.Unenforced) > 0 || r.BudgetCap.isCritical() {
-		u.Heading("Action required — these are NOT locked down")
+		u.Heading("Action required: these are not locked down")
 		for _, s := range r.Unenforced {
 			label := s.Fix
 			if label == "" {

--- a/cli/gh-teacher/internal/auth/login.go
+++ b/cli/gh-teacher/internal/auth/login.go
@@ -23,7 +23,7 @@ func NewLoginCmd() *cobra.Command {
 			"endpoints (`gh teacher invite`), and workflow lets `gh teacher\n" +
 			"init` commit the classroom50 repository's `.github/workflows/` files\n" +
 			"(GitHub 404s that Git Data API write without it).\n\n" +
-			"delete_repo is NOT requested by default — opt in with\n" +
+			"delete_repo is not requested by default; opt in with\n" +
 			"`gh teacher login -s delete_repo` for `gh teacher teardown`.\n\n" +
 			"Additional scopes can be added with -s; they are appended to the\n" +
 			"login request the same way `gh auth login -s` accepts them.",

--- a/cli/gh-teacher/internal/classroom/classroom.go
+++ b/cli/gh-teacher/internal/classroom/classroom.go
@@ -42,7 +42,7 @@ func NewCmd() *cobra.Command {
 		Short: "Manage classroom directories inside the classroom50 repository",
 		Long: "Manage classrooms within an org's classroom50 repository.\n\n" +
 			"A classroom is a directory at the root of <org>/classroom50,\n" +
-			"named by its short-name (e.g., cs-principles). Each classroom\n" +
+			"named by its short-name (cs-principles, say). Each classroom\n" +
 			"holds four files: classroom.json (metadata), assignments.json\n" +
 			"(assignment manifest), roster.csv (roster), and scores.json\n" +
 			"(collected scores). The runner-side bootstrap (runner.py)\n" +
@@ -90,14 +90,15 @@ func classroomAddCmd() *cobra.Command {
 			"assignment slug and any username.\n\n" +
 			"Unlisted resources (opt-in): pass --unlisted to publish this\n" +
 			"classroom's resources at an unguessable URL path segment\n" +
-			"(`<classroom>/<key>/...`) instead of the guessable default. This\n" +
-			"is obscurity, not access control — anyone who has the link can\n" +
-			"read the files, and links can leak. You'll be shown a generated\n" +
-			"key to accept or replace, or supply your own with --key <value>.\n" +
-			"Off by default.\n\n" +
+			"(`<classroom>/<key>/...`) instead of the guessable default.\n" +
+			"  - This is obscurity, not access control: anyone who has the\n" +
+			"    link can read the files, and links can leak.\n" +
+			"  - You'll be shown a generated key to accept or replace, or\n" +
+			"    supply your own with --key <value>.\n" +
+			"  - Off by default.\n\n" +
 			"If <org>/classroom50 doesn't exist yet, run `gh teacher init\n" +
-			"<org>` first. If <short-name> already exists in the repo, the\n" +
-			"command exits with an error rather than overwriting state —\n" +
+			"<org>` first. If <short-name> already exists in the repository,\n" +
+			"the command exits with an error rather than overwriting state;\n" +
 			"use `gh teacher roster add` or `gh teacher assignment add` to\n" +
 			"modify an existing classroom.",
 		Example: "  gh teacher classroom add cs50-fall-2026 cs-principles --name \"CS Principles\" --term Spring-2026\n" +
@@ -138,8 +139,8 @@ func classroomAddCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&name, "name", "", `Full display name for the classroom (e.g., "CS Principles")`)
-	cmd.Flags().StringVar(&term, "term", "", "Term identifier (e.g., Spring-2026)")
+	cmd.Flags().StringVar(&name, "name", "", `Full display name for the classroom, for example "CS Principles"`)
+	cmd.Flags().StringVar(&term, "term", "", "Term identifier, for example Spring-2026")
 	cmd.Flags().BoolVar(&unlisted, "unlisted", false, "Publish this classroom's resources at an unguessable URL path segment (obscurity, not access control; prompts to accept a generated key)")
 	cmd.Flags().StringVar(&key, "key", "", "Supply a specific access key for the unlisted URL (implies --unlisted); must match "+configrepo.SecretPatternDescription)
 	return cmd
@@ -197,7 +198,7 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 	if exists, err := configrepo.ContentsExists(client, org, configrepo.ConfigRepoName, shortName, branch); err != nil {
 		return err
 	} else if exists {
-		return fmt.Errorf("classroom %q already exists in %s/%s — refusing to overwrite (inspect or edit at https://github.com/%s/%s/tree/%s/%s)",
+		return fmt.Errorf("classroom %q already exists in %s/%s: refusing to overwrite (inspect or edit at https://github.com/%s/%s/tree/%s/%s)",
 			shortName, org, configrepo.ConfigRepoName,
 			org, configrepo.ConfigRepoName, branch, shortName)
 	}
@@ -254,7 +255,7 @@ func addClassroom(client githubapi.Client, out, errOut io.Writer, org, shortName
 			return nil, err
 		}
 		if exists {
-			return nil, fmt.Errorf("classroom %q already exists in %s/%s — refusing to overwrite (inspect or edit at https://github.com/%s/%s/tree/%s/%s)",
+			return nil, fmt.Errorf("classroom %q already exists in %s/%s: refusing to overwrite (inspect or edit at https://github.com/%s/%s/tree/%s/%s)",
 				shortName, org, configrepo.ConfigRepoName,
 				org, configrepo.ConfigRepoName, branch, shortName)
 		}
@@ -349,7 +350,7 @@ func dropCreatorFromNonTeacherTeams(client githubapi.Client, errOut io.Writer, o
 			continue
 		}
 		if err := configrepo.RemoveTeamMembership(client, org, slug, login); err != nil {
-			_, _ = fmt.Fprintf(errOut, "Warning: couldn't remove you (%s) from team %s (%v); you were auto-added when it was created — remove yourself at https://github.com/orgs/%s/teams/%s if you don't want to appear on its roster.\n",
+			_, _ = fmt.Fprintf(errOut, "Warning: couldn't remove you (%s) from team %s (%v); you were auto-added when it was created. Remove yourself at https://github.com/orgs/%s/teams/%s if you don't want to appear on its roster.\n",
 				login, slug, err, org, slug)
 		}
 	}
@@ -377,18 +378,19 @@ func classroomListCmd() *cobra.Command {
 		Short: "List the classrooms registered in the classroom50 repository",
 		Long: "List every classroom registered in <org>/classroom50.\n\n" +
 			"A classroom is a root-level directory holding a classroom.json;\n" +
-			"directories without one (e.g., .github) are skipped.\n\n" +
-			"Archived classrooms (classroom.json `active: false`) are hidden\n" +
-			"by default, mirroring the web's default classes list; pass --all\n" +
-			"to include them. In the default output an archived classroom is\n" +
-			"tagged ` (archived)` after its short-name; in --json it carries\n" +
-			"`\"active\": false`.\n\n" +
-			"Default output is one short-name per line on stdout — pipeable\n" +
-			"into `xargs`, `grep`, or an agent loop. Pass --json to emit the\n" +
-			"full array of {short_name, name, term} objects instead. A\n" +
-			"one-line `<org>/<repo>: N classroom(s)` summary goes to stderr\n" +
-			"unless --quiet is set.\n\n" +
-			"This is a read-only command; no commit lands on the repo.",
+			"directories without one (such as .github) are skipped.\n\n" +
+			"  - Archived classrooms (classroom.json `active: false`) are\n" +
+			"    hidden by default, mirroring the web's default classes list;\n" +
+			"    pass --all to include them. In the default output an archived\n" +
+			"    classroom is tagged ` (archived)` after its short-name; in\n" +
+			"    --json it carries `\"active\": false`.\n" +
+			"  - Default output is one short-name per line on stdout, pipeable\n" +
+			"    into `xargs`, `grep`, or an agent loop.\n" +
+			"  - Pass --json to emit the full array of {short_name, name, term}\n" +
+			"    objects instead.\n" +
+			"  - A one-line `<org>/<repo>: N classroom(s)` summary goes to\n" +
+			"    stderr unless --quiet is set.\n\n" +
+			"This is a read-only command; no commit lands on the repository.",
 		Example: "  gh teacher classroom list cs50-fall-2026\n" +
 			"  gh teacher classroom list cs50-fall-2026 --all\n" +
 			"  gh teacher classroom list cs50-fall-2026 --json",
@@ -479,7 +481,7 @@ func summarizeClassroomList(org string, count int) string {
 	path := fmt.Sprintf("%s/%s", org, configrepo.ConfigRepoName)
 	switch count {
 	case 0:
-		return fmt.Sprintf("%s: no classrooms registered yet — use `gh teacher classroom add %s <short-name>` to create one", path, org)
+		return fmt.Sprintf("%s: no classrooms registered yet. Create one with `gh teacher classroom add %s <short-name>`", path, org)
 	case 1:
 		return fmt.Sprintf("%s: 1 classroom", path)
 	default:
@@ -498,10 +500,10 @@ func classroomEditCmd() *cobra.Command {
 		Long: "Update the display name and/or term in\n" +
 			"<org>/classroom50/<short-name>/classroom.json. At least one of\n" +
 			"--name or --term must be provided.\n\n" +
-			"The short-name itself is immutable — it flows into student\n" +
+			"The short-name itself is immutable: it flows into student\n" +
 			"repo names (`<short-name>-<assignment>-<username>`), so renaming\n" +
 			"would orphan existing repos. To rename, add a new classroom.\n\n" +
-			"Lands as a single Tree commit on the classroom50 repository. Re-running\n" +
+			"Lands as a single commit on the classroom50 repository. Re-running\n" +
 			"with values that already match the file is a no-op.",
 		Example: "  gh teacher classroom edit cs50-fall-2026 cs-principles --name \"CS Principles\"\n" +
 			"  gh teacher classroom edit cs50-fall-2026 cs-principles --term Fall-2026",
@@ -515,7 +517,7 @@ func classroomEditCmd() *cobra.Command {
 			setName := cmd.Flags().Changed("name")
 			setTerm := cmd.Flags().Changed("term")
 			if !setName && !setTerm {
-				return errors.New("nothing to update — pass --name and/or --term")
+				return errors.New("nothing to update: pass --name and/or --term")
 			}
 			client, err := githubapi.RequireAuthClient(cmd)
 			if err != nil {
@@ -524,8 +526,8 @@ func classroomEditCmd() *cobra.Command {
 			return editClassroom(client, cmd.OutOrStdout(), cmd.ErrOrStderr(), org, shortName, setName, strings.TrimSpace(name), setTerm, strings.TrimSpace(term))
 		},
 	}
-	cmd.Flags().StringVar(&name, "name", "", `New display name for the classroom (e.g., "CS Principles")`)
-	cmd.Flags().StringVar(&term, "term", "", "New term identifier (e.g., Fall-2026)")
+	cmd.Flags().StringVar(&name, "name", "", `New display name for the classroom, for example "CS Principles"`)
+	cmd.Flags().StringVar(&term, "term", "", "New term identifier, for example Fall-2026")
 	return cmd
 }
 
@@ -546,7 +548,7 @@ func commitClassroomMutation(client githubapi.Client, org, shortName, message st
 			return nil, err
 		}
 		if !ok {
-			return nil, fmt.Errorf("classroom %q not found in %s/%s — run `gh teacher classroom add %s %s` first",
+			return nil, fmt.Errorf("classroom %q not found in %s/%s: run `gh teacher classroom add %s %s` first",
 				shortName, org, configrepo.ConfigRepoName, org, shortName)
 		}
 		var c configrepo.ClassroomJSON
@@ -734,9 +736,9 @@ func classroomRemoveCmd() *cobra.Command {
 		Long: "Delete the <short-name>/ directory (classroom.json,\n" +
 			"assignments.json, roster.csv, scores.json, and any\n" +
 			"autograders/) from <org>/classroom50 in a single commit.\n\n" +
-			"This removes the classroom's configuration only. It does NOT\n" +
+			"This removes the classroom's configuration only. It does not\n" +
 			"delete student assignment repositories already created in the\n" +
-			"org — remove those via the GitHub web UI if intended.\n\n" +
+			"org; remove those via the GitHub web UI if intended.\n\n" +
 			"You'll be asked to type the short-name to confirm; pass --yes\n" +
 			"to skip the prompt (scripted runs only).",
 		Example: "  gh teacher classroom remove cs50-fall-2026 cs-principles\n" +
@@ -775,7 +777,7 @@ func removeClassroom(client githubapi.Client, in io.Reader, out, errOut io.Write
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("classroom %q not found in %s/%s — nothing to remove", shortName, org, configrepo.ConfigRepoName)
+		return fmt.Errorf("classroom %q not found in %s/%s: nothing to remove", shortName, org, configrepo.ConfigRepoName)
 	}
 
 	if !skipConfirm {
@@ -860,7 +862,7 @@ func confirmClassroomRemove(in io.Reader, out io.Writer, shortName string) error
 		return fmt.Errorf("read confirmation: %w", err)
 	}
 	if strings.TrimSpace(line) != shortName {
-		return errors.New("confirmation did not match short-name — aborted without deleting anything")
+		return errors.New("confirmation did not match the short-name: aborted without deleting anything")
 	}
 	return nil
 }

--- a/cli/gh-teacher/internal/configrepo/assignments.go
+++ b/cli/gh-teacher/internal/configrepo/assignments.go
@@ -18,7 +18,7 @@ func LoadAssignments(client githubapi.Client, org, classroom, ref string) (assig
 		return assignment.AssignmentsJSON{}, err
 	}
 	if !ok {
-		return assignment.AssignmentsJSON{}, fmt.Errorf("%s/%s/%s not found — run `gh teacher classroom add %s %s` first, or restore the file if it was deleted",
+		return assignment.AssignmentsJSON{}, fmt.Errorf("%s/%s/%s not found: run `gh teacher classroom add %s %s` first, or restore the file if it was deleted",
 			org, ConfigRepoName, path, org, classroom)
 	}
 	file, err := assignment.ParseAssignments(data)

--- a/cli/gh-teacher/internal/configrepo/contents.go
+++ b/cli/gh-teacher/internal/configrepo/contents.go
@@ -146,7 +146,7 @@ func ListSubtreeBlobPaths(client githubapi.Client, owner, repo, commitSHA, prefi
 		return nil, fmt.Errorf("GET %s: %w", path, err)
 	}
 	if resp.Truncated {
-		return nil, fmt.Errorf("GET %s: tree listing truncated — too many files to enumerate the %q subtree safely", path, prefix)
+		return nil, fmt.Errorf("GET %s: tree listing truncated, too many files to enumerate the %q subtree safely", path, prefix)
 	}
 	want := prefix + "/"
 	var paths []string

--- a/cli/gh-teacher/internal/configrepo/invite_team.go
+++ b/cli/gh-teacher/internal/configrepo/invite_team.go
@@ -259,7 +259,7 @@ func EnsureInviteTeam(client githubapi.Client, org, classroom, email, actor stri
 	}
 	if team.Privacy != "secret" {
 		return TeamRef{ID: team.ID, Slug: team.Slug}, created,
-			fmt.Errorf("%w: %q at %s is %s — refusing to store an invited email on a team other org members could read; make it secret or delete it by hand", ErrInviteTeamNotSecret, team.Slug, org, team.Privacy)
+			fmt.Errorf("%w: %q at %s is %s: refusing to store an invited email on a team other org members could read; make it secret or delete it by hand", ErrInviteTeamNotSecret, team.Slug, org, team.Privacy)
 	}
 
 	if err := requireTeacherFreeInviteTeam(client, org, team.Slug, actor); err != nil {
@@ -277,7 +277,7 @@ func EnsureInviteTeam(client githubapi.Client, org, classroom, email, actor stri
 	}
 	if patched.Privacy != "secret" {
 		return TeamRef{ID: patched.ID, Slug: patched.Slug}, created,
-			fmt.Errorf("%w: %q at %s came back %s after the record write — delete the team by hand, it holds an invited email", ErrInviteTeamNotSecret, patched.Slug, org, patched.Privacy)
+			fmt.Errorf("%w: %q at %s came back %s after the record write; delete the team by hand, it holds an invited email", ErrInviteTeamNotSecret, patched.Slug, org, patched.Privacy)
 	}
 	return TeamRef{ID: patched.ID, Slug: patched.Slug}, created, nil
 }
@@ -344,7 +344,7 @@ func requireTeacherFreeInviteTeam(client githubapi.Client, org, slug, actor stri
 		return err
 	}
 	if len(members) > 0 {
-		return fmt.Errorf("%w: %q at %s still has %d member(s) after dropping %s — a sync would misread them as the invitee; remove them from the team and retry",
+		return fmt.Errorf("%w: %q at %s still has %d member(s) after dropping %s, and a sync would misread them as the invitee; remove them from the team and retry",
 			ErrInviteTeamNotEmpty, slug, org, len(members), actor)
 	}
 	return nil

--- a/cli/gh-teacher/internal/configrepo/roster.go
+++ b/cli/gh-teacher/internal/configrepo/roster.go
@@ -32,7 +32,7 @@ func ResolveConfigRepoBranch(client githubapi.Client, org string) (string, error
 	var repo ConfigRepo
 	if err := client.Get(repoPath, &repo); err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
-			return "", fmt.Errorf("%s/%s not found — run `gh teacher init %s` first", org, ConfigRepoName, org)
+			return "", fmt.Errorf("%s/%s not found: run `gh teacher init %s` first", org, ConfigRepoName, org)
 		}
 		return "", fmt.Errorf("GET %s: %w", repoPath, err)
 	}
@@ -66,7 +66,7 @@ func loadRoster(client githubapi.Client, org, classroom, parentSHA string, lenie
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("%s/%s/%s not found — run `gh teacher classroom add %s %s` first, or restore the file if it was deleted",
+		return nil, fmt.Errorf("%s/%s/%s not found: run `gh teacher classroom add %s %s` first, or restore the file if it was deleted",
 			org, ConfigRepoName, path, org, classroom)
 	}
 	parse := ParseRoster

--- a/cli/gh-teacher/internal/configrepo/students_csv.go
+++ b/cli/gh-teacher/internal/configrepo/students_csv.go
@@ -315,7 +315,7 @@ func ParseImportCSV(data []byte) ([]RosterRow, error) {
 		// no action for a row it can't address, so those stay per-line errors
 		// here rather than silently passing through.
 		if row.Username == "" && row.Email == "" && strings.TrimSpace(record[5]) == "" {
-			rowErrs = append(rowErrs, fmt.Errorf("line %d: row has no username, github_id, or email — at least one is required to identify a student", line))
+			rowErrs = append(rowErrs, fmt.Errorf("line %d: row has no username, github_id, or email; at least one is required to identify a student", line))
 			continue
 		}
 		// Canonicalize rather than only validate: the parsed address is what a
@@ -367,7 +367,7 @@ func recordToRow(record []string, canonicalLen int, extraColumns []string, line 
 	// cli/shared/testdata/roster_row_cases.json.
 	hasName := strings.TrimSpace(row.FirstName) != "" || strings.TrimSpace(row.LastName) != ""
 	if row.Username == "" && row.Email == "" && strings.TrimSpace(record[5]) == "" && !hasName {
-		return RosterRow{}, fmt.Errorf("line %d: row has no username, github_id, email, or name — at least one is required to identify a student", line)
+		return RosterRow{}, fmt.Errorf("line %d: row has no username, github_id, email, or name; at least one is required to identify a student", line)
 	}
 	if trimmed := strings.TrimSpace(record[5]); trimmed != "" {
 		id, err := parseGitHubID(trimmed)
@@ -757,7 +757,7 @@ func CanonicalRosterEmail(email string) (string, error) {
 		return "", fmt.Errorf("invalid email %q: %w", email, err)
 	}
 	if parsed.Name != "" {
-		return "", fmt.Errorf("invalid email %q: include only the address (e.g., alice@example.edu), not a display name", email)
+		return "", fmt.Errorf("invalid email %q: include only the address (like alice@example.edu), not a display name", email)
 	}
 	return NormalizeInviteEmail(parsed.Address), nil
 }

--- a/cli/gh-teacher/internal/configrepo/team.go
+++ b/cli/gh-teacher/internal/configrepo/team.go
@@ -210,7 +210,7 @@ func EnsureClassroomTeam(client githubapi.Client, org, shortName, description st
 	// Guard the slug==name invariant (see CanonicalTeamSlugShortName):
 	// ShortNamePattern alone permits hyphens GitHub would slugify away.
 	if !CanonicalTeamSlugShortName(shortName) {
-		return TeamRef{}, fmt.Errorf("classroom short-name %q can't back a GitHub team — remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking membership and template grants)", shortName)
+		return TeamRef{}, fmt.Errorf("classroom short-name %q can't back a GitHub team: remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking membership and template grants)", shortName)
 	}
 	return ensureSecretTeamByName(client, org, classroomTeamName(shortName), description, notificationsDisabled)
 }
@@ -222,7 +222,7 @@ func EnsureClassroomTeam(client githubapi.Client, org, shortName, description st
 // (#335).
 func EnsureClassroomStaffTeam(client githubapi.Client, org, shortName string, role StaffRole) (TeamRef, error) {
 	if !CanonicalTeamSlugShortName(shortName) {
-		return TeamRef{}, fmt.Errorf("classroom short-name %q can't back a GitHub team — remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking staff membership and classroom50 repository access)", shortName)
+		return TeamRef{}, fmt.Errorf("classroom short-name %q can't back a GitHub team: remove consecutive or trailing hyphens (GitHub would rewrite the team slug, breaking staff membership and classroom50 repository access)", shortName)
 	}
 	// Staff teams carry no bootstrap description: staff read the authoritative
 	// classroom.json directly, and the secret belongs only on the student team.
@@ -471,13 +471,13 @@ func DeleteClassroomTeam(client githubapi.Client, org string, team TeamRef) erro
 	}
 	// Namespace guard: only ever delete a `classroom50-`-prefixed team.
 	if !strings.HasPrefix(team.Slug, "classroom50-") {
-		return fmt.Errorf("refusing to delete team %q at %s — not a classroom50-namespaced team; remove it by hand if intended", team.Slug, org)
+		return fmt.Errorf("refusing to delete team %q at %s: not a classroom50-namespaced team; remove it by hand if intended", team.Slug, org)
 	}
 	// Fail closed on a non-positive id: without a recorded id we can't confirm
 	// the live team at this slug is the one this classroom created. (The
 	// load-bearing half of the web's guard an earlier port dropped.)
 	if team.ID <= 0 {
-		return fmt.Errorf("refusing to delete team %q at %s — no recorded id to verify it against; remove it by hand if intended", team.Slug, org)
+		return fmt.Errorf("refusing to delete team %q at %s: no recorded id to verify it against; remove it by hand if intended", team.Slug, org)
 	}
 	// Defense-in-depth: confirm the team at this slug is the one we recorded
 	// (same id) before deleting.
@@ -492,7 +492,7 @@ func DeleteClassroomTeam(client githubapi.Client, org string, team TeamRef) erro
 		return fmt.Errorf("GET %s (verify team before delete): %w", getPath, err)
 	}
 	if live.ID != team.ID {
-		return fmt.Errorf("team %q at %s now has id %d, not the recorded %d — refusing to delete a team that isn't the one this classroom created; remove it by hand if intended",
+		return fmt.Errorf("team %q at %s now has id %d, not the recorded %d: refusing to delete a team that isn't the one this classroom created; remove it by hand if intended",
 			team.Slug, org, live.ID, team.ID)
 	}
 	path := fmt.Sprintf("orgs/%s/teams/%s", url.PathEscape(org), url.PathEscape(team.Slug))
@@ -573,7 +573,7 @@ func DeleteInviteTeam(client githubapi.Client, org, slug string) error {
 		return nil
 	}
 	if !IsInviteTeamSlug(slug) {
-		return fmt.Errorf("refusing to delete team %q at %s — not a %s<hash> invite team; remove it by hand if intended", slug, org, contract.InviteTeamPrefix)
+		return fmt.Errorf("refusing to delete team %q at %s: not a %s<hash> invite team; remove it by hand if intended", slug, org, contract.InviteTeamPrefix)
 	}
 	path := fmt.Sprintf("orgs/%s/teams/%s", url.PathEscape(org), url.PathEscape(slug))
 	resp, err := client.Request(http.MethodDelete, path, nil)

--- a/cli/gh-teacher/internal/download/download.go
+++ b/cli/gh-teacher/internal/download/download.go
@@ -97,31 +97,35 @@ func NewCmd() *cobra.Command {
 		Use:   "download <org> <classroom> <assignment>",
 		Short: "Clone every student submission repo for an assignment",
 		Long: "Clone every student submission repo for an assignment under <org>/classroom50.\n\n" +
-			"Default (team-driven): lists the classroom GitHub team's members (the\n" +
-			"source of truth for enrollment), derives the expected\n" +
-			"<classroom>-<assignment>-<username> repo for each, clones whichever\n" +
-			"ones exist, and refreshes <repo>/result.json\n" +
-			"and <repo>/results.json from the repo's submit-tag releases alongside\n" +
-			"the clone — results.json holds every submission (newest first), result.json\n" +
-			"the latest. Team members\n" +
-			"with no repo on the org are reported as `not yet accepted` and don't\n" +
-			"fail the run. A scores.csv summary is written at the destination root\n" +
-			"with one line per submission (newest first) for each team member —\n" +
-			"group members repeat the shared submission's lines under their own\n" +
-			"username, and non-submitters get one line with blank score columns.\n" +
-			"roster.csv (if present) supplies optional\n" +
-			"name/section/email metadata for that summary; it never decides who is\n" +
-			"cloned.\n\n" +
-			"Pass --by-pattern to skip the team lookup and clone every <org> repo\n" +
-			"whose name starts with <classroom>-<assignment>-. No result.json fetch,\n" +
-			"no scores.csv summary — useful when the classroom50 repository isn't bootstrapped\n" +
-			"yet or when you want every matching repo regardless of the roster.\n\n" +
-			"Clones go through `gh repo clone`, so authentication flows through the\n" +
-			"current gh session. The default destination is\n" +
+			"Default (team-driven):\n" +
+			"  - Lists the classroom GitHub team's members (the source of truth\n" +
+			"    for enrollment) and derives the expected\n" +
+			"    <classroom>-<assignment>-<username> repo for each.\n" +
+			"  - Clones whichever repos exist, and refreshes <repo>/result.json\n" +
+			"    and <repo>/results.json from the repo's submit-tag releases\n" +
+			"    alongside the clone: results.json holds every submission\n" +
+			"    (newest first), result.json the latest.\n" +
+			"  - Team members with no repo on the org are reported as\n" +
+			"    `not yet accepted` and don't fail the run.\n" +
+			"  - A scores.csv summary is written at the destination root with\n" +
+			"    one line per submission (newest first) for each team member.\n" +
+			"    Group members repeat the shared submission's lines under\n" +
+			"    their own username, and non-submitters get one line with\n" +
+			"    blank score columns.\n" +
+			"  - roster.csv (if present) supplies optional name/section/email\n" +
+			"    metadata for that summary; it never decides who is cloned.\n\n" +
+			"Pass --by-pattern to skip the team lookup and clone every <org>\n" +
+			"repo whose name starts with <classroom>-<assignment>-. No\n" +
+			"result.json fetch, no scores.csv summary. Useful when the\n" +
+			"classroom50 repository isn't bootstrapped yet or when you want\n" +
+			"every matching repo regardless of the roster.\n\n" +
+			"Clones go through `gh repo clone`, so authentication flows through\n" +
+			"the current gh session. The default destination is\n" +
 			"<classroom>-<assignment>_submissions_<timestamp>/. Pass -d/--dir to\n" +
-			"override (value used literally, no timestamp). Existing clones on disk\n" +
-			"are skipped on the clone step, but result.json is still refreshed so a\n" +
-			"re-run after the next collect run picks up the newest scores.",
+			"override (value used literally, no timestamp). Existing clones on\n" +
+			"disk are skipped on the clone step, but result.json is still\n" +
+			"refreshed so a re-run after the next collect run picks up the\n" +
+			"newest scores.",
 		Example: "  gh teacher download cs50-fall-2026 cs-principles hello\n" +
 			"  gh teacher download -d submissions cs50-fall-2026 cs-principles hello\n" +
 			"  gh teacher download --by-pattern cs50-fall-2026 cs-principles hello",
@@ -188,7 +192,7 @@ func downloadByRoster(client githubapi.Client, out, errOut io.Writer, org, class
 		return err
 	}
 	if !assignmentRegistered(assignments, assignment) {
-		return fmt.Errorf("assignment %q is not registered in %s/%s/%s — run `gh teacher assignment add %s %s %s --name <name> --template <owner>/<repo>` first, or pass --by-pattern to skip the team lookup",
+		return fmt.Errorf("assignment %q is not registered in %s/%s/%s: run `gh teacher assignment add %s %s %s --name <name> --template <owner>/<repo>` first, or pass --by-pattern to skip the team lookup",
 			assignment, org, configrepo.ConfigRepoName, assignmentsPath(classroom), org, classroom, assignment)
 	}
 
@@ -213,7 +217,7 @@ func downloadByRoster(client githubapi.Client, out, errOut io.Writer, org, class
 
 	if len(teamLogins) == 0 {
 		if !quiet {
-			_, _ = fmt.Fprintf(out, "%s: classroom team %q has no members — nothing to download\n", classroom, teamSlug)
+			_, _ = fmt.Fprintf(out, "%s: classroom team %q has no members, nothing to download\n", classroom, teamSlug)
 		}
 		return nil
 	}
@@ -283,13 +287,13 @@ func downloadByRoster(client githubapi.Client, out, errOut io.Writer, org, class
 				// Group assignment, no own repo, not credited — a genuine
 				// non-participant. Still report.
 				if !quiet {
-					_, _ = fmt.Fprintf(out, "Missing: %s (group assignment — no own repo and not yet credited via a teammate)\n", username)
+					_, _ = fmt.Fprintf(out, "Missing: %s (group assignment; no own repo and not yet credited via a teammate)\n", username)
 				}
 				missing = append(missing, username)
 				continue
 			}
 			if !quiet {
-				_, _ = fmt.Fprintf(out, "Missing: %s (no repo at %s/%s — not accepted yet?)\n", username, org, repoName)
+				_, _ = fmt.Fprintf(out, "Missing: %s (no repo at %s/%s; not accepted yet?)\n", username, org, repoName)
 			}
 			missing = append(missing, username)
 			continue
@@ -1019,7 +1023,7 @@ func rewriteAssetURL(assetURL, apiBase string) string {
 // belt-and-suspenders, mirroring collect_scores.py's _AuthStrippingRedirect.
 func downloadAssetBytes(token, assetURL string) ([]byte, error) {
 	if token == "" {
-		return nil, errors.New("no GitHub token available — run `gh auth login` or `gh teacher login`")
+		return nil, errors.New("no GitHub token available: run `gh auth login` or `gh teacher login`")
 	}
 	c := &http.Client{
 		Timeout: assetDownloadTimeout,

--- a/cli/gh-teacher/internal/feedbackpr/ensure.go
+++ b/cli/gh-teacher/internal/feedbackpr/ensure.go
@@ -259,7 +259,7 @@ func verifyFeedbackBaseRef(client githubapi.Client, org, repoName, acceptSHA str
 		return err
 	}
 	if sha != acceptSHA {
-		return fmt.Errorf("%w: %s branch is at %s, not the expected baseline %s — an org admin must delete it so it can be re-frozen correctly",
+		return fmt.Errorf("%w: %s branch is at %s, not the expected baseline %s; an org admin must delete it so it can be re-frozen correctly",
 			errBaseMismatch, contract.FeedbackBaseBranch, sha, acceptSHA)
 	}
 	return nil

--- a/cli/gh-teacher/internal/feedbackpr/feedbackpr.go
+++ b/cli/gh-teacher/internal/feedbackpr/feedbackpr.go
@@ -36,13 +36,13 @@ func NewCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "feedback-pr <org> <classroom> <assignment>",
-		Short: "Open or repair the Feedback PR on every student repo for an assignment",
+		Short: "Open or repair the Feedback PR on student repos",
 		Long: "Open (or repair) the Feedback PR on every existing student repo for an\n" +
 			"assignment, retroactively and idempotently.\n\n" +
 			"The Feedback PR is normally opened at accept time (by `gh student\n" +
 			"accept` / the web app) or by the autograde runner. A GitHub outage, a\n" +
 			"transient error, or a repo that predates the feature can leave a student\n" +
-			"without one. This command re-runs the SAME idempotent ensure flow with\n" +
+			"without one. This command re-runs the same idempotent ensure flow with\n" +
 			"your (teacher) token: base = the frozen `feedback` branch at the repo's\n" +
 			"accept commit, head = the default branch. The PR it produces is\n" +
 			"byte-identical to an accept-time or runner-opened one, so the runner\n" +
@@ -53,7 +53,7 @@ func NewCmd() *cobra.Command {
 			"(not accepted). Pass --user to target a single student's repo.\n\n" +
 			"Idempotent: a repo that already has a Feedback PR (in any state) is left\n" +
 			"as-is, so re-running only fills the gaps. A student-precreated `feedback`\n" +
-			"branch frozen at the wrong commit is reported as BLOCKED — an org admin\n" +
+			"branch frozen at the wrong commit is reported as blocked: an org admin\n" +
 			"must delete that branch before the PR can open; re-running never fixes\n" +
 			"it. Requires owner/admin access to the org's repos.",
 		Example: "  gh teacher assignment feedback-pr cs50-fall-2026 cs-principles hello\n" +
@@ -137,7 +137,7 @@ func run(client githubapi.Client, out, errOut io.Writer, p runParams) error {
 	}
 	entry, ok := findAssignment(assignments, p.assignment)
 	if !ok {
-		return fmt.Errorf("assignment %q is not registered in %s/%s/%s — run `gh teacher assignment add %s %s %s --name <name> --template <owner>/<repo>` first",
+		return fmt.Errorf("assignment %q is not registered in %s/%s/%s: run `gh teacher assignment add %s %s %s --name <name> --template <owner>/<repo>` first",
 			p.assignment, p.org, configrepo.ConfigRepoName, assignment.AssignmentsFilePath(p.classroom), p.org, p.classroom, p.assignment)
 	}
 
@@ -187,9 +187,9 @@ func run(client githubapi.Client, out, errOut io.Writer, p runParams) error {
 			// On the explicit --user path the teacher named this one repo, so a
 			// missing repo is the answer they asked for: report it unconditionally.
 			if p.user != "" {
-				_, _ = fmt.Fprintf(out, "%s does not exist — %s has not accepted %s yet\n", repo, p.user, p.assignment)
+				_, _ = fmt.Fprintf(out, "%s does not exist: %s has not accepted %s yet\n", repo, p.user, p.assignment)
 			} else if p.verbose && !p.quiet {
-				_, _ = fmt.Fprintf(out, "Skipped %s (no repo — not accepted yet?)\n", repo)
+				_, _ = fmt.Fprintf(out, "Skipped %s (no repo; not accepted yet?)\n", repo)
 			}
 			continue
 		}
@@ -349,7 +349,7 @@ func summarize(out, errOut io.Writer, p runParams, results []repoResult) error {
 		}
 	}
 	if len(failed) > 0 {
-		_, _ = fmt.Fprintln(errOut, "Failed (transient — re-run to retry just these):")
+		_, _ = fmt.Fprintln(errOut, "Failed (transient; re-run to retry just these):")
 		for _, r := range failed {
 			_, _ = fmt.Fprintf(errOut, "  %s: %s\n", r.repo, r.reason)
 		}

--- a/cli/gh-teacher/internal/githubapi/pagination.go
+++ b/cli/gh-teacher/internal/githubapi/pagination.go
@@ -60,7 +60,7 @@ func PaginateAll[T any](
 		}
 		path = pageURL(page + 1)
 	}
-	return nil, fmt.Errorf("pagination hit the %d-page safety cap (>%d items) -- unexpected; retry or file an issue",
+	return nil, fmt.Errorf("pagination hit the %d-page safety cap (>%d items), which is unexpected; retry or file an issue",
 		maxPages, maxPages*perPage)
 }
 

--- a/cli/gh-teacher/internal/member/member_list.go
+++ b/cli/gh-teacher/internal/member/member_list.go
@@ -45,15 +45,15 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "member",
 		Short: "Inspect organization and repository membership",
-		Long: "Read-only views of who is actually a member of an org or a\n" +
-			"collaborator on a repo -- the counterpart to `gh teacher\n" +
+		Long: "Read-only views of who is actually a member of an organization or\n" +
+			"a collaborator on a repository: the counterpart to `gh teacher\n" +
 			"invite` / `gh teacher remove`.\n\n" +
-			"The roster (roster.csv) is the INTENDED membership; this\n" +
-			"command shows ACTUAL GitHub membership, so you can spot\n" +
+			"The roster (roster.csv) is the intended membership; this\n" +
+			"command shows actual GitHub membership, so you can spot\n" +
 			"mismatches (a student on the roster who never\n" +
 			"accepted their invite, or a collaborator added out of band).\n\n" +
 			"Subcommands:\n" +
-			"  list   list org members + pending invitations, or repo collaborators",
+			"  list   list org members and pending invitations, or repo collaborators",
 	}
 	cmd.AddCommand(memberListCmd())
 	return cmd
@@ -66,7 +66,7 @@ func memberListCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "list <org>[/<repo>]",
-		Short: "List org members + pending invitations, or repo collaborators",
+		Short: "List org members and pending invitations, or collaborators",
 		Long: "List actual GitHub membership for a target.\n\n" +
 			"Forms:\n" +
 			"  gh teacher member list <org>         # org members + pending invitations, with role\n" +
@@ -75,10 +75,10 @@ func memberListCmd() *cobra.Command {
 			"role, github_id) with a one-line `<target>: N member(s)`\n" +
 			"summary on stderr. Pass --json for the full array of\n" +
 			"{login, kind, role, github_id} objects, or --quiet for one\n" +
-			"login per line (no table, no stderr summary) -- pipeable into\n" +
+			"login per line (no table, no stderr summary), pipeable into\n" +
 			"`xargs`, `grep`, or an agent loop. --json takes precedence.\n\n" +
-			"For an org, `kind` is `member` (active) or `invitation`\n" +
-			"(pending -- needs the admin:org scope to read). For a repo,\n" +
+			"For an organization, `kind` is `member` (active) or `invitation`\n" +
+			"(pending; needs the admin:org scope to read). For a repository,\n" +
 			"`kind` is `collaborator` and `role` is the permission level\n" +
 			"(read/triage/write/maintain/admin). Read-only; no write lands.",
 		Example: "  gh teacher member list cs50-fall-2026\n" +

--- a/cli/gh-teacher/internal/membership/membership.go
+++ b/cli/gh-teacher/internal/membership/membership.go
@@ -281,9 +281,9 @@ func ClassifyMembershipReadError(path, subject string, err error) error {
 		case OrgForbiddenScopeMissing:
 			return ErrMissingOrgAdminScope
 		case OrgForbiddenNotAdmin:
-			return fmt.Errorf("%s: forbidden — you may not have admin access to read it", subject)
+			return fmt.Errorf("%s: forbidden: you may not have admin access to read it", subject)
 		default:
-			return fmt.Errorf("%s: forbidden — ensure your token has the admin:org scope (`gh teacher login`) and that you have access", subject)
+			return fmt.Errorf("%s: forbidden: ensure your token has the admin:org scope (`gh teacher login`) and that you have access", subject)
 		}
 	}
 	return fmt.Errorf("GET %s: %w", path, err)

--- a/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
+++ b/cli/gh-teacher/internal/orgpolicy/orgpolicy.go
@@ -66,14 +66,14 @@ var nonEnterpriseOverrides = map[string]MemberDefaultSetting{
 	"members_can_create_private_repositories": {
 		Value:      true,
 		Desc:       "private repo creation enabled",
-		ManualFix:  `under "Repository creation", allow members to create repositories — on this plan "Private" is enabled together with "Public"`,
+		ManualFix:  `under "Repository creation", allow members to create repositories; on this plan "Private" is enabled together with "Public"`,
 		Critical:   false,
 		VerifyOnly: true,
 	},
 	"members_can_create_public_repositories": {
 		Value:     true,
 		Desc:      "public repo creation enabled (Team/Free couples it to private)",
-		ManualFix: `under "Repository creation", allow members to create repositories — on this plan "Public" cannot be unchecked while "Private" is checked`,
+		ManualFix: `under "Repository creation", allow members to create repositories; on this plan "Public" cannot be unchecked while "Private" is checked`,
 		// An enabling field, like private-repo creation: the master switch
 		// already carries the critical verdict for repo creation being off.
 		Critical:   false,
@@ -156,7 +156,7 @@ func allMemberDefaultSettings() []MemberDefaultSetting {
 			Field:     "members_can_create_private_repositories",
 			Value:     true,
 			Desc:      "private repo creation enabled",
-			ManualFix: `under "Repository creation", check "Private" — without it, gh student accept can't create student repos`,
+			ManualFix: `under "Repository creation", check "Private"; without it, gh student accept can't create student repos`,
 		},
 		{
 			// Enterprise Cloud only: narrows repo creation to private-only. On

--- a/cli/gh-teacher/internal/roster/cancel_invite.go
+++ b/cli/gh-teacher/internal/roster/cancel_invite.go
@@ -24,8 +24,8 @@ func rosterCancelInviteCmd() *cobra.Command {
 			"metadata team retaining the address, and the pending row in\n" +
 			"<org>/classroom50/<classroom>/roster.csv. The same teardown the web\n" +
 			"app performs, so either tool can revoke either tool's invitation.\n\n" +
-			"Only ever acts on a PENDING invitation. With no pending invitation\n" +
-			"for the address this reports and changes nothing — an invitation the\n" +
+			"Only ever acts on a pending invitation. With no pending invitation\n" +
+			"for the address this reports and changes nothing: an invitation the\n" +
 			"student already accepted looks exactly the same from here, and the\n" +
 			"metadata team holds the only record of which address their account\n" +
 			"came from. Run `gh teacher roster sync` in that case: it records the\n" +
@@ -76,7 +76,7 @@ func runRosterCancelInvite(client githubapi.Client, out, errOut io.Writer, org, 
 	invitationID, found := pendingEmailInvitationID(pending, email)
 	if !found {
 		_, _ = fmt.Fprintf(out, "%s: no pending invitation for %s, nothing was cancelled\n", org, email)
-		_, _ = fmt.Fprintf(errOut, "If they already accepted, run `gh teacher roster sync %s %s` to record their username and github_id — it also collects a genuine leftover invite team or pending row under its own checks, which this command deliberately won't do without a pending invitation to revoke.\n",
+		_, _ = fmt.Fprintf(errOut, "If they already accepted, run `gh teacher roster sync %s %s` to record their username and github_id. It also collects a genuine leftover invite team or pending row under its own checks, which this command deliberately won't do without a pending invitation to revoke.\n",
 			org, classroom)
 		return nil
 	}
@@ -175,7 +175,7 @@ func requireClassroomOwnsInvite(client githubapi.Client, org, classroom, email s
 	// blanked description): it names no classroom and must authorize nothing.
 	// `roster sync` deliberately skips such a team, so it is no help here.
 	if state.Record == nil {
-		return "", fmt.Errorf("%s: the metadata team %s holds no invite record — an interrupted send leaves exactly that — so nothing proves the pending invitation for %s is %s's and nothing was cancelled; revoke it from the web app's %s roster or from https://github.com/orgs/%s/people/pending_invitations, and delete the team by hand",
+		return "", fmt.Errorf("%s: the metadata team %s holds no invite record (an interrupted send leaves exactly that), so nothing proves the pending invitation for %s is %s's and nothing was cancelled; revoke it from the web app's %s roster or from https://github.com/orgs/%s/people/pending_invitations, and delete the team by hand",
 			org, slug, email, classroom, classroom, org)
 	}
 	if state.Record.Classroom != classroom {

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -31,7 +31,7 @@ func rosterInviteCmd() *cobra.Command {
 		Use:   "invite <org> <classroom> [email]",
 		Short: "Invite one student (or a whole list with --file) by email address",
 		Long: "Send a GitHub organization invitation to <email> and record it as a\n" +
-			"pending row in <org>/classroom50/<classroom>/roster.csv — the same\n" +
+			"pending row in <org>/classroom50/<classroom>/roster.csv, the same\n" +
 			"three artifacts the web app's email invite creates, so either tool\n" +
 			"can complete the invitation.\n\n" +
 			"Use this when the student has no GitHub account yet (or you only have\n" +
@@ -47,18 +47,25 @@ func rosterInviteCmd() *cobra.Command {
 			"Once the student accepts, run `gh teacher roster sync` to fill in\n" +
 			"their username and github_id (the web app does this on its own).\n\n" +
 			"Bulk mode: pass --file <path> instead of an email to invite a whole\n" +
-			"list. The file is plaintext, one address per line; blank lines and\n" +
-			"lines starting with `#` are ignored. Every address is validated first,\n" +
-			"and if any line is unusable nothing is sent. Successful invitations are\n" +
-			"retained as pending rows in one commit. --file carries no names or\n" +
-			"sections (fill those later with `roster import`, or `roster update`\n" +
-			"once the student has accepted; a sync never writes either), so the\n" +
-			"--first-name/--last-name/--section flags are rejected with it.\n" +
-			"Each address is reported as it resolves, then a summary counts them.\n\n" +
-			"Bulk exit codes follow `roster sync`: 0 every address was invited or\n" +
-			"cleanly skipped, 2 nothing failed but a GitHub rate limit left\n" +
-			"addresses uninvited (re-run to continue — already-invited addresses are\n" +
-			"skipped), 1 an address genuinely failed or the roster write failed.\n\n" +
+			"list.\n" +
+			"  - The file is plaintext, one address per line; blank lines and\n" +
+			"    lines starting with `#` are ignored.\n" +
+			"  - Every address is validated first, and if any line is unusable\n" +
+			"    nothing is sent.\n" +
+			"  - Successful invitations are retained as pending rows in one\n" +
+			"    commit.\n" +
+			"  - --file carries no names or sections (fill those later with\n" +
+			"    `roster import`, or `roster update` once the student has\n" +
+			"    accepted; a sync never writes either), so the\n" +
+			"    --first-name/--last-name/--section flags are rejected with it.\n" +
+			"  - Each address is reported as it resolves, then a summary\n" +
+			"    counts them.\n\n" +
+			"Bulk exit codes follow `roster sync`:\n" +
+			"  0  every address was invited or cleanly skipped\n" +
+			"  2  nothing failed but a GitHub rate limit left addresses\n" +
+			"     uninvited (re-run to continue; already-invited addresses\n" +
+			"     are skipped)\n" +
+			"  1  an address genuinely failed or the roster write failed\n\n" +
 			"A single address returns non-zero on: classroom missing a GitHub team,\n" +
 			"an address the roster already lists as invited, or a failed\n" +
 			"invitation. With --file that same already-listed address is reported\n" +
@@ -162,7 +169,7 @@ func readTeacherFile(errOut io.Writer, path, what string) (string, []byte, error
 	}
 	normalized, transcoded := configrepo.NormalizeTeacherText(data)
 	if transcoded {
-		_, _ = fmt.Fprintf(errOut, "Notice: %s is not UTF-8 encoded and was read as Windows-1252 — double-check any non-ASCII names\n", abs)
+		_, _ = fmt.Fprintf(errOut, "Notice: %s is not UTF-8 encoded and was read as Windows-1252. Double-check any non-ASCII names\n", abs)
 	}
 	return abs, normalized, nil
 }
@@ -174,7 +181,7 @@ func readTeacherFile(errOut io.Writer, path, what string) (string, []byte, error
 // unusable, since the invitation carries team ids rather than slugs. Shared so
 // the single and bulk paths refuse identically.
 func errClassroomTeamUnusable(org, classroom string) error {
-	return fmt.Errorf("%s: classroom %s has no usable team recorded in classroom.json, so an invitation would enroll nobody — nothing was sent; run `gh teacher classroom add %s %s` to create the team, then retry",
+	return fmt.Errorf("%s: classroom %s has no usable team recorded in classroom.json, so an invitation would enroll nobody and nothing was sent. Run `gh teacher classroom add %s %s` to create the team, then retry",
 		org, classroom, org, classroom)
 }
 
@@ -222,7 +229,7 @@ func sendOneEmailInvite(client githubapi.Client, errOut io.Writer, org, classroo
 		return outcomePendingBlocked, configrepo.TeamRef{}, nil
 	}
 	if holder != "" {
-		_, _ = fmt.Fprintf(errOut, "Note: %s already appears on the %s roster on %s's row. An address can be shared (a parent or a lab contact), so the invitation is still being sent — but no second row is written for it, matching the web app. If that row is the same person, cancel this invite and run `gh teacher roster update %s %s %s` instead.\n",
+		_, _ = fmt.Fprintf(errOut, "Note: %s already appears on the %s roster on %s's row. An address can be shared (a parent or a lab contact), so the invitation is still being sent, but no second row is written for it, matching the web app. If that row is the same person, cancel this invite and run `gh teacher roster update %s %s %s` instead.\n",
 			email, classroom, holder, org, classroom, holder)
 	}
 
@@ -289,7 +296,7 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 	// name the sync/cancel-invite remedies; the helper's own check stays
 	// authoritative for the bulk path.
 	if _, pending := rosterEmailClaim(rows, email); pending {
-		return fmt.Errorf("%s is already invited to %s — run `gh teacher roster sync %s %s` if they accepted, or `gh teacher roster cancel-invite %s %s %s` to revoke it; nothing was sent",
+		return fmt.Errorf("%s is already invited to %s and nothing was sent. Run `gh teacher roster sync %s %s` if they accepted, or `gh teacher roster cancel-invite %s %s %s` to revoke it",
 			email, classroom, org, classroom, org, classroom, email)
 	}
 
@@ -306,7 +313,7 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 		_, _ = fmt.Fprintf(out, "%s: invited %s as direct_member (teams %s, %s)\n",
 			org, email, classroomTeam.Slug, inviteTeam.Slug)
 	case outcomeSkippedAlready:
-		_, _ = fmt.Fprintf(out, "%s: skipped %s — already a member of the org or already invited\n", org, email)
+		_, _ = fmt.Fprintf(out, "%s: skipped %s (already a member of the org or already invited)\n", org, email)
 		_, _ = fmt.Fprintf(errOut, "If they accepted an earlier invitation, run `gh teacher roster sync %s %s` to record them on the roster.\n", org, classroom)
 		return nil
 	case outcomeRateLimited, outcomeFailed:

--- a/cli/gh-teacher/internal/roster/invite_file.go
+++ b/cli/gh-teacher/internal/roster/invite_file.go
@@ -113,7 +113,7 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 		return err
 	}
 	if len(entries) == 0 {
-		return errors.New("no email addresses to invite — the file has only blank or # comment lines")
+		return errors.New("no email addresses to invite: the file has only blank or # comment lines")
 	}
 
 	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
@@ -162,14 +162,14 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 			_, _ = fmt.Fprintf(out, "  invited %s (line %d)\n", entry.email, entry.line)
 		case outcomeSkippedAlready:
 			skipped = append(skipped, entry)
-			_, _ = fmt.Fprintf(out, "  skipped %s (line %d) — already a member of the org or already invited\n", entry.email, entry.line)
+			_, _ = fmt.Fprintf(out, "  skipped %s (line %d): already a member of the org or already invited\n", entry.email, entry.line)
 		case outcomePendingBlocked:
 			pendingBlocked = append(pendingBlocked, entry)
-			_, _ = fmt.Fprintf(out, "  skipped %s (line %d) — already a pending invitation on this roster\n", entry.email, entry.line)
+			_, _ = fmt.Fprintf(out, "  skipped %s (line %d): already a pending invitation on this roster\n", entry.email, entry.line)
 		case outcomeRateLimited:
 			rateLimitErr = sendErr
 			deferredList = append(deferredList, entry)
-			_, _ = fmt.Fprintf(out, "  deferred %s (line %d) — GitHub rate limit reached\n", entry.email, entry.line)
+			_, _ = fmt.Fprintf(out, "  deferred %s (line %d): GitHub rate limit reached\n", entry.email, entry.line)
 		default:
 			// outcomeFailed, plus any outcome a future change forgets to handle:
 			// both mean "not invited", which must never read as success.
@@ -196,11 +196,11 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 		len(invited), appended, len(skipped), len(pendingBlocked), len(failedErrs), len(deferredList))
 
 	for _, entry := range skipped {
-		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already a member of the org or already invited — run `gh teacher roster sync %s %s` if they accepted an earlier invitation.\n",
+		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already a member of the org or already invited. Run `gh teacher roster sync %s %s` if they accepted an earlier invitation.\n",
 			entry.email, entry.line, org, classroom)
 	}
 	for _, entry := range pendingBlocked {
-		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already a pending invitation on the roster — run `gh teacher roster sync %s %s` if they accepted.\n",
+		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already a pending invitation on the roster. Run `gh teacher roster sync %s %s` if they accepted.\n",
 			entry.email, entry.line, org, classroom)
 	}
 	for _, addr := range alreadyHeld {
@@ -221,7 +221,7 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 		// Never a rollback: the invitations are the source of truth and each
 		// metadata team retains its address, so a sync heals the rows once the
 		// students accept.
-		_, _ = fmt.Fprintf(errOut, "Warning: %d invitation(s) were sent, but recording them in %s failed; the invitations are unaffected — re-run this command to record them, or `gh teacher roster sync %s %s` once the students accept.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %d invitation(s) were sent, but recording them in %s failed; the invitations are unaffected. Re-run this command to record them, or `gh teacher roster sync %s %s` once the students accept.\n",
 			len(invited), configrepo.RosterFilePath(classroom), org, classroom)
 		return fmt.Errorf("invitations sent, but the roster rows were not written: %w", commitErr)
 	}

--- a/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
@@ -478,7 +478,7 @@ func TestRunRosterInviteFile_CommitFailureWarnsRepair(t *testing.T) {
 	}
 	// The repair must be one that actually works: re-running records the row,
 	// and a sync heals it once the student accepts.
-	if !strings.Contains(errOut, "re-run this command") {
+	if !strings.Contains(errOut, "Re-run this command") {
 		t.Errorf("commit-failure warning must name re-running as the repair:\n%s", errOut)
 	}
 	if len(mock.invitedEmails) != 1 {

--- a/cli/gh-teacher/internal/roster/list.go
+++ b/cli/gh-teacher/internal/roster/list.go
@@ -50,19 +50,19 @@ func rosterListCmd() *cobra.Command {
 			"The `role` column is a display snapshot of the account's\n" +
 			"highest team-derived role (teacher/hta/ta/student, or empty\n" +
 			"when unknown), refreshed whenever the web app syncs the\n" +
-			"roster; the classroom's GitHub teams — not this column —\n" +
+			"roster; the classroom's GitHub teams, not this column,\n" +
 			"remain the enrollment/role authority. An account\n" +
 			"holding several roles (dual roles aren't disallowed) reads as\n" +
 			"its highest one here while still being an enrolled student.\n\n" +
 			"Pass --json for the full array of\n" +
 			"{username, first_name, last_name, email, section, github_id, role}\n" +
 			"objects. Pass --quiet for one username per line on stdout (no\n" +
-			"table, no stderr summary) -- pipeable into `xargs`, `grep`, or\n" +
+			"table, no stderr summary), pipeable into `xargs`, `grep`, or\n" +
 			"an agent loop. --json takes precedence over --quiet.\n\n" +
 			"An empty roster is a clean exit-0 (empty stdout under --json /\n" +
 			"--quiet, a 'no students' note on stderr otherwise). A missing\n" +
 			"roster points at `gh teacher classroom add`. This is a\n" +
-			"read-only command; no commit lands on the repo.",
+			"read-only command; no commit lands on the repository.",
 		Example: "  gh teacher roster list cs50-fall-2026 cs-principles\n" +
 			"  gh teacher roster list cs50-fall-2026 cs-principles --json\n" +
 			"  gh teacher roster list cs50-fall-2026 cs-principles --quiet",
@@ -178,7 +178,7 @@ func dashIfEmpty(s string) string {
 func summarizeRosterList(org, classroom string, count int) string {
 	path := fmt.Sprintf("%s/%s/%s", org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom))
 	if count == 0 {
-		return fmt.Sprintf("%s: no students on the roster — add some with `gh teacher roster add %s %s <username>`", path, org, classroom)
+		return fmt.Sprintf("%s: no students on the roster. Add some with `gh teacher roster add %s %s <username>`", path, org, classroom)
 	}
 	return fmt.Sprintf("%s: %d student(s)", path, count)
 }

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -35,13 +35,13 @@ func NewCmd() *cobra.Command {
 			"  update   correct fields on an existing student (roster-only; never invites)\n" +
 			"  remove   remove one student from the roster (does NOT touch org membership)\n" +
 			"  import   bulk upsert from a local CSV (the stored 7-column roster.csv, or 6/5-column forms)\n\n" +
-			"All writes use a single Tree commit on <org>/classroom50's\n" +
+			"All writes use a single commit on <org>/classroom50's\n" +
 			"default branch and retry with an optimistic rebase loop\n" +
 			"(up to 5 attempts) so concurrent edits don't silently lose\n" +
 			"each other's work. Each row that names an account stores the\n" +
-			"student's immutable numeric github_id — resolved from\n" +
+			"student's immutable numeric github_id (resolved from\n" +
 			"GET /users/{username} on add/import, or from the classroom team\n" +
-			"on sync — so a username change mid-class doesn't desynchronize\n" +
+			"on sync), so a username change mid-class doesn't desynchronize\n" +
 			"records. A row awaiting an email invitation carries only the\n" +
 			"address until a sync records the account.",
 	}
@@ -87,7 +87,7 @@ func rosterAddCmd() *cobra.Command {
 			"Adding a user who is already a teacher/TA on this classroom is\n" +
 			"not disallowed: they become an enrolled student too and show\n" +
 			"both roles in the app. The roster's `role` column records only\n" +
-			"their highest role (e.g. teacher), so a later sync rewriting it\n" +
+			"their highest role (teacher, say), so a later sync rewriting it\n" +
 			"doesn't change the student enrollment.\n\n" +
 			"Returns non-zero on: classroom directory missing, roster\n" +
 			"missing or malformed, GitHub user not found, or after 5\n" +
@@ -123,7 +123,7 @@ func rosterAddCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&firstName, "first-name", "", "Student's first name (written into the first_name column)")
 	cmd.Flags().StringVar(&lastName, "last-name", "", "Student's last name (written into the last_name column)")
-	cmd.Flags().StringVar(&email, "email", "", "Student's email address (written into the email column; bare local@domain form, e.g., alice@example.edu; optional)")
+	cmd.Flags().StringVar(&email, "email", "", "Student's email address (written into the email column; bare local@domain form like alice@example.edu; optional)")
 	cmd.Flags().StringVar(&section, "section", "", "Section identifier (free-form text, written into the section column)")
 	return cmd
 }
@@ -142,8 +142,8 @@ func rosterUpdateCmd() *cobra.Command {
 		Long: "Update fields on an existing row in\n" +
 			"<org>/classroom50/<classroom>/roster.csv, matched by\n" +
 			"<username> (case-insensitive).\n\n" +
-			"Only the flags you pass are changed; every other column —\n" +
-			"including the immutable github_id — is left untouched. This is\n" +
+			"Only the flags you pass are changed; every other column,\n" +
+			"including the immutable github_id, is left untouched. This is\n" +
 			"the key difference from `roster add`, which rewrites the whole\n" +
 			"row and blanks any field you don't re-supply.\n\n" +
 			"Roster-only: unlike `roster add`, this never sends an org invite\n" +
@@ -190,7 +190,7 @@ func rosterUpdateCmd() *cobra.Command {
 				patch.Section = &v
 			}
 			if patch.FirstName == nil && patch.LastName == nil && patch.Email == nil && patch.Section == nil {
-				return errors.New("nothing to update — pass --first-name, --last-name, --email, and/or --section")
+				return errors.New("nothing to update: pass --first-name, --last-name, --email, and/or --section")
 			}
 
 			client, err := githubapi.RequireAuthClient(cmd)
@@ -213,8 +213,8 @@ func rosterRemoveCmd() *cobra.Command {
 		Short: "Remove one student from roster.csv",
 		Long: "Drop the row whose username matches <username> (case-insensitive)\n" +
 			"from <org>/classroom50/<classroom>/roster.csv.\n\n" +
-			"Does NOT remove the student from the org. Use\n" +
-			"`gh teacher remove <org> <username>` for that — it's a\n" +
+			"Does not remove the student from the org. Use\n" +
+			"`gh teacher remove <org> <username>` for that: it's a\n" +
 			"deliberate two-step process so an off-by-one roster edit\n" +
 			"can't accidentally revoke a student's access to every repo\n" +
 			"in the org.\n\n" +
@@ -250,7 +250,7 @@ func rosterImportCmd() *cobra.Command {
 			"<org>/classroom50/<classroom>/roster.csv. The header may be\n" +
 			"the stored roster shape\n" +
 			"`username,first_name,last_name,email,section,github_id,role`,\n" +
-			"the same without `role`, or just the first five columns — so\n" +
+			"the same without `role`, or just the first five columns, so\n" +
 			"a roster.csv exported from the web app imports as-is. The\n" +
 			"`email` column may be empty per row.\n\n" +
 			"github_id is re-resolved from `GET /users/{username}` so the\n" +
@@ -261,7 +261,7 @@ func rosterImportCmd() *cobra.Command {
 			"already-recorded role is never overwritten.\n\n" +
 			"A row with only an email is a pending email invitation: it\n" +
 			"updates that invitation's stored name/section and nothing\n" +
-			"else — import never sends or cancels an invitation. A row with\n" +
+			"else; import never sends or cancels an invitation. A row with\n" +
 			"a github_id but no username is skipped with a notice.\n\n" +
 			"Every unusable line is reported in one pass and nothing is\n" +
 			"committed. The whole file is written in one Tree commit, not\n" +
@@ -428,7 +428,7 @@ func runRosterAdd(client githubapi.Client, out, errOut io.Writer, org, classroom
 	// — the add already landed). See staffRoleForLogin for the rationale.
 	if staffRole, ok := staffRoleForLogin(client, org, classroom, branch, login); ok {
 		_, _ = fmt.Fprintf(errOut,
-			"Note: %s is also a %s on classroom %s. Dual roles aren't disallowed — they'll show both roles in the app and stay an enrolled student, but the automatic sync records their highest role (%s) in the roster's `role` column. That doesn't change the student enrollment.\n",
+			"Note: %s is also a %s on classroom %s. Dual roles aren't disallowed: they'll show both roles in the app and stay an enrolled student, but the automatic sync records their highest role (%s) in the roster's `role` column. That doesn't change the student enrollment.\n",
 			login, staffRole, classroom, staffRole)
 	}
 	return nil
@@ -486,7 +486,7 @@ func runRosterUpdate(client githubapi.Client, out io.Writer, org, classroom, use
 		}
 		next, found, changed := configrepo.UpdateRosterRow(rows, username, patch)
 		if !found {
-			return configwrite.CommitChange{}, fmt.Errorf("%s not in %s roster — add them with `gh teacher roster add %s %s %s` first",
+			return configwrite.CommitChange{}, fmt.Errorf("%s not in %s roster: add them with `gh teacher roster add %s %s %s` first",
 				username, classroom, org, classroom, username)
 		}
 		if !changed {
@@ -594,7 +594,7 @@ func planRosterImport(client githubapi.Client, imported []configrepo.RosterRow, 
 			// naming an account AND a different id addresses two students, so
 			// guessing which one the teacher meant is worse than refusing.
 			if row.GitHubID != 0 && row.GitHubID != userID {
-				failures = append(failures, fmt.Errorf("line %d (%s): github_id %d in the file is not this account's id (%s is github_id %d) — fix the username or clear the github_id cell",
+				failures = append(failures, fmt.Errorf("line %d (%s): github_id %d in the file is not this account's id (%s is github_id %d); fix the username or clear the github_id cell",
 					line, row.Username, row.GitHubID, login, userID))
 				continue
 			}
@@ -613,13 +613,13 @@ func planRosterImport(client githubapi.Client, imported []configrepo.RosterRow, 
 			// Round-trip cargo: import resolves students by username and has no
 			// id→account lookup, so acting on an id alone would guess. Skipping
 			// leaves any stored row for that id exactly as it is.
-			cargoNotices = append(cargoNotices, fmt.Sprintf("line %d: row has a github_id but no username — skipped; `roster import` resolves students by username, so import id-keyed rows with the web app's roster Upload instead. Any stored row for that id is untouched.", line))
+			cargoNotices = append(cargoNotices, fmt.Sprintf("line %d: row has a github_id but no username, so it was skipped. `roster import` resolves students by username; import id-keyed rows with the web app's roster Upload instead. Any stored row for that id is untouched.", line))
 		case row.Email != "":
 			pending = append(pending, importedPendingRow{line: line, row: row})
 		default:
 			// ParseImportCSV enforces one identity column, so this is a row whose
 			// only identity is an unusable github_id cell — cargo as well.
-			cargoNotices = append(cargoNotices, fmt.Sprintf("line %d: row has no username and no usable github_id — skipped; nothing stored was changed.", line))
+			cargoNotices = append(cargoNotices, fmt.Sprintf("line %d: row has no username and no usable github_id, so it was skipped; nothing stored was changed.", line))
 		}
 	}
 	if len(failures) > 0 {
@@ -719,7 +719,7 @@ func runRosterImport(client githubapi.Client, out, errOut io.Writer, org, classr
 				pendingUpdated++
 				continue
 			}
-			pendingMissing = append(pendingMissing, fmt.Sprintf("line %d (%s): no pending email-invite row with this address — skipped; import never sends an invitation, so it can't create one.", p.line, p.row.Email))
+			pendingMissing = append(pendingMissing, fmt.Sprintf("line %d (%s): no pending email-invite row with this address, so it was skipped; import never sends an invitation, so it can't create one.", p.line, p.row.Email))
 		}
 		// Reachable with a file of nothing but cargo and unmatched addresses:
 		// the rows come back untouched, and committing their re-encoding lands a

--- a/cli/gh-teacher/internal/roster/sync.go
+++ b/cli/gh-teacher/internal/roster/sync.go
@@ -87,14 +87,14 @@ func rosterSyncCmd() *cobra.Command {
 			"record the students who accepted an email invitation and fill in\n" +
 			"any missing github_id. The web app runs this same sync when a\n" +
 			"teacher opens the roster (and additionally refreshes recorded\n" +
-			"roles) — here it is explicit and script-callable.\n\n" +
+			"roles); here it is explicit and script-callable.\n\n" +
 			"Reports by default and changes nothing: a dry run issues no write\n" +
 			"request at all. Pass --write to apply what it found.\n\n" +
 			"An accepted email invitation is the case that needs this: GitHub\n" +
 			"stops reporting the invited address once it's accepted, so the\n" +
 			"per-invite `secret` metadata team holds the only record of which\n" +
 			"address the new account came from. This folds that mapping onto the\n" +
-			"pending row and then retires the team — in that order, so a failed\n" +
+			"pending row and then retires the team, in that order, so a failed\n" +
 			"cleanup never loses the address.\n\n" +
 			"The sync never REMOVES a roster row. An email row nothing backs\n" +
 			"stays on the roster for the teacher to link or delete by hand (the\n" +
@@ -210,7 +210,7 @@ func loadClassroomIndex(client githubapi.Client, org, classroom, branch string) 
 		}
 		if !found {
 			idx.ok = false
-			return idx, fmt.Errorf("team %s is recorded for classroom %s but GitHub has no such team — it was renamed or deleted, so who is enrolled cannot be read; restore the team (or correct %s in the config repo) before syncing",
+			return idx, fmt.Errorf("team %s is recorded for classroom %s but GitHub has no such team (renamed or deleted), so who is enrolled cannot be read; restore the team (or correct %s in the config repo) before syncing",
 				team.slug, classroom, configrepo.ClassroomFilePath(classroom))
 		}
 		for _, m := range members {
@@ -249,7 +249,7 @@ func scanInviteTeams(client githubapi.Client, errOut io.Writer, org, classroom s
 	// contract turns on.
 	if pending, err := pendingEmailInvitations(client, org); err != nil {
 		scan.trusted = false
-		_, _ = fmt.Fprintf(errOut, "Warning: %s: reading the pending invitations failed (%v); no metadata team will be deleted this pass — liveness can't be proven without them.\n", org, err)
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: reading the pending invitations failed (%v); no metadata team will be deleted this pass, since liveness can't be proven without them.\n", org, err)
 	} else {
 		scan.pendingEmails = pending
 	}
@@ -289,7 +289,7 @@ scanLoop:
 			// An unreadable team can't prove any team is redundant.
 			scan.trusted = false
 			if cliutil.IsRateLimited(err) {
-				_, _ = fmt.Fprintf(errOut, "Warning: %s: rate-limited while reading %s; stopping the invite pass early — re-run later.\n", org, team.Slug)
+				_, _ = fmt.Fprintf(errOut, "Warning: %s: rate-limited while reading %s; stopping the invite pass early. Re-run later.\n", org, team.Slug)
 				break
 			}
 			_, _ = fmt.Fprintf(errOut, "Warning: %s: reading invite team %s failed (%v); leaving it alone.\n", org, team.Slug, err)
@@ -305,7 +305,7 @@ scanLoop:
 			// run of either tool still in flight, and its team holds no address
 			// to lose.
 			if !state.Provisional {
-				scan.anomalies = append(scan.anomalies, fmt.Sprintf("%s: description is no longer a readable invite record — left alone; delete it by hand once you've checked it", team.Slug))
+				scan.anomalies = append(scan.anomalies, fmt.Sprintf("%s: description is no longer a readable invite record; left alone; delete it by hand once you've checked it", team.Slug))
 				scan.trusted = false
 			}
 			continue
@@ -320,7 +320,7 @@ scanLoop:
 		// after accepting, so only a record whose address still hashes back to
 		// this team's name may bind a roster row.
 		if configrepo.InviteTeamName(classroom, email) != team.Slug {
-			scan.anomalies = append(scan.anomalies, fmt.Sprintf("%s: stored address does not match the team name hash — left alone; delete it by hand once you've checked it", team.Slug))
+			scan.anomalies = append(scan.anomalies, fmt.Sprintf("%s: stored address does not match the team name hash; left alone; delete it by hand once you've checked it", team.Slug))
 			continue
 		}
 
@@ -341,7 +341,7 @@ scanLoop:
 				scan.staleSlugs = append(scan.staleSlugs, team.Slug)
 			}
 		case len(members) > 1:
-			scan.anomalies = append(scan.anomalies, fmt.Sprintf("%s: %d members, so no single invitee can be identified — left alone", team.Slug, len(members)))
+			scan.anomalies = append(scan.anomalies, fmt.Sprintf("%s: %d members, so no single invitee can be identified; left alone", team.Slug, len(members)))
 		default:
 			invitee := members[0]
 			if !idx.ok || len(idx.enrolled) == 0 {
@@ -365,7 +365,7 @@ scanLoop:
 				if confErr != nil {
 					scan.trusted = false
 					if cliutil.IsRateLimited(confErr) {
-						_, _ = fmt.Fprintf(errOut, "Warning: %s: rate-limited while re-checking %s's classroom membership; stopping the invite pass early — re-run later.\n", org, invitee.Login)
+						_, _ = fmt.Fprintf(errOut, "Warning: %s: rate-limited while re-checking %s's classroom membership; stopping the invite pass early. Re-run later.\n", org, invitee.Login)
 						break scanLoop
 					}
 					_, _ = fmt.Fprintf(errOut, "Warning: %s: re-checking %s's classroom membership failed (%v); leaving %s alone.\n", org, invitee.Login, confErr, team.Slug)
@@ -605,7 +605,7 @@ func runRosterSync(client githubapi.Client, out, errOut io.Writer, org, classroo
 	// assertClassroomNotArchived), but a dry run stays allowed so the leftovers
 	// remain inspectable.
 	if write && idx.archived {
-		return fmt.Errorf("classroom %q is archived (classroom.json active:false) — its roster is frozen, so `roster sync --write` is refused; run `gh teacher classroom unarchive %s %s` first, or re-run without --write to see what is pending",
+		return fmt.Errorf("classroom %q is archived (classroom.json active:false) and its roster is frozen, so `roster sync --write` is refused. Run `gh teacher classroom unarchive %s %s` first, or re-run without --write to see what is pending",
 			classroom, org, classroom)
 	}
 
@@ -650,7 +650,7 @@ func runRosterSync(client githubapi.Client, out, errOut io.Writer, org, classroo
 		return err
 	}
 	if !scan.trusted {
-		_, _ = fmt.Fprintf(errOut, "Note: %s: no metadata team was deleted — this pass could not read enough to prove one is redundant.\n", org)
+		_, _ = fmt.Fprintf(errOut, "Note: %s: no metadata team was deleted; this pass could not read enough to prove one is redundant.\n", org)
 		return syncDegradedError(org, classroom)
 	}
 	if !deleteRetiredInviteTeams(client, out, errOut, org, classroom, scan, retired) {
@@ -702,7 +702,7 @@ func retirableSlugs(rows []configrepo.RosterRow, scan inviteScan) []string {
 func syncDegradedError(org, classroom string) error {
 	return &cliutil.ExitCodeError{
 		Code: syncExitDegraded,
-		Err:  fmt.Errorf("%s: the %s sync was incomplete — a read was degraded, so no metadata team was deleted; re-run once GitHub is healthy", org, classroom),
+		Err:  fmt.Errorf("%s: the %s sync was incomplete: a read was degraded, so no metadata team was deleted; re-run once GitHub is healthy", org, classroom),
 	}
 }
 
@@ -716,13 +716,13 @@ func reportSyncPlan(out, errOut io.Writer, org, classroom string, scan inviteSca
 		_, _ = fmt.Fprintf(out, "%s: up to date (no invites to record, no ids to fill)\n", path)
 	}
 	for _, rec := range plan.folds {
-		_, _ = fmt.Fprintf(out, "%s: %s accepted — record as %s (github_id %d)\n", path, rec.Email, rec.Login, rec.ID)
+		_, _ = fmt.Fprintf(out, "%s: %s accepted: record as %s (github_id %d)\n", path, rec.Email, rec.Login, rec.ID)
 	}
 	for _, rec := range plan.emailFills {
-		_, _ = fmt.Fprintf(out, "%s: %s accepted — record that address on %s's row (github_id %d)\n", path, rec.Email, rec.Login, rec.ID)
+		_, _ = fmt.Fprintf(out, "%s: %s accepted: record that address on %s's row (github_id %d)\n", path, rec.Email, rec.Login, rec.ID)
 	}
 	for _, rec := range plan.appends {
-		_, _ = fmt.Fprintf(out, "%s: %s accepted but has no row — add %s (github_id %d)\n", path, rec.Email, rec.Login, rec.ID)
+		_, _ = fmt.Fprintf(out, "%s: %s accepted but has no row: add %s (github_id %d)\n", path, rec.Email, rec.Login, rec.ID)
 	}
 	for _, username := range plan.backfills {
 		_, _ = fmt.Fprintf(out, "%s: fill in %s's github_id from the classroom team\n", path, username)
@@ -731,10 +731,10 @@ func reportSyncPlan(out, errOut io.Writer, org, classroom string, scan inviteSca
 		_, _ = fmt.Fprintf(out, "%s: delete the leftover metadata team %s\n", org, slug)
 	}
 	for _, slug := range retirable {
-		_, _ = fmt.Fprintf(out, "%s: retire the metadata team %s — the roster already records its address\n", org, slug)
+		_, _ = fmt.Fprintf(out, "%s: retire the metadata team %s (the roster already records its address)\n", org, slug)
 	}
 	for _, username := range plan.findings.dupLogins {
-		_, _ = fmt.Fprintf(errOut, "Warning: %s: left a second row for %q alone — more than one row carries that username, and only the first can be filled in, so which student the id belongs to is not this pass's guess. Remove the duplicate row (or give it its own username) to let the sync finish it.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: left a second row for %q alone: more than one row carries that username, and only the first can be filled in, so which student the id belongs to is not this pass's guess. Remove the duplicate row (or give it its own username) to let the sync finish it.\n",
 			path, username)
 	}
 	for _, anomaly := range scan.anomalies {
@@ -842,7 +842,7 @@ func deleteRetiredInviteTeams(client githubapi.Client, out, errOut io.Writer, or
 	slugs := make([]string, 0, len(retired)+len(scan.staleSlugs))
 	for _, rec := range scan.recovered {
 		if !recordedSlug[rec.Slug] {
-			_, _ = fmt.Fprintf(errOut, "Note: %s: kept metadata team %s — no row records %s against %s's account, so this team is still the only record of that address. Add it to their row (or clear the address they carry) and re-run.\n",
+			_, _ = fmt.Fprintf(errOut, "Note: %s: kept metadata team %s: no row records %s against %s's account, so this team is still the only record of that address. Add it to their row (or clear the address they carry) and re-run.\n",
 				org, rec.Slug, rec.Email, rec.Login)
 			continue
 		}
@@ -856,13 +856,13 @@ func deleteRetiredInviteTeams(client githubapi.Client, out, errOut io.Writer, or
 
 	live, err := liveInviteSlugs(client, org, classroom)
 	if err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: %s: re-checking the pending invitations failed (%v); every metadata team was left in place — a leftover is collected next pass, whereas a wrong delete loses the address for good.\n", org, err)
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: re-checking the pending invitations failed (%v); every metadata team was left in place. A leftover is collected next pass, whereas a wrong delete loses the address for good.\n", org, err)
 		return false
 	}
 	ok := true
 	for _, slug := range slugs {
 		if live[slug] {
-			_, _ = fmt.Fprintf(errOut, "Note: %s: kept metadata team %s — a same-email re-invite now maps to it, so deleting it would strip a live invitation.\n", org, slug)
+			_, _ = fmt.Fprintf(errOut, "Note: %s: kept metadata team %s: a same-email re-invite now maps to it, so deleting it would strip a live invitation.\n", org, slug)
 			continue
 		}
 		if err := configrepo.DeleteInviteTeam(client, org, slug); err != nil {

--- a/cli/gh-teacher/internal/roster/sync_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/sync_cmd_test.go
@@ -1418,7 +1418,7 @@ func TestRunRosterSync_RowWithAnUnusableGitHubIDFoldsLikeTheWeb(t *testing.T) {
 	if got := exitCode(err); got != 2 {
 		t.Fatalf("dry-run exit code = %d (err %v), want 2 for a fold pending", got, err)
 	}
-	if !strings.Contains(out, "accepted — record as") {
+	if !strings.Contains(out, "accepted: record as") {
 		t.Errorf("dry run must report the fold:\n%s", out)
 	}
 	if writes := writeCalls(dry.calls); len(writes) != 0 {

--- a/cli/gh-teacher/internal/servicetoken/servicetoken.go
+++ b/cli/gh-teacher/internal/servicetoken/servicetoken.go
@@ -170,14 +170,14 @@ func validateTokenWithClient(tokenClient githubapi.Client, org string, out io.Wr
 	// Token can read the repo, but regrade needs Contents: write to push
 	// submit/* tags. A read-only PAT reports push == false; reject it.
 	if !repo.Permissions.Push {
-		return fmt.Errorf("the supplied token can read %s/%s but lacks write access (Contents: write) — collecting scores needs read, but regrading needs to push submit/* tags to student repos. Re-create the fine-grained PAT with Resource owner = %q, Repository access = All repositories, and Repository permissions -> Contents: Read and write AND Actions: Read and write AND Administration: Read and write (regrade re-runs student autograde workflow runs; collect grants staff teams repo access)", org, configrepo.ConfigRepoName, org)
+		return fmt.Errorf("the supplied token can read %s/%s but lacks write access (Contents: write): collecting scores needs read, but regrading needs to push submit/* tags to student repos. Re-create the fine-grained personal access token with Resource owner = %q, Repository access = All repositories, and Repository permissions -> Contents: Read and write, Actions: Read and write, and Administration: Read and write (regrade re-runs student autograde workflow runs; collect grants staff teams repo access)", org, configrepo.ConfigRepoName, org)
 	}
 
 	// Contents is proven, but collect grants staff teams repo access, needing
 	// Administration (not implied by Contents); reject an admin-less PAT here
 	// rather than as a collect-time 403 on the first grant.
 	if !repo.Permissions.Admin {
-		return fmt.Errorf("the supplied token can read and write %s/%s but lacks admin access (Administration: write) — collecting scores grants staff teams (e.g., TAs) read access to student repos, which needs the Administration permission. Re-create the fine-grained PAT with Resource owner = %q, Repository access = All repositories, and Repository permissions -> Contents: Read and write AND Actions: Read and write AND Administration: Read and write", org, configrepo.ConfigRepoName, org)
+		return fmt.Errorf("the supplied token can read and write %s/%s but lacks admin access (Administration: write): collecting scores grants staff teams (TAs, for example) read access to student repos, which needs the Administration permission. Re-create the fine-grained personal access token with Resource owner = %q, Repository access = All repositories, and Repository permissions -> Contents: Read and write, Actions: Read and write, and Administration: Read and write", org, configrepo.ConfigRepoName, org)
 	}
 
 	// Contents is proven, but collection is team-driven: it lists the
@@ -188,7 +188,7 @@ func validateTokenWithClient(tokenClient githubapi.Client, org string, out io.Wr
 	membersPath := fmt.Sprintf("orgs/%s/members?per_page=1", url.PathEscape(org))
 	if err := tokenClient.Get(membersPath, nil); err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusNotFound) || cliutil.IsHTTPStatus(err, http.StatusForbidden) {
-			return fmt.Errorf("the supplied token can read %s/%s but can't read the org's members — collecting scores is team-driven and lists the classroom team's members, which needs the org-level Members permission. Re-create the fine-grained PAT with Resource owner = %q and add Organization permissions -> Members: Read (this is a separate section from Repository permissions; it appears only once the org is selected as Resource owner). Underlying error: %v", org, configrepo.ConfigRepoName, org, err)
+			return fmt.Errorf("the supplied token can read %s/%s but can't read the org's members: collecting scores is team-driven and lists the classroom team's members, which needs the org-level Members permission. Re-create the fine-grained personal access token with Resource owner = %q and add Organization permissions -> Members: Read (this is a separate section from Repository permissions; it appears only once the org is selected as Resource owner). Underlying error: %v", org, configrepo.ConfigRepoName, org, err)
 		}
 		// Inconclusive (401 after a 200 repo read, 5xx, rate-limit, timeout):
 		// proceed but WARN — Members: Read wasn't confirmed, and an
@@ -262,26 +262,28 @@ func ProvisionSecret(client githubapi.Client, out io.Writer, owner, repo string,
 func NewRotateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rotate-service-token <org>",
-		Short: "Rotate the CLASSROOM50_SERVICE_TOKEN repo secret",
-		Long: "Re-uploads the CLASSROOM50_SERVICE_TOKEN repo-level\n" +
-			"Actions secret on <org>/classroom50 with a freshly-supplied\n" +
-			"PAT value. The token is read from the\n" +
-			"CLASSROOM50_SERVICE_TOKEN environment variable, falling\n" +
-			"back to a hidden stdin prompt when run interactively.\n\n" +
-			"The token is validated against the org before it's stored\n" +
-			"(it must be able to read AND write repository contents:\n" +
-			"collect-scores reads, regrade pushes submit/* tags; it must\n" +
-			"be able to administer repos: collect grants staff teams repo\n" +
-			"access; and it must be able to read the org's members:\n" +
-			"collection is team-driven and lists the classroom team). So a\n" +
-			"misconfigured PAT is caught here rather than via a failed\n" +
-			"collect-scores or regrade run.\n\n" +
-			"Required fine-grained PAT scopes: Repository permissions ->\n" +
-			"Contents: Read and write AND Actions: Read and write AND\n" +
-			"Administration: Read and write (Metadata: Read is auto-included),\n" +
-			"and Organization permissions -> Members: Read (a separate section\n" +
-			"shown only once the org is the Resource owner).\n\n" +
-			"Idempotent: the repo secret is replaced in place.",
+		Short: "Rotate the classroom service token",
+		Long: "Replace the CLASSROOM50_SERVICE_TOKEN repository secret on\n" +
+			"<org>/classroom50 with a freshly-supplied personal access token.\n" +
+			"The token is read from the CLASSROOM50_SERVICE_TOKEN environment\n" +
+			"variable, falling back to a hidden stdin prompt when run\n" +
+			"interactively.\n\n" +
+			"The token is validated against the organization before it's\n" +
+			"stored, so a misconfigured token is caught here rather than via\n" +
+			"a failed collect-scores or regrade run. It must be able to:\n" +
+			"  - read and write repository contents (collect-scores reads,\n" +
+			"    regrade pushes submit/* tags)\n" +
+			"  - administer repositories (collect grants staff teams repo\n" +
+			"    access)\n" +
+			"  - read the org's members (collection is team-driven and lists\n" +
+			"    the classroom team)\n\n" +
+			"Required fine-grained token permissions:\n" +
+			"  - Repository permissions -> Contents: Read and write, Actions:\n" +
+			"    Read and write, and Administration: Read and write\n" +
+			"    (Metadata: Read is auto-included)\n" +
+			"  - Organization permissions -> Members: Read (a separate section\n" +
+			"    shown only once the org is the Resource owner)\n\n" +
+			"Idempotent: the repository secret is replaced in place.",
 		Example: "  CLASSROOM50_SERVICE_TOKEN=github_pat_xxx gh teacher rotate-service-token cs50-fall-2026\n" +
 			"  gh teacher rotate-service-token cs50-fall-2026   # interactive prompt",
 		Args: cobra.ExactArgs(1),

--- a/cli/gh-teacher/internal/staff/staff.go
+++ b/cli/gh-teacher/internal/staff/staff.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 			"Staff roles are GitHub Teams. The teacher and head-TA (hta) teams\n" +
 			"get write on the classroom50 repository so members can author assignments; the\n" +
 			"ta team gets read-only. Head TAs are org members, never org owners.\n" +
-			"This mirrors the web GUI's \"Staff & roles\" section — a classroom\n" +
+			"This mirrors the web GUI's \"Staff & roles\" section: a classroom\n" +
 			"managed from either surface has the same staff.\n\n" +
 			"Subcommands:\n" +
 			"  add     add a user to a classroom's teacher, hta, or ta team\n" +
@@ -194,7 +194,7 @@ func ensureStaffTeamRecorded(client githubapi.Client, out io.Writer, org, classr
 	if _, ok, err := configrepo.LoadClassroom(client, org, classroom, branch); err != nil {
 		return configrepo.TeamRef{}, err
 	} else if !ok {
-		return configrepo.TeamRef{}, fmt.Errorf("%s: classroom %s not found in %s — run `gh teacher classroom add %s %s` first",
+		return configrepo.TeamRef{}, fmt.Errorf("%s: classroom %s not found in %s: run `gh teacher classroom add %s %s` first",
 			org, classroom, configrepo.ConfigRepoName, org, classroom)
 	}
 	team, err := configrepo.EnsureClassroomStaffTeam(client, org, classroom, role)
@@ -264,7 +264,7 @@ func runStaffRemove(client githubapi.Client, out io.Writer, org, classroom, user
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("%s: classroom %s has no %s staff team recorded in classroom.json — nothing to remove",
+		return fmt.Errorf("%s: classroom %s has no %s staff team recorded in classroom.json: nothing to remove",
 			org, classroom, role)
 	}
 	if err := configrepo.RemoveTeamMembership(client, org, team.Slug, login); err != nil {

--- a/cli/gh-teacher/internal/teardown/teardown.go
+++ b/cli/gh-teacher/internal/teardown/teardown.go
@@ -31,15 +31,15 @@ func NewCmd() *cobra.Command {
 		Use:   "teardown <org>",
 		Short: "Delete every repo in a Classroom 50 org (development reset)",
 		Long: "Delete every repository in <org> after confirming the org is a\n" +
-			"Classroom 50 setup (i.e., <org>/classroom50 exists). Intended for\n" +
-			"resetting a development org between iterations — production\n" +
+			"Classroom 50 setup (<org>/classroom50 exists). Intended for\n" +
+			"resetting a development org between iterations; production\n" +
 			"teachers should use the GitHub web UI for selective deletion.\n\n" +
-			"Before any deletion, the command lists every repo it would\n" +
+			"Before any deletion, the command lists every repository it would\n" +
 			"remove and requires you to type the org name to confirm.\n" +
 			"Pass --yes to skip the prompt (scripted runs only).\n\n" +
 			"<org>/classroom50 is deleted last so a mid-run failure leaves\n" +
-			"the marker repo behind — re-running teardown stays safe.\n\n" +
-			"Requires the `delete_repo` OAuth scope, which is NOT part of\n" +
+			"the marker repository behind and re-running teardown stays safe.\n\n" +
+			"Requires the `delete_repo` OAuth scope, which is not part of\n" +
 			"the default `gh teacher login` scope set. Opt in once with\n" +
 			"`gh teacher login -s delete_repo` before running teardown.\n" +
 			"This is intentional: teachers who haven't explicitly opted in\n" +
@@ -189,7 +189,7 @@ func runTeardown(client githubapi.Client, in io.Reader, out, errOut io.Writer, o
 	sweepInviteTeams(client, org, out, errOut)
 
 	if failed > 0 {
-		return fmt.Errorf("%d repo(s) failed to delete — see stderr for per-repo errors", failed)
+		return fmt.Errorf("%d repo(s) failed to delete; see stderr for per-repo errors", failed)
 	}
 	return nil
 }
@@ -265,7 +265,7 @@ func requireConfigRepo(client githubapi.Client, org string) error {
 	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), configrepo.ConfigRepoName)
 	if err := client.Get(path, nil); err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
-			return fmt.Errorf("%s/%s not found — refusing teardown on an org without the Classroom 50 marker repo. Run `gh teacher init %s` first if this is intended, or delete repos manually via the web UI",
+			return fmt.Errorf("%s/%s not found: refusing teardown on an org without the Classroom 50 marker repository. Run `gh teacher init %s` first if this is intended, or delete repos manually via the web UI",
 				org, configrepo.ConfigRepoName, org)
 		}
 		return fmt.Errorf("GET %s: %w", path, err)
@@ -299,7 +299,7 @@ func deleteRepo(client githubapi.Client, owner, repo string) error {
 	resp, err := client.Request(http.MethodDelete, path, nil)
 	if err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusForbidden) {
-			return fmt.Errorf("403 Forbidden — typically your token lacks the `delete_repo` OAuth scope (opt in with `gh teacher login -s delete_repo`); 403 can also mean your account doesn't have delete permission on this repo")
+			return fmt.Errorf("403 Forbidden: typically your token lacks the `delete_repo` OAuth scope (opt in with `gh teacher login -s delete_repo`); 403 can also mean your account doesn't have delete permission on this repo")
 		}
 		return fmt.Errorf("DELETE %s: %w", path, err)
 	}
@@ -321,7 +321,7 @@ func confirmTeardown(in io.Reader, out io.Writer, org string) error {
 		return fmt.Errorf("read confirmation: %w", err)
 	}
 	if strings.TrimSpace(line) != org {
-		return errors.New("confirmation did not match org name — aborted without deleting anything")
+		return errors.New("confirmation did not match the org name: aborted without deleting anything")
 	}
 	return nil
 }

--- a/cli/gh-teacher/internal/validate/validate.go
+++ b/cli/gh-teacher/internal/validate/validate.go
@@ -98,7 +98,7 @@ func ComposedRepoNameOverflows(classroom, slug string) (worstCase int, overflows
 // ShortNamePattern's 100 stay fully operable.
 func ClassroomShortNameBudget(shortName string) error {
 	if len(shortName) > contract.ClassroomShortNameMaxLen {
-		return fmt.Errorf("classroom short-name %q is %d characters; new classrooms are capped at %d because student repos are named `<short-name>-<assignment>-<username>` and GitHub caps repo names at %d characters — a shorter short-name keeps room for assignment slugs and any username",
+		return fmt.Errorf("classroom short-name %q is %d characters; new classrooms are capped at %d because student repos are named `<short-name>-<assignment>-<username>` and GitHub caps repo names at %d characters. A shorter short-name keeps room for assignment slugs and any username",
 			shortName, len(shortName), contract.ClassroomShortNameMaxLen, contract.GitHubRepoNameMaxLen)
 	}
 	return nil
@@ -117,10 +117,10 @@ func ComposedRepoNameBudget(classroom, slug string) error {
 	}
 	budget := contract.AssignmentSlugBudget(classroom)
 	if budget < 2 {
-		return fmt.Errorf("student repos are named `<classroom>-<assignment>-<username>`; %q + %q reaches %d characters with a %d-char username, over GitHub's %d-char repo-name limit — classroom %q leaves no room for any slug, so create a classroom with a shorter short-name (at most %d characters) and add the assignment there",
+		return fmt.Errorf("student repos are named `<classroom>-<assignment>-<username>`; %q + %q reaches %d characters with a %d-char username, over GitHub's %d-char repo-name limit. Classroom %q leaves no room for any slug, so create a classroom with a shorter short-name (at most %d characters) and add the assignment there",
 			classroom, slug, worst, contract.GitHubLoginMaxLen, contract.GitHubRepoNameMaxLen, classroom, contract.ClassroomShortNameMaxLen)
 	}
-	return fmt.Errorf("student repos are named `<classroom>-<assignment>-<username>`; %q + %q reaches %d characters with a %d-char username, over GitHub's %d-char repo-name limit — use a slug of at most %d characters, or create a classroom with a shorter short-name",
+	return fmt.Errorf("student repos are named `<classroom>-<assignment>-<username>`; %q + %q reaches %d characters with a %d-char username, over GitHub's %d-char repo-name limit. Use a slug of at most %d characters, or create a classroom with a shorter short-name",
 		classroom, slug, worst, contract.GitHubLoginMaxLen, contract.GitHubRepoNameMaxLen, budget)
 }
 

--- a/cli/gh-teacher/main.go
+++ b/cli/gh-teacher/main.go
@@ -44,7 +44,7 @@ var (
 func main() {
 	root := &cobra.Command{
 		Use:     "gh-teacher",
-		Short:   "Teacher-facing GitHub CLI extension",
+		Short:   "Manage Classroom 50 classrooms, rosters, and assignments",
 		Version: versionString(),
 	}
 	root.SetErrPrefix("gh-teacher:")

--- a/cli/gh-teacher/service_token.go
+++ b/cli/gh-teacher/service_token.go
@@ -43,7 +43,7 @@ func provisionServiceToken(cmd *cobra.Command, client githubapi.Client, summary 
 	// 2. Re-run with the secret already present: don't re-prompt.
 	if secretExists {
 		summary.ServiceToken = "already configured"
-		_, _ = fmt.Fprintf(errOut, "Service token: already configured — left as-is. To replace it, run `gh teacher rotate-service-token %s` (or set %s and re-run).\n", org, servicetoken.EnvServiceToken)
+		_, _ = fmt.Fprintf(errOut, "Service token: already configured, left as-is. To replace it, run `gh teacher rotate-service-token %s` (or set %s and re-run).\n", org, servicetoken.EnvServiceToken)
 		return nil
 	}
 

--- a/cli/shared/ghauth/ghauth.go
+++ b/cli/shared/ghauth/ghauth.go
@@ -90,7 +90,7 @@ func RequireClient(out, errOut writer, opts Options) (*api.RESTClient, error) {
 	// `gh auth refresh`; env/PAT tokens must be fixed by the user.
 	if !isGhManagedToken(source) {
 		return nil, fmt.Errorf(
-			"your %s token (source: %s) is missing scopes %s needs (%s); it wasn't set by `gh auth login`, so re-run won't fix it — re-issue the token with those scopes, or unset it and run `%s login`",
+			"your %s token (source: %s) is missing scopes %s needs (%s); it wasn't set by `gh auth login`, so re-running won't fix it. Re-issue the token with those scopes, or unset it and run `%s login`",
 			host, source, opts.CommandName, strings.Join(opts.RequiredScopes, ", "), opts.CommandName)
 	}
 	if !IsInteractiveTTY() {
@@ -217,7 +217,7 @@ func confirmProceed(errOut writer, in io.Reader) bool {
 func printLoginDeclinedHelp(errOut writer, host string, requiredScopes []string) {
 	scopeCSV := strings.Join(requiredScopes, ",")
 	_, _ = fmt.Fprintf(errOut,
-		"Aborted — your existing %s authentication is unchanged. To get the scopes without replacing your token, either:\n"+
+		"Aborted: your existing %s authentication is unchanged. To get the scopes without replacing your token, either:\n"+
 			"  • widen your current login in place:  gh auth refresh -h %s -s %s\n"+
 			"  • or use your own token:               export GH_TOKEN=<a PAT with %s>\n",
 		host, host, scopeCSV, strings.Join(requiredScopes, ", "))


### PR DESCRIPTION
## Summary

The CLI half of the copy program (web landed in #813): every user-facing string in `gh teacher`, `gh student`, and `cli/shared` audited and rewritten against the [Zen of GitHub](https://primer.style/product/getting-started/#the-zen-of-github) and gh CLI help conventions. ~330 strings across 58 files.

- **Scannable help:** the long `Long:` walls restructure into a short intro plus bullet sections — 11 blocks in gh-teacher (init, assignment add, reuse, download, rotate-service-token, ...) and the three student walls (`accept`, `submit`, `invite`). Every fact, caveat, and scope from the prose survives; the accept help now reads as "What accept does:" / "Visibility and access:" lists instead of one paragraph.
- **gh CLI conventions:** `Short:` capitalized, verb-first, no trailing period; flag descriptions as capitalized fragments; realistic examples.
- **GitHub voice:** no please/sorry/successfully, no em dashes (all re-expressed as periods, colons, or commas), no Latin abbreviations, US spelling.
- **Errors that help:** returned errors stay Go-idiomatic (lowercase, unpunctuated, `%w` wrapping intact) but say what happened and what to do next; printed failures route students to "ask your teacher" when they can't act, matching the web accept flow.
- **Student jargon bar:** no unexplained `assignments.json` ("the classroom's published assignment list"), shim, or YAML in student-facing text.
- **Terminology matches the web app:** score (not grade), release for assignment availability vs publish for the site, invite link, organization/repository spelled out in prose.

A hunk-by-hunk independent review (268 hunks) verified meaning preservation, that sentinel strings with exact-match consumers were updated together, that every flag referenced in new help exists, and that format verbs match argument lists. Its four findings (a slug-precision loss, one accidentally broadened test assertion, two comma splices) are fixed in this commit.

## Test plan

- [x] `go build ./...` + `go test ./...` green in gh-teacher, gh-student, and shared (39 packages)
- [x] `golangci-lint run` and `golangci-lint fmt --diff` clean in all three modules
- [x] 0 em dashes / 0 please-sorry-successfully in added lines
- [ ] Manual skim: `gh teacher --help`, `gh teacher init --help`, `gh student accept --help`, `gh student submit --help`
- [ ] Trigger one failing path per binary (bad org, missing key) and confirm the error reads well end-to-end