### PR TITLE
fix: fetch the org repo listing in parallel and probe known repo names

### DIFF
--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -119,7 +119,15 @@ TRANSIENT_RETRY_CAP_SECONDS = 30
 MAX_TOTAL_THROTTLE_SLEEP_SECONDS = 300
 
 _throttle_sleep_spent = 0.0
-# Guards _throttle_sleep_spent and _request_count: the bulk listings fetch
+# Wall-clock accounting for the budget above. Bulk listings sleep out a
+# throttle on up to PARALLEL_PAGE_WORKERS threads at once; charging each thread
+# would spend the whole budget on one episode. Overlapping waits count once:
+# `_throttle_sleep_until` is the latest deadline any thread is waiting for, and
+# a thread's own waits are sequential, so its next wait starts at its own last
+# deadline (kept in `_throttle_local`), never earlier.
+_throttle_sleep_until = 0.0
+_throttle_local = threading.local()
+# Guards the throttle accounting and _request_count: the bulk listings fetch
 # pages on a thread pool, so the transport runs concurrently.
 _transport_lock = threading.Lock()
 _request_count = 0
@@ -633,11 +641,12 @@ class RepoIndex:
         self._token = token
         self._repos: dict[str, bool] | None = None
         self._loaded = False
+        self._started = 0.0
         # Probe mode: page 1 plus per-name answers. `_found` maps a name to its
         # private flag, or None when its read failed (unknown, fails open);
-        # `_missing` holds the names that 404ed.
+        # `_missing` holds the names that 404ed so they are not probed twice.
         self._probing = False
-        self._pages_left = 0
+        self._last_page = 1
         self._probes_spent = 0
         self._found: dict[str, bool | None] = {}
         self._missing: set[str] = set()
@@ -661,22 +670,16 @@ class RepoIndex:
         rather than spending the run on the degraded answer."""
         if self._loaded:
             return self._repos
+        self._started = time.monotonic()
         self._repos = self._read(hint)
         self._loaded = True
         return self._repos
 
-    def _read(self, hint: list[str] | None) -> dict[str, bool] | None:
-        """One attempt at the org listing (or, given a small enough hint, its
-        first page plus probes)."""
-        started = time.monotonic()
+    def _soft_read(self, read: Callable[[], Any]) -> Any:
+        """Run one listing read. A SKIPPABLE HTTP error or a malformed body warns
+        and returns None (unknown, so callers fail open); anything else raises."""
         try:
-            if hint is None:
-                repos = list_org_repos(self._api_url, self._org, self._token)
-                pages_left = 0
-            else:
-                repos, pages_left = list_org_repos_first_page(
-                    self._api_url, self._org, self._token
-                )
+            return read()
         except urllib.error.HTTPError as exc:
             if classify(exc) is not SKIPPABLE:
                 raise
@@ -693,46 +696,72 @@ class RepoIndex:
                 f"falling back to probing every (member, assignment) repo name."
             )
             return None
+
+    def _read(self, hint: list[str] | None) -> dict[str, bool] | None:
+        """One attempt at the org listing (or, given a small enough hint, its
+        first page plus probes)."""
+        if hint is None:
+            repos = self._soft_read(
+                lambda: list_org_repos(self._api_url, self._org, self._token)
+            )
+            return self._listing(repos)
+        first = self._soft_read(
+            lambda: list_org_repos_first_page(self._api_url, self._org, self._token)
+        )
+        if first is None:
+            return None
+        repos, last = first
         # Unknown, not "nothing exists": a token scoped to zero repos must not
         # silently skip every poll.
         if not repos:
             return None
-        if pages_left:
-            unresolved = [name for name in (hint or []) if name not in repos]
-            if len(unresolved) <= pages_left:
+        if last > 1:
+            unresolved = [name for name in hint if name not in repos]
+            if len(unresolved) <= last - 1:
                 self._probing = True
-                self._pages_left = pages_left
+                self._last_page = last
                 self._found = dict(repos)
                 print(
-                    f"{self._org}: {pages_left + 1} page(s) of repos; checking "
+                    f"{self._org}: {last} page(s) of repos; checking "
                     f"{len(unresolved)} candidate repo name(s) directly instead"
                 )
                 return None
-            repos.update(
-                list_org_repos_rest(self._api_url, self._org, self._token, pages_left)
+            rest = self._soft_read(
+                lambda: list_org_repos_rest(self._api_url, self._org, self._token, last)
             )
+            if rest is None:
+                return None
+            repos.update(rest)
+        return self._listing(repos)
+
+    def _listing(self, repos: dict[str, bool] | None) -> dict[str, bool] | None:
+        """Accept a complete listing, treating empty as unknown."""
+        if not repos:
+            return None
         print(
             f"{self._org}: {len(repos)} repo(s) visible to the service token "
-            f"({time.monotonic() - started:.1f}s)"
+            f"({time.monotonic() - self._started:.1f}s)"
         )
         return repos
 
-    def _complete_listing(self) -> dict[str, bool]:
+    def _complete_listing(self) -> dict[str, bool] | None:
         """Leave probe mode by reading the rest of the listing. Probed answers
         are kept: a name found by probe is in the org whether or not it lands on
-        a page (a repo created mid-walk shifts the pages)."""
-        rest = list_org_repos_rest(
-            self._api_url, self._org, self._token, self._pages_left
+        a page (a repo created mid-walk shifts the pages). A soft failure leaves
+        the listing unknown, like a failed first read."""
+        rest = self._soft_read(
+            lambda: list_org_repos_rest(
+                self._api_url, self._org, self._token, self._last_page
+            )
         )
-        repos: dict[str, bool] = {}
-        for name, private in self._found.items():
-            if private is not None:
-                repos[name] = private
-        repos.update(rest)
-        self._repos = repos
         self._probing = False
-        print(f"{self._org}: {len(repos)} repo(s) visible to the service token")
-        return repos
+        if rest is None:
+            self._repos = None
+            return None
+        repos = {name: private for name, private in self._found.items() if private is not None}
+        repos.update(rest)
+        self._repos = self._listing(repos)
+        return self._repos
 
     def _resolved(self, name: str) -> bool:
         return name in self._found or name in self._missing
@@ -742,46 +771,40 @@ class RepoIndex:
         probes would cost more than the pages they stand in for."""
         if not names:
             return
-        if self._probes_spent + len(names) > self._pages_left:
+        if self._probes_spent + len(names) > self._last_page - 1:
             self._complete_listing()
             return
-        self._probes_spent += len(names)
         found = probe_org_repos(self._api_url, self._org, names, self._token)
+        self._probes_spent += len(names)
         self._found.update(found)
         self._missing.update(name for name in names if name not in found)
 
-    def _lookup(self, name: str) -> None:
-        """Probe-mode resolution of one lowercased name, if not yet known. May
-        leave probe mode (see _probe), after which `_repos` holds the answer."""
-        if not self._resolved(name):
-            self._probe([name])
+    def _answers(self, name: str) -> dict[str, bool | None] | None:
+        """The map that holds `name`'s answer: the listing, or in probe mode the
+        probe results once `name` is resolved (which may complete the listing).
+        None when the listing is unknown. In probe mode an unknown name maps to
+        None and a 404 name is absent, so both maps read the same way."""
+        repos = self._load()
+        if repos is None and self._probing:
+            if not self._resolved(name):
+                self._probe([name])
+            return self._found if self._probing else self._repos
+        return repos
 
     def contains(self, repo_name: str) -> bool:
         """Whether `repo_name` exists — True whenever the listing is unknown, so
         an unreadable index never hides a repo from either pass."""
         name = repo_name.lower()
-        repos = self._load()
-        if repos is None and self._probing:
-            self._lookup(name)
-            if self._probing:
-                return name not in self._missing
-            repos = self._repos
-        return repos is None or name in repos
+        answers = self._answers(name)
+        return answers is None or name in answers
 
     def is_private(self, repo_name: str) -> bool | None:
         """Whether `repo_name` is private, or None when the index can't say (the
         listing was unreadable, or the name isn't in it). Answers from the
         listing already read, saving the caller a per-repo request."""
         name = repo_name.lower()
-        repos = self._load()
-        if repos is None and self._probing:
-            self._lookup(name)
-            if self._probing:
-                return self._found.get(name)
-            repos = self._repos
-        if repos is None:
-            return None
-        return repos.get(name)
+        answers = self._answers(name)
+        return None if answers is None else answers.get(name)
 
     def names(self) -> list[str] | None:
         """Every visible repo name (lowercased), or None when the listing is
@@ -2948,6 +2971,40 @@ def _fetch_pages_parallel(
             raise
 
 
+def _first_page(
+    page_url: Callable[[int], str],
+    api_url: str,
+    token: str,
+    resource_label: str,
+) -> tuple[list[dict[str, Any]], int | None]:
+    """Page 1 of a list endpoint and its page count from `Link: rel="last"`.
+
+    A None count means the returned items are already the whole listing: the
+    header named no other page, or it named only a `rel="next"` (a
+    cursor-paginated endpoint), in which case the walk is finished here by
+    _paginate_objects without re-reading page 1. Raises IncompleteListing when
+    the count exceeds MAX_LISTING_PAGES; otherwise the _paginate_objects error
+    contract applies."""
+    batch, headers = _fetch_page(page_url(1), token)
+    link_header = headers.get("Link") if headers else None
+    last = _last_page_number(link_header, api_url)
+    if last is None:
+        if _next_page_link(link_header):
+            return (
+                _paginate_objects(
+                    page_url, api_url, token, resource_label, first=(batch, headers)
+                ),
+                None,
+            )
+        return _dict_items(batch), None
+    if last > MAX_LISTING_PAGES:
+        raise IncompleteListing(
+            f"{resource_label}: too many entries to enumerate "
+            f"({last} pages, cap {MAX_LISTING_PAGES})"
+        )
+    return _dict_items(batch), last
+
+
 def _paginate_objects_parallel(
     page_url: Callable[[int], str],
     api_url: str,
@@ -2955,32 +3012,13 @@ def _paginate_objects_parallel(
     resource_label: str,
 ) -> list[dict[str, Any]]:
     """Every object of a paginated list endpoint, with pages 2..last fetched
-    concurrently.
+    concurrently. The remaining pages are built from `page_url` (same host by
+    construction, so no Link is followed) and fetched on a thread pool.
 
-    Page 1 is read alone; its `Link: rel="last"` names the page count, and the
-    remaining pages are built from `page_url` (same host by construction, so no
-    Link is followed) and fetched on a thread pool. An org with 9,000 repos is
-    90 pages: sequentially that is minutes, in parallel it is seconds. When the
-    header names no last page but does name a next one (a cursor-paginated
-    endpoint), the walk falls back to _paginate_objects.
-
-    Same error contract as _paginate_objects: urllib.error.HTTPError on any
-    non-2xx, ValueError on a non-array body, IncompleteListing when the page
-    count exceeds MAX_LISTING_PAGES.
-    """
-    first, headers = _fetch_page(page_url(1), token)
-    link_header = headers.get("Link") if headers else None
-    last = _last_page_number(link_header, api_url)
+    Same error contract as _first_page."""
+    items, last = _first_page(page_url, api_url, token, resource_label)
     if last is None:
-        if _next_page_link(link_header):
-            return _paginate_objects(page_url, api_url, token, resource_label)
-        return _dict_items(first)
-    if last > MAX_LISTING_PAGES:
-        raise IncompleteListing(
-            f"{resource_label}: too many entries to enumerate "
-            f"({last} pages, cap {MAX_LISTING_PAGES})"
-        )
-    items = _dict_items(first)
+        return items
     for batch in _fetch_pages_parallel(page_url, token, range(2, last + 1)):
         items.extend(batch)
     return items
@@ -3011,6 +3049,7 @@ def _paginate_objects(
     token: str,
     resource_label: str,
     stop_after: Callable[[dict[str, Any]], bool] | None = None,
+    first: tuple[list[Any], Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Walk a paginated GitHub list endpoint, returning every object it yields.
 
@@ -3025,6 +3064,9 @@ def _paginate_objects(
     accept-baseline commit), sparing the rest of a long history. The whole page
     is still returned, so the caller cuts precisely.
 
+    `first` (optional) is page 1 as (raw array, headers) already read by the
+    caller, so a walk that starts elsewhere does not fetch it twice.
+
     Raises urllib.error.HTTPError on any non-2xx (including 404) so the caller
     can choose soft fallback vs. hard failure; raises ValueError on a non-array
     body, and IncompleteListing (a ValueError) when the walk can't be completed
@@ -3036,7 +3078,10 @@ def _paginate_objects(
     url = page_url(1)
     seen_next: set[str] = set()
     for page in range(1, max_pages + 1):
-        batch, headers = _fetch_page(url, token)
+        if page == 1 and first is not None:
+            batch, headers = first
+        else:
+            batch, headers = _fetch_page(url, token)
         page_items = _dict_items(batch)
         items.extend(page_items)
         if stop_after is not None and any(stop_after(item) for item in page_items):
@@ -3144,8 +3189,12 @@ def list_team_member_logins(
 
 
 def _org_repos_page_url(api_url: str, org: str) -> Callable[[int], str]:
+    # Oldest first, so a repo created while pages 2..last are in flight lands
+    # after them instead of shifting every page (the default is newest first).
     base = f"{api_url}/orgs/{urllib.parse.quote(org, safe='')}/repos"
-    return lambda page: f"{base}?per_page=100&page={page}&type=all"
+    return lambda page: (
+        f"{base}?per_page=100&page={page}&type=all&sort=created&direction=asc"
+    )
 
 
 def list_org_repos(api_url: str, org: str, token: str) -> dict[str, bool]:
@@ -3170,36 +3219,25 @@ def list_org_repos(api_url: str, org: str, token: str) -> dict[str, bool]:
 def list_org_repos_first_page(
     api_url: str, org: str, token: str
 ) -> tuple[dict[str, bool], int]:
-    """Page 1 of the org listing as (lowercased name -> private, pages left).
-    0 pages left means the map already is the whole listing. Lets RepoIndex
+    """Page 1 of the org listing as (lowercased name -> private, page count).
+    A count of 1 means the map already is the whole listing. Lets RepoIndex
     learn the org's size from one request before deciding whether listing the
     rest or probing the candidate names is cheaper.
 
     Same error contract as list_org_repos."""
-    page_url = _org_repos_page_url(api_url, org)
-    batch, headers = _fetch_page(page_url(1), token)
-    link_header = headers.get("Link") if headers else None
-    last = _last_page_number(link_header, api_url)
-    if last is None:
-        if _next_page_link(link_header):
-            # No page count to plan with: take the whole listing now.
-            return list_org_repos(api_url, org, token), 0
-        return _repo_privacy_map(_dict_items(batch)), 0
-    if last > MAX_LISTING_PAGES:
-        raise IncompleteListing(
-            f"orgs/{org}/repos: too many entries to enumerate "
-            f"({last} pages, cap {MAX_LISTING_PAGES})"
-        )
-    return _repo_privacy_map(_dict_items(batch)), last - 1
+    items, last = _first_page(
+        _org_repos_page_url(api_url, org), api_url, token, f"orgs/{org}/repos"
+    )
+    return _repo_privacy_map(items), last or 1
 
 
 def list_org_repos_rest(
-    api_url: str, org: str, token: str, pages_left: int
+    api_url: str, org: str, token: str, last: int
 ) -> dict[str, bool]:
-    """Pages 2..(pages_left + 1) of the org listing, fetched in parallel. The
-    second half of list_org_repos_first_page."""
+    """Pages 2..last of the org listing, fetched in parallel. The second half
+    of list_org_repos_first_page."""
     batches = _fetch_pages_parallel(
-        _org_repos_page_url(api_url, org), token, range(2, pages_left + 2)
+        _org_repos_page_url(api_url, org), token, range(2, last + 1)
     )
     return _repo_privacy_map(item for batch in batches for item in batch)
 
@@ -3708,12 +3746,21 @@ def throttle_sleep_budget_spent(delay: float) -> bool:
 
     A recovering throttle raises nothing, so the sleeps stay invisible until the
     job timeout kills the run. This ceiling converts that into the named
-    THROTTLED error instead."""
-    global _throttle_sleep_spent
+    THROTTLED error instead.
+
+    Charged in wall-clock seconds: the part of this wait that extends past every
+    wait already in progress on another thread (see _throttle_sleep_until)."""
+    global _throttle_sleep_spent, _throttle_sleep_until
+    now = time.monotonic()
     with _transport_lock:
-        if _throttle_sleep_spent + delay > MAX_TOTAL_THROTTLE_SLEEP_SECONDS:
+        start = max(now, getattr(_throttle_local, "sleep_until", 0.0))
+        end = start + delay
+        charge = max(0.0, end - max(start, _throttle_sleep_until))
+        if _throttle_sleep_spent + charge > MAX_TOTAL_THROTTLE_SLEEP_SECONDS:
             return True
-        _throttle_sleep_spent += delay
+        _throttle_sleep_spent += charge
+        _throttle_sleep_until = max(_throttle_sleep_until, end)
+        _throttle_local.sleep_until = end
         return False
 
 

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -52,6 +52,7 @@ Exit codes:
 
 from __future__ import annotations
 
+import concurrent.futures
 import csv
 import datetime
 import hashlib
@@ -60,6 +61,7 @@ import os
 import pathlib
 import re
 import sys
+import threading
 import time
 import urllib.error
 import urllib.parse
@@ -117,6 +119,20 @@ TRANSIENT_RETRY_CAP_SECONDS = 30
 MAX_TOTAL_THROTTLE_SLEEP_SECONDS = 300
 
 _throttle_sleep_spent = 0.0
+# Guards _throttle_sleep_spent and _request_count: the bulk listings fetch
+# pages on a thread pool, so the transport runs concurrently.
+_transport_lock = threading.Lock()
+_request_count = 0
+
+# Pages fetched at once by the bulk listings. GitHub's secondary limit allows
+# 100 concurrent requests; a handful keeps a 90-page org listing to seconds
+# without crowding the per-repo reads that follow.
+PARALLEL_PAGE_WORKERS = 8
+
+# Upper bound on the pages a bulk listing will fan out to (50k items). The
+# sequential walk's 100-page cap read a 10k-repo org as "unlistable" and fell
+# back to probing every candidate name, so the largest orgs paid the most.
+MAX_LISTING_PAGES = 500
 
 # Bounded read for the error-body snippet: only 300 characters are kept, and a
 # body can come from a proxy or the asset redirect rather than GitHub.
@@ -217,6 +233,7 @@ def warn_grant_deferred(classroom_short: str, detail: str) -> None:
 
 
 def main() -> int:
+    run_started = time.monotonic()
     base_dir = pathlib.Path(os.environ.get("GITHUB_WORKSPACE") or ".").resolve()
     classroom_filter = (os.environ.get("CLASSROOM_FILTER") or "").strip()
     assignment_filter = (os.environ.get("ASSIGNMENT_FILTER") or "").strip()
@@ -261,6 +278,7 @@ def main() -> int:
     # no-match classroom filter.
     assignment_filter_matched = not assignment_filter
     for classroom_short, classroom_meta, assignments in classroom_dirs:
+        classroom_started = time.monotonic()
         if assignment_filter and any(
             entry.get("slug") == assignment_filter
             for entry in assignments.get("assignments") or []
@@ -463,12 +481,21 @@ def main() -> int:
             failed_classrooms.append(classroom_short)
             continue
 
-        print(f"{classroom_short}: {n_changes} updated submission(s)")
+        print(
+            f"{classroom_short}: {n_changes} updated submission(s) "
+            f"({time.monotonic() - classroom_started:.1f}s)"
+        )
         total_changes += n_changes
 
     print(
         f"collect: {total_changes} total submission(s) updated across "
         f"{len(classroom_dirs)} classroom(s)"
+    )
+    # The per-phase lines above say where a slow run spent its time; this says
+    # what it cost, so a report can name the number instead of "a long time".
+    print(
+        f"collect: {request_count()} GitHub API request(s) in "
+        f"{time.monotonic() - run_started:.1f}s"
     )
     if not assignment_filter_matched:
         # Same contract as the classroom-filter no-match above: a scoped run
@@ -589,6 +616,15 @@ class RepoIndex:
     repo would read a real submission as "not submitted". Both detectable shapes
     fail open instead — empty reads as unknown, truncated raises
     IncompleteListing.
+
+    Two ways to answer. A caller that knows its candidate names up front
+    (`prefetch`) lets the index read page 1 of the org listing, learn the page
+    count, and pick the cheaper source: the rest of the listing (an org of
+    thousands of repos is ~90 pages) or one GET /repos/{org}/{name} per
+    candidate (a single-assignment run over a small section is a few dozen).
+    Probing is bounded by what the listing would have cost; past that the index
+    completes the listing instead. A caller that asks without a hint gets the
+    listing.
     """
 
     def __init__(self, api_url: str, org: str, token: str) -> None:
@@ -597,24 +633,50 @@ class RepoIndex:
         self._token = token
         self._repos: dict[str, bool] | None = None
         self._loaded = False
+        # Probe mode: page 1 plus per-name answers. `_found` maps a name to its
+        # private flag, or None when its read failed (unknown, fails open);
+        # `_missing` holds the names that 404ed.
+        self._probing = False
+        self._pages_left = 0
+        self._probes_spent = 0
+        self._found: dict[str, bool | None] = {}
+        self._missing: set[str] = set()
 
-    def _load(self) -> dict[str, bool] | None:
-        """The repos, or None when the listing could not be read. Reads once; a
-        soft failure warns once and stays None.
+    def prefetch(self, repo_names: Iterable[str]) -> None:
+        """Tell the index which names the caller is about to ask about, so it can
+        resolve them in one parallel batch (and choose probing over the listing
+        when that is cheaper). Optional: `contains` and `is_private` answer
+        without it, one request per unseen name in probe mode."""
+        names = list(dict.fromkeys(name.lower() for name in repo_names))
+        if self._load(names) is not None or not self._probing:
+            return
+        self._probe([name for name in names if not self._resolved(name)])
+
+    def _load(self, hint: list[str] | None = None) -> dict[str, bool] | None:
+        """The repos, or None when the listing is unknown (unreadable, or being
+        answered by probes). Reads once; a soft failure warns once and stays None.
 
         A THROTTLED or FATAL failure propagates and leaves the read UNLATCHED, so
         a caller that survives it (the grant pass defers a throttle) retries
         rather than spending the run on the degraded answer."""
         if self._loaded:
             return self._repos
-        self._repos = self._read()
+        self._repos = self._read(hint)
         self._loaded = True
         return self._repos
 
-    def _read(self) -> dict[str, bool] | None:
-        """One attempt at the org listing."""
+    def _read(self, hint: list[str] | None) -> dict[str, bool] | None:
+        """One attempt at the org listing (or, given a small enough hint, its
+        first page plus probes)."""
+        started = time.monotonic()
         try:
-            repos = list_org_repos(self._api_url, self._org, self._token)
+            if hint is None:
+                repos = list_org_repos(self._api_url, self._org, self._token)
+                pages_left = 0
+            else:
+                repos, pages_left = list_org_repos_first_page(
+                    self._api_url, self._org, self._token
+                )
         except urllib.error.HTTPError as exc:
             if classify(exc) is not SKIPPABLE:
                 raise
@@ -635,30 +697,100 @@ class RepoIndex:
         # silently skip every poll.
         if not repos:
             return None
+        if pages_left:
+            unresolved = [name for name in (hint or []) if name not in repos]
+            if len(unresolved) <= pages_left:
+                self._probing = True
+                self._pages_left = pages_left
+                self._found = dict(repos)
+                print(
+                    f"{self._org}: {pages_left + 1} page(s) of repos; checking "
+                    f"{len(unresolved)} candidate repo name(s) directly instead"
+                )
+                return None
+            repos.update(
+                list_org_repos_rest(self._api_url, self._org, self._token, pages_left)
+            )
+        print(
+            f"{self._org}: {len(repos)} repo(s) visible to the service token "
+            f"({time.monotonic() - started:.1f}s)"
+        )
+        return repos
+
+    def _complete_listing(self) -> dict[str, bool]:
+        """Leave probe mode by reading the rest of the listing. Probed answers
+        are kept: a name found by probe is in the org whether or not it lands on
+        a page (a repo created mid-walk shifts the pages)."""
+        rest = list_org_repos_rest(
+            self._api_url, self._org, self._token, self._pages_left
+        )
+        repos: dict[str, bool] = {}
+        for name, private in self._found.items():
+            if private is not None:
+                repos[name] = private
+        repos.update(rest)
+        self._repos = repos
+        self._probing = False
         print(f"{self._org}: {len(repos)} repo(s) visible to the service token")
         return repos
+
+    def _resolved(self, name: str) -> bool:
+        return name in self._found or name in self._missing
+
+    def _probe(self, names: list[str]) -> None:
+        """Resolve `names` by direct reads, or by completing the listing once the
+        probes would cost more than the pages they stand in for."""
+        if not names:
+            return
+        if self._probes_spent + len(names) > self._pages_left:
+            self._complete_listing()
+            return
+        self._probes_spent += len(names)
+        found = probe_org_repos(self._api_url, self._org, names, self._token)
+        self._found.update(found)
+        self._missing.update(name for name in names if name not in found)
+
+    def _lookup(self, name: str) -> None:
+        """Probe-mode resolution of one lowercased name, if not yet known. May
+        leave probe mode (see _probe), after which `_repos` holds the answer."""
+        if not self._resolved(name):
+            self._probe([name])
 
     def contains(self, repo_name: str) -> bool:
         """Whether `repo_name` exists — True whenever the listing is unknown, so
         an unreadable index never hides a repo from either pass."""
+        name = repo_name.lower()
         repos = self._load()
-        return repos is None or repo_name.lower() in repos
+        if repos is None and self._probing:
+            self._lookup(name)
+            if self._probing:
+                return name not in self._missing
+            repos = self._repos
+        return repos is None or name in repos
 
     def is_private(self, repo_name: str) -> bool | None:
         """Whether `repo_name` is private, or None when the index can't say (the
         listing was unreadable, or the name isn't in it). Answers from the
         listing already read, saving the caller a per-repo request."""
+        name = repo_name.lower()
         repos = self._load()
+        if repos is None and self._probing:
+            self._lookup(name)
+            if self._probing:
+                return self._found.get(name)
+            repos = self._repos
         if repos is None:
             return None
-        return repos.get(repo_name.lower())
+        return repos.get(name)
 
     def names(self) -> list[str] | None:
         """Every visible repo name (lowercased), or None when the listing is
         unknown. Team-mode collection derives its poll targets from these
         (the `<classroom>-<assignment>-group-<n>` repos carry no username to
-        derive them from)."""
+        derive them from), so probe mode completes the listing here."""
         repos = self._load()
+        if repos is None and self._probing:
+            repos = self._complete_listing()
         if repos is None:
             return None
         return list(repos)
@@ -727,6 +859,35 @@ def all_assignment_slugs(assignments: dict[str, Any]) -> list[str]:
         if isinstance(slug, str) and slug:
             slugs.append(slug)
     return slugs
+
+
+def poll_candidate_names(
+    classroom_short: str,
+    assignments: dict[str, Any],
+    assignment_filter: str,
+    usernames: Iterable[str],
+) -> list[str]:
+    """Every repo name collection may poll for `usernames`: one per (collectable
+    or detected assignment, member). empty_repo assignments are skipped outright
+    and team assignments derive their targets from the listing, so neither is
+    a candidate. Feeds RepoIndex.prefetch so the poll loop's lookups are one
+    batch instead of one request each."""
+    slugs: list[str] = []
+    for entry in assignments.get("assignments") or []:
+        slug = entry.get("slug")
+        if not isinstance(slug, str) or not slug:
+            continue
+        if assignment_filter and slug != assignment_filter:
+            continue
+        if is_empty_repo(entry) or normalize_assignment_type(entry.get("mode")) == "team":
+            continue
+        slugs.append(slug)
+    users = list(usernames)
+    return [
+        assignment_repo_name(classroom_short, slug, username)
+        for slug in slugs
+        for username in users
+    ]
 
 
 class TeamMembers:
@@ -1034,6 +1195,13 @@ def collect_classroom(
     # (owner always credited) — same trust model, team-sourced set. Staff are in
     # the union, so a staff collaborator on a group repo can be credited too.
     roster_logins = {u.lower() for u in team_usernames}
+    if repo_index is not None:
+        # Every name the poll below can ask about, resolved in one batch.
+        repo_index.prefetch(
+            poll_candidate_names(
+                classroom_short, assignments, assignment_filter, team_usernames
+            )
+        )
     for entry in assignments.get("assignments") or []:
         slug = entry.get("slug")
         if not isinstance(slug, str) or not slug:
@@ -1689,13 +1857,18 @@ def grant_classroom_team_access(
 
     # Resolved once rather than per staff role. Knowing the full list up front is
     # also what lets a throttled pass say how much is left for the next run.
-    targets: list[tuple[str, str]] = []
-    for slug in slugs:
-        for username in usernames:
-            repo_name = assignment_repo_name(classroom_short, slug, username)
-            if repo_index is not None and not repo_index.contains(repo_name):
-                continue
-            targets.append((org, repo_name))
+    candidates = [
+        assignment_repo_name(classroom_short, slug, username)
+        for slug in slugs
+        for username in usernames
+    ]
+    if repo_index is not None:
+        repo_index.prefetch(candidates)
+    targets: list[tuple[str, str]] = [
+        (org, repo_name)
+        for repo_name in candidates
+        if repo_index is None or repo_index.contains(repo_name)
+    ]
     targets.extend(
         private_template_targets(
             api_url, org, assignments, service_token, repo_index=repo_index,
@@ -2719,6 +2892,100 @@ def _next_page_link(link_header: str | None) -> str | None:
     return m.group(1) if m else None
 
 
+def _last_page_number(link_header: str | None, api_url: str) -> int | None:
+    """The page number of the `rel="last"` URL in a GitHub `Link` header, or None
+    when the header names no last page (no header, a single page, or a
+    cursor-paginated endpoint). The URL is host-pinned like a followed
+    `rel="next"`, though only its `page` query parameter is used."""
+    if not link_header:
+        return None
+    m = re.search(r'<([^>]+)>\s*;\s*[^,]*rel="last"', link_header)
+    if not m:
+        return None
+    last_url = _assert_same_host(m.group(1), api_url)
+    page_values = urllib.parse.parse_qs(urllib.parse.urlsplit(last_url).query).get("page")
+    if not page_values or not page_values[0].isdigit():
+        return None
+    return int(page_values[0])
+
+
+def _fetch_page(url: str, token: str) -> tuple[list[Any], Any]:
+    """One page of a list endpoint: (raw array, response headers). Raises
+    ValueError on a non-array body."""
+    body, headers = _http_get_with_headers(
+        url, token, accept="application/vnd.github+json"
+    )
+    batch = json.loads(body.decode("utf-8"))
+    if not isinstance(batch, list):
+        raise ValueError(
+            f"GET {url}: expected JSON array, got {type(batch).__name__}"
+        )
+    return batch, headers
+
+
+def _dict_items(batch: list[Any]) -> list[dict[str, Any]]:
+    return [item for item in batch if isinstance(item, dict)]
+
+
+def _fetch_pages_parallel(
+    page_url: Callable[[int], str],
+    token: str,
+    pages: range,
+) -> list[list[dict[str, Any]]]:
+    """Pages `pages` of a list endpoint, fetched PARALLEL_PAGE_WORKERS at a time
+    and returned in page order. The first failure propagates and abandons the
+    pages not yet started."""
+    if not pages:
+        return []
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(PARALLEL_PAGE_WORKERS, len(pages))
+    ) as pool:
+        futures = [pool.submit(_fetch_page, page_url(page), token) for page in pages]
+        try:
+            return [_dict_items(future.result()[0]) for future in futures]
+        except BaseException:
+            pool.shutdown(wait=False, cancel_futures=True)
+            raise
+
+
+def _paginate_objects_parallel(
+    page_url: Callable[[int], str],
+    api_url: str,
+    token: str,
+    resource_label: str,
+) -> list[dict[str, Any]]:
+    """Every object of a paginated list endpoint, with pages 2..last fetched
+    concurrently.
+
+    Page 1 is read alone; its `Link: rel="last"` names the page count, and the
+    remaining pages are built from `page_url` (same host by construction, so no
+    Link is followed) and fetched on a thread pool. An org with 9,000 repos is
+    90 pages: sequentially that is minutes, in parallel it is seconds. When the
+    header names no last page but does name a next one (a cursor-paginated
+    endpoint), the walk falls back to _paginate_objects.
+
+    Same error contract as _paginate_objects: urllib.error.HTTPError on any
+    non-2xx, ValueError on a non-array body, IncompleteListing when the page
+    count exceeds MAX_LISTING_PAGES.
+    """
+    first, headers = _fetch_page(page_url(1), token)
+    link_header = headers.get("Link") if headers else None
+    last = _last_page_number(link_header, api_url)
+    if last is None:
+        if _next_page_link(link_header):
+            return _paginate_objects(page_url, api_url, token, resource_label)
+        return _dict_items(first)
+    if last > MAX_LISTING_PAGES:
+        raise IncompleteListing(
+            f"{resource_label}: too many entries to enumerate "
+            f"({last} pages, cap {MAX_LISTING_PAGES})"
+        )
+    items = _dict_items(first)
+    for batch in _fetch_pages_parallel(page_url, token, range(2, last + 1)):
+        items.extend(batch)
+    return items
+
+
 def _assert_same_host(next_url: str, api_url: str) -> str:
     """Return next_url only if its scheme+host match api_url's; else raise
     ValueError. The pagination loop attaches `Authorization: Bearer <token>` to
@@ -2769,15 +3036,8 @@ def _paginate_objects(
     url = page_url(1)
     seen_next: set[str] = set()
     for page in range(1, max_pages + 1):
-        body, headers = _http_get_with_headers(
-            url, token, accept="application/vnd.github+json"
-        )
-        batch = json.loads(body.decode("utf-8"))
-        if not isinstance(batch, list):
-            raise ValueError(
-                f"GET {url}: expected JSON array, got {type(batch).__name__}"
-            )
-        page_items = [item for item in batch if isinstance(item, dict)]
+        batch, headers = _fetch_page(url, token)
+        page_items = _dict_items(batch)
         items.extend(page_items)
         if stop_after is not None and any(stop_after(item) for item in page_items):
             return items
@@ -2810,12 +3070,15 @@ def _paginate_field_list(
     token: str,
     resource_label: str,
     field: str = "login",
+    parallel: bool = False,
 ) -> list[str]:
     """Every object's `field` from a paginated endpoint (accounts by `login`,
-    repos by `name`/`full_name`). The one-field view of _paginate_objects, which
-    owns the walk and its error contract."""
+    repos by `name`/`full_name`). The one-field view of _paginate_objects (or,
+    for `parallel`, _paginate_objects_parallel), which owns the walk and its
+    error contract."""
+    walk = _paginate_objects_parallel if parallel else _paginate_objects
     values: list[str] = []
-    for item in _paginate_objects(page_url, api_url, token, resource_label):
+    for item in walk(page_url, api_url, token, resource_label):
         value = item.get(field)
         if isinstance(value, str) and value:
             values.append(value)
@@ -2876,12 +3139,18 @@ def list_team_member_logins(
         api_url=api_url,
         token=token,
         resource_label=f"orgs/{org}/teams/{team_slug}/members",
+        parallel=True,
     )
+
+
+def _org_repos_page_url(api_url: str, org: str) -> Callable[[int], str]:
+    base = f"{api_url}/orgs/{urllib.parse.quote(org, safe='')}/repos"
+    return lambda page: f"{base}?per_page=100&page={page}&type=all"
 
 
 def list_org_repos(api_url: str, org: str, token: str) -> dict[str, bool]:
     """Lowercased name -> `private` flag for every repo in `org` the token can
-    see, walking pagination. Hits GET /orgs/{org}/repos.
+    see, walking pagination in parallel. Hits GET /orgs/{org}/repos.
 
     Read once per run — see RepoIndex, which documents why a name absent here
     can be skipped. The `private` flag rides along from the same response
@@ -2889,14 +3158,93 @@ def list_org_repos(api_url: str, org: str, token: str) -> dict[str, bool]:
 
     Raises urllib.error.HTTPError on any non-2xx so the caller can fall back to
     per-repo probing."""
-    per_page = 100
-    base = f"{api_url}/orgs/{urllib.parse.quote(org, safe='')}/repos"
-    repos = _paginate_objects(
-        page_url=lambda page: f"{base}?per_page={per_page}&page={page}&type=all",
+    repos = _paginate_objects_parallel(
+        page_url=_org_repos_page_url(api_url, org),
         api_url=api_url,
         token=token,
         resource_label=f"orgs/{org}/repos",
     )
+    return _repo_privacy_map(repos)
+
+
+def list_org_repos_first_page(
+    api_url: str, org: str, token: str
+) -> tuple[dict[str, bool], int]:
+    """Page 1 of the org listing as (lowercased name -> private, pages left).
+    0 pages left means the map already is the whole listing. Lets RepoIndex
+    learn the org's size from one request before deciding whether listing the
+    rest or probing the candidate names is cheaper.
+
+    Same error contract as list_org_repos."""
+    page_url = _org_repos_page_url(api_url, org)
+    batch, headers = _fetch_page(page_url(1), token)
+    link_header = headers.get("Link") if headers else None
+    last = _last_page_number(link_header, api_url)
+    if last is None:
+        if _next_page_link(link_header):
+            # No page count to plan with: take the whole listing now.
+            return list_org_repos(api_url, org, token), 0
+        return _repo_privacy_map(_dict_items(batch)), 0
+    if last > MAX_LISTING_PAGES:
+        raise IncompleteListing(
+            f"orgs/{org}/repos: too many entries to enumerate "
+            f"({last} pages, cap {MAX_LISTING_PAGES})"
+        )
+    return _repo_privacy_map(_dict_items(batch)), last - 1
+
+
+def list_org_repos_rest(
+    api_url: str, org: str, token: str, pages_left: int
+) -> dict[str, bool]:
+    """Pages 2..(pages_left + 1) of the org listing, fetched in parallel. The
+    second half of list_org_repos_first_page."""
+    batches = _fetch_pages_parallel(
+        _org_repos_page_url(api_url, org), token, range(2, pages_left + 2)
+    )
+    return _repo_privacy_map(item for batch in batches for item in batch)
+
+
+def probe_org_repos(
+    api_url: str, org: str, names: list[str], token: str
+) -> dict[str, bool | None]:
+    """Lowercased name -> private flag for each of `names` that exists, None for
+    a name whose read failed with a skippable error (unknown, so callers fail
+    open); a 404 name is absent. Reads GET /repos/{org}/{name} in parallel.
+
+    A throttle or a fatal error propagates, abandoning the probes not yet
+    started, so the caller's retry sees an unresolved name rather than a wrong
+    answer."""
+    def probe(name: str) -> tuple[str, bool | None, bool]:
+        try:
+            repo = get_repo(api_url, org, name, token)
+        except urllib.error.HTTPError as exc:
+            if classify(exc) is not SKIPPABLE:
+                raise
+            return name.lower(), None, True
+        if repo is None:
+            return name.lower(), None, False
+        return name.lower(), repo.get("private") is True, True
+
+    if not names:
+        return {}
+    found: dict[str, bool | None] = {}
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(PARALLEL_PAGE_WORKERS, len(names))
+    ) as pool:
+        futures = [pool.submit(probe, name) for name in names]
+        try:
+            for future in futures:
+                name, private, present = future.result()
+                if present:
+                    found[name] = private
+        except BaseException:
+            pool.shutdown(wait=False, cancel_futures=True)
+            raise
+    return found
+
+
+def _repo_privacy_map(repos: Iterable[dict[str, Any]]) -> dict[str, bool]:
+    """Lowercased name -> strict-boolean `private` from repo objects."""
     visible: dict[str, bool] = {}
     for repo in repos:
         name = repo.get("name")
@@ -2925,6 +3273,7 @@ def list_team_repo_full_names(
         token=token,
         resource_label=f"orgs/{org}/teams/{team_slug}/repos",
         field="full_name",
+        parallel=True,
     )
     return {name.lower() for name in full_names}
 
@@ -3156,6 +3505,7 @@ def _http_request(
         headers["Content-Type"] = "application/json"
     for attempt in range(_retries):
         req = urllib.request.Request(url, method=method, data=body, headers=headers)
+        _count_request()
         try:
             with _OPENER.open(req, timeout=30) as resp:
                 resp_body = (
@@ -3186,6 +3536,19 @@ def _http_request(
                 fp=None,
             ) from exc
     raise RuntimeError(f"_http_request called with _retries={_retries}")
+
+
+def _count_request() -> None:
+    global _request_count
+    with _transport_lock:
+        _request_count += 1
+
+
+def request_count() -> int:
+    """HTTP requests issued so far this run (retries included), for the
+    end-of-run summary."""
+    with _transport_lock:
+        return _request_count
 
 
 def team_has_repo_access(
@@ -3347,10 +3710,11 @@ def throttle_sleep_budget_spent(delay: float) -> bool:
     job timeout kills the run. This ceiling converts that into the named
     THROTTLED error instead."""
     global _throttle_sleep_spent
-    if _throttle_sleep_spent + delay > MAX_TOTAL_THROTTLE_SLEEP_SECONDS:
-        return True
-    _throttle_sleep_spent += delay
-    return False
+    with _transport_lock:
+        if _throttle_sleep_spent + delay > MAX_TOTAL_THROTTLE_SLEEP_SECONDS:
+            return True
+        _throttle_sleep_spent += delay
+        return False
 
 
 def _retry_after_seconds(headers: Any) -> str | None:

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -1062,6 +1062,9 @@ class _FakeRepoIndex:
     def __init__(self, repo_names):
         self._names = [n.lower() for n in repo_names]
 
+    def prefetch(self, repo_names):
+        pass
+
     def names(self):
         return list(self._names)
 
@@ -4393,6 +4396,9 @@ class StubIndex:
     def __init__(self, names):
         self._names = {n.lower() for n in names}
 
+    def prefetch(self, repo_names):
+        pass
+
     def contains(self, repo_name):
         return repo_name.lower() in self._names
 
@@ -4783,6 +4789,404 @@ class TestRepoIndexLatch:
         assert index.contains("a") is True
         assert index.contains("b") is True
         assert len(calls) == 1  # read once, warned once
+
+
+def _page_of(names, start):
+    return [{"name": f"{names}-{i}", "private": False} for i in range(start, start + 100)]
+
+
+def _link(base, *, last=None, next_page=None):
+    parts = []
+    if next_page is not None:
+        parts.append(f'<{base}&page={next_page}>; rel="next"')
+    if last is not None:
+        parts.append(f'<{base}&page={last}>; rel="last"')
+    return {"Link": ", ".join(parts)} if parts else {}
+
+
+class TestParallelPagination:
+    """The bulk listings fetch pages 2..last concurrently off page 1's
+    `rel="last"`: a 9,000-repo org is 90 pages, which sequentially was the whole
+    of a five-minute collect run (#825)."""
+
+    BASE = "https://api.github.com/orgs/cs50/repos?per_page=100"
+
+    def _serve(self, monkeypatch, pages, *, headers_for_page1):
+        seen: list[int] = []
+
+        def fake_get(url, token, *, accept, max_bytes=None, _retries=3):
+            page = int(re.search(r"[?&]page=(\d+)", url).group(1))
+            seen.append(page)
+            headers = headers_for_page1 if page == 1 else {}
+            return json.dumps(pages[page]).encode(), headers
+
+        monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
+        return seen
+
+    def _walk(self):
+        return cs._paginate_objects_parallel(
+            page_url=lambda page: f"{self.BASE}&page={page}",
+            api_url="https://api.github.com",
+            token="tok",
+            resource_label="orgs/cs50/repos",
+        )
+
+    def test_fetches_every_page_named_by_rel_last_in_order(self, monkeypatch):
+        pages = {
+            1: _page_of("p1", 0),
+            2: _page_of("p2", 0),
+            3: _page_of("p3", 0),
+            4: [{"name": "p4-0", "private": True}],
+        }
+        seen = self._serve(
+            monkeypatch, pages, headers_for_page1=_link(self.BASE, next_page=2, last=4)
+        )
+        got = self._walk()
+        assert sorted(seen) == [1, 2, 3, 4]
+        assert len(got) == 301
+        # Page order survives the concurrent fetch.
+        assert [item["name"] for item in got][::100] == ["p1-0", "p2-0", "p3-0", "p4-0"]
+
+    def test_single_short_page_without_link_is_one_request(self, monkeypatch):
+        seen = self._serve(monkeypatch, {1: [{"name": "only"}]}, headers_for_page1={})
+        assert [item["name"] for item in self._walk()] == ["only"]
+        assert seen == [1]
+
+    def test_next_without_last_falls_back_to_following_links(self, monkeypatch):
+        # A cursor-paginated endpoint names no last page; the sequential walk
+        # still finishes it.
+        pages = {1: _page_of("p1", 0), 2: [{"name": "p2-0"}]}
+        calls: list[str] = []
+
+        def fake_get(url, token, *, accept, max_bytes=None, _retries=3):
+            calls.append(url)
+            page = int(re.search(r"[?&]page=(\d+)", url).group(1))
+            headers = _link(self.BASE, next_page=2) if page == 1 else {}
+            return json.dumps(pages[page]).encode(), headers
+
+        monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
+        got = self._walk()
+        assert len(got) == 101
+        assert got[-1]["name"] == "p2-0"
+
+    def test_page_count_past_the_cap_is_incomplete(self, monkeypatch):
+        self._serve(
+            monkeypatch,
+            {1: _page_of("p1", 0)},
+            headers_for_page1=_link(self.BASE, next_page=2, last=cs.MAX_LISTING_PAGES + 1),
+        )
+        with pytest.raises(cs.IncompleteListing):
+            self._walk()
+
+    def test_off_host_rel_last_is_refused(self, monkeypatch):
+        evil = "https://evil.example/orgs/cs50/repos?per_page=100"
+        self._serve(
+            monkeypatch,
+            {1: _page_of("p1", 0)},
+            headers_for_page1=_link(evil, next_page=2, last=3),
+        )
+        with pytest.raises(ValueError, match="off-host"):
+            self._walk()
+
+    def test_a_failing_page_propagates(self, monkeypatch):
+        def fake_get(url, token, *, accept, max_bytes=None, _retries=3):
+            page = int(re.search(r"[?&]page=(\d+)", url).group(1))
+            if page == 3:
+                raise http_error(500, {}, b"boom")
+            headers = _link(self.BASE, next_page=2, last=4) if page == 1 else {}
+            return json.dumps(_page_of(f"p{page}", 0)).encode(), headers
+
+        monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
+        with pytest.raises(cs.urllib.error.HTTPError):
+            self._walk()
+
+    def test_last_page_number_parses_only_the_page_param(self):
+        assert cs._last_page_number(_link(self.BASE, last=90)["Link"], "https://api.github.com") == 90
+        assert cs._last_page_number(_link(self.BASE, next_page=2)["Link"], "https://api.github.com") is None
+        assert cs._last_page_number(None, "https://api.github.com") is None
+        assert cs._last_page_number("", "https://api.github.com") is None
+
+    def test_team_listings_use_the_parallel_walk(self, monkeypatch):
+        walks: list[str] = []
+
+        def fake_parallel(page_url, api_url, token, resource_label):
+            walks.append(resource_label)
+            return [{"login": "alice", "full_name": "cs50/x"}]
+
+        monkeypatch.setattr(cs, "_paginate_objects_parallel", fake_parallel)
+        cs.list_team_member_logins("https://api.github.com", "cs50", "students", "tok")
+        cs.list_team_repo_full_names("https://api.github.com", "cs50", "tas", "tok")
+        cs.list_org_repos("https://api.github.com", "cs50", "tok")
+        assert walks == [
+            "orgs/cs50/teams/students/members",
+            "orgs/cs50/teams/tas/repos",
+            "orgs/cs50/repos",
+        ]
+
+
+class TestRepoIndexProbeMode:
+    """Given its candidate names up front, the index reads page 1, learns the
+    page count, and probes the names directly when that is fewer requests than
+    the remaining pages. Probing is bounded by what the listing would have
+    cost, so it can never be the more expensive choice."""
+
+    API = "https://api.github.com"
+
+    def _index(self, monkeypatch, *, pages_left, page1=None, existing=(), fail=()):
+        page1 = {"starter": False} if page1 is None else dict(page1)
+        probed: list[str] = []
+        rest_reads: list[int] = []
+
+        def first_page(api_url, org, token):
+            return dict(page1), pages_left
+
+        def rest(api_url, org, token, n):
+            rest_reads.append(n)
+            return {name: False for name in existing}
+
+        def get_repo(api_url, owner, repo, token):
+            probed.append(repo)
+            if repo in fail:
+                raise http_error(451, {}, b"legal")
+            if repo in existing:
+                return {"name": repo, "private": repo.startswith("priv")}
+            return None
+
+        monkeypatch.setattr(cs, "list_org_repos_first_page", first_page)
+        monkeypatch.setattr(cs, "list_org_repos_rest", rest)
+        monkeypatch.setattr(cs, "get_repo", get_repo)
+        monkeypatch.setattr(cs, "list_org_repos", lambda *a, **k: pytest.fail("full listing read"))
+        return cs.RepoIndex(self.API, "cs50", "tok"), probed, rest_reads
+
+    def test_small_hint_probes_instead_of_listing(self, monkeypatch, capsys):
+        index, probed, rest_reads = self._index(
+            monkeypatch, pages_left=89, existing={"cs-hw1-alice", "priv-cs-hw1-bob"}
+        )
+        index.prefetch(["cs-hw1-ALICE", "priv-cs-hw1-bob", "cs-hw1-carol", "starter"])
+        # Page 1 answered `starter`; the other three were probed, in parallel.
+        assert sorted(probed) == ["cs-hw1-alice", "cs-hw1-carol", "priv-cs-hw1-bob"]
+        assert rest_reads == []
+        assert index.contains("cs-hw1-alice") is True
+        assert index.contains("cs-hw1-carol") is False
+        assert index.contains("starter") is True
+        assert index.is_private("priv-cs-hw1-bob") is True
+        assert index.is_private("cs-hw1-alice") is False
+        assert index.is_private("cs-hw1-carol") is None
+        out = capsys.readouterr().out
+        assert "90 page(s) of repos" in out and "3 candidate repo name(s)" in out
+
+    def test_large_hint_reads_the_rest_of_the_listing(self, monkeypatch, capsys):
+        index, probed, rest_reads = self._index(
+            monkeypatch, pages_left=2, existing={"cs-hw1-alice"}
+        )
+        index.prefetch([f"cs-hw1-user{i}" for i in range(5)])
+        assert probed == []
+        assert rest_reads == [2]
+        assert index.contains("cs-hw1-alice") is True
+        assert index.contains("cs-hw1-user0") is False
+        assert "2 repo(s) visible" in capsys.readouterr().out
+
+    def test_probe_budget_is_the_listing_cost(self, monkeypatch):
+        # Two classrooms' hints together exceed the pages left, so the second
+        # prefetch completes the listing rather than probing past the budget.
+        index, probed, rest_reads = self._index(
+            monkeypatch, pages_left=3, existing={"cs-hw1-alice", "cs-hw2-dan"}
+        )
+        index.prefetch(["cs-hw1-alice", "cs-hw1-bob"])
+        assert len(probed) == 2 and rest_reads == []
+        index.prefetch(["cs-hw2-carol", "cs-hw2-dan"])
+        assert len(probed) == 2  # no further probes
+        assert rest_reads == [3]
+        assert index.contains("cs-hw1-alice") is True  # probed answer kept
+        assert index.contains("cs-hw2-dan") is True
+        assert index.contains("cs-hw2-carol") is False
+
+    def test_unhinted_name_is_probed_on_demand_once(self, monkeypatch):
+        index, probed, _ = self._index(monkeypatch, pages_left=10, existing={"late"})
+        index.prefetch(["cs-hw1-alice"])
+        assert index.contains("late") is True
+        assert index.contains("LATE") is True
+        assert probed.count("late") == 1
+
+    def test_failed_probe_fails_open(self, monkeypatch):
+        index, _, _ = self._index(monkeypatch, pages_left=10, fail={"cs-hw1-alice"})
+        index.prefetch(["cs-hw1-alice"])
+        assert index.contains("cs-hw1-alice") is True
+        assert index.is_private("cs-hw1-alice") is None
+
+    def test_throttled_probe_propagates(self, monkeypatch):
+        index, _, _ = self._index(monkeypatch, pages_left=10)
+
+        def throttled(*a, **k):
+            raise http_error(403, {"Retry-After": "60"}, b"secondary rate limit")
+
+        monkeypatch.setattr(cs, "get_repo", throttled)
+        with pytest.raises(cs.urllib.error.HTTPError):
+            index.prefetch(["cs-hw1-alice"])
+
+    def test_names_completes_the_listing(self, monkeypatch):
+        index, _, rest_reads = self._index(
+            monkeypatch, pages_left=10, existing={"cs-hw1-group-1"}
+        )
+        index.prefetch(["cs-hw1-alice"])
+        assert rest_reads == []
+        assert sorted(index.names()) == ["cs-hw1-group-1", "starter"]
+        assert rest_reads == [10]
+
+    def test_no_hint_reads_the_whole_listing(self, monkeypatch):
+        monkeypatch.setattr(cs, "list_org_repos", lambda *a, **k: {"cs-hw1-alice": False})
+        monkeypatch.setattr(
+            cs, "list_org_repos_first_page", lambda *a, **k: pytest.fail("split read")
+        )
+        index = cs.RepoIndex(self.API, "cs50", "tok")
+        assert index.contains("cs-hw1-alice") is True
+
+    def test_empty_first_page_is_unknown(self, monkeypatch):
+        index, probed, _ = self._index(monkeypatch, pages_left=0, page1={})
+        index.prefetch(["cs-hw1-alice"])
+        assert index.contains("anything") is True
+        assert probed == []
+
+
+class TestListOrgReposFirstPage:
+    BASE = "https://api.github.com/orgs/cs50/repos?per_page=100"
+
+    def test_reports_pages_left_from_rel_last(self, monkeypatch):
+        def fake_get(url, token, *, accept, max_bytes=None, _retries=3):
+            return (
+                json.dumps([{"name": "A", "private": True}]).encode(),
+                _link(self.BASE, next_page=2, last=90),
+            )
+
+        monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
+        repos, left = cs.list_org_repos_first_page("https://api.github.com", "cs50", "tok")
+        assert repos == {"a": True} and left == 89
+
+    def test_single_page_has_nothing_left(self, monkeypatch):
+        def fake_get(url, token, *, accept, max_bytes=None, _retries=3):
+            return json.dumps([{"name": "a"}]).encode(), {}
+
+        monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
+        assert cs.list_org_repos_first_page("https://api.github.com", "cs50", "tok") == (
+            {"a": False},
+            0,
+        )
+
+    def test_rest_fetches_pages_two_onward(self, monkeypatch):
+        seen: list[int] = []
+
+        def fake_get(url, token, *, accept, max_bytes=None, _retries=3):
+            page = int(re.search(r"[?&]page=(\d+)", url).group(1))
+            seen.append(page)
+            return json.dumps([{"name": f"r{page}", "private": page == 3}]).encode(), {}
+
+        monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
+        got = cs.list_org_repos_rest("https://api.github.com", "cs50", "tok", 3)
+        assert sorted(seen) == [2, 3, 4]
+        assert got == {"r2": False, "r3": True, "r4": False}
+
+
+class TestProbeOrgRepos:
+    def test_present_missing_and_unknown(self, monkeypatch):
+        def get_repo(api_url, owner, repo, token):
+            if repo == "gone":
+                return None
+            if repo == "blocked":
+                raise http_error(451, {}, b"legal")
+            return {"name": repo, "private": repo == "Priv"}
+
+        monkeypatch.setattr(cs, "get_repo", get_repo)
+        got = cs.probe_org_repos(
+            "https://api.github.com", "cs50", ["Priv", "pub", "gone", "blocked"], "tok"
+        )
+        assert got == {"priv": True, "pub": False, "blocked": None}
+
+    def test_fatal_propagates(self, monkeypatch):
+        def get_repo(*a, **k):
+            raise http_error(401, {}, b"bad token")
+
+        monkeypatch.setattr(cs, "get_repo", get_repo)
+        with pytest.raises(cs.urllib.error.HTTPError):
+            cs.probe_org_repos("https://api.github.com", "cs50", ["a", "b"], "tok")
+
+
+class TestPollCandidateNames:
+    ASSIGNMENTS = {
+        "schema": cs.ASSIGNMENTS_SCHEMA_V1,
+        "assignments": [
+            {"slug": "hw1"},
+            {"slug": "hw2", "mode": "group"},
+            {"slug": "proj", "mode": "team"},
+            {"slug": "warmup", "empty_repo": True},
+            {"slug": "essay", "no_autograder": True},
+            {"slug": ""},
+        ],
+    }
+
+    def test_individual_group_and_detected_assignments_for_every_member(self):
+        names = cs.poll_candidate_names("cs", self.ASSIGNMENTS, "", ["Alice", "bob"])
+        assert names == [
+            "cs-hw1-alice",
+            "cs-hw1-bob",
+            "cs-hw2-alice",
+            "cs-hw2-bob",
+            "cs-essay-alice",
+            "cs-essay-bob",
+        ]
+
+    def test_filter_narrows_to_one_assignment(self):
+        assert cs.poll_candidate_names("cs", self.ASSIGNMENTS, "hw2", ["alice"]) == [
+            "cs-hw2-alice"
+        ]
+
+
+class TestRequestCounter:
+    def test_every_transport_attempt_is_counted(self, monkeypatch):
+        before = cs.request_count()
+        attempts: list[int] = []
+
+        class _Ctx:
+            status = 200
+            headers = {}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, n=None):
+                return b"[]"
+
+        def fake_open(req, timeout=None):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise http_error(503, {}, b"")
+            return _Ctx()
+
+        monkeypatch.setattr(cs._OPENER, "open", fake_open)
+        monkeypatch.setattr(cs.time, "sleep", lambda s: None)
+        cs._http_get_with_headers("https://api.github.com/x", "tok", accept="a")
+        assert cs.request_count() - before == 2
+
+    def test_main_prints_the_request_total(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
+        monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "tok")
+        monkeypatch.delenv("CLASSROOM_FILTER", raising=False)
+        monkeypatch.delenv("ASSIGNMENT_FILTER", raising=False)
+        (tmp_path / "cs").mkdir()
+        (tmp_path / "cs" / "classroom.json").write_text(
+            json.dumps({"schema": cs.CLASSROOM_SCHEMA_V1, "short": "cs", "name": "CS"})
+        )
+        (tmp_path / "cs" / "assignments.json").write_text(
+            json.dumps({"schema": cs.ASSIGNMENTS_SCHEMA_V1, "assignments": []})
+        )
+        monkeypatch.setattr(cs, "list_team_member_logins", lambda *a, **k: [])
+        assert cs.main() == 0
+        out = capsys.readouterr().out
+        assert re.search(r"collect: \d+ GitHub API request\(s\) in \d+\.\ds", out)
+        assert re.search(r"cs: 0 updated submission\(s\) \(\d+\.\ds\)", out)
 
 
 class TestIncompleteListingNeverPersists:

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -4868,6 +4868,8 @@ class TestParallelPagination:
         got = self._walk()
         assert len(got) == 101
         assert got[-1]["name"] == "p2-0"
+        # Page 1 is handed to the sequential walk, not read again.
+        assert [int(re.search(r"[?&]page=(\d+)", u).group(1)) for u in calls] == [1, 2]
 
     def test_page_count_past_the_cap_is_incomplete(self, monkeypatch):
         self._serve(
@@ -4932,16 +4934,20 @@ class TestRepoIndexProbeMode:
 
     API = "https://api.github.com"
 
-    def _index(self, monkeypatch, *, pages_left, page1=None, existing=(), fail=()):
+    def _index(
+        self, monkeypatch, *, last, page1=None, existing=(), fail=(), rest_error=None
+    ):
         page1 = {"starter": False} if page1 is None else dict(page1)
         probed: list[str] = []
         rest_reads: list[int] = []
 
         def first_page(api_url, org, token):
-            return dict(page1), pages_left
+            return dict(page1), last
 
         def rest(api_url, org, token, n):
             rest_reads.append(n)
+            if rest_error is not None:
+                raise rest_error
             return {name: False for name in existing}
 
         def get_repo(api_url, owner, repo, token):
@@ -4960,7 +4966,7 @@ class TestRepoIndexProbeMode:
 
     def test_small_hint_probes_instead_of_listing(self, monkeypatch, capsys):
         index, probed, rest_reads = self._index(
-            monkeypatch, pages_left=89, existing={"cs-hw1-alice", "priv-cs-hw1-bob"}
+            monkeypatch, last=90, existing={"cs-hw1-alice", "priv-cs-hw1-bob"}
         )
         index.prefetch(["cs-hw1-ALICE", "priv-cs-hw1-bob", "cs-hw1-carol", "starter"])
         # Page 1 answered `starter`; the other three were probed, in parallel.
@@ -4977,45 +4983,56 @@ class TestRepoIndexProbeMode:
 
     def test_large_hint_reads_the_rest_of_the_listing(self, monkeypatch, capsys):
         index, probed, rest_reads = self._index(
-            monkeypatch, pages_left=2, existing={"cs-hw1-alice"}
+            monkeypatch, last=3, existing={"cs-hw1-alice"}
         )
         index.prefetch([f"cs-hw1-user{i}" for i in range(5)])
         assert probed == []
-        assert rest_reads == [2]
+        assert rest_reads == [3]
         assert index.contains("cs-hw1-alice") is True
         assert index.contains("cs-hw1-user0") is False
         assert "2 repo(s) visible" in capsys.readouterr().out
+
+    def test_hint_equal_to_pages_left_probes(self, monkeypatch):
+        # The boundary: as many candidates as pages left costs the same either
+        # way, and the probes are the lighter requests.
+        index, probed, rest_reads = self._index(monkeypatch, last=3)
+        index.prefetch(["cs-hw1-alice", "cs-hw1-bob"])
+        assert len(probed) == 2 and rest_reads == []
 
     def test_probe_budget_is_the_listing_cost(self, monkeypatch):
         # Two classrooms' hints together exceed the pages left, so the second
         # prefetch completes the listing rather than probing past the budget.
         index, probed, rest_reads = self._index(
-            monkeypatch, pages_left=3, existing={"cs-hw1-alice", "cs-hw2-dan"}
+            monkeypatch, last=4, existing={"cs-hw1-alice", "cs-hw2-dan"}
         )
         index.prefetch(["cs-hw1-alice", "cs-hw1-bob"])
         assert len(probed) == 2 and rest_reads == []
         index.prefetch(["cs-hw2-carol", "cs-hw2-dan"])
         assert len(probed) == 2  # no further probes
-        assert rest_reads == [3]
+        assert rest_reads == [4]
         assert index.contains("cs-hw1-alice") is True  # probed answer kept
         assert index.contains("cs-hw2-dan") is True
         assert index.contains("cs-hw2-carol") is False
+        assert index.is_private("cs-hw2-dan") is False
 
     def test_unhinted_name_is_probed_on_demand_once(self, monkeypatch):
-        index, probed, _ = self._index(monkeypatch, pages_left=10, existing={"late"})
+        index, probed, _ = self._index(monkeypatch, last=11, existing={"late"})
         index.prefetch(["cs-hw1-alice"])
         assert index.contains("late") is True
         assert index.contains("LATE") is True
         assert probed.count("late") == 1
 
     def test_failed_probe_fails_open(self, monkeypatch):
-        index, _, _ = self._index(monkeypatch, pages_left=10, fail={"cs-hw1-alice"})
+        index, _, _ = self._index(monkeypatch, last=11, fail={"cs-hw1-alice"})
         index.prefetch(["cs-hw1-alice"])
         assert index.contains("cs-hw1-alice") is True
         assert index.is_private("cs-hw1-alice") is None
 
-    def test_throttled_probe_propagates(self, monkeypatch):
-        index, _, _ = self._index(monkeypatch, pages_left=10)
+    def test_throttled_probe_propagates_and_stays_unlatched(self, monkeypatch):
+        index, probed, rest_reads = self._index(
+            monkeypatch, last=11, existing={"cs-hw1-alice"}
+        )
+        working = cs.get_repo
 
         def throttled(*a, **k):
             raise http_error(403, {"Retry-After": "60"}, b"secondary rate limit")
@@ -5023,15 +5040,60 @@ class TestRepoIndexProbeMode:
         monkeypatch.setattr(cs, "get_repo", throttled)
         with pytest.raises(cs.urllib.error.HTTPError):
             index.prefetch(["cs-hw1-alice"])
+        # The failed batch charged no budget and the name is still unresolved,
+        # so the retry probes it for real instead of answering from a guess.
+        monkeypatch.setattr(cs, "get_repo", working)
+        index.prefetch(["cs-hw1-alice"])
+        assert probed == ["cs-hw1-alice"]
+        assert index.contains("cs-hw1-alice") is True
+        assert index.is_private("cs-hw1-alice") is False
+        assert rest_reads == []
 
     def test_names_completes_the_listing(self, monkeypatch):
         index, _, rest_reads = self._index(
-            monkeypatch, pages_left=10, existing={"cs-hw1-group-1"}
+            monkeypatch, last=11, existing={"cs-hw1-group-1"}
         )
         index.prefetch(["cs-hw1-alice"])
         assert rest_reads == []
         assert sorted(index.names()) == ["cs-hw1-group-1", "starter"]
-        assert rest_reads == [10]
+        assert rest_reads == [11]
+
+    def test_soft_failure_completing_the_listing_fails_open(self, monkeypatch, capsys):
+        # A 5xx on a later page must not abort the run: the listing becomes
+        # unknown, every name polls, and team mode falls back to its own source.
+        index, probed, rest_reads = self._index(
+            monkeypatch, last=11, rest_error=http_error(502, {}, b"bad gateway")
+        )
+        index.prefetch(["cs-hw1-alice"])
+        assert index.names() is None
+        assert rest_reads == [11]
+        assert index.contains("cs-hw1-alice") is True
+        assert index.contains("never-probed") is True
+        assert index.is_private("cs-hw1-alice") is None
+        assert len(probed) == 1  # no further probes once the listing is unknown
+        assert "could not list" in capsys.readouterr().err
+
+    def test_malformed_rest_of_listing_fails_open(self, monkeypatch, capsys):
+        index, _, _ = self._index(
+            monkeypatch, last=3, rest_error=cs.IncompleteListing("orgs/cs50/repos: loop")
+        )
+        # A hint larger than the pages left reads the rest inside _read.
+        index.prefetch(["cs-hw1-alice", "cs-hw1-bob", "cs-hw1-carol"])
+        assert index.contains("cs-hw1-carol") is True
+        assert "malformed" in capsys.readouterr().err
+
+    def test_throttled_rest_of_listing_propagates(self, monkeypatch):
+        index, _, _ = self._index(
+            monkeypatch,
+            last=11,
+            rest_error=http_error(403, {"Retry-After": "60"}, b"secondary rate limit"),
+        )
+        index.prefetch(["cs-hw1-alice"])
+        with pytest.raises(cs.urllib.error.HTTPError):
+            index.names()
+        # Still in probe mode: the next attempt retries the completion.
+        with pytest.raises(cs.urllib.error.HTTPError):
+            index.names()
 
     def test_no_hint_reads_the_whole_listing(self, monkeypatch):
         monkeypatch.setattr(cs, "list_org_repos", lambda *a, **k: {"cs-hw1-alice": False})
@@ -5041,38 +5103,118 @@ class TestRepoIndexProbeMode:
         index = cs.RepoIndex(self.API, "cs50", "tok")
         assert index.contains("cs-hw1-alice") is True
 
+    def test_single_page_org_with_a_hint_is_the_listing(self, monkeypatch):
+        index, probed, rest_reads = self._index(monkeypatch, last=1)
+        index.prefetch(["cs-hw1-alice"])
+        assert probed == [] and rest_reads == []
+        assert index.contains("starter") is True
+        assert index.contains("cs-hw1-alice") is False
+
     def test_empty_first_page_is_unknown(self, monkeypatch):
-        index, probed, _ = self._index(monkeypatch, pages_left=0, page1={})
+        index, probed, _ = self._index(monkeypatch, last=1, page1={})
         index.prefetch(["cs-hw1-alice"])
         assert index.contains("anything") is True
         assert probed == []
 
 
+class TestCollectPassHintsEveryPoll:
+    """collect_classroom must hand the index every name it will ask about, or
+    each miss costs a request; the hint list is derived separately from the
+    poll loop, so the two are pinned to agree here."""
+
+    class RecordingIndex:
+        def __init__(self):
+            self.hinted: set[str] = set()
+            self.unhinted: list[str] = []
+
+        def prefetch(self, names):
+            self.hinted.update(n.lower() for n in names)
+
+        def contains(self, name):
+            if name.lower() not in self.hinted:
+                self.unhinted.append(name)
+            return False
+
+        def is_private(self, name):
+            return None
+
+        def names(self):
+            return []
+
+    ASSIGNMENTS = {
+        "schema": cs.ASSIGNMENTS_SCHEMA_V1,
+        "assignments": [
+            {"slug": "hw1"},
+            {"slug": "hw2", "mode": "group"},
+            {"slug": "proj", "mode": "team"},
+            {"slug": "warmup", "empty_repo": True},
+            {"slug": "essay", "no_autograder": True},
+        ],
+    }
+
+    @pytest.mark.parametrize("assignment_filter", ["", "essay"])
+    def test_every_polled_name_was_hinted(self, monkeypatch, assignment_filter):
+        monkeypatch.setattr(
+            cs, "list_team_member_logins", lambda *a, **k: ["alice", "bob"]
+        )
+        index = self.RecordingIndex()
+        cs.collect_classroom(
+            api_url="https://api.github.com",
+            org="cs50",
+            classroom_short="cs",
+            classroom_meta={"schema": cs.CLASSROOM_SCHEMA_V1, "short": "cs", "name": "CS"},
+            assignments=self.ASSIGNMENTS,
+            service_token="tok",
+            assignment_filter=assignment_filter,
+            repo_index=index,
+        )
+        assert index.unhinted == []
+        assert index.hinted  # the pass did ask about something
+
+
 class TestListOrgReposFirstPage:
     BASE = "https://api.github.com/orgs/cs50/repos?per_page=100"
 
-    def test_reports_pages_left_from_rel_last(self, monkeypatch):
+    def test_reports_the_page_count_from_rel_last(self, monkeypatch):
         def fake_get(url, token, *, accept, max_bytes=None, _retries=3):
+            self.url = url
             return (
                 json.dumps([{"name": "A", "private": True}]).encode(),
                 _link(self.BASE, next_page=2, last=90),
             )
 
         monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
-        repos, left = cs.list_org_repos_first_page("https://api.github.com", "cs50", "tok")
-        assert repos == {"a": True} and left == 89
+        repos, last = cs.list_org_repos_first_page("https://api.github.com", "cs50", "tok")
+        assert repos == {"a": True} and last == 90
+        # Oldest first: a repo created mid-walk lands after the pages in flight.
+        assert "sort=created" in self.url and "direction=asc" in self.url
 
-    def test_single_page_has_nothing_left(self, monkeypatch):
+    def test_single_page_counts_as_one(self, monkeypatch):
         def fake_get(url, token, *, accept, max_bytes=None, _retries=3):
             return json.dumps([{"name": "a"}]).encode(), {}
 
         monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
         assert cs.list_org_repos_first_page("https://api.github.com", "cs50", "tok") == (
             {"a": False},
-            0,
+            1,
         )
 
-    def test_rest_fetches_pages_two_onward(self, monkeypatch):
+    def test_next_without_last_walks_everything_reading_page_one_once(self, monkeypatch):
+        seen: list[int] = []
+        pages = {1: [{"name": f"p1-{i}"} for i in range(100)], 2: [{"name": "p2-0"}]}
+
+        def fake_get(url, token, *, accept, max_bytes=None, _retries=3):
+            page = int(re.search(r"[?&]page=(\d+)", url).group(1))
+            seen.append(page)
+            headers = _link(self.BASE, next_page=2) if page == 1 else {}
+            return json.dumps(pages[page]).encode(), headers
+
+        monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
+        repos, last = cs.list_org_repos_first_page("https://api.github.com", "cs50", "tok")
+        assert len(repos) == 101 and last == 1
+        assert seen == [1, 2]
+
+    def test_rest_fetches_pages_two_through_last(self, monkeypatch):
         seen: list[int] = []
 
         def fake_get(url, token, *, accept, max_bytes=None, _retries=3):
@@ -5081,9 +5223,50 @@ class TestListOrgReposFirstPage:
             return json.dumps([{"name": f"r{page}", "private": page == 3}]).encode(), {}
 
         monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
-        got = cs.list_org_repos_rest("https://api.github.com", "cs50", "tok", 3)
+        got = cs.list_org_repos_rest("https://api.github.com", "cs50", "tok", 4)
         assert sorted(seen) == [2, 3, 4]
         assert got == {"r2": False, "r3": True, "r4": False}
+
+
+class TestThrottleBudgetUnderConcurrency:
+    """The sleep budget is wall-clock: eight workers waiting out the same
+    throttle at once spend it once, while one thread's back-to-back waits each
+    count in full."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh_budget(self):
+        cs._throttle_sleep_spent = 0.0
+        cs._throttle_sleep_until = 0.0
+        cs._throttle_local.__dict__.clear()
+        yield
+        cs._throttle_sleep_spent = 0.0
+        cs._throttle_sleep_until = 0.0
+        cs._throttle_local.__dict__.clear()
+
+    def test_overlapping_waits_on_other_threads_count_once(self):
+        import threading
+
+        refused: list[bool] = []
+        barrier = threading.Barrier(cs.PARALLEL_PAGE_WORKERS)
+
+        def worker():
+            barrier.wait(timeout=5)
+            refused.append(cs.throttle_sleep_budget_spent(60))
+
+        threads = [threading.Thread(target=worker) for _ in range(cs.PARALLEL_PAGE_WORKERS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+        assert refused == [False] * cs.PARALLEL_PAGE_WORKERS
+        # Threads arrive microseconds apart, so the union is a hair over 60s.
+        assert 60 <= cs._throttle_sleep_spent < 61
+
+    def test_sequential_waits_on_one_thread_each_count(self):
+        for _ in range(5):
+            assert cs.throttle_sleep_budget_spent(60) is False
+        assert cs._throttle_sleep_spent == 300
+        assert cs.throttle_sleep_budget_spent(1) is True
 
 
 class TestProbeOrgRepos:

--- a/web/src/github-core/client.ts
+++ b/web/src/github-core/client.ts
@@ -51,6 +51,9 @@ export type GitHubRequestOptions = {
   // Composed with `signal`; defaults to DEFAULT_REQUEST_TIMEOUT_MS. Pass a
   // larger value for a legitimately long call, or `0` to opt out.
   timeoutMs?: number
+  // Called with the response headers of a 2xx before the body is parsed, for
+  // callers that read pagination metadata (`Link`) alongside the body.
+  onHeaders?: (headers: Headers) => void
 }
 
 // Per-response signal about the token's live state, reported to the provider
@@ -173,6 +176,7 @@ export function createGitHubClient(args: {
     }
 
     log.debug("response", { method, path, status: res.status })
+    options.onHeaders?.(res.headers)
     return res
   }
 

--- a/web/src/github-core/mutations/inviteTeams.ts
+++ b/web/src/github-core/mutations/inviteTeams.ts
@@ -3,7 +3,7 @@ import type { GitHubTeam, GitHubUser } from "../types"
 import { GitHubAPIError, tolerateGitHubError } from "../errors"
 import { createTeam } from "../teamWrites"
 import { removeUserFromTeam } from "./teams"
-import { paginateAll } from "../paginate"
+import { PAGE_FETCH_CONCURRENCY, paginateAll } from "../paginate"
 import {
   INVITE_TEAM_PREFIX,
   inviteTeamName,
@@ -241,6 +241,7 @@ export async function listInviteTeams(
     client,
     (page) =>
       `/orgs/${encodeURIComponent(org)}/teams?per_page=100&page=${page}`,
+    { concurrency: PAGE_FETCH_CONCURRENCY },
   )
   return teams.filter((t) => t.slug && isInviteTeamSlug(t.slug))
 }

--- a/web/src/github-core/paginate.test.ts
+++ b/web/src/github-core/paginate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest"
 
-import { lastPageNumber, paginateAll } from "./paginate"
+import { lastPageNumber, PAGE_FETCH_CONCURRENCY, paginateAll } from "./paginate"
 import type { GitHubClient, GitHubRequestOptions } from "./client"
 import { GitHubAPIError } from "./errors"
 
@@ -67,7 +67,7 @@ const apiError = (status: number, retryAfter: number | null = null) =>
 describe("paginateAll", () => {
   const makePath = (page: number) => `${BASE}&page=${page}`
 
-  it("fetches pages 2..last concurrently after page 1 names the count", async () => {
+  it("fetches pages 2..last concurrently when a bulk listing opts in", async () => {
     const pages = {
       1: pageOf(1),
       2: pageOf(2),
@@ -75,7 +75,9 @@ describe("paginateAll", () => {
       4: pageOf(4, 7),
     }
     const { client, requested, peak } = fakeClient({ pages, last: 4 })
-    const all = await paginateAll<{ id: number }>(client, makePath)
+    const all = await paginateAll<{ id: number }>(client, makePath, {
+      concurrency: PAGE_FETCH_CONCURRENCY,
+    })
     expect(all).toHaveLength(307)
     // Page order survives the parallel fetch.
     expect(all.map((r) => r.id).filter((id) => id % 1000 === 0)).toEqual([
@@ -84,6 +86,14 @@ describe("paginateAll", () => {
     expect(requested[0]).toBe(1)
     expect([...requested].sort()).toEqual([1, 2, 3, 4])
     expect(peak()).toBeGreaterThan(1)
+  })
+
+  it("reads one page at a time by default (callers may sit inside a read slot)", async () => {
+    const pages = { 1: pageOf(1), 2: pageOf(2), 3: pageOf(3, 1) }
+    const { client, requested, peak } = fakeClient({ pages, last: 3 })
+    await paginateAll(client, makePath)
+    expect(requested).toEqual([1, 2, 3])
+    expect(peak()).toBe(1)
   })
 
   it("honours the concurrency option", async () => {
@@ -157,7 +167,7 @@ describe("paginateAll", () => {
     }
   })
 
-  it("waits out a rate limit on one page", async () => {
+  it("waits out a short rate limit on one page", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     try {
       const pages = { 1: pageOf(1), 2: pageOf(2, 1) }
@@ -172,6 +182,77 @@ describe("paginateAll", () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it("fails at once on a rate limit longer than a page load can absorb", async () => {
+    // A real secondary limit asks for ~60s; re-requesting after 8s would only
+    // burn requests while GitHub is still refusing.
+    const { client, requested } = fakeClient({
+      pages: { 1: pageOf(1) },
+      last: 2,
+      failures: { 2: [apiError(403, 60)] },
+    })
+    await expect(
+      paginateAll(client, makePath, { retryPages: true }),
+    ).rejects.toMatchObject({ status: 403 })
+    expect(requested.filter((p) => p === 2)).toHaveLength(1)
+  })
+
+  it("fails at once on a rate limit with no Retry-After", async () => {
+    const primaryLimit = new GitHubAPIError({
+      status: 403,
+      url: BASE,
+      message: "API rate limit exceeded",
+      body: null,
+      rateLimit: {
+        limit: 5000,
+        remaining: 0,
+        used: 5000,
+        reset: null,
+        resource: null,
+        retryAfter: null,
+      },
+    })
+    const { client, requested } = fakeClient({
+      pages: { 1: pageOf(1) },
+      last: 2,
+      failures: { 2: [primaryLimit] },
+    })
+    await expect(
+      paginateAll(client, makePath, { retryPages: true }),
+    ).rejects.toMatchObject({ status: 403 })
+    expect(requested.filter((p) => p === 2)).toHaveLength(1)
+  })
+
+  it("aborts the sibling pages once one page fails for good", async () => {
+    const seenSignals: AbortSignal[] = []
+    let inFlight = 0
+    const request = vi.fn(
+      async (path: string, options?: GitHubRequestOptions) => {
+        const page = Number(/[?&]page=(\d+)/.exec(path)?.[1] ?? 1)
+        if (page === 1) {
+          options?.onHeaders?.(new Headers({ link: linkHeader(4) }))
+          return pageOf(1)
+        }
+        if (options?.signal) seenSignals.push(options.signal)
+        if (page === 2) throw apiError(404)
+        // Pages 3 and 4 are slow; they should be aborted, not completed.
+        inFlight++
+        await new Promise((_, reject) => {
+          options?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          )
+        })
+        return []
+      },
+    )
+    await expect(
+      paginateAll({ request } as unknown as GitHubClient, makePath, {
+        concurrency: PAGE_FETCH_CONCURRENCY,
+      }),
+    ).rejects.toMatchObject({ status: 404 })
+    expect(inFlight).toBe(2)
+    expect(seenSignals.every((s) => s.aborted)).toBe(true)
   })
 
   it("does not retry a definitive status", async () => {
@@ -203,24 +284,29 @@ describe("paginateAll", () => {
     }
   })
 
-  it("forwards the caller's signal to every page", async () => {
-    const seen: Array<AbortSignal | undefined> = []
+  it("forwards the caller's abort to every page", async () => {
+    const seen: AbortSignal[] = []
+    const controller = new AbortController()
     const request = vi.fn(
       async (path: string, options?: GitHubRequestOptions) => {
-        seen.push(options?.signal)
+        if (options?.signal) seen.push(options.signal)
         if (/page=1\b/.test(path)) {
           options?.onHeaders?.(new Headers({ link: linkHeader(2) }))
           return pageOf(1)
         }
+        // The caller gives up while page 2 is in flight.
+        controller.abort()
         return pageOf(2, 1)
       },
     )
-    const controller = new AbortController()
     await paginateAll({ request } as unknown as GitHubClient, makePath, {
       signal: controller.signal,
     })
     expect(seen).toHaveLength(2)
-    expect(seen.every((s) => s === controller.signal)).toBe(true)
+    expect(seen[0]).toBe(controller.signal)
+    // Later pages get the walk's own signal, linked to the caller's.
+    expect(seen[1]).not.toBe(controller.signal)
+    expect(seen[1].aborted).toBe(true)
   })
 
   it("does not retry once aborted", async () => {

--- a/web/src/github-core/paginate.test.ts
+++ b/web/src/github-core/paginate.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi } from "vitest"
+
+import { lastPageNumber, paginateAll } from "./paginate"
+import type { GitHubClient, GitHubRequestOptions } from "./client"
+import { GitHubAPIError } from "./errors"
+
+const BASE = "https://api.github.com/orgs/acme/repos?per_page=100"
+
+function linkHeader(last: number) {
+  return `<${BASE}&page=2>; rel="next", <${BASE}&page=${last}>; rel="last"`
+}
+
+function pageOf(page: number, size = 100) {
+  return Array.from({ length: size }, (_, i) => ({ id: page * 1000 + i }))
+}
+
+// A client whose page 1 carries `Link` (when `last` is given) and which
+// records the order pages were REQUESTED and the peak concurrency.
+function fakeClient(opts: {
+  pages: Record<number, unknown[]>
+  last?: number
+  failures?: Record<number, unknown[]>
+}) {
+  const requested: number[] = []
+  let inFlight = 0
+  let peak = 0
+  const failures = { ...(opts.failures ?? {}) }
+  const request = vi.fn(
+    async (path: string, options?: GitHubRequestOptions) => {
+      const page = Number(/[?&]page=(\d+)/.exec(path)?.[1] ?? 1)
+      requested.push(page)
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      await new Promise((r) => setTimeout(r, 1))
+      inFlight--
+      const queued = failures[page]
+      if (queued?.length) throw queued.shift()
+      if (page === 1 && opts.last !== undefined) {
+        options?.onHeaders?.(new Headers({ link: linkHeader(opts.last) }))
+      }
+      return opts.pages[page] ?? []
+    },
+  )
+  return {
+    client: { request } as unknown as GitHubClient,
+    requested,
+    peak: () => peak,
+  }
+}
+
+const apiError = (status: number, retryAfter: number | null = null) =>
+  new GitHubAPIError({
+    status,
+    url: BASE,
+    message: `HTTP ${status}`,
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter,
+    },
+  })
+
+describe("paginateAll", () => {
+  const makePath = (page: number) => `${BASE}&page=${page}`
+
+  it("fetches pages 2..last concurrently after page 1 names the count", async () => {
+    const pages = {
+      1: pageOf(1),
+      2: pageOf(2),
+      3: pageOf(3),
+      4: pageOf(4, 7),
+    }
+    const { client, requested, peak } = fakeClient({ pages, last: 4 })
+    const all = await paginateAll<{ id: number }>(client, makePath)
+    expect(all).toHaveLength(307)
+    // Page order survives the parallel fetch.
+    expect(all.map((r) => r.id).filter((id) => id % 1000 === 0)).toEqual([
+      1000, 2000, 3000, 4000,
+    ])
+    expect(requested[0]).toBe(1)
+    expect([...requested].sort()).toEqual([1, 2, 3, 4])
+    expect(peak()).toBeGreaterThan(1)
+  })
+
+  it("honours the concurrency option", async () => {
+    const pages = Object.fromEntries(
+      Array.from({ length: 10 }, (_, i) => [i + 1, pageOf(i + 1)]),
+    )
+    const { client, peak } = fakeClient({ pages, last: 10 })
+    await paginateAll(client, makePath, { concurrency: 2 })
+    expect(peak()).toBe(2)
+  })
+
+  it("walks one page at a time when the header names no last page", async () => {
+    const { client, requested } = fakeClient({
+      pages: { 1: pageOf(1), 2: pageOf(2), 3: pageOf(3, 1) },
+    })
+    const all = await paginateAll(client, makePath)
+    expect(all).toHaveLength(201)
+    expect(requested).toEqual([1, 2, 3])
+  })
+
+  it("returns a short first page in one request", async () => {
+    const { client, requested } = fakeClient({ pages: { 1: pageOf(1, 3) } })
+    expect(await paginateAll(client, makePath)).toHaveLength(3)
+    expect(requested).toEqual([1])
+  })
+
+  it("stops at the page cap when a server keeps returning full pages", async () => {
+    const request = vi.fn().mockResolvedValue(pageOf(0))
+    const client = { request } as unknown as GitHubClient
+    const all = await paginateAll(client, makePath)
+    expect(request).toHaveBeenCalledTimes(100)
+    expect(all).toHaveLength(10_000)
+  })
+
+  it("clamps a rel=last beyond the cap instead of fanning out unbounded", async () => {
+    const pages = Object.fromEntries(
+      Array.from({ length: 100 }, (_, i) => [i + 1, pageOf(i + 1, 1)]),
+    )
+    const { client, requested } = fakeClient({ pages, last: 5000 })
+    await paginateAll(client, makePath)
+    expect(requested).toHaveLength(100)
+  })
+
+  it("fails fast on a transient page error unless asked to retry", async () => {
+    const { client, requested } = fakeClient({
+      pages: { 1: pageOf(1) },
+      last: 2,
+      failures: { 2: [apiError(502)] },
+    })
+    await expect(paginateAll(client, makePath)).rejects.toMatchObject({
+      status: 502,
+    })
+    expect(requested.filter((p) => p === 2)).toHaveLength(1)
+  })
+
+  it("retries a transient page failure without restarting the walk", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const pages = { 1: pageOf(1), 2: pageOf(2), 3: pageOf(3, 1) }
+      const { client, requested } = fakeClient({
+        pages,
+        last: 3,
+        failures: { 2: [apiError(502)] },
+      })
+      const all = await paginateAll(client, makePath, { retryPages: true })
+      expect(all).toHaveLength(201)
+      expect(requested.filter((p) => p === 1)).toHaveLength(1)
+      expect(requested.filter((p) => p === 2)).toHaveLength(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("waits out a rate limit on one page", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const pages = { 1: pageOf(1), 2: pageOf(2, 1) }
+      const { client, requested } = fakeClient({
+        pages,
+        last: 2,
+        failures: { 2: [apiError(429, 1)] },
+      })
+      const all = await paginateAll(client, makePath, { retryPages: true })
+      expect(all).toHaveLength(101)
+      expect(requested.filter((p) => p === 2)).toHaveLength(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not retry a definitive status", async () => {
+    const { client, requested } = fakeClient({
+      pages: { 1: pageOf(1) },
+      last: 2,
+      failures: { 2: [apiError(404)] },
+    })
+    await expect(
+      paginateAll(client, makePath, { retryPages: true }),
+    ).rejects.toMatchObject({ status: 404 })
+    expect(requested.filter((p) => p === 2)).toHaveLength(1)
+  })
+
+  it("gives up after the retry budget", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const { client, requested } = fakeClient({
+        pages: { 1: pageOf(1) },
+        last: 2,
+        failures: { 2: [apiError(500), apiError(500), apiError(500)] },
+      })
+      await expect(
+        paginateAll(client, makePath, { retryPages: true }),
+      ).rejects.toMatchObject({ status: 500 })
+      expect(requested.filter((p) => p === 2)).toHaveLength(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("forwards the caller's signal to every page", async () => {
+    const seen: Array<AbortSignal | undefined> = []
+    const request = vi.fn(
+      async (path: string, options?: GitHubRequestOptions) => {
+        seen.push(options?.signal)
+        if (/page=1\b/.test(path)) {
+          options?.onHeaders?.(new Headers({ link: linkHeader(2) }))
+          return pageOf(1)
+        }
+        return pageOf(2, 1)
+      },
+    )
+    const controller = new AbortController()
+    await paginateAll({ request } as unknown as GitHubClient, makePath, {
+      signal: controller.signal,
+    })
+    expect(seen).toHaveLength(2)
+    expect(seen.every((s) => s === controller.signal)).toBe(true)
+  })
+
+  it("does not retry once aborted", async () => {
+    const controller = new AbortController()
+    const request = vi.fn(async (path: string) => {
+      if (/page=1\b/.test(path)) {
+        controller.abort()
+        throw new DOMException("Aborted", "AbortError")
+      }
+      return []
+    })
+    await expect(
+      paginateAll({ request } as unknown as GitHubClient, makePath, {
+        signal: controller.signal,
+        retryPages: true,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" })
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("lastPageNumber", () => {
+  it("reads the page param of the rel=last URL", () => {
+    expect(lastPageNumber(linkHeader(90))).toBe(90)
+  })
+
+  it("is null without a header, without rel=last, or with a non-numeric page", () => {
+    expect(lastPageNumber(null)).toBeNull()
+    expect(lastPageNumber("")).toBeNull()
+    expect(lastPageNumber(`<${BASE}&page=2>; rel="next"`)).toBeNull()
+    expect(lastPageNumber(`<${BASE}&page=abc>; rel="last"`)).toBeNull()
+    expect(lastPageNumber(`<not a url>; rel="last"`)).toBeNull()
+  })
+})

--- a/web/src/github-core/paginate.ts
+++ b/web/src/github-core/paginate.ts
@@ -10,19 +10,26 @@ const log = logger.scope(LOG_SCOPE_QUERIES)
 // page param and keeps returning full pages can't loop unbounded.
 const MAX_PAGES = 100
 
-// Pages fetched at once after page 1 reveals the count. Separate from
-// REPO_READ_CONCURRENCY on purpose: a listing walk shouldn't starve the per-repo
-// fan-outs that share that semaphore, and vice versa.
+// Pages fetched at once by a bulk listing that opts in via `concurrency`.
+// Separate from REPO_READ_CONCURRENCY on purpose: a listing walk shouldn't
+// starve the per-repo fan-outs that share that semaphore, and vice versa.
 export const PAGE_FETCH_CONCURRENCY = 8
 
 // Per-page retry: a single 15s timeout or 5xx on page 40 of 90 used to fail the
 // whole query and React Query re-walked every page from 1.
 const PAGE_RETRY_ATTEMPTS = 3
 const PAGE_RETRY_BASE_MS = 500
+// A rate limit whose Retry-After is longer than this is not waited out: the
+// page is failed at once rather than re-requested while GitHub is still
+// refusing (the UI reports it and the user retries later).
 const MAX_RATE_LIMIT_WAIT_MS = 8000
 
 export type PaginateOptions = {
   signal?: AbortSignal
+  // Pages fetched at once after page 1 reveals the count. Defaults to 1
+  // because many callers already run inside a per-repo read slot
+  // (withGithubReadSlot); only top-level bulk listings pass
+  // PAGE_FETCH_CONCURRENCY.
   concurrency?: number
   // Retry a page that fails transiently (5xx, rate limit, timeout) instead of
   // failing the walk. Off by default: most callers surface a failure at once
@@ -73,7 +80,7 @@ export async function paginateRemaining<T>(
   first: FirstPage<T>,
   options: PaginateOptions = {},
 ): Promise<T[]> {
-  const { concurrency = PAGE_FETCH_CONCURRENCY } = options
+  const { concurrency = 1 } = options
 
   if (first.lastPage === null) {
     return paginateSequentially(client, makePath, first.items, options)
@@ -87,11 +94,24 @@ export async function paginateRemaining<T>(
     })
   }
 
+  // One page failing definitively ends the walk; the sibling pages in flight
+  // are aborted rather than left to finish (and retry) for nothing.
+  const walk = new AbortController()
+  const onCallerAbort = () => walk.abort(options.signal?.reason)
+  options.signal?.addEventListener("abort", onCallerAbort, { once: true })
+  const pageOptions = { ...options, signal: walk.signal }
   const pages = Array.from({ length: lastPage - 1 }, (_, i) => i + 2)
-  const rest = await mapWithConcurrency(pages, concurrency, (page) =>
-    fetchPage<T>(client, makePath(page), options),
-  )
-  return first.items.concat(...rest)
+  try {
+    const rest = await mapWithConcurrency(pages, concurrency, (page) =>
+      fetchPage<T>(client, makePath(page), pageOptions),
+    )
+    return first.items.concat(...rest)
+  } catch (err) {
+    walk.abort(err)
+    throw err
+  } finally {
+    options.signal?.removeEventListener("abort", onCallerAbort)
+  }
 }
 
 async function paginateSequentially<T>(
@@ -128,7 +148,7 @@ function fetchPage<T>(
   const { signal, retryPages = false } = options
   const read = () =>
     client.request<T[]>(path, { method: "GET", signal, onHeaders })
-  return retryPages ? withPageRetry(read, signal) : read()
+  return retryPages ? withTransientRetry(read, signal) : read()
 }
 
 // The page number of the `rel="last"` URL in a `Link` header, or null when the
@@ -147,9 +167,10 @@ export function lastPageNumber(linkHeader: string | null): number | null {
   return Number(page)
 }
 
-// Retry one page on transient failures (5xx, rate limit, timeout, network).
-// Definitive statuses (401/403/404) and caller aborts propagate at once.
-async function withPageRetry<T>(
+// Retry one read on transient failures (5xx, short rate limit, timeout,
+// network). Definitive statuses (401/403/404), caller aborts, and a rate limit
+// longer than MAX_RATE_LIMIT_WAIT_MS propagate at once.
+export async function withTransientRetry<T>(
   fn: () => Promise<T>,
   signal: AbortSignal | undefined,
 ): Promise<T> {
@@ -161,18 +182,25 @@ async function withPageRetry<T>(
       lastError = err
       if (signal?.aborted || !isTransientPageError(err)) throw err
       if (attempt === PAGE_RETRY_ATTEMPTS - 1) break
-      const waitMs =
-        err instanceof GitHubAPIError && err.isRateLimited
-          ? Math.min(
-              (err.rateLimit.retryAfter ?? 1) * 1000,
-              MAX_RATE_LIMIT_WAIT_MS,
-            )
-          : PAGE_RETRY_BASE_MS * 2 ** attempt
+      const waitMs = retryWaitMs(err, attempt)
+      if (waitMs === null) throw err
       log.debug("retrying page", { attempt, waitMs })
       await sleep(waitMs, signal)
     }
   }
   throw lastError
+}
+
+// How long to wait before retrying `err`, or null when the wait would exceed
+// what a page load can absorb (a real secondary limit asks for ~60s).
+function retryWaitMs(err: unknown, attempt: number): number | null {
+  if (err instanceof GitHubAPIError && err.isRateLimited) {
+    const retryAfter = err.rateLimit.retryAfter
+    if (retryAfter === null) return null
+    const waitMs = retryAfter * 1000
+    return waitMs > MAX_RATE_LIMIT_WAIT_MS ? null : waitMs
+  }
+  return PAGE_RETRY_BASE_MS * 2 ** attempt
 }
 
 function isTransientPageError(err: unknown): boolean {

--- a/web/src/github-core/paginate.ts
+++ b/web/src/github-core/paginate.ts
@@ -1,33 +1,198 @@
 import type { GitHubClient } from "./client"
+import { GitHubAPIError, isDefinitiveGitHubStatus } from "./errors"
 import { logger } from "@/lib/logger"
 import { LOG_SCOPE_QUERIES } from "@/lib/logScopes"
+import { mapWithConcurrency } from "@/util/concurrency"
 
 const log = logger.scope(LOG_SCOPE_QUERIES)
 
+// Hard cap (100 pages x 100/page = 10k items) so a server that ignores the
+// page param and keeps returning full pages can't loop unbounded.
+const MAX_PAGES = 100
+
+// Pages fetched at once after page 1 reveals the count. Separate from
+// REPO_READ_CONCURRENCY on purpose: a listing walk shouldn't starve the per-repo
+// fan-outs that share that semaphore, and vice versa.
+export const PAGE_FETCH_CONCURRENCY = 8
+
+// Per-page retry: a single 15s timeout or 5xx on page 40 of 90 used to fail the
+// whole query and React Query re-walked every page from 1.
+const PAGE_RETRY_ATTEMPTS = 3
+const PAGE_RETRY_BASE_MS = 500
+const MAX_RATE_LIMIT_WAIT_MS = 8000
+
+export type PaginateOptions = {
+  signal?: AbortSignal
+  concurrency?: number
+  // Retry a page that fails transiently (5xx, rate limit, timeout) instead of
+  // failing the walk. Off by default: most callers surface a failure at once
+  // and let the user retry; a long walk opts in so one late page out of ninety
+  // doesn't send the whole listing back to page 1.
+  retryPages?: boolean
+}
+
+// Page 1 of a list endpoint plus the page count its `Link: rel="last"` names
+// (null when the header names none: a single page, or a cursor-paginated
+// endpoint). Lets a caller size the rest of the walk before paying for it.
+export type FirstPage<T> = { items: T[]; lastPage: number | null }
+
 // Walk a GitHub list endpoint to exhaustion, 100 items per page. `makePath`
-// receives the 1-based page number. Stops when a page returns fewer than 100.
+// receives the 1-based page number.
+//
+// Page 1 is read alone; its `Link: rel="last"` names the page count and the
+// remaining pages are fetched concurrently (an org with 9,000 repos is 90
+// pages: sequentially that is minutes, in parallel it is seconds). When the
+// header names no last page, the walk proceeds one page at a time and stops on
+// a short page.
 export async function paginateAll<T>(
   client: GitHubClient,
   makePath: (page: number) => string,
+  options: PaginateOptions = {},
 ): Promise<T[]> {
-  const all: T[] = []
-  let page = 1
-  // Hard cap (100 pages x 100/page = 10k items) so a server that ignores the
-  // page param and keeps returning full pages can't loop unbounded.
-  const MAX_PAGES = 100
+  const first = await paginateFirstPage<T>(client, makePath, options)
+  return paginateRemaining(client, makePath, first, options)
+}
 
-  while (page <= MAX_PAGES) {
-    const batch = await client.request<T[]>(makePath(page))
-    all.push(...batch)
-    if (batch.length < 100) break
-    page++
+export async function paginateFirstPage<T>(
+  client: GitHubClient,
+  makePath: (page: number) => string,
+  options: PaginateOptions = {},
+): Promise<FirstPage<T>> {
+  let linkHeader: string | null = null
+  const items = await fetchPage<T>(client, makePath(1), options, (headers) => {
+    linkHeader = headers.get("link")
+  })
+  return { items, lastPage: lastPageNumber(linkHeader) }
+}
+
+// Pages 2..last after paginateFirstPage: concurrent when the count is known,
+// one at a time (stopping on a short page) when it is not.
+export async function paginateRemaining<T>(
+  client: GitHubClient,
+  makePath: (page: number) => string,
+  first: FirstPage<T>,
+  options: PaginateOptions = {},
+): Promise<T[]> {
+  const { concurrency = PAGE_FETCH_CONCURRENCY } = options
+
+  if (first.lastPage === null) {
+    return paginateSequentially(client, makePath, first.items, options)
   }
 
-  if (page > MAX_PAGES) {
+  const lastPage = Math.min(first.lastPage, MAX_PAGES)
+  if (first.lastPage > MAX_PAGES) {
+    log.warn("pagination hit MAX_PAGES cap, results may be truncated", {
+      maxPages: MAX_PAGES,
+      lastPage: first.lastPage,
+    })
+  }
+
+  const pages = Array.from({ length: lastPage - 1 }, (_, i) => i + 2)
+  const rest = await mapWithConcurrency(pages, concurrency, (page) =>
+    fetchPage<T>(client, makePath(page), options),
+  )
+  return first.items.concat(...rest)
+}
+
+async function paginateSequentially<T>(
+  client: GitHubClient,
+  makePath: (page: number) => string,
+  first: T[],
+  options: PaginateOptions,
+): Promise<T[]> {
+  const all = [...first]
+  let page = 1
+  let batch = first
+
+  while (batch.length >= 100 && page < MAX_PAGES) {
+    page++
+    batch = await fetchPage<T>(client, makePath(page), options)
+    all.push(...batch)
+  }
+
+  if (batch.length >= 100) {
     log.warn("pagination hit MAX_PAGES cap, results may be truncated", {
       maxPages: MAX_PAGES,
     })
   }
 
   return all
+}
+
+function fetchPage<T>(
+  client: GitHubClient,
+  path: string,
+  options: PaginateOptions,
+  onHeaders?: (headers: Headers) => void,
+): Promise<T[]> {
+  const { signal, retryPages = false } = options
+  const read = () =>
+    client.request<T[]>(path, { method: "GET", signal, onHeaders })
+  return retryPages ? withPageRetry(read, signal) : read()
+}
+
+// The page number of the `rel="last"` URL in a `Link` header, or null when the
+// header names none (absent, a single page, or a cursor-paginated endpoint).
+export function lastPageNumber(linkHeader: string | null): number | null {
+  if (!linkHeader) return null
+  const match = /<([^>]+)>\s*;\s*[^,]*rel="last"/.exec(linkHeader)
+  if (!match) return null
+  let page: string | null
+  try {
+    page = new URL(match[1]).searchParams.get("page")
+  } catch {
+    return null
+  }
+  if (!page || !/^\d+$/.test(page)) return null
+  return Number(page)
+}
+
+// Retry one page on transient failures (5xx, rate limit, timeout, network).
+// Definitive statuses (401/403/404) and caller aborts propagate at once.
+async function withPageRetry<T>(
+  fn: () => Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < PAGE_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastError = err
+      if (signal?.aborted || !isTransientPageError(err)) throw err
+      if (attempt === PAGE_RETRY_ATTEMPTS - 1) break
+      const waitMs =
+        err instanceof GitHubAPIError && err.isRateLimited
+          ? Math.min(
+              (err.rateLimit.retryAfter ?? 1) * 1000,
+              MAX_RATE_LIMIT_WAIT_MS,
+            )
+          : PAGE_RETRY_BASE_MS * 2 ** attempt
+      log.debug("retrying page", { attempt, waitMs })
+      await sleep(waitMs, signal)
+    }
+  }
+  throw lastError
+}
+
+function isTransientPageError(err: unknown): boolean {
+  if (err instanceof GitHubAPIError) {
+    return err.isRateLimited || !isDefinitiveGitHubStatus(err.status)
+  }
+  // A timeout (`TimeoutError` DOMException) or network failure.
+  return !(err instanceof DOMException && err.name === "AbortError")
+}
+
+function sleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(signal?.reason ?? new DOMException("Aborted", "AbortError"))
+    }
+    signal?.addEventListener("abort", onAbort, { once: true })
+  })
 }

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -48,6 +48,7 @@ export {
   commitQuery,
   repoQuery,
   getOrgRepos,
+  getAssignmentRepos,
   getOpenPullRequests,
   listPullRequestsByBaseHead,
 } from "./queries/repoRefReads"

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -29,6 +29,23 @@ export const githubKeys = {
 
   orgRepos: (org: string) => [...githubKeys.all, "org-repos", org] as const,
 
+  // One assignment's slice of the org repo list, resolved for a known set of
+  // candidate logins (see getOrgRepos candidateNames). Prefixed by `orgRepos`
+  // so every invalidation of the full listing reaches it too.
+  assignmentRepos: (
+    org: string,
+    classroom: string,
+    assignment: string,
+    logins: readonly string[],
+  ) =>
+    [
+      ...githubKeys.orgRepos(org),
+      "assignment",
+      classroom,
+      assignment,
+      logins,
+    ] as const,
+
   // The org's template repos (GET /orgs/{org}/repos, filtered locally). Distinct
   // from `orgRepos`: this is a bounded, recency-sorted walk cached for the
   // picker, not the exhaustive listing the submissions signals use.

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -30,8 +30,10 @@ export const githubKeys = {
   orgRepos: (org: string) => [...githubKeys.all, "org-repos", org] as const,
 
   // One assignment's slice of the org repo list, resolved for a known set of
-  // candidate logins (see getOrgRepos candidateNames). Prefixed by `orgRepos`
-  // so every invalidation of the full listing reaches it too.
+  // candidate logins (see getAssignmentRepos). The logins are part of the key
+  // because the result depends on them: a roster change must re-resolve.
+  // Prefixed by `orgRepos` so every invalidation of the full listing reaches
+  // it too.
   assignmentRepos: (
     org: string,
     classroom: string,

--- a/web/src/github-core/queries/orgReads.ts
+++ b/web/src/github-core/queries/orgReads.ts
@@ -8,7 +8,7 @@ import type {
 } from "../types"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubAPIError, tolerateGitHubError } from "../errors"
-import { paginateAll } from "../paginate"
+import { PAGE_FETCH_CONCURRENCY, paginateAll } from "../paginate"
 import type { OrgRunner, OrgRunnersResult } from "@/util/runners"
 import { githubKeys } from "./keys"
 
@@ -90,6 +90,7 @@ export function listAllOrgMembers(client: GitHubClient, org: string) {
   return paginateAll<GitHubUser>(
     client,
     (page) => `/orgs/${org}/members?per_page=100&page=${page}`,
+    { concurrency: PAGE_FETCH_CONCURRENCY },
   )
 }
 

--- a/web/src/github-core/queries/repoRefReads.test.ts
+++ b/web/src/github-core/queries/repoRefReads.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest"
 
-import { getOldestCommitShaForPath, getOrgRepos } from "./repoRefReads"
+import {
+  getAssignmentRepos,
+  getOldestCommitShaForPath,
+  getOrgRepos,
+} from "./repoRefReads"
 import type { GitHubClient, GitHubRequestOptions } from "../client"
 import { GitHubAPIError } from "../errors"
 
@@ -46,14 +50,14 @@ describe("getOldestCommitShaForPath", () => {
 
 // The org listing is the submissions dashboard's "accepted" signal. In a large
 // org it is dozens of pages, so when the caller names the repos it will look up
-// and there are fewer of them than pages, each is read directly instead.
-describe("getOrgRepos", () => {
+// and there are no more of them than pages left, each is read directly instead.
+describe("getOrgRepos / getAssignmentRepos", () => {
   const LIST = "https://api.github.com/orgs/acme/repos?per_page=100"
-  const notFound = () =>
+  const apiError = (status: number) =>
     new GitHubAPIError({
-      status: 404,
+      status,
       url: "x",
-      message: "Not Found",
+      message: `HTTP ${status}`,
       body: null,
       rateLimit: {
         limit: null,
@@ -64,18 +68,24 @@ describe("getOrgRepos", () => {
         retryAfter: null,
       },
     })
+  const notFound = () => apiError(404)
 
   // `lastPage` pages of listing, each holding the repos in `pages[n]`;
   // `existing` names answer a direct GET /repos read, anything else 404s.
+  // `probeFailures` queues errors a named probe throws before succeeding.
   function fakeOrg(opts: {
     pages: Record<number, string[]>
     lastPage?: number
     existing?: string[]
+    probeFailures?: Record<string, unknown[]>
   }) {
     const listed: number[] = []
     const probed: string[] = []
+    const urls: string[] = []
+    const failures = { ...(opts.probeFailures ?? {}) }
     const request = vi.fn(
       async (path: string, options?: GitHubRequestOptions) => {
+        urls.push(path)
         const page = /[?&]page=(\d+)/.exec(path)
         if (page) {
           const n = Number(page[1])
@@ -91,15 +101,22 @@ describe("getOrgRepos", () => {
         }
         const name = decodeURIComponent(path.split("/").pop() ?? "")
         probed.push(name)
+        const queued = failures[name]
+        if (queued?.length) throw queued.shift()
         if (opts.existing?.includes(name)) return { name, private: false }
         throw notFound()
       },
     )
-    return { client: { request } as unknown as GitHubClient, listed, probed }
+    return {
+      client: { request } as unknown as GitHubClient,
+      listed,
+      probed,
+      urls,
+    }
   }
 
-  it("walks the whole listing without candidates", async () => {
-    const { client, listed, probed } = fakeOrg({
+  it("walks the whole listing oldest first", async () => {
+    const { client, listed, probed, urls } = fakeOrg({
       pages: { 1: ["a"], 2: ["b"], 3: ["c"] },
       lastPage: 3,
     })
@@ -107,6 +124,8 @@ describe("getOrgRepos", () => {
     expect(repos?.map((r) => r.name)).toEqual(["a", "b", "c"])
     expect(listed.sort()).toEqual([1, 2, 3])
     expect(probed).toEqual([])
+    // A repo created mid-walk lands after the pages in flight, not before.
+    expect(urls[0]).toContain("sort=created&direction=asc")
   })
 
   it("probes the candidates when they are fewer than the pages left", async () => {
@@ -115,9 +134,11 @@ describe("getOrgRepos", () => {
       lastPage: 10,
       existing: ["cs-hw1-bob"],
     })
-    const repos = await getOrgRepos(client, "acme", {
-      candidateNames: ["cs-hw1-alice", "cs-hw1-bob", "cs-hw1-carol"],
-    })
+    const { repos, complete } = await getAssignmentRepos(client, "acme", [
+      "cs-hw1-alice",
+      "cs-hw1-bob",
+      "cs-hw1-carol",
+    ])
     // Page 1 answered alice; bob and carol were read directly; only bob exists.
     expect(listed).toEqual([1])
     expect(probed.sort()).toEqual(["cs-hw1-bob", "cs-hw1-carol"])
@@ -126,6 +147,17 @@ describe("getOrgRepos", () => {
       "cs-hw1-bob",
       "other",
     ])
+    expect(complete).toBe(false)
+  })
+
+  it("probes when the candidates equal the pages left", async () => {
+    const { client, listed, probed } = fakeOrg({
+      pages: { 1: ["a"] },
+      lastPage: 3,
+    })
+    await getAssignmentRepos(client, "acme", ["cs-hw1-bob", "cs-hw1-carol"])
+    expect(listed).toEqual([1])
+    expect(probed).toHaveLength(2)
   })
 
   it("lists the rest when the candidates outnumber the pages left", async () => {
@@ -133,22 +165,60 @@ describe("getOrgRepos", () => {
       pages: { 1: ["a"], 2: ["cs-hw1-bob"] },
       lastPage: 2,
     })
-    const repos = await getOrgRepos(client, "acme", {
-      candidateNames: ["cs-hw1-bob", "cs-hw1-carol"],
-    })
+    const { repos, complete } = await getAssignmentRepos(client, "acme", [
+      "cs-hw1-bob",
+      "cs-hw1-carol",
+    ])
     expect(listed.sort()).toEqual([1, 2])
     expect(probed).toEqual([])
     expect(repos?.map((r) => r.name)).toEqual(["a", "cs-hw1-bob"])
+    expect(complete).toBe(true)
   })
 
   it("lists when the page count is unknown", async () => {
     const { client, listed, probed } = fakeOrg({ pages: { 1: ["a"] } })
-    const repos = await getOrgRepos(client, "acme", {
-      candidateNames: ["cs-hw1-bob"],
-    })
+    const { repos, complete } = await getAssignmentRepos(client, "acme", [
+      "cs-hw1-bob",
+    ])
     expect(listed).toEqual([1])
     expect(probed).toEqual([])
     expect(repos?.map((r) => r.name)).toEqual(["a"])
+    expect(complete).toBe(true)
+  })
+
+  it("retries a probe that fails transiently", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const { client, probed } = fakeOrg({
+        pages: { 1: ["a"] },
+        lastPage: 10,
+        existing: ["cs-hw1-bob"],
+        probeFailures: { "cs-hw1-bob": [apiError(502)] },
+      })
+      const { repos } = await getAssignmentRepos(client, "acme", ["cs-hw1-bob"])
+      expect(probed).toEqual(["cs-hw1-bob", "cs-hw1-bob"])
+      expect(repos?.map((r) => r.name)).toEqual(["a", "cs-hw1-bob"])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("never reads a probe that keeps failing as absent", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const { client } = fakeOrg({
+        pages: { 1: ["a"] },
+        lastPage: 10,
+        probeFailures: {
+          "cs-hw1-bob": [apiError(502), apiError(502), apiError(502)],
+        },
+      })
+      await expect(
+        getAssignmentRepos(client, "acme", ["cs-hw1-bob"]),
+      ).rejects.toMatchObject({ status: 502 })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("resolves null when the org itself 404s", async () => {
@@ -156,5 +226,8 @@ describe("getOrgRepos", () => {
     await expect(
       getOrgRepos({ request } as unknown as GitHubClient, "acme"),
     ).resolves.toBeNull()
+    await expect(
+      getAssignmentRepos({ request } as unknown as GitHubClient, "acme", ["x"]),
+    ).resolves.toEqual({ repos: null, complete: false })
   })
 })

--- a/web/src/github-core/queries/repoRefReads.test.ts
+++ b/web/src/github-core/queries/repoRefReads.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from "vitest"
 
-import { getOldestCommitShaForPath } from "./repoRefReads"
-import type { GitHubClient } from "../client"
+import { getOldestCommitShaForPath, getOrgRepos } from "./repoRefReads"
+import type { GitHubClient, GitHubRequestOptions } from "../client"
+import { GitHubAPIError } from "../errors"
 
 // The Feedback-PR base must be frozen at the commit the autograde runner's
 // baseline_sha() resolves — the OLDEST commit touching the accept marker. A
@@ -39,6 +40,121 @@ describe("getOldestCommitShaForPath", () => {
     const { client } = fakeClient([[]])
     await expect(
       getOldestCommitShaForPath(client, "o", "r", ".classroom50.yaml"),
+    ).resolves.toBeNull()
+  })
+})
+
+// The org listing is the submissions dashboard's "accepted" signal. In a large
+// org it is dozens of pages, so when the caller names the repos it will look up
+// and there are fewer of them than pages, each is read directly instead.
+describe("getOrgRepos", () => {
+  const LIST = "https://api.github.com/orgs/acme/repos?per_page=100"
+  const notFound = () =>
+    new GitHubAPIError({
+      status: 404,
+      url: "x",
+      message: "Not Found",
+      body: null,
+      rateLimit: {
+        limit: null,
+        remaining: null,
+        used: null,
+        reset: null,
+        resource: null,
+        retryAfter: null,
+      },
+    })
+
+  // `lastPage` pages of listing, each holding the repos in `pages[n]`;
+  // `existing` names answer a direct GET /repos read, anything else 404s.
+  function fakeOrg(opts: {
+    pages: Record<number, string[]>
+    lastPage?: number
+    existing?: string[]
+  }) {
+    const listed: number[] = []
+    const probed: string[] = []
+    const request = vi.fn(
+      async (path: string, options?: GitHubRequestOptions) => {
+        const page = /[?&]page=(\d+)/.exec(path)
+        if (page) {
+          const n = Number(page[1])
+          listed.push(n)
+          if (n === 1 && opts.lastPage && opts.lastPage > 1) {
+            options?.onHeaders?.(
+              new Headers({
+                link: `<${LIST}&page=2>; rel="next", <${LIST}&page=${opts.lastPage}>; rel="last"`,
+              }),
+            )
+          }
+          return (opts.pages[n] ?? []).map((name) => ({ name, private: true }))
+        }
+        const name = decodeURIComponent(path.split("/").pop() ?? "")
+        probed.push(name)
+        if (opts.existing?.includes(name)) return { name, private: false }
+        throw notFound()
+      },
+    )
+    return { client: { request } as unknown as GitHubClient, listed, probed }
+  }
+
+  it("walks the whole listing without candidates", async () => {
+    const { client, listed, probed } = fakeOrg({
+      pages: { 1: ["a"], 2: ["b"], 3: ["c"] },
+      lastPage: 3,
+    })
+    const repos = await getOrgRepos(client, "acme")
+    expect(repos?.map((r) => r.name)).toEqual(["a", "b", "c"])
+    expect(listed.sort()).toEqual([1, 2, 3])
+    expect(probed).toEqual([])
+  })
+
+  it("probes the candidates when they are fewer than the pages left", async () => {
+    const { client, listed, probed } = fakeOrg({
+      pages: { 1: ["cs-hw1-Alice", "other"] },
+      lastPage: 10,
+      existing: ["cs-hw1-bob"],
+    })
+    const repos = await getOrgRepos(client, "acme", {
+      candidateNames: ["cs-hw1-alice", "cs-hw1-bob", "cs-hw1-carol"],
+    })
+    // Page 1 answered alice; bob and carol were read directly; only bob exists.
+    expect(listed).toEqual([1])
+    expect(probed.sort()).toEqual(["cs-hw1-bob", "cs-hw1-carol"])
+    expect(repos?.map((r) => r.name).sort()).toEqual([
+      "cs-hw1-Alice",
+      "cs-hw1-bob",
+      "other",
+    ])
+  })
+
+  it("lists the rest when the candidates outnumber the pages left", async () => {
+    const { client, listed, probed } = fakeOrg({
+      pages: { 1: ["a"], 2: ["cs-hw1-bob"] },
+      lastPage: 2,
+    })
+    const repos = await getOrgRepos(client, "acme", {
+      candidateNames: ["cs-hw1-bob", "cs-hw1-carol"],
+    })
+    expect(listed.sort()).toEqual([1, 2])
+    expect(probed).toEqual([])
+    expect(repos?.map((r) => r.name)).toEqual(["a", "cs-hw1-bob"])
+  })
+
+  it("lists when the page count is unknown", async () => {
+    const { client, listed, probed } = fakeOrg({ pages: { 1: ["a"] } })
+    const repos = await getOrgRepos(client, "acme", {
+      candidateNames: ["cs-hw1-bob"],
+    })
+    expect(listed).toEqual([1])
+    expect(probed).toEqual([])
+    expect(repos?.map((r) => r.name)).toEqual(["a"])
+  })
+
+  it("resolves null when the org itself 404s", async () => {
+    const request = vi.fn().mockRejectedValue(notFound())
+    await expect(
+      getOrgRepos({ request } as unknown as GitHubClient, "acme"),
     ).resolves.toBeNull()
   })
 })

--- a/web/src/github-core/queries/repoRefReads.ts
+++ b/web/src/github-core/queries/repoRefReads.ts
@@ -15,8 +15,11 @@ import {
   paginateAll,
   paginateFirstPage,
   paginateRemaining,
+  withTransientRetry,
 } from "../paginate"
+import { getRepo } from "../repoReads"
 import { githubKeys } from "./keys"
+import { REPO_READ_CONCURRENCY, withGithubReadSlot } from "./shared"
 
 export function getBranchRefRepo(
   client: GitHubClient,
@@ -108,62 +111,95 @@ export function repoQuery(client: GitHubClient, owner: string, repo: string) {
   })
 }
 
-export type OrgReposOptions = {
-  signal?: AbortSignal
-  // Repo names the caller will look up in the result. When there are fewer
-  // of them than pages left after page 1, each is read directly instead of
-  // walking the org: a 30-student section in a 9,000-repo org is 30 small
-  // requests instead of 89 heavy pages. The result is then page 1 plus the
-  // candidates that exist, which is a superset of what the caller asked for.
-  candidateNames?: readonly string[]
+// The org listing walk: page 1 alone, then the rest concurrently. Oldest first,
+// so a repo created while pages are in flight lands after them instead of
+// shifting every page (the default is newest first). The longest walk in the
+// app, so one late page retries on its own rather than sending the query back
+// to page 1.
+function orgReposWalk(owner: string, signal: AbortSignal | undefined) {
+  return {
+    makePath: (page: number) =>
+      `/orgs/${owner}/repos?per_page=100&page=${page}&type=all&sort=created&direction=asc`,
+    options: { signal, retryPages: true, concurrency: PAGE_FETCH_CONCURRENCY },
+  }
 }
 
+// Every repo in the org. Paginate to exhaustion: a single per_page=100 page
+// silently under-counts orgs with >100 repos, making repo-list-derived signals
+// (e.g., assignment acceptance on the submissions dashboard) miss students in
+// large orgs. A first-page 404 surfaces as null.
 export async function getOrgRepos(
   client: GitHubClient,
   owner: string,
-  options: OrgReposOptions = {},
+  options: { signal?: AbortSignal } = {},
 ) {
-  const { signal, candidateNames } = options
-  const makePath = (page: number) =>
-    `/orgs/${owner}/repos?per_page=100&page=${page}&type=all`
-  // The longest walk in the app, so one late page retries on its own rather
-  // than sending the query back to page 1.
-  const walk = { signal, retryPages: true }
-  // Paginate to exhaustion: a single per_page=100 page silently under-counts
-  // orgs with >100 repos, making repo-list-derived signals (e.g., assignment
-  // acceptance on the submissions dashboard) miss students in large orgs. A
-  // first-page 404 surfaces as null.
-  return tolerateGitHubError(async () => {
-    const first = await paginateFirstPage<GitHubRepo>(client, makePath, walk)
-    const pagesLeft = first.lastPage === null ? null : first.lastPage - 1
-    if (candidateNames && pagesLeft !== null) {
-      const onFirstPage = new Set(
-        first.items.map((repo) => repo.name.toLowerCase()),
-      )
-      const unresolved = [
-        ...new Set(candidateNames.map((name) => name.toLowerCase())),
-      ].filter((name) => !onFirstPage.has(name))
-      if (unresolved.length < pagesLeft) {
-        const probed = await mapWithConcurrency(
-          unresolved,
-          PAGE_FETCH_CONCURRENCY,
-          (name) =>
-            tolerateGitHubError(
-              () =>
-                client.request<GitHubRepo>(
-                  `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`,
-                  { method: "GET", signal },
+  const { makePath, options: walk } = orgReposWalk(owner, options.signal)
+  return tolerateGitHubError(
+    () => paginateAll<GitHubRepo>(client, makePath, walk),
+    null,
+  )
+}
+
+export type AssignmentRepos = {
+  // null when the org itself 404s, like getOrgRepos.
+  repos: GitHubRepo[] | null
+  // Whether `repos` is the whole org listing (and so worth caching as one)
+  // rather than page 1 plus the candidates that exist.
+  complete: boolean
+}
+
+// The org repos a caller will look up by exact name. After page 1 reveals the
+// page count, when there are no more candidates left unresolved than pages
+// left, each candidate is read directly instead of walking the org: a
+// 30-student section in a 9,000-repo org is 30 small requests instead of 89
+// heavy pages. Either way the result is a superset of the candidates that
+// exist, which the name-filtering consumers read unchanged.
+export async function getAssignmentRepos(
+  client: GitHubClient,
+  owner: string,
+  candidateNames: readonly string[],
+  options: { signal?: AbortSignal } = {},
+): Promise<AssignmentRepos> {
+  const { signal } = options
+  const { makePath, options: walk } = orgReposWalk(owner, signal)
+  return tolerateGitHubError(
+    async () => {
+      const first = await paginateFirstPage<GitHubRepo>(client, makePath, walk)
+      if (first.lastPage !== null) {
+        const onFirstPage = new Set(
+          first.items.map((repo) => repo.name.toLowerCase()),
+        )
+        const unresolved = [
+          ...new Set(candidateNames.map((name) => name.toLowerCase())),
+        ].filter((name) => !onFirstPage.has(name))
+        // Same rule as the collect script: never more requests than the pages.
+        if (unresolved.length <= first.lastPage - 1) {
+          const probed = await mapWithConcurrency(
+            unresolved,
+            REPO_READ_CONCURRENCY,
+            (name) =>
+              withGithubReadSlot(() =>
+                withTransientRetry(
+                  () => getRepo(client, owner, name, signal),
+                  signal,
                 ),
-              null,
+              ),
+          )
+          return {
+            repos: first.items.concat(
+              probed.filter((repo): repo is GitHubRepo => repo !== null),
             ),
-        )
-        return first.items.concat(
-          probed.filter((repo): repo is GitHubRepo => repo !== null),
-        )
+            complete: false,
+          }
+        }
       }
-    }
-    return paginateRemaining(client, makePath, first, walk)
-  }, null)
+      return {
+        repos: await paginateRemaining(client, makePath, first, walk),
+        complete: true,
+      }
+    },
+    { repos: null, complete: false },
+  )
 }
 
 // Open PRs on a student/group repo. The autograde workflow opens one Feedback

--- a/web/src/github-core/queries/repoRefReads.ts
+++ b/web/src/github-core/queries/repoRefReads.ts
@@ -8,8 +8,14 @@ import type {
   GitHubRepo,
 } from "../types"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
+import { mapWithConcurrency } from "@/util/concurrency"
 import { tolerateGitHubError } from "../errors"
-import { paginateAll } from "../paginate"
+import {
+  PAGE_FETCH_CONCURRENCY,
+  paginateAll,
+  paginateFirstPage,
+  paginateRemaining,
+} from "../paginate"
 import { githubKeys } from "./keys"
 
 export function getBranchRefRepo(
@@ -102,19 +108,62 @@ export function repoQuery(client: GitHubClient, owner: string, repo: string) {
   })
 }
 
-export async function getOrgRepos(client: GitHubClient, owner: string) {
+export type OrgReposOptions = {
+  signal?: AbortSignal
+  // Repo names the caller will look up in the result. When there are fewer
+  // of them than pages left after page 1, each is read directly instead of
+  // walking the org: a 30-student section in a 9,000-repo org is 30 small
+  // requests instead of 89 heavy pages. The result is then page 1 plus the
+  // candidates that exist, which is a superset of what the caller asked for.
+  candidateNames?: readonly string[]
+}
+
+export async function getOrgRepos(
+  client: GitHubClient,
+  owner: string,
+  options: OrgReposOptions = {},
+) {
+  const { signal, candidateNames } = options
+  const makePath = (page: number) =>
+    `/orgs/${owner}/repos?per_page=100&page=${page}&type=all`
+  // The longest walk in the app, so one late page retries on its own rather
+  // than sending the query back to page 1.
+  const walk = { signal, retryPages: true }
   // Paginate to exhaustion: a single per_page=100 page silently under-counts
   // orgs with >100 repos, making repo-list-derived signals (e.g., assignment
   // acceptance on the submissions dashboard) miss students in large orgs. A
   // first-page 404 surfaces as null.
-  return tolerateGitHubError(
-    () =>
-      paginateAll<GitHubRepo>(
-        client,
-        (page) => `/orgs/${owner}/repos?per_page=100&page=${page}&type=all`,
-      ),
-    null,
-  )
+  return tolerateGitHubError(async () => {
+    const first = await paginateFirstPage<GitHubRepo>(client, makePath, walk)
+    const pagesLeft = first.lastPage === null ? null : first.lastPage - 1
+    if (candidateNames && pagesLeft !== null) {
+      const onFirstPage = new Set(
+        first.items.map((repo) => repo.name.toLowerCase()),
+      )
+      const unresolved = [
+        ...new Set(candidateNames.map((name) => name.toLowerCase())),
+      ].filter((name) => !onFirstPage.has(name))
+      if (unresolved.length < pagesLeft) {
+        const probed = await mapWithConcurrency(
+          unresolved,
+          PAGE_FETCH_CONCURRENCY,
+          (name) =>
+            tolerateGitHubError(
+              () =>
+                client.request<GitHubRepo>(
+                  `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`,
+                  { method: "GET", signal },
+                ),
+              null,
+            ),
+        )
+        return first.items.concat(
+          probed.filter((repo): repo is GitHubRepo => repo !== null),
+        )
+      }
+    }
+    return paginateRemaining(client, makePath, first, walk)
+  }, null)
 }
 
 // Open PRs on a student/group repo. The autograde workflow opens one Feedback

--- a/web/src/github-core/queries/teamReads.ts
+++ b/web/src/github-core/queries/teamReads.ts
@@ -9,7 +9,7 @@ import {
   tolerateGitHubError,
 } from "../errors"
 import { createTeam } from "../teamWrites"
-import { paginateAll } from "../paginate"
+import { PAGE_FETCH_CONCURRENCY, paginateAll } from "../paginate"
 import { githubKeys } from "./keys"
 
 export async function getTeam(
@@ -80,6 +80,7 @@ export async function listTeamMembers(
           `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(
             teamSlug,
           )}/members?per_page=100&page=${page}`,
+        { concurrency: PAGE_FETCH_CONCURRENCY },
       ),
     [],
   )
@@ -134,6 +135,7 @@ export async function listOrgTeams(
         client,
         (page) =>
           `/orgs/${encodeURIComponent(org)}/teams?per_page=100&page=${page}`,
+        { concurrency: PAGE_FETCH_CONCURRENCY },
       ),
     [],
   )

--- a/web/src/github-core/repoReads.ts
+++ b/web/src/github-core/repoReads.ts
@@ -6,11 +6,13 @@ export async function getRepo(
   client: GitHubClient,
   owner: string,
   repo: string,
+  signal?: AbortSignal,
 ) {
   return tolerateGitHubError(
     () =>
       client.request<GitHubRepo>(
         `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+        { method: "GET", signal },
       ),
     null,
   )

--- a/web/src/hooks/mutations/useAcceptAssignment.ts
+++ b/web/src/hooks/mutations/useAcceptAssignment.ts
@@ -39,9 +39,10 @@ export function useAcceptAssignment(params: {
         onStepUpdate,
       }),
     onSuccess: () => {
+      // Prefix match on purpose: the submissions page keeps an
+      // assignment-scoped slice under this key too (githubKeys.assignmentRepos).
       void queryClient.invalidateQueries({
         queryKey: githubKeys.orgRepos(org),
-        exact: true,
         refetchType: "all",
       })
     },

--- a/web/src/hooks/useAssignmentRepos.test.tsx
+++ b/web/src/hooks/useAssignmentRepos.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+const request = vi.fn()
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({ request }),
+}))
+
+import { useAssignmentRepos } from "./useAssignmentRepos"
+import { githubKeys } from "@/github-core/queries"
+import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
+import type { GitHubRequestOptions } from "@/github-core/client"
+
+const noRateLimit: GitHubRateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+
+const notFound = () =>
+  new GitHubAPIError({
+    status: 404,
+    url: "https://api.github.com/x",
+    message: "Not Found",
+    body: null,
+    rateLimit: noRateLimit,
+  })
+
+const LIST = "https://api.github.com/orgs/acme/repos?per_page=100"
+
+// An org of `lastPage` listing pages where only `existing` repos answer a
+// direct read; records which of the two shapes each call took.
+function serveOrg(opts: { lastPage: number; existing: string[] }) {
+  const listed: number[] = []
+  const probed: string[] = []
+  request.mockImplementation(
+    async (path: string, options?: GitHubRequestOptions) => {
+      const page = /[?&]page=(\d+)/.exec(path)
+      if (page) {
+        const n = Number(page[1])
+        listed.push(n)
+        if (n === 1) {
+          options?.onHeaders?.(
+            new Headers({
+              link: `<${LIST}&page=2>; rel="next", <${LIST}&page=${opts.lastPage}>; rel="last"`,
+            }),
+          )
+        }
+        return n === opts.lastPage
+          ? opts.existing.map((name) => ({ name, private: true }))
+          : [{ name: `filler-${n}`, private: true }]
+      }
+      const name = decodeURIComponent(path.split("/").pop() ?? "")
+      probed.push(name)
+      if (opts.existing.includes(name)) return { name, private: true }
+      throw notFound()
+    },
+  )
+  return { listed, probed }
+}
+
+const makeClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+const wrapper =
+  (client: QueryClient) =>
+  ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+
+const base = { org: "acme", classroom: "cs101", assignment: "hw1" }
+
+beforeEach(() => {
+  request.mockReset()
+})
+
+describe("useAssignmentRepos", () => {
+  it("reads a small roster's repos directly instead of walking the org", async () => {
+    const { listed, probed } = serveOrg({
+      lastPage: 20,
+      existing: ["cs101-hw1-alice"],
+    })
+    const { result } = renderHook(
+      () => useAssignmentRepos({ ...base, logins: ["Alice", "bob"] }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(listed).toEqual([1])
+    expect(probed.sort()).toEqual(["cs101-hw1-alice", "cs101-hw1-bob"])
+    expect(result.current.data?.map((r) => r.name)).toEqual([
+      "filler-1",
+      "cs101-hw1-alice",
+    ])
+  })
+
+  it("walks the whole org when the logins are not derivable", async () => {
+    const { listed, probed } = serveOrg({
+      lastPage: 3,
+      existing: ["cs101-hw1-group-1"],
+    })
+    const { result } = renderHook(
+      () => useAssignmentRepos({ ...base, logins: undefined }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(listed.sort()).toEqual([1, 2, 3])
+    expect(probed).toEqual([])
+    expect(result.current.data?.map((r) => r.name)).toContain(
+      "cs101-hw1-group-1",
+    )
+  })
+
+  it("does nothing while disabled", async () => {
+    serveOrg({ lastPage: 2, existing: [] })
+    const { result } = renderHook(
+      () => useAssignmentRepos({ ...base, logins: ["alice"], enabled: false }),
+      { wrapper: wrapper(makeClient()) },
+    )
+    await new Promise((r) => setTimeout(r, 20))
+    expect(request).not.toHaveBeenCalled()
+    expect(result.current.isPending).toBe(true)
+  })
+
+  it("is invalidated by the org repo list key", async () => {
+    const { listed } = serveOrg({ lastPage: 20, existing: [] })
+    const client = makeClient()
+    const { result } = renderHook(
+      () => useAssignmentRepos({ ...base, logins: ["alice"] }),
+      { wrapper: wrapper(client) },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(listed).toEqual([1])
+    await client.invalidateQueries({ queryKey: githubKeys.orgRepos("acme") })
+    await waitFor(() => expect(listed).toEqual([1, 1]))
+  })
+})

--- a/web/src/hooks/useAssignmentRepos.test.tsx
+++ b/web/src/hooks/useAssignmentRepos.test.tsx
@@ -139,4 +139,51 @@ describe("useAssignmentRepos", () => {
     await client.invalidateQueries({ queryKey: githubKeys.orgRepos("acme") })
     await waitFor(() => expect(listed).toEqual([1, 1]))
   })
+
+  it("stores a walk that covered the whole org under the full-listing key", async () => {
+    // A roster larger than the pages left walks the org; the assignments page
+    // (useGetOrgRepos) must not walk it again.
+    const { listed } = serveOrg({ lastPage: 3, existing: ["cs101-hw1-alice"] })
+    const client = makeClient()
+    const { result } = renderHook(
+      () =>
+        useAssignmentRepos({
+          ...base,
+          logins: ["alice", "bob", "carol", "dan"],
+        }),
+      { wrapper: wrapper(client) },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(listed.sort()).toEqual([1, 2, 3])
+    const full = client.getQueryData<{ name: string }[]>(
+      githubKeys.orgRepos("acme"),
+    )
+    expect(full?.map((r) => r.name)).toContain("cs101-hw1-alice")
+  })
+
+  it("does not store a probe result as the full listing", async () => {
+    serveOrg({ lastPage: 20, existing: [] })
+    const client = makeClient()
+    const { result } = renderHook(
+      () => useAssignmentRepos({ ...base, logins: ["alice"] }),
+      { wrapper: wrapper(client) },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(client.getQueryData(githubKeys.orgRepos("acme"))).toBeUndefined()
+  })
+
+  it("answers from a fresh full listing without a request", async () => {
+    serveOrg({ lastPage: 20, existing: [] })
+    const client = makeClient()
+    client.setQueryData(githubKeys.orgRepos("acme"), [
+      { name: "cs101-hw1-alice", private: true },
+    ])
+    const { result } = renderHook(
+      () => useAssignmentRepos({ ...base, logins: ["alice"] }),
+      { wrapper: wrapper(client) },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(request).not.toHaveBeenCalled()
+    expect(result.current.data?.map((r) => r.name)).toEqual(["cs101-hw1-alice"])
+  })
 })

--- a/web/src/hooks/useAssignmentRepos.ts
+++ b/web/src/hooks/useAssignmentRepos.ts
@@ -1,0 +1,66 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { getOrgRepos, githubKeys } from "@/github-core/queries"
+import { studentRepoName } from "@/util/studentRepo"
+import useGetOrgRepos, { ORG_REPOS_STALE_MS } from "./useGetMyOrgRepos"
+
+type Args = {
+  org: string
+  classroom: string
+  assignment: string
+  // Logins whose `<classroom>-<assignment>-<login>` repos the caller looks up.
+  // `undefined` means the names are not derivable (a shared-repo assignment, or
+  // the roster hasn't loaded), so the whole org listing is read instead.
+  logins: readonly string[] | undefined
+  enabled?: boolean
+}
+
+// The org repo list as the submissions dashboard consumes it. For an
+// individual assignment the candidate repo names are known from the roster, so
+// getOrgRepos can read them directly when that beats walking the org (see
+// candidateNames); shared-repo assignments fall back to the full listing.
+// Either way the result is a `GitHubRepo[]` the existing name-filtering
+// consumers (acceptedUsernames, latestAssignmentPush, ...) read unchanged.
+export function useAssignmentRepos({
+  org,
+  classroom,
+  assignment,
+  logins,
+  enabled = true,
+}: Args) {
+  const client = useGitHubClient()
+  const sortedLogins = useMemo(
+    () =>
+      logins === undefined
+        ? undefined
+        : [...new Set(logins.map((login) => login.trim().toLowerCase()))]
+            .filter(Boolean)
+            .sort(),
+    [logins],
+  )
+  const scoped = sortedLogins !== undefined
+
+  const scopedQuery = useQuery({
+    queryKey: githubKeys.assignmentRepos(
+      org,
+      classroom,
+      assignment,
+      sortedLogins ?? [],
+    ),
+    queryFn: ({ signal }) =>
+      getOrgRepos(client, org, {
+        signal,
+        candidateNames: (sortedLogins ?? []).map((login) =>
+          studentRepoName(classroom, assignment, login),
+        ),
+      }),
+    staleTime: ORG_REPOS_STALE_MS,
+    retry: false,
+    enabled: enabled && scoped && Boolean(org && classroom && assignment),
+  })
+  const fullQuery = useGetOrgRepos(org, enabled && !scoped)
+
+  return scoped ? scopedQuery : fullQuery
+}

--- a/web/src/hooks/useAssignmentRepos.ts
+++ b/web/src/hooks/useAssignmentRepos.ts
@@ -1,8 +1,9 @@
 import { useMemo } from "react"
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
-import { getOrgRepos, githubKeys } from "@/github-core/queries"
+import { getAssignmentRepos, githubKeys } from "@/github-core/queries"
+import type { GitHubRepo } from "@/github-core/types"
 import { studentRepoName } from "@/util/studentRepo"
 import useGetOrgRepos, { ORG_REPOS_STALE_MS } from "./useGetMyOrgRepos"
 
@@ -19,10 +20,15 @@ type Args = {
 
 // The org repo list as the submissions dashboard consumes it. For an
 // individual assignment the candidate repo names are known from the roster, so
-// getOrgRepos can read them directly when that beats walking the org (see
-// candidateNames); shared-repo assignments fall back to the full listing.
-// Either way the result is a `GitHubRepo[]` the existing name-filtering
-// consumers (acceptedUsernames, latestAssignmentPush, ...) read unchanged.
+// getAssignmentRepos can read them directly when that beats walking the org;
+// shared-repo assignments fall back to the full listing. Either way the result
+// is a `GitHubRepo[]` the existing name-filtering consumers (acceptedUsernames,
+// latestAssignmentPush, ...) read unchanged.
+//
+// The scoped read shares its cache with the full listing in both directions: a
+// fresh full listing answers it without a request, and a scoped read that ended
+// up walking the whole org (a large roster) is stored under the full-listing
+// key too, so the assignments page does not walk the org again.
 export function useAssignmentRepos({
   org,
   classroom,
@@ -31,6 +37,7 @@ export function useAssignmentRepos({
   enabled = true,
 }: Args) {
   const client = useGitHubClient()
+  const queryClient = useQueryClient()
   const sortedLogins = useMemo(
     () =>
       logins === undefined
@@ -49,13 +56,26 @@ export function useAssignmentRepos({
       assignment,
       sortedLogins ?? [],
     ),
-    queryFn: ({ signal }) =>
-      getOrgRepos(client, org, {
-        signal,
-        candidateNames: (sortedLogins ?? []).map((login) =>
+    queryFn: async ({ signal }) => {
+      const fullKey = githubKeys.orgRepos(org)
+      const cached = queryClient.getQueryState<GitHubRepo[] | null>(fullKey)
+      if (
+        cached?.data &&
+        Date.now() - cached.dataUpdatedAt < ORG_REPOS_STALE_MS
+      ) {
+        return cached.data
+      }
+      const { repos, complete } = await getAssignmentRepos(
+        client,
+        org,
+        (sortedLogins ?? []).map((login) =>
           studentRepoName(classroom, assignment, login),
         ),
-      }),
+        { signal },
+      )
+      if (complete) queryClient.setQueryData(fullKey, repos)
+      return repos
+    },
     staleTime: ORG_REPOS_STALE_MS,
     retry: false,
     enabled: enabled && scoped && Boolean(org && classroom && assignment),

--- a/web/src/hooks/useGetMyOrgRepos.ts
+++ b/web/src/hooks/useGetMyOrgRepos.ts
@@ -2,16 +2,23 @@ import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { useQuery } from "@tanstack/react-query"
 import { getOrgRepos, githubKeys } from "@/github-core/queries"
 
+// Freshness for the org repo list. It drives the "Accepted" signal, so it is
+// refreshed on explicit Refresh, after accept/collect/rename (invalidations),
+// and on normal staleness rather than on every tab refocus or return to the
+// page: on a large org the walk is dozens of requests, and a student who
+// accepts between visits is picked up by the next Refresh or collect.
+export const ORG_REPOS_STALE_MS = 5 * 60 * 1000
+
 const useGetOrgRepos = (org: string, enabled = true) => {
   const client = useGitHubClient()
 
   return useQuery({
     queryKey: githubKeys.orgRepos(org),
-    queryFn: () => getOrgRepos(client, org),
-    // The org repo list (paginated across the whole org) drives the "Accepted"
-    // signal. It's refreshed on explicit Refresh + normal staleness rather than
-    // on every tab refocus, which used to re-paginate the entire org on focus.
-    staleTime: 60 * 1000,
+    queryFn: ({ signal }) => getOrgRepos(client, org, { signal }),
+    staleTime: ORG_REPOS_STALE_MS,
+    // Pages retry individually inside the walk; a query-level retry would
+    // re-walk the whole org after one late page.
+    retry: false,
     // Callers that only need the list conditionally opt out via `enabled` so a
     // whole-org pagination isn't paid for nothing (e.g. the sidebar gating a
     // staff-only read on role).

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2713,7 +2713,8 @@
     "funnel": {
       "submittedTitle": "{{submitted}} of {{total}} students submitted",
       "submittedTitleGroup": "{{submitted}} of {{accepted}} groups submitted",
-      "showNotSubmitted": "Show who hasn't submitted"
+      "showNotSubmitted": "Show who hasn't submitted",
+      "checkingAccepted": "Checking who accepted…"
     },
     "downloadCsv": "Download scores (CSV)",
     "viewSourceRepo": "View template",

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -118,7 +118,7 @@ import useEmptyRosterWarning from "@/hooks/useEmptyRosterWarning"
 import { EmptyRosterNotice } from "@/components/EmptyRosterNotice"
 import useAcceptShareSummary from "@/hooks/useAcceptShareSummary"
 import { QueryErrorAlert } from "@/components/QueryErrorAlert"
-import useGetOrgRepos from "@/hooks/useGetMyOrgRepos"
+import { useAssignmentRepos } from "@/hooks/useAssignmentRepos"
 import { useGroupRepoMemberLogins } from "@/hooks/useGroupRepoMembers"
 import useTriggerScoreCollection from "@/hooks/useTriggerScoreCollection"
 import useTriggerRegrade from "@/hooks/useTriggerRegrade"
@@ -184,8 +184,11 @@ const SubmissionsPageContent = () => {
   // comes from the PRIVATE config repo (source:"config"); students never reach
   // this page. `assignments` carries the sibling list for repo-prefix
   // disambiguation below.
-  const { assignment: assignmentInfo, assignments: allAssignments } =
-    useSubmissionAssignment(org, classroom, assignment, { source: "config" })
+  const {
+    assignment: assignmentInfo,
+    assignments: allAssignments,
+    isLoading: assignmentLoading,
+  } = useSubmissionAssignment(org, classroom, assignment, { source: "config" })
   // Team-driven usernames: the classroom GitHub teams are authoritative for
   // enrollment; roster.csv enriches display only. The dashboard consumes
   // Student[], so map enrolled team rows into that shape (see
@@ -251,11 +254,32 @@ const SubmissionsPageContent = () => {
   // staleness heuristic). `refetch` is wired to Collect now + collect-completion so
   // `latestPush` isn't frozen at page load (else a push after load never flips
   // the freshness line to "Out of date").
+  //
+  // For an individual assignment the repo names are derivable from the enrolled
+  // roster (students and staff alike), so the read is scoped to them and can
+  // skip walking a large org. Shared-repo flavors read the whole listing: a
+  // team repo's `group-<n>` segment is not derivable from any login.
+  const candidateLogins = useMemo(
+    () =>
+      isGroupFlavor
+        ? undefined
+        : teamRows
+            .filter((row) => row.state === "enrolled")
+            .map((row) => row.username),
+    [isGroupFlavor, teamRows],
+  )
   const {
     data: orgRepos,
     isLoading: orgReposLoading,
+    isPending: orgReposPending,
     refetch: refetchOrgRepos,
-  } = useGetOrgRepos(org ?? "")
+  } = useAssignmentRepos({
+    org: org ?? "",
+    classroom: classroom ?? "",
+    assignment: assignment ?? "",
+    logins: candidateLogins,
+    enabled: !assignmentLoading && (isGroupFlavor || !rosterLoading),
+  })
   // Sibling slugs guard group-repo attribution against a slug-extending sibling
   // ("hw1-bonus" under "hw1"); see existingGroupRepos.
   const siblingSlugs = useMemo(
@@ -1261,6 +1285,18 @@ const SubmissionsPageContent = () => {
           // number — and doubles as a one-click jump to who hasn't submitted.
           <MetaStrip
             items={[
+              // The bar's denominator comes from the org repo list. Until that
+              // resolves (a large org is many requests), say so in place,
+              // rather than leaving only the global progress bar to explain the
+              // wait.
+              !showSubmissionProgress &&
+                orgReposPending &&
+                !isEmptyRepoAssignment && (
+                  <MetaItem>
+                    <InlineSpinner />
+                    {t("submissions.funnel.checkingAccepted")}
+                  </MetaItem>
+                ),
               showSubmissionProgress && (
                 <button
                   type="button"

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -66,6 +66,7 @@ import {
   acceptedRosterCount,
   acceptedUsernames,
   applyStatusSelection,
+  assignmentRepoCandidateLogins,
   assignmentRepoNames,
   buildScoresCsvRows,
   buildSectionLookup,
@@ -82,11 +83,13 @@ import {
   effectiveCollectedAt,
   mergeDetectedSubmissions,
   mergeLiveRows,
+  orgReposReadEnabled,
   reconcileNonSubmitters,
   pendingMayHide,
   rosterScopedRows,
   rowInSection,
   selectActiveWorkflowAction,
+  showCheckingAccepted,
   showsNonSubmitters,
   snapshotIsStale,
   sortNameMode,
@@ -254,18 +257,10 @@ const SubmissionsPageContent = () => {
   // staleness heuristic). `refetch` is wired to Collect now + collect-completion so
   // `latestPush` isn't frozen at page load (else a push after load never flips
   // the freshness line to "Out of date").
-  //
   // For an individual assignment the repo names are derivable from the enrolled
-  // roster (students and staff alike), so the read is scoped to them and can
-  // skip walking a large org. Shared-repo flavors read the whole listing: a
-  // team repo's `group-<n>` segment is not derivable from any login.
+  // roster, so the read is scoped to them and can skip walking a large org.
   const candidateLogins = useMemo(
-    () =>
-      isGroupFlavor
-        ? undefined
-        : teamRows
-            .filter((row) => row.state === "enrolled")
-            .map((row) => row.username),
+    () => assignmentRepoCandidateLogins(isGroupFlavor, teamRows),
     [isGroupFlavor, teamRows],
   )
   const {
@@ -278,7 +273,11 @@ const SubmissionsPageContent = () => {
     classroom: classroom ?? "",
     assignment: assignment ?? "",
     logins: candidateLogins,
-    enabled: !assignmentLoading && (isGroupFlavor || !rosterLoading),
+    enabled: orgReposReadEnabled({
+      assignmentLoading,
+      isGroupFlavor,
+      rosterLoading,
+    }),
   })
   // Sibling slugs guard group-repo attribution against a slug-extending sibling
   // ("hw1-bonus" under "hw1"); see existingGroupRepos.
@@ -1285,18 +1284,16 @@ const SubmissionsPageContent = () => {
           // number — and doubles as a one-click jump to who hasn't submitted.
           <MetaStrip
             items={[
-              // The bar's denominator comes from the org repo list. Until that
-              // resolves (a large org is many requests), say so in place,
-              // rather than leaving only the global progress bar to explain the
-              // wait.
-              !showSubmissionProgress &&
-                orgReposPending &&
-                !isEmptyRepoAssignment && (
-                  <MetaItem>
-                    <InlineSpinner />
-                    {t("submissions.funnel.checkingAccepted")}
-                  </MetaItem>
-                ),
+              showCheckingAccepted({
+                showSubmissionProgress,
+                orgReposPending,
+                isEmptyRepoAssignment,
+              }) && (
+                <MetaItem>
+                  <InlineSpinner />
+                  {t("submissions.funnel.checkingAccepted")}
+                </MetaItem>
+              ),
               showSubmissionProgress && (
                 <button
                   type="button"

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -43,12 +43,15 @@ import {
   rowPassState,
   scoreTone,
   selectActiveWorkflowAction,
+  showCheckingAccepted,
   showsNonSubmitters,
   snapshotIsStale,
   statusSelectValue,
   submissionRosterStudents,
   teamMissingForOwner,
   teamsWithoutRepos,
+  assignmentRepoCandidateLogins,
+  orgReposReadEnabled,
   type SubmissionFilters,
 } from "./dashboard"
 import type { GroupTeamRef } from "@/domain/teams/groupTeams"
@@ -2565,5 +2568,118 @@ describe("pagination helpers", () => {
       // Near the start, no gap between first and the neighbor cluster.
       expect(paginationRange(1, 20)).toEqual([0, 1, 2, null, 19])
     })
+  })
+})
+
+describe("assignmentRepoCandidateLogins", () => {
+  it("names every enrolled row, students and staff alike", () => {
+    const rows = [
+      teamRow({ username: "alice" }),
+      teamRow({ username: "Prof", roles: ["teacher"] }),
+      teamRow({ username: "invited", state: "pending" }),
+      teamRow({ username: "csvonly", state: "unlinked" }),
+    ]
+    expect(assignmentRepoCandidateLogins(false, rows)).toEqual([
+      "alice",
+      "Prof",
+    ])
+  })
+
+  it("agrees with the gradee roster on who can be looked up", () => {
+    // Every student the table lists as a gradee must be a candidate, or the
+    // scoped read would report them as not accepted.
+    const rows = [
+      teamRow({ username: "alice" }),
+      teamRow({ username: "bob" }),
+      teamRow({ username: "Prof", roles: ["teacher"] }),
+      teamRow({ username: "invited", state: "pending" }),
+    ]
+    const candidates = new Set(
+      assignmentRepoCandidateLogins(false, rows)?.map((l) => l.toLowerCase()),
+    )
+    const students = submissionRosterStudents(rows, {
+      acceptedStaffLogins: new Set(["prof"]),
+      groupRepoMembers: new Set(),
+    })
+    expect(students).toHaveLength(3)
+    for (const student of students) {
+      expect(candidates.has(student.username.toLowerCase())).toBe(true)
+    }
+  })
+
+  it("is undefined for a shared-repo assignment", () => {
+    expect(assignmentRepoCandidateLogins(true, [teamRow()])).toBeUndefined()
+  })
+})
+
+describe("orgReposReadEnabled", () => {
+  it("waits for the assignment shape", () => {
+    expect(
+      orgReposReadEnabled({
+        assignmentLoading: true,
+        isGroupFlavor: false,
+        rosterLoading: false,
+      }),
+    ).toBe(false)
+  })
+
+  it("waits for the roster only when the read is roster-scoped", () => {
+    expect(
+      orgReposReadEnabled({
+        assignmentLoading: false,
+        isGroupFlavor: false,
+        rosterLoading: true,
+      }),
+    ).toBe(false)
+    expect(
+      orgReposReadEnabled({
+        assignmentLoading: false,
+        isGroupFlavor: true,
+        rosterLoading: true,
+      }),
+    ).toBe(true)
+    expect(
+      orgReposReadEnabled({
+        assignmentLoading: false,
+        isGroupFlavor: false,
+        rosterLoading: false,
+      }),
+    ).toBe(true)
+  })
+})
+
+describe("showCheckingAccepted", () => {
+  it("shows only while the read is pending and the bar is not up", () => {
+    expect(
+      showCheckingAccepted({
+        showSubmissionProgress: false,
+        orgReposPending: true,
+        isEmptyRepoAssignment: false,
+      }),
+    ).toBe(true)
+    expect(
+      showCheckingAccepted({
+        showSubmissionProgress: true,
+        orgReposPending: true,
+        isEmptyRepoAssignment: false,
+      }),
+    ).toBe(false)
+    expect(
+      showCheckingAccepted({
+        showSubmissionProgress: false,
+        orgReposPending: false,
+        isEmptyRepoAssignment: false,
+      }),
+    ).toBe(false)
+  })
+
+  it("never shows for an empty_repo assignment", () => {
+    expect(
+      showCheckingAccepted({
+        showSubmissionProgress: false,
+        orgReposPending: true,
+        isEmptyRepoAssignment: true,
+      }),
+    ).toBe(false)
   })
 })

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -334,6 +334,11 @@ function latestCommitDetectedAt(
 // match, sibling-slug guard) is shared with existingAssignmentRepos so the two
 // repo-list-derived signals can never disagree on which repos belong to an
 // assignment. Returns the winning repo's ISO `pushed_at`.
+//
+// For an individual assignment the page reads a roster-scoped slice of the
+// listing (useAssignmentRepos), so a push to a repo whose owner has since left
+// the classroom no longer counts: the gradebook does not list that person
+// either, so the heuristic and the table agree on whose work is "out of date".
 export function latestAssignmentPush(
   repos: GitHubRepo[] | null | undefined,
   classroom: string,
@@ -1581,4 +1586,48 @@ export function paginationRange(
     prev = p
   }
   return out
+}
+
+// Logins whose `<classroom>-<assignment>-<login>` repo the submissions page
+// looks up, for the roster-scoped org repo read (useAssignmentRepos). Every
+// enrolled row counts, students and staff alike (a staff member who accepted is
+// a gradee too). `undefined` for a shared-repo assignment: a team repo's
+// `group-<n>` segment is not derivable from any login, so the page reads the
+// whole listing instead.
+export function assignmentRepoCandidateLogins(
+  isGroupFlavor: boolean,
+  teamRows: readonly TeamRosterRow[],
+): string[] | undefined {
+  if (isGroupFlavor) return undefined
+  return teamRows
+    .filter((row) => row.state === "enrolled")
+    .map((row) => row.username)
+}
+
+// Whether the org repo read may start. The assignment shape decides which read
+// runs (scoped or full), so it must be known first; the scoped read also needs
+// the roster, since its candidate names come from it. A shared-repo assignment
+// does not wait for the roster.
+export function orgReposReadEnabled(args: {
+  assignmentLoading: boolean
+  isGroupFlavor: boolean
+  rosterLoading: boolean
+}): boolean {
+  return !args.assignmentLoading && (args.isGroupFlavor || !args.rosterLoading)
+}
+
+// Whether to show "Checking who accepted..." in place of the submission
+// progress bar: the bar's denominator comes from the org repo read, so until
+// that resolves the wait is explained where the bar will appear. Never for an
+// empty_repo assignment, which has no repos to check.
+export function showCheckingAccepted(args: {
+  showSubmissionProgress: boolean
+  orgReposPending: boolean
+  isEmptyRepoAssignment: boolean
+}): boolean {
+  return (
+    !args.showSubmissionProgress &&
+    args.orgReposPending &&
+    !args.isEmptyRepoAssignment
+  )
 }


### PR DESCRIPTION
## Summary

Towards #825 and #826. Both share one root cause: to learn which students have accepted, the collect script and the submissions page listed every repo in the org via `GET /orgs/{org}/repos?per_page=100`, one page at a time, regardless of the classroom or assignment filter. In an org with ~9,000 repos that is ~90 sequential heavy requests, which is essentially the whole of the reported 4m48s collect run and the ~2 minute page load.

**collect_scores.py**

- Page 1 of a listing reveals the page count via `Link: rel="last"`; pages 2..last are fetched on a thread pool (8 workers). Used for the org repo, team member, and team repo listings.
- `RepoIndex.prefetch(names)`: both passes hand the index their exact candidate repo names (`<classroom>-<assignment>-<login>`). After page 1, the index probes `GET /repos/{org}/{name}` directly when there are no more candidates than pages left (a small section in a large org), otherwise it lists the rest. Probing is capped at what the listing would have cost; a caller without a hint gets the full listing as before.
- The listing is read oldest first (`sort=created&direction=asc`) so a repo created mid-walk appends instead of shifting pages, and the 100-page cliff (10k repos read as "unlistable") is raised to 500.
- Fail-open is preserved end to end: a soft failure on any page leaves the listing unknown and everything polls; THROTTLED/FATAL errors still propagate. The throttle sleep budget is charged in wall-clock seconds so eight workers waiting out one throttle spend it once.
- Per-classroom and per-run timings plus a request counter are printed, so the next report can name numbers.

**web**

- `paginateAll` reads page 1, then fetches the rest concurrently when a bulk listing opts in (org repos, team members, org members, org teams); per-repo listings inside a read slot stay one page at a time. The org walk retries a transient page on its own instead of restarting from page 1, forwards the query's abort signal, aborts sibling pages once one fails for good, and fails fast on a long `Retry-After`.
- `useAssignmentRepos` scopes the read to the enrolled roster for individual assignments (same probe-vs-list rule as the script, probes with transient retry inside the shared read slot); group/team modes read the full listing. A scoped read that walked the whole org seeds the full-listing cache, and a fresh full listing answers it without a request.
- `useGetOrgRepos`: `retry: false`, cancellable, `staleTime` 5 minutes so navigating away and back no longer re-walks the org; accept, collect, and rename invalidations still reach both keys.
- The submissions header shows "Checking who accepted..." while acceptance data loads, in place of only the global progress bar.

Orgs pick up the new script through the existing skeleton drift banner / `gh teacher init` refresh; no pin to bump.

Follow-ups worth their own issues (not in this PR): `orgMembersAllQuery` re-walks all org members on every tab focus after 30s; `useClassroomReconcile` re-lists every org team and invitation on each classroom entry; `useDetectedSubmissions` pages each repo's full commit log; the assignments list page still walks the full org listing (shared via the cache after a submissions visit); the web `paginateAll` still clamps at 100 pages and returns the truncated list.

## Test plan

- [x] `python3 -m pytest cli/gh-teacher/skeleton_tests` (947 pass; 39 new: parallel walk order, no-`rel=last` fallback reads page 1 once, off-host `rel=last` refused, cap, probe-vs-list choice and budget, fail-open on every listing read, throttled probe stays unlatched, concurrent vs sequential throttle budget, `collect_classroom` hints every name it polls, request counter)
- [x] `python3 -m pytest cli/gh-teacher/autograders_tests` (421 pass), `go test ./...` and `go vet ./...` in `cli/gh-teacher` (parity tests green)
- [x] `npm run check` in `web/` (4900 tests; new `paginate.test.ts`, `getAssignmentRepos` tests, `useAssignmentRepos.test.tsx`, dashboard helper tests; dependency-cruiser clean), `audit_i18n.py --strict` passes
- [x] Manual: collect with `CLASSROOM_FILTER`/`ASSIGNMENT_FILTER` on a large org and compare the new `collect: N GitHub API request(s) in X.Xs` line against the 4m48s baseline
- [ ] Manual: refresh the submissions page for a large class in a large org; the header shows "Checking who accepted..." and resolves in seconds, and a tab-back within 5 minutes does not refetch