### PR TITLE
fix(cli): explain hand-written tests.json errors and where tests belong

### DIFF
--- a/cli/gh-teacher/autograders_tests/test_declarative_grader.py
+++ b/cli/gh-teacher/autograders_tests/test_declarative_grader.py
@@ -388,7 +388,25 @@ class TestLoadTests:
 
     def test_bad_schema(self, tmp_path):
         p = self._write(tmp_path, '{"schema": "nope", "tests": []}')
-        with pytest.raises(ag.TestsConfigError):
+        with pytest.raises(ag.TestsConfigError, match="gh teacher assignment test add"):
+            ag.load_tests(p)
+
+    def test_bare_array_names_the_mistake(self, tmp_path):
+        # Discussion #805: a teacher pasted the `--tests` file (a bare array)
+        # into CLASSROOM/autograders/ASSIGNMENT/tests.json. The error must say
+        # which format they used and how to author tests instead.
+        p = self._write(tmp_path, [{"name": "a", "type": "run", "run": "true", "points": 1}])
+        with pytest.raises(ag.TestsConfigError) as excinfo:
+            ag.load_tests(p)
+        msg = str(excinfo.value)
+        assert "bare test array" in msg
+        assert "--tests" in msg
+        assert "Remove the tests.json" in msg
+        assert "gh teacher assignment test add" in msg
+
+    def test_non_object_scalar_points_to_authoring_path(self, tmp_path):
+        p = self._write(tmp_path, '"hello"')
+        with pytest.raises(ag.TestsConfigError, match="not a JSON object.*Remove the tests.json"):
             ag.load_tests(p)
 
     def test_empty_tests_list(self, tmp_path):
@@ -905,7 +923,7 @@ class TestRunDeclarative:
         assert result["score"] == 5 and result["max-score"] == 5
         assert "status=success" in gho.read_text()
 
-    def test_malformed_tests_json_routes_to_error_result(self, tmp_path):
+    def test_malformed_tests_json_routes_to_error_result(self, tmp_path, capsys):
         fin, gho = _finalizer(tmp_path)
         p = tmp_path / "tests.json"
         p.write_text('{"schema": "wrong", "tests": []}')
@@ -914,6 +932,20 @@ class TestRunDeclarative:
         result = json.loads((tmp_path / "result.json").read_text())
         assert result["tests"] == [] and result["score"] == 0
         assert "status=error" in gho.read_text()
+        # The annotation names the file once, not "tests.json: tests.json ...".
+        err = capsys.readouterr().err
+        assert "::error::tests.json schema is 'wrong'" in err
+        assert "tests.json: tests.json" not in err
+
+    def test_bare_array_tests_json_routes_to_error_result(self, tmp_path, capsys):
+        fin, gho = _finalizer(tmp_path)
+        p = tmp_path / "tests.json"
+        p.write_text('[{"name": "a", "type": "run", "run": "true", "points": 1}]')
+        rc = ag.run_declarative(p, fin, tmp_path)
+        assert rc == 0
+        assert "status=error" in gho.read_text()
+        err = capsys.readouterr().err
+        assert "bare test array" in err and "gh teacher assignment test add" in err
 
     def test_unexpected_grader_crash_routes_to_error(self, tmp_path, monkeypatch):
         # Backstop: if execute_test raises something unexpected (future

--- a/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
+++ b/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
@@ -32,10 +32,12 @@ func assignmentTestCmd() *cobra.Command {
 			"  - io      compare stdout\n" +
 			"  - run     check the exit code\n" +
 			"  - python  run pytest\n\n" +
-			"Describe tests here instead of writing an autograder script: the\n" +
-			"publish-pages workflow materializes them into the assignment's\n" +
-			"Pages bundle and runner.py grades them on every submission. See\n" +
-			"the Autograding-Basics wiki page for the field reference.\n\n" +
+			"Describe tests here instead of writing an autograder script. Tests\n" +
+			"are stored on the assignment; the Publish Pages workflow generates\n" +
+			"the bundled tests.json from them, so never commit a tests.json under\n" +
+			"<classroom>/autograders/<slug>/ (that directory is for fixtures and\n" +
+			"grading scripts). See the Autograding-Basics wiki page for the\n" +
+			"field reference.\n\n" +
 			"For bulk edits (or a GUI/agent export), `gh teacher assignment\n" +
 			"add <org> <classroom> <slug> --tests <file.json>` sets the whole\n" +
 			"array at once; these subcommands edit one test at a time.",

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py
@@ -70,6 +70,15 @@ def materialize(root: pathlib.Path) -> int:
 
             outdir = root / classroom / "autograders" / slug
             outdir.mkdir(parents=True, exist_ok=True)
+            target = outdir / TESTS_FILENAME
+            if target.exists():
+                # Only a hand-committed file can be here: this script runs on a
+                # fresh checkout. The assignment's own tests win, so say so in
+                # the run log instead of clobbering silently.
+                print(f"::warning::{target}: replaced by the tests stored on the "
+                      f"assignment. tests.json is generated at publish time; remove "
+                      f"the committed copy and manage tests with the web assignment "
+                      f"form or `gh teacher assignment test add`.")
             payload = {"schema": TESTS_SCHEMA_V1, "tests": tests}
             # Assignment-level defaults for the per-test reporting options
             # (failure-details / show-output) ride the envelope; runner.py's
@@ -77,9 +86,9 @@ def materialize(root: pathlib.Path) -> int:
             defaults = entry.get("test_defaults")
             if isinstance(defaults, dict) and defaults:
                 payload["defaults"] = defaults
-            (outdir / TESTS_FILENAME).write_text(
+            target.write_text(
                 json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-            print(f"materialized {outdir / TESTS_FILENAME} ({len(tests)} test(s))")
+            print(f"materialized {target} ({len(tests)} test(s))")
             written += 1
     return written
 

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
@@ -1914,17 +1914,36 @@ def _validate_test_defaults(d: Any) -> str | None:
     return None
 
 
+# publish-pages always materializes a well-formed envelope, so a structurally
+# wrong tests.json means a teacher committed one by hand under
+# <classroom>/autograders/<slug>/ (see discussion #805). Point them back to the
+# supported authoring path instead of describing a format they never write.
+HAND_WRITTEN_TESTS_HINT = (
+    "Declarative tests are stored on the assignment and tests.json is generated "
+    "from them when the classroom50 repository publishes. Remove the tests.json "
+    "you committed under CLASSROOM/autograders/ASSIGNMENT/ and add the tests "
+    "with the web assignment form or `gh teacher assignment test add` instead.")
+
+
 def load_tests(path: pathlib.Path) -> list[dict[str, Any]]:
     """Parse + re-validate a materialized tests.json, folding the envelope's
     `defaults` (assignment-level failure-details / show-output) into each spec
     that doesn't set its own. Raises TestsConfigError on any structural
     problem."""
     data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        # The predictable mistake: the bare array `gh teacher assignment add
+        # --tests` accepts, copied from the wiki into the bundle directory.
+        raise TestsConfigError(
+            f"{TESTS_FILENAME} is a bare test array, the `--tests` file format, "
+            f"not the generated bundle format. {HAND_WRITTEN_TESTS_HINT}")
     if not isinstance(data, dict):
-        raise TestsConfigError(f"{TESTS_FILENAME} is not a JSON object")
+        raise TestsConfigError(
+            f"{TESTS_FILENAME} is not a JSON object. {HAND_WRITTEN_TESTS_HINT}")
     if data.get("schema") != TESTS_SCHEMA_V1:
         raise TestsConfigError(
-            f"{TESTS_FILENAME} schema is {data.get('schema')!r}, want {TESTS_SCHEMA_V1!r}")
+            f"{TESTS_FILENAME} schema is {data.get('schema')!r}, want {TESTS_SCHEMA_V1!r}. "
+            f"{HAND_WRITTEN_TESTS_HINT}")
     tests = data.get("tests")
     if not isinstance(tests, list) or not tests:
         raise TestsConfigError(f"{TESTS_FILENAME} 'tests' must be a non-empty list")
@@ -2228,7 +2247,10 @@ def run_declarative(tests_path: pathlib.Path, finalize: Finalizer,
     never fails the runner."""
     try:
         tests = load_tests(tests_path)
-    except (json.JSONDecodeError, TestsConfigError, OSError) as exc:
+    except TestsConfigError as exc:
+        # Already names the file and says what to do next.
+        return finalize.error(str(exc))
+    except (json.JSONDecodeError, OSError) as exc:
         return finalize.error(f"{TESTS_FILENAME}: {exc}")
 
     grader = DeclarativeGrader(

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -5265,7 +5265,8 @@ class TestThrottleBudgetUnderConcurrency:
     def test_sequential_waits_on_one_thread_each_count(self):
         for _ in range(5):
             assert cs.throttle_sleep_budget_spent(60) is False
-        assert cs._throttle_sleep_spent == 300
+        # (start + 60) - start on a large monotonic clock loses a few ULPs.
+        assert cs._throttle_sleep_spent == pytest.approx(300)
         assert cs.throttle_sleep_budget_spent(1) is True
 
 

--- a/cli/gh-teacher/skeleton_tests/test_materialize_tests.py
+++ b/cli/gh-teacher/skeleton_tests/test_materialize_tests.py
@@ -65,7 +65,7 @@ class TestMaterialize:
         assert mt.materialize(tmp_path) == 0
         assert not (tmp_path / "cs" / "autograders" / "intro").exists()
 
-    def test_preserves_existing_fixtures_in_override_dir(self, tmp_path):
+    def test_preserves_existing_fixtures_in_override_dir(self, tmp_path, capsys):
         # A teacher who uses expected-file keeps the fixture in the override
         # dir; materialize must drop tests.json alongside, not clobber it.
         override = tmp_path / "cs" / "autograders" / "hello"
@@ -81,6 +81,24 @@ class TestMaterialize:
         mt.materialize(tmp_path)
         assert (override / "expected.txt").read_text() == "golden output"
         assert (override / "tests.json").is_file()
+        assert "::warning::" not in capsys.readouterr().out
+
+    def test_warns_when_replacing_hand_committed_tests_json(self, tmp_path, capsys):
+        # Discussion #805: a teacher committed their own tests.json under the
+        # override dir. The assignment's tests still win, but the publish log
+        # must say the file was replaced and where tests belong.
+        override = tmp_path / "cs" / "autograders" / "hello"
+        override.mkdir(parents=True)
+        (override / "tests.json").write_text('[{"name": "stale", "type": "run", "run": "true", "points": 1}]')
+        _write_classroom(tmp_path, "cs", _manifest([
+            {"slug": "hello", "tests": [_io_test()]}]))
+        assert mt.materialize(tmp_path) == 1
+        payload = json.loads((override / "tests.json").read_text())
+        assert [t["name"] for t in payload["tests"]] == ["prints"]
+        out = capsys.readouterr().out
+        assert "::warning::" in out
+        assert "replaced by the tests stored on the assignment" in out
+        assert "gh teacher assignment test add" in out
 
     def test_rejects_traversal_slug(self, tmp_path):
         # A hand-edited manifest with a path-traversal slug must not escape

--- a/wiki/Advanced-Autograding.md
+++ b/wiki/Advanced-Autograding.md
@@ -18,21 +18,25 @@ two scopes:
 | Path | Scope | Used when |
 |---|---|---|
 | `CLASSROOM/autograders/ASSIGNMENT/autograder.py` | One assignment | Present in the bundle. |
-| `CLASSROOM/autograders/ASSIGNMENT/tests.json` | One assignment | [Declarative tests](Autograding-Basics#declarative-tests); no per-assignment `autograder.py`. |
-| `CLASSROOM/autograder.py` | One classroom | Neither of the above exists. |
+| `CLASSROOM/autograder.py` | One classroom | No per-assignment `autograder.py` and no declarative tests. |
 
-If none exist, the runner emits a vacuous pass (score 0/0) and the submission
-still lands as a tagged Release — a valid mid-setup state.
+Declarative tests sit between the two: the **Publish Pages** workflow generates
+them into the bundle as `CLASSROOM/autograders/ASSIGNMENT/tests.json`. You
+never create or commit that file. See
+[Where tests live](Autograding-Basics#where-tests-live).
+
+If none of the three exist, the runner emits a vacuous pass (score 0/0) and the
+submission still lands as a tagged Release, a valid mid-setup state.
 
 ### Precedence
 
-`runner.py` resolves the grading entrypoint in this order:
+The runner resolves the grading entrypoint in this order:
 
 1. Per-assignment `CLASSROOM/autograders/ASSIGNMENT/autograder.py` (an override
    always wins).
-2. Per-assignment `tests.json` (declarative tests).
+2. The assignment's declarative tests (the generated `tests.json`).
 3. Classroom default `CLASSROOM/autograder.py`.
-4. None of the above → vacuous pass.
+4. None of the above: vacuous pass.
 
 To keep precedence from silently swallowing tests, the CLI refuses `assignment
 test add` / `--tests` while a per-assignment `autograder.py` exists.

--- a/wiki/Autograding-Basics.md
+++ b/wiki/Autograding-Basics.md
@@ -75,12 +75,15 @@ Two related, optional settings:
 ### Declarative tests
 
 The lowest-friction way to grade: describe io/run/pytest checks directly on the
-assignment, and the runner grades them with a built-in interpreter — no grading
+assignment, and the runner grades them with a built-in interpreter, no grading
 code to write. The three types map onto GitHub Classroom's legacy autograder
 presets.
 
-In the web app, add tests in the assignment form's **Autograding tests**
-section. From the CLI, author them one at a time:
+Tests are stored on the assignment itself (its entry in `assignments.json`).
+Add them in one of two ways:
+
+- In the web app, use the assignment form's **Autograding tests** section.
+- From the CLI, add them one at a time with `gh teacher assignment test add`:
 
 ```sh
 gh teacher assignment test add cs50-fall-2026 cs-principles hello \
@@ -92,9 +95,11 @@ gh teacher assignment test list cs50-fall-2026 cs-principles hello
 gh teacher assignment test remove cs50-fall-2026 cs-principles hello compiles
 ```
 
-Or set the whole array at once with `gh teacher assignment add ... --tests
-<file.json>` (`--tests -` reads stdin). The file is a bare JSON array — the same
-shape `assignment test list --json` emits:
+To set the whole list at once, pass a file to `gh teacher assignment add ...
+--tests hello-tests.json` (`--tests -` reads stdin). The file is a bare JSON
+array, the same shape `assignment test list --json` emits. Keep it anywhere
+outside the `classroom50` repository; the CLI copies its contents into the
+assignment.
 
 ```json
 [
@@ -107,6 +112,29 @@ shape `assignment test list --json` emits:
   { "name": "pytest suite", "type": "python", "run": "python -m pytest -q", "timeout": 120, "points": 10 }
 ]
 ```
+
+#### Where tests live
+
+You never write a `tests.json` yourself. When you push to the `classroom50`
+repository, the **Publish Pages** workflow reads each assignment's tests and
+generates `CLASSROOM/autograders/ASSIGNMENT/tests.json` inside the published
+bundle, wrapped in an envelope (`schema`, `tests`, and optional `defaults`)
+that the runner checks at grade time.
+
+Don't commit a `tests.json` to `CLASSROOM/autograders/ASSIGNMENT/` in the
+`classroom50` repository:
+
+- If the assignment has tests, publishing replaces your file and logs a warning.
+- If it doesn't, the runner rejects your file (`tests.json is a bare test
+  array` or `tests.json is not a JSON object`), and every submission ends as an
+  error until you remove it. See
+  [Troubleshooting](Troubleshooting#testsjson-is-a-bare-test-array-or-testsjson-is-not-a-json-object-in-the-grading-log).
+
+That directory is for the files tests read: fixtures for `input-file` and
+`expected-file`, and grading scripts students must not see. See
+[Teacher-only test files](#teacher-only-test-files). In paths and commands on
+this page, replace `CLASSROOM` with the classroom's short name and `ASSIGNMENT`
+with the assignment slug.
 
 #### Test types
 
@@ -139,10 +167,8 @@ shape `assignment test list --json` emits:
 
 At most 100 tests per assignment. Put large fixtures in files
 (`input-file` / `expected-file`) under `CLASSROOM/autograders/ASSIGNMENT/`, not
-inline; that directory is also where grading scripts students must not see
-belong (see [Teacher-only test files](#teacher-only-test-files)). In paths and
-commands on this page, replace `CLASSROOM` with the classroom's short name and
-`ASSIGNMENT` with the assignment slug.
+inline. See [Where tests live](#where-tests-live) for what else belongs in that
+directory, and what doesn't.
 
 #### Report options
 
@@ -228,20 +254,18 @@ and GitHub Actions reads `$GITHUB_ENV` only after that step finishes. A write
 cannot change the runner process or the environment of later tests.
 
 <details>
-<summary>How tests flow, and where failures surface</summary>
+<summary>Where failures surface</summary>
 
-Tests live inline in `assignments.json`. On the next push to the `classroom50`
-repository, publish-pages **materializes** them into the assignment's Pages
-bundle as `tests.json`. At grade time, `runner.py` runs each spec in the student checkout:
-one row per test in `result.json`, plus a failure breakdown in three places — the
-**Release body**, the **grade job log** ("Grade details"), and the **run Summary
-page**. What the breakdown contains follows the test's
+At grade time, the runner runs each test in the student checkout: one row per
+test in `result.json`, plus a failure breakdown in three places: the **Release
+body**, the **grade job log** ("Grade details"), and the **run Summary page**.
+What the breakdown contains follows the test's
 [report options](#report-options). Captured output is clipped per block:
 2,000 characters in the Release body and Summary, 100,000 in the grade job
 log, so long compiler or build output stays readable in the log.
 
-Specs are validated three times: by the CLI at write time, by the runner
-workflow at submission setup, and by `runner.py` before executing.
+Tests are validated three times: by the CLI or web form when you save them, by
+the runner workflow at submission setup, and by the runner before executing.
 
 </details>
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -770,6 +770,29 @@ this used to mean a missing `pytest`; the built-in autograder now installs
   your tests import there. See the
   [Python recipe](Autograder-Recipes#python).
 
+### `tests.json is a bare test array` or `tests.json is not a JSON object` in the grading log
+
+Every submission ends as an error, and the **Grade details** step says the
+bundled `tests.json` has the wrong shape. Someone committed a `tests.json` to
+`CLASSROOM/autograders/ASSIGNMENT/` in the `classroom50` repository, usually by
+copying the `--tests` file example from the wiki. That directory holds fixtures
+and grading scripts only; the Publish Pages workflow generates `tests.json`
+from the tests stored on the assignment, so a hand-written one is never valid
+there.
+
+1. Delete `CLASSROOM/autograders/ASSIGNMENT/tests.json` from the `classroom50`
+   repository and push.
+2. Add the tests on the assignment instead: the web form's **Autograding
+   tests** section, `gh teacher assignment test add`, or `gh teacher assignment
+   add --tests FILE` with the bare-array file.
+3. Wait for the **Publish Pages** workflow to finish, then submit as a test
+   student.
+
+If the assignment already had tests, the publish log also warns
+`replaced by the tests stored on the assignment`: grading works, but delete
+the committed file so the next person doesn't edit it. See
+[Where tests live](Autograding-Basics#where-tests-live).
+
 ## Collecting scores and downloading submissions
 
 ### `collect-scores` warns "collected 0 submissions"


### PR DESCRIPTION
## Summary

Closes the confusion in #805: a teacher followed the wiki, committed the `--tests` example (a bare JSON array) to `CLASSROOM/autograders/ASSIGNMENT/tests.json`, and every submission failed with `tests.json: tests.json is not a JSON object`. That file is a publish-time artifact generated from the tests stored on the assignment, but nothing in the docs, the CLI help, or the error said so.

- **Runner error is actionable.** `load_tests` names the bare-array case explicitly (the `--tests` file format) and every structural error ends with what to do: remove the committed file and add tests with the web form or `gh teacher assignment test add`. The `tests.json: tests.json ...` double prefix is gone.
- **Publish warns instead of clobbering silently.** `materialize_tests.py` emits a `::warning::` when it replaces a hand-committed `tests.json`, so the other half of the confusion (assignment has tests, teacher's file vanishes) is visible in the Publish Pages log.
- **CLI help** for `gh teacher assignment test` says never to commit a `tests.json` under the autograders directory.
- **Wiki.** `Autograding-Basics` now states the model first (tests live on the assignment), renames the example file to `hello-tests.json`, and adds a **Where tests live** section. `Advanced-Autograding` no longer lists `tests.json` as a path you create. `Troubleshooting` gets an entry for the exact error strings with recovery steps. Copy follows `docs/github-docs-writing-style.md`.

Deliberately not done: accepting a bare array in the runner. That would create a second authoring path that skips write-time validation in `tests.go`.

## Test plan

- [x] `python3 -m pytest cli/gh-teacher/skeleton_tests` (948 passed, includes new overwrite-warning test)
- [x] `python3 -m pytest cli/gh-teacher/autograders_tests` (430 passed, includes new bare-array / non-object / annotation tests)
- [x] `ruff check --select E4,E7,E9,F cli/gh-teacher/skeleton/dotgithub/scripts/`
- [x] `go build ./... && go test ./internal/assignmentcmd/...` in `cli/gh-teacher`
- [ ] After merge: confirm the new wiki anchor `Autograding-Basics#where-tests-live` resolves on the published wiki