### PR TITLE
fix: make staff access grants visible and catch repo-scoped service tokens

### DIFF
--- a/cli/gh-teacher/internal/servicetoken/servicetoken.go
+++ b/cli/gh-teacher/internal/servicetoken/servicetoken.go
@@ -115,7 +115,7 @@ func SecretExists(client githubapi.Client, owner, repo string) (bool, error) {
 // members — also not implied by any repository permission). Catches a
 // misconfigured PAT at provisioning time rather than as an opaque collect-time 403.
 func ValidateToken(token []byte, org string) error {
-	return ValidateTokenVerbose(token, org, io.Discard)
+	return ValidateTokenVerbose(token, org, nil, io.Discard)
 }
 
 // ValidateTokenVerbose is ValidateToken with a writer for advisory notes. When
@@ -123,7 +123,12 @@ func ValidateToken(token []byte, org string) error {
 // repo read), validation still passes (fail-open) but warns to `out` so the
 // teacher knows Members: Read wasn't positively confirmed and should run the
 // `probe-token` workflow before relying on collection.
-func ValidateTokenVerbose(token []byte, org string, out io.Writer) error {
+//
+// `teacher` is the caller's own authenticated client. When non-nil it is used
+// to find a private repo other than classroom50 to read as the token, which is
+// the only way to tell a PAT scoped to "All repositories" from one scoped to
+// selected repositories (see validateRepoScopeWithClients). nil skips that probe.
+func ValidateTokenVerbose(token []byte, org string, teacher githubapi.Client, out io.Writer) error {
 	tokenClient, err := githubapi.NewClient(githubapi.ClientOptions{
 		AuthToken: string(token),
 	})
@@ -131,7 +136,13 @@ func ValidateTokenVerbose(token []byte, org string, out io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("build token client: %w", err)
 	}
-	return validateTokenWithClient(tokenClient, org, out)
+	if err := validateTokenWithClient(tokenClient, org, out); err != nil {
+		return err
+	}
+	if teacher == nil {
+		return nil
+	}
+	return validateRepoScopeWithClients(tokenClient, teacher, org, out)
 }
 
 // validateTokenWithClient is ValidateToken's testable core: reads the config
@@ -195,6 +206,46 @@ func validateTokenWithClient(tokenClient githubapi.Client, org string, out io.Wr
 		// unconfirmed Members-less token 403s at collect time. Point at
 		// probe-token.
 		_, _ = fmt.Fprintf(out, "Warning: couldn't confirm the token's Organization -> Members: Read scope (%v). Proceeding, since the repo read proved the token live, but if it in fact lacks Members: Read, collection will 403 and skip. Run the `probe-token` workflow to verify all scopes before the first collect.\n", err)
+	}
+	return nil
+}
+
+// validateRepoScopeWithClients checks that the token reaches repos beyond
+// classroom50. The config-repo read proves nothing about the student repos: a
+// PAT scoped to "Only select repositories" (with classroom50 selected) passes
+// every check above and then 404s on every student repo, which surfaces weeks
+// later as a collect-time 403 on the first staff-team grant.
+//
+// The teacher's own client picks a private org repo other than classroom50 (a
+// repo they can see, so a token they own with All repositories can see it too)
+// and the token reads it. 404 is definitive: the repo is outside the token's
+// selection, or its Resource owner isn't the org. No other private repo yet
+// means there is nothing to prove; any other failure is inconclusive and warns.
+func validateRepoScopeWithClients(tokenClient, teacher githubapi.Client, org string, out io.Writer) error {
+	listPath := fmt.Sprintf("orgs/%s/repos?type=private&sort=created&direction=asc&per_page=10", url.PathEscape(org))
+	var repos []struct {
+		Name string `json:"name"`
+	}
+	if err := teacher.Get(listPath, &repos); err != nil {
+		_, _ = fmt.Fprintf(out, "Warning: couldn't list %s's private repositories to confirm the token's Repository access setting (%v). Proceeding; if the token is scoped to selected repositories, collection can't reach student repos. Run the `probe-token` workflow to verify.\n", org, err)
+		return nil
+	}
+	probe := ""
+	for _, r := range repos {
+		if !strings.EqualFold(r.Name, configrepo.ConfigRepoName) {
+			probe = r.Name
+			break
+		}
+	}
+	if probe == "" {
+		return nil
+	}
+	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(probe))
+	if err := tokenClient.Get(path, nil); err != nil {
+		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
+			return fmt.Errorf("the supplied token can read %s/%s but not %s/%s, so it is scoped to selected repositories (or its Resource owner isn't %q). Collecting scores reads every student repo and grants staff teams access to them. Re-create the fine-grained personal access token with Resource owner = %q and Repository access = All repositories, keeping Contents: Read and write, Actions: Read and write, Administration: Read and write, and Organization permissions -> Members: Read", org, configrepo.ConfigRepoName, org, probe, org, org)
+		}
+		_, _ = fmt.Fprintf(out, "Warning: couldn't confirm the token's Repository access setting by reading %s/%s (%v). Proceeding; if the token is scoped to selected repositories, collection can't reach student repos. Run the `probe-token` workflow to verify.\n", org, probe, err)
 	}
 	return nil
 }
@@ -278,6 +329,8 @@ func NewRotateCmd() *cobra.Command {
 			"  - read the org's members (collection is team-driven and lists\n" +
 			"    the classroom team)\n\n" +
 			"Required fine-grained token permissions:\n" +
+			"  - Repository access -> All repositories (a token limited to\n" +
+			"    selected repositories can't reach student repos)\n" +
 			"  - Repository permissions -> Contents: Read and write, Actions:\n" +
 			"    Read and write, and Administration: Read and write\n" +
 			"    (Metadata: Read is auto-included)\n" +
@@ -315,7 +368,7 @@ func NewRotateCmd() *cobra.Command {
 			}
 			// Validate before storing: catch a bad PAT now, not weeks later.
 			// Verbose so an inconclusive Members-scope probe warns.
-			if err := ValidateTokenVerbose(token, org, out); err != nil {
+			if err := ValidateTokenVerbose(token, org, client, out); err != nil {
 				return fmt.Errorf("service token validation failed: %w", err)
 			}
 			return ProvisionSecret(client, out, org, configrepo.ConfigRepoName, token, "rotated")

--- a/cli/gh-teacher/internal/servicetoken/servicetoken_test.go
+++ b/cli/gh-teacher/internal/servicetoken/servicetoken_test.go
@@ -179,6 +179,85 @@ func boolJSON(b bool) string {
 	return "false"
 }
 
+// TestValidateRepoScope pins the "All repositories" probe: the teacher's client
+// lists private org repos, the token reads the first one that isn't
+// classroom50, and only a 404 there rejects the token. A token scoped to
+// selected repositories passes every config-repo check (discussion #768), so
+// this probe is the one place the misconfiguration can be caught before it
+// shows up as a collect-time 403 on the first staff-team grant.
+func TestValidateRepoScope(t *testing.T) {
+	cases := []struct {
+		name string
+		// listing is the teacher's GET /orgs/cs50/repos body (or a status).
+		listStatus int
+		listing    string
+		// probeStatus is the token's GET /repos/cs50/<probe> status.
+		probeStatus int
+		wantProbe   string // "" when no probe should be made
+		wantErr     bool
+		wantWarn    bool
+	}{
+		{"all repositories", http.StatusOK, `[{"name":"classroom50"},{"name":"cs-hw1-alice"}]`, http.StatusOK, "cs-hw1-alice", false, false},
+		{"selected repositories rejected", http.StatusOK, `[{"name":"classroom50"},{"name":"cs-hw1-alice"}]`, http.StatusNotFound, "cs-hw1-alice", true, false},
+		{"config repo is never the probe", http.StatusOK, `[{"name":"Classroom50"},{"name":"other"}]`, http.StatusOK, "other", false, false},
+		{"only the config repo exists: nothing to prove", http.StatusOK, `[{"name":"classroom50"}]`, 0, "", false, false},
+		{"no private repos: nothing to prove", http.StatusOK, `[]`, 0, "", false, false},
+		{"teacher listing fails: inconclusive", http.StatusInternalServerError, ``, 0, "", false, true},
+		{"probe 403 is inconclusive, not a scope verdict", http.StatusOK, `[{"name":"cs-hw1-alice"}]`, http.StatusForbidden, "cs-hw1-alice", false, true},
+		{"probe 5xx is inconclusive", http.StatusOK, `[{"name":"cs-hw1-alice"}]`, http.StatusBadGateway, "cs-hw1-alice", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var probed []string
+			teacherServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, "/orgs/cs50/repos") {
+					t.Errorf("teacher client: unexpected request %s", r.URL.Path)
+				}
+				if got := r.URL.Query().Get("type"); got != "private" {
+					t.Errorf("listing type = %q, want private (a public repo proves nothing)", got)
+				}
+				if tc.listStatus != http.StatusOK {
+					w.WriteHeader(tc.listStatus)
+					return
+				}
+				_, _ = w.Write([]byte(tc.listing))
+			}))
+			t.Cleanup(teacherServer.Close)
+			tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				probed = append(probed, strings.TrimPrefix(r.URL.Path, "/repos/cs50/"))
+				if tc.probeStatus != http.StatusOK {
+					w.WriteHeader(tc.probeStatus)
+					return
+				}
+				_, _ = w.Write([]byte(`{"name":"x"}`))
+			}))
+			t.Cleanup(tokenServer.Close)
+
+			var warnOut strings.Builder
+			err := validateRepoScopeWithClients(
+				githubtest.NewTestClient(t, tokenServer),
+				githubtest.NewTestClient(t, teacherServer),
+				"cs50", &warnOut,
+			)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr && (!strings.Contains(err.Error(), "All repositories") || !strings.Contains(err.Error(), "cs50/cs-hw1-alice")) {
+				t.Errorf("rejection should name the unreadable repo and the All repositories fix: %q", err.Error())
+			}
+			if tc.wantWarn != strings.Contains(warnOut.String(), "probe-token") {
+				t.Errorf("inconclusive warning = %v, want %v (out=%q)", !tc.wantWarn, tc.wantWarn, warnOut.String())
+			}
+			if tc.wantProbe == "" && len(probed) != 0 {
+				t.Errorf("token must not be used when there is nothing to prove; probed %v", probed)
+			}
+			if tc.wantProbe != "" && (len(probed) != 1 || probed[0] != tc.wantProbe) {
+				t.Errorf("probed %v, want exactly [%s]", probed, tc.wantProbe)
+			}
+		})
+	}
+}
+
 // TestProvisionServiceSecret_PutStatus pins the PUT status handling: the
 // Actions-secret upload must succeed on 201 (created) and 204 (updated),
 // and the new assertion must reject any other 2xx (e.g., a 200 that means

--- a/cli/gh-teacher/service_token.go
+++ b/cli/gh-teacher/service_token.go
@@ -29,7 +29,7 @@ func provisionServiceToken(cmd *cobra.Command, client githubapi.Client, summary 
 	// 1. Env var wins (CI / scripted / explicit refresh).
 	if v := strings.TrimSpace(os.Getenv(servicetoken.EnvServiceToken)); v != "" {
 		token := []byte(v)
-		if err := servicetoken.ValidateTokenVerbose(token, org, errOut); err != nil {
+		if err := servicetoken.ValidateTokenVerbose(token, org, client, errOut); err != nil {
 			return fmt.Errorf("the %s in your environment failed validation: %w", servicetoken.EnvServiceToken, err)
 		}
 		if err := servicetoken.ProvisionSecret(client, io.Discard, org, configrepo.ConfigRepoName, token, "stored"); err != nil {
@@ -52,7 +52,7 @@ func provisionServiceToken(cmd *cobra.Command, client githubapi.Client, summary 
 	if err != nil {
 		return err
 	}
-	if err := servicetoken.ValidateTokenVerbose(token, org, errOut); err != nil {
+	if err := servicetoken.ValidateTokenVerbose(token, org, client, errOut); err != nil {
 		return fmt.Errorf("service token validation failed: %w", err)
 	}
 	if err := servicetoken.ProvisionSecret(client, io.Discard, org, configrepo.ConfigRepoName, token, "stored"); err != nil {

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -66,7 +66,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, NamedTuple
 
 # Schema sentinels — keep in lockstep with the Go-side constants in
 # `cli/gh-teacher/classroom.go` and `cli/gh-teacher/assignments_json.go`.
@@ -87,6 +87,10 @@ SUBMIT_TAG_PREFIX = "submit/"
 # here gets nothing (the teacher team is an org owner with access via ownership,
 # so only the non-owner staff teams — head-TA and TA — need a grant).
 STAFF_TEAM_PERMISSIONS = {"hta": "pull", "ta": "pull"}
+
+# Every staff role that has a classroom team. Mirrors Go contract.StaffRoles and
+# the web STAFF_ROLES; the derived slug for each is `classroom50-<short>-<role>`.
+STAFF_ROLES = ("teacher", "hta", "ta")
 
 # Body markers that identify a rate-limit response, for the cases no header
 # names: GitHub words the secondary limit and the abuse detector differently.
@@ -345,7 +349,9 @@ def main() -> int:
             else:
                 grant_hint = (
                     f" — grant staff teams repo access needs a fine-grained PAT with "
-                    f"Repository -> Administration: Read and write; run "
+                    f"Repository access: All repositories and Repository -> "
+                    f"Administration: Read and write (a token scoped to selected "
+                    f"repositories can't reach the student repos); run "
                     f"`gh teacher rotate-service-token {org}`"
                     if exc.code in (401, 403)
                     else ""
@@ -974,12 +980,16 @@ def list_enrolled_logins(
     # lowercases anyway, so casing is cosmetic — but keep it deterministic).
     student_logins = read(student_slug)
     logins = list(student_logins)
-    for role, staff_slug in resolve_staff_team_slugs(classroom_meta).items():
+    for role, staff_team in resolve_staff_team_slugs(classroom_meta, classroom_short).items():
+        staff_slug = staff_team.slug
         try:
             logins.extend(read(staff_slug))
         except urllib.error.HTTPError as exc:
             if classify(exc) is not SKIPPABLE:
                 raise
+            if exc.code == 404 and not staff_team.recorded:
+                # A derived team that was never recorded may simply not exist.
+                continue
             emit_warning(
                 f"{classroom_short}: could not read staff team {staff_slug!r} "
                 f"({role}) members: HTTP {exc.code} ({exc.reason or 'no reason'}); "
@@ -1732,22 +1742,46 @@ def resolve_team_slug(classroom_meta: dict[str, Any], classroom_short: str) -> s
     return f"classroom50-{classroom_short}"
 
 
-def resolve_staff_team_slugs(classroom_meta: dict[str, Any]) -> dict[str, str]:
-    """Map each staff role present in classroom.json `teams` to its authoritative
-    slug (role -> slug). Only roles with a non-empty slug are returned; a
-    classroom with no `teams` block yields {}. The slug is authoritative — never
-    re-derived — mirroring resolve_team_slug's contract for the student team."""
+class StaffTeam(NamedTuple):
+    slug: str
+    # False when the slug was derived because classroom.json doesn't record the
+    # role: the team may legitimately not exist, so a 404 on it is not news.
+    recorded: bool
+
+
+def resolve_staff_team_slugs(
+    classroom_meta: dict[str, Any], classroom_short: str
+) -> dict[str, StaffTeam]:
+    """Map each staff role to its GitHub team (role -> StaffTeam). A slug
+    recorded in classroom.json `teams` is authoritative (GitHub may re-slug on a
+    name collision); every other role in STAFF_ROLES falls back to the derived
+    `classroom50-<short>-<role>`, the same fallback the web app applies.
+
+    The fallback matters for classrooms whose `teams` block predates a role or
+    was never written: the web creates and populates that role's team on first
+    use without recording it, and without the fallback the grant pass would
+    never see it and the classroom's TAs would silently get no access.
+
+    Roles recorded under `teams` that aren't in STAFF_ROLES are kept as-is."""
+    out: dict[str, StaffTeam] = {}
     teams = classroom_meta.get("teams")
-    if not isinstance(teams, dict):
-        return {}
-    out: dict[str, str] = {}
-    for role, ref in teams.items():
-        if not isinstance(ref, dict):
-            continue
-        slug = ref.get("slug")
-        if isinstance(slug, str) and slug.strip():
-            out[role] = slug.strip()
+    if isinstance(teams, dict):
+        for role, ref in teams.items():
+            if not isinstance(ref, dict):
+                continue
+            slug = ref.get("slug")
+            if isinstance(slug, str) and slug.strip():
+                out[role] = StaffTeam(slug.strip(), recorded=True)
+    for role in STAFF_ROLES:
+        if role not in out:
+            out[role] = StaffTeam(staff_team_slug(classroom_short, role), recorded=False)
     return out
+
+
+def staff_team_slug(classroom_short: str, role: str) -> str:
+    """The derived staff team slug `classroom50-<short>-<role>`. Mirrors Go's
+    contract.StaffTeamSlug and the web's classroomTeamSlug(short, role)."""
+    return f"classroom50-{classroom_short}-{role}"
 
 
 def get_repo(api_url: str, owner: str, repo: str, token: str) -> dict[str, Any] | None:
@@ -1822,22 +1856,26 @@ def grant_classroom_team_access(
     each). A per-repo 404/422 (repo not accepted yet, or template not
     org-owned) is warned-and-skipped; a hard error (401/403/599) propagates so
     main() aborts; a throttle raises GrantThrottled, which main() reports as a
-    deferral rather than a failure. A classroom with no mapped staff team is a
-    no-op.
+    deferral rather than a failure. The head-TA and TA teams are resolved from
+    classroom.json `teams`, falling back to the derived slug (see
+    resolve_staff_team_slugs).
 
     A staff team with no members is skipped per-slug (its grants would benefit
-    nobody), so an empty ta team still lets a populated hta team grant.
+    nobody), so an empty ta team still lets a populated hta team grant. The pass
+    is never silent about its outcome: each populated team gets a summary line,
+    and when no staff team has members at all (so nothing was granted) a warning
+    says so, because that run otherwise looks identical to a healthy one.
 
     `assignment_filter` scopes the grant to one assignment (its student repos
     and its private template); blank grants every assignment as before.
     """
-    role_slugs = resolve_staff_team_slugs(classroom_meta)
-    grant_slugs = [
-        (slug, STAFF_TEAM_PERMISSIONS[role])
-        for role, slug in role_slugs.items()
+    staff_teams = resolve_staff_team_slugs(classroom_meta, classroom_short)
+    grant_teams = [
+        (role, team, STAFF_TEAM_PERMISSIONS[role])
+        for role, team in staff_teams.items()
         if role in STAFF_TEAM_PERMISSIONS
     ]
-    if not grant_slugs:
+    if not grant_teams:
         return
 
     # ALL slugs, not just the collectable subset: empty_repo assignments are
@@ -1885,7 +1923,7 @@ def grant_classroom_team_access(
         for slug in slugs
         for username in usernames
     ]
-    if repo_index is not None:
+    if repo_index is not None and candidates:
         repo_index.prefetch(candidates)
     targets: list[tuple[str, str]] = [
         (org, repo_name)
@@ -1901,7 +1939,11 @@ def grant_classroom_team_access(
     if not targets:
         return
 
-    for team_slug, permission in grant_slugs:
+    # Which teams the pass could work with, so the tail can tell "nothing to
+    # grant" (no populated staff team) from "already granted" (all idempotent).
+    populated_teams: list[str] = []
+    for role, staff_team, permission in grant_teams:
+        team_slug = staff_team.slug
         # Read this staff team's members to skip it when empty (see docstring).
         # Same SKIPPABLE-warn-and-skip contract as the student read above: any
         # non-401/403/599/throttle (404 = team not created yet, 422, …) skips
@@ -1915,6 +1957,12 @@ def grant_classroom_team_access(
         except urllib.error.HTTPError as exc:
             if classify(exc) is not SKIPPABLE:
                 raise
+            if exc.code == 404 and not staff_team.recorded:
+                print(
+                    f"{classroom_short}: no {role} team recorded in classroom.json and "
+                    f"{team_slug!r} does not exist on GitHub; nothing to grant for that role."
+                )
+                continue
             emit_warning(
                 f"{classroom_short}: could not read staff team {team_slug!r} members: "
                 f"HTTP {exc.code} ({exc.reason or 'no reason'}); skipping its grant this run."
@@ -1927,7 +1975,12 @@ def grant_classroom_team_access(
             )
             continue
         if not staff_logins:
+            print(
+                f"{classroom_short}: staff team {team_slug!r} ({role}) has no members; "
+                f"nothing to grant for that role."
+            )
             continue
+        populated_teams.append(team_slug)
 
         # One bulk read replaces grant_team_repo's per-repo access check: after
         # the first run nearly every target is already granted, so that check —
@@ -1968,6 +2021,33 @@ def grant_classroom_team_access(
 
         if granted:
             print(f"{classroom_short}: granted {team_slug} {permission} on {granted} repo(s)")
+        else:
+            print(
+                f"{classroom_short}: {team_slug} needed no new {permission} grant "
+                f"({len(targets)} target repo(s) checked)"
+            )
+
+    if not populated_teams:
+        emit_warning(warn_no_staff_to_grant(classroom_short, org, grant_teams))
+
+
+def warn_no_staff_to_grant(
+    classroom_short: str,
+    org: str,
+    grant_teams: list[tuple[str, StaffTeam, str]],
+) -> str:
+    """The verdict for a grant pass that found student repos but no populated
+    staff team to grant them to. Without it, "every TA was moved to a team the
+    pass can't see" exits 0 exactly like a healthy run, and the teacher learns
+    the TAs have no access only when they ask."""
+    slugs = ", ".join(team.slug for _, team, _ in grant_teams)
+    return (
+        f"{classroom_short}: no staff access was granted because no head-TA or TA "
+        f"team has members ({slugs}). Staff get read access to student repositories "
+        f"only through those teams. Check that each TA has the head TA or TA role on "
+        f"the roster page, or run `gh teacher staff add {org} {classroom_short} "
+        f"<username> --role ta`, then run this workflow again."
+    )
 
 
 def private_template_targets(

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/probe_token.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/probe_token.py
@@ -34,11 +34,12 @@ Scope -> probe (mirrors the wiki REST table):
 Config + org scopes are ALWAYS probed. Per-classroom, the probe also reads the
 classroom team's members (the exact call collect-scores makes), which exercises
 team VISIBILITY — a secret team the token can't see 404/403s here even when the
-org-members proxy passes. It additionally reads each STAFF team (classroom.json
-`teams`, e.g., `classroom50-<short>-ta`) the collect-time grant targets, so a
-secret/invisible staff team fails RED here rather than silently granting TAs no
-access at collect time. A team that doesn't exist yet (404) is a PASS with a note (an
-early-term classroom legitimately has no team), never a failure.
+org-members proxy passes. It additionally reads each STAFF team the collect-time
+grant targets (classroom.json `teams`, falling back to the derived
+`classroom50-<short>-<role>`), so a secret/invisible staff team fails RED here
+rather than silently granting TAs no access at collect time. A team that doesn't
+exist yet (404) is a PASS with a note (an early-term classroom legitimately has
+no team), never a failure.
 
 Environment (set by `probe-token.yaml`):
   CLASSROOM50_SERVICE_TOKEN — the fine-grained PAT to probe.
@@ -72,6 +73,9 @@ CONFIG_REPO = "classroom50"
 
 # Schema sentinel for a classroom.json — keep aligned with collect_scores.py.
 CLASSROOM_SCHEMA_V1 = "classroom50/classroom/v1"
+
+# Staff roles with a classroom team; mirrors collect_scores.py STAFF_ROLES.
+STAFF_ROLES = ("teacher", "hta", "ta")
 
 # Throttle classifier constants, hand-mirrored from collect_scores.py (which
 # documents them); pinned by TestRateLimitMarkersParity_GoVsInlinePython.
@@ -398,20 +402,26 @@ def resolve_team_slug(classroom_meta: dict[str, Any], classroom_short: str) -> s
     return f"classroom50-{classroom_short}"
 
 
-def resolve_staff_team_slugs(classroom_meta: dict[str, Any]) -> dict[str, str]:
-    """role -> slug for each staff team present in classroom.json `teams`.
-    Mirrors collect_scores.py's resolve_staff_team_slugs so the probe reads the
-    EXACT staff teams the grant pass targets."""
-    teams = classroom_meta.get("teams")
-    if not isinstance(teams, dict):
-        return {}
+def resolve_staff_team_slugs(
+    classroom_meta: dict[str, Any], classroom_short: str
+) -> dict[str, str]:
+    """role -> slug for each staff team the grant pass targets: a slug recorded
+    in classroom.json `teams` is authoritative; every other role in STAFF_ROLES
+    falls back to the derived `classroom50-<short>-<role>`. Mirrors
+    collect_scores.py's resolve_staff_team_slugs so the probe reads the EXACT
+    staff teams the grant pass targets (a derived team that doesn't exist reads
+    as a 404, which check_staff_team_visible already treats as a skip)."""
     out: dict[str, str] = {}
-    for role, ref in teams.items():
-        if not isinstance(ref, dict):
-            continue
-        slug = ref.get("slug")
-        if isinstance(slug, str) and slug.strip():
-            out[role] = slug.strip()
+    teams = classroom_meta.get("teams")
+    if isinstance(teams, dict):
+        for role, ref in teams.items():
+            if not isinstance(ref, dict):
+                continue
+            slug = ref.get("slug")
+            if isinstance(slug, str) and slug.strip():
+                out[role] = slug.strip()
+    for role in STAFF_ROLES:
+        out.setdefault(role, f"{CONFIG_REPO}-{classroom_short}-{role}")
     return out
 
 
@@ -575,7 +585,7 @@ def main() -> int:
             print_check(check)
             checks.append(check)
             # Probe each staff team the grant targets (see check_staff_team_visible).
-            for role, staff_slug in resolve_staff_team_slugs(meta).items():
+            for role, staff_slug in resolve_staff_team_slugs(meta, classroom_short).items():
                 staff_check = check_staff_team_visible(
                     api_url, org, token, classroom_short, role, staff_slug
                 )

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -4497,6 +4497,9 @@ class TestGrantThrottled:
         # Collection can't defer — an incomplete gradebook must not report
         # success — but the message still must not blame the token.
         write_minimal_classroom(tmp_path)
+        # The grant pass runs first and reads the student team; keep it off the
+        # network so the only error under test is collection's throttle.
+        stub_team_members(monkeypatch, [])
 
         def fail_collect(**kwargs):
             raise http_error(403, {"Retry-After": "60"}, b"secondary rate limit")

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -1489,6 +1489,33 @@ class TestListEnrolledLogins:
         assert logins == ["alice"]
         assert students == {"alice"}
 
+    def test_unrecorded_staff_team_is_polled_via_derived_slug(self, monkeypatch):
+        # No `teams` block, but the derived hta team exists and has a member:
+        # that head TA is polled like any other staffer.
+        stub_team_members_by_slug(monkeypatch, {
+            "classroom50-cs-principles": ["alice"],
+            "classroom50-cs-principles-hta": ["headta"],
+        })
+        logins, _ = cs.list_enrolled_logins(
+            "https://api.github.com", "cs50", {}, "cs-principles", "token"
+        )
+        assert logins == ["alice", "headta"]
+
+    def test_derived_staff_team_404_is_quiet(self, monkeypatch, capsys):
+        import urllib.error
+
+        def fake(api_url, org, team_slug, token):
+            if team_slug == "classroom50-cs-principles":
+                return ["alice"]
+            raise urllib.error.HTTPError("u", 404, "Not Found", None, None)
+
+        monkeypatch.setattr(cs, "list_team_member_logins", fake)
+        logins, _ = cs.list_enrolled_logins(
+            "https://api.github.com", "cs50", {}, "cs-principles", "token"
+        )
+        assert logins == ["alice"]
+        assert "::warning::" not in capsys.readouterr().err
+
     def test_soft_staff_error_skips_that_team(self, monkeypatch, capsys):
         import urllib.error
 
@@ -2612,6 +2639,13 @@ class TestCommitWalkEarlyStop:
 
 
 class TestMain:
+    @pytest.fixture(autouse=True)
+    def _no_team_members(self, monkeypatch):
+        # These tests stub collect_classroom and exercise main()'s plumbing; the
+        # grant pass still reads the student team (it now targets derived staff
+        # teams even without a `teams` block), so keep that read off the network.
+        stub_team_members(monkeypatch, [])
+
     def test_api_url_prefers_explicit_override_then_actions_value(
         self, tmp_path, monkeypatch
     ):
@@ -2928,6 +2962,7 @@ class TestDetectedPersistence:
         monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
         monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
         monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
+        stub_team_members(monkeypatch, [])  # keep the grant pass off the network
 
     def _seed(self, tmp_path, detected):
         path = tmp_path / "cs-principles" / "scores.json"
@@ -3013,6 +3048,7 @@ class TestCollectedAtStamp:
         monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
         monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
         monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
+        stub_team_members(monkeypatch, [])  # keep the grant pass off the network
 
     def test_utc_now_iso_matches_schema_shape(self):
         # The writer's stamp source must emit the schema's UTC-Z shape directly
@@ -3650,24 +3686,47 @@ class TestStaffTeamPermissions:
 
 
 class TestResolveStaffTeamSlugs:
-    def test_returns_present_roles_with_slugs(self):
+    def test_recorded_slugs_are_authoritative(self):
         meta = {
             "teams": {
-                "teacher": {"id": 1, "slug": "classroom50-cs-teacher"},
+                "teacher": {"id": 1, "slug": "classroom50-cs-teacher-1"},
                 "ta": {"id": 2, "slug": "classroom50-cs-ta"},
             }
         }
-        assert cs.resolve_staff_team_slugs(meta) == {
-            "teacher": "classroom50-cs-teacher",
-            "ta": "classroom50-cs-ta",
+        out = cs.resolve_staff_team_slugs(meta, "cs")
+        # A GitHub re-slug on collision (`-1`) is kept verbatim, never re-derived.
+        assert out["teacher"] == cs.StaffTeam("classroom50-cs-teacher-1", recorded=True)
+        assert out["ta"] == cs.StaffTeam("classroom50-cs-ta", recorded=True)
+
+    def test_missing_roles_fall_back_to_derived_slug(self):
+        # hta is absent from a `teams` block written before the role existed:
+        # the web creates + populates `classroom50-cs-hta` on first use without
+        # recording it, so the grant pass must still find it.
+        meta = {"teams": {"ta": {"id": 2, "slug": "classroom50-cs-ta"}}}
+        out = cs.resolve_staff_team_slugs(meta, "cs")
+        assert out["hta"] == cs.StaffTeam("classroom50-cs-hta", recorded=False)
+        assert out["teacher"] == cs.StaffTeam("classroom50-cs-teacher", recorded=False)
+        assert set(out) == set(cs.STAFF_ROLES)
+
+    def test_no_teams_block_derives_every_role(self):
+        out = cs.resolve_staff_team_slugs({}, "cs")
+        assert out == {
+            role: cs.StaffTeam(f"classroom50-cs-{role}", recorded=False)
+            for role in cs.STAFF_ROLES
         }
 
-    def test_no_teams_block_yields_empty(self):
-        assert cs.resolve_staff_team_slugs({}) == {}
-
-    def test_skips_role_without_slug(self):
+    def test_role_without_slug_falls_back(self):
         meta = {"teams": {"ta": {"id": 2}, "teacher": {"slug": "  "}}}
-        assert cs.resolve_staff_team_slugs(meta) == {}
+        out = cs.resolve_staff_team_slugs(meta, "cs")
+        assert out["ta"] == cs.StaffTeam("classroom50-cs-ta", recorded=False)
+        assert out["teacher"] == cs.StaffTeam("classroom50-cs-teacher", recorded=False)
+
+    def test_derived_slug_mirrors_go_contract(self):
+        # contract.StaffTeamSlug: ConfigRepoName + "-" + short + "-" + role.
+        assert cs.staff_team_slug("cs-principles", "hta") == "classroom50-cs-principles-hta"
+
+    def test_staff_roles_cover_every_grantable_role(self):
+        assert set(cs.STAFF_TEAM_PERMISSIONS) <= set(cs.STAFF_ROLES)
 
 
 class TestAssignmentTemplateRef:
@@ -3768,7 +3827,9 @@ class TestGrantClassroomTeamAccess:
 
     def test_grants_ta_pull_on_each_student_repo(self, monkeypatch):
         grants = self._capture_grants(monkeypatch)
-        monkeypatch.setattr(cs, "list_team_member_logins", lambda *a, **k: ["alice", "bob"])
+        stub_team_members_by_slug(
+            monkeypatch, {"classroom50-cs": ["alice", "bob"], "classroom50-cs-ta": ["ta1"]}
+        )
         cs.grant_classroom_team_access(
             api_url="https://api.github.com", org="cs50", classroom_short="cs",
             classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
@@ -3780,23 +3841,54 @@ class TestGrantClassroomTeamAccess:
         assert len([g for g in grants if g[2].startswith("cs-")]) == 4
         assert all(team == "classroom50-cs-ta" and perm == "pull" for team, _, _, perm in grants)
 
-    def test_no_teams_block_is_noop(self, monkeypatch):
+    def test_no_teams_block_grants_via_derived_slugs(self, monkeypatch):
+        # A legacy classroom.json with no `teams` block: the pass still targets
+        # the derived hta/ta teams, so a TA the web put on `classroom50-cs-ta`
+        # is granted even though nothing recorded that team.
         grants = self._capture_grants(monkeypatch)
-        called = {"members": False}
-
-        def fake_members(*a, **k):
-            called["members"] = True
-            return ["alice"]
-
-        monkeypatch.setattr(cs, "list_team_member_logins", fake_members)
+        stub_team_members_by_slug(
+            monkeypatch,
+            {"classroom50-cs": ["alice"], "classroom50-cs-ta": ["ta1"]},
+        )
         cs.grant_classroom_team_access(
             api_url="https://api.github.com", org="cs50", classroom_short="cs",
             classroom_meta={"schema": cs.CLASSROOM_SCHEMA_V1, "short_name": "cs"},
             assignments=self.ASSIGNMENTS, service_token="tok",
         )
-        assert grants == []
-        # No team block => no membership read either (fully short-circuited).
-        assert called["members"] is False
+        assert {team for team, _, _, _ in grants} == {"classroom50-cs-ta"}
+
+    def test_derived_team_404_is_quiet_recorded_team_404_warns(self, monkeypatch, capsys):
+        # A derived team that doesn't exist is expected (nothing said it would);
+        # a RECORDED team that 404s is a real inconsistency worth a warning.
+        grants = self._capture_grants(monkeypatch)
+
+        def fake_members(api_url, org, team_slug, token):
+            if team_slug == "classroom50-cs":
+                return ["alice"]
+            if team_slug == "classroom50-cs-hta":
+                return ["prof"]
+            raise cs.urllib.error.HTTPError(url="u", code=404, msg="no", hdrs=None, fp=None)
+
+        monkeypatch.setattr(cs, "list_team_member_logins", fake_members)
+        # ta is recorded (and 404s); hta is derived and populated.
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
+        )
+        err = capsys.readouterr().err
+        assert "could not read staff team 'classroom50-cs-ta'" in err
+        assert {team for team, _, _, _ in grants} == {"classroom50-cs-hta"}
+
+        capsys.readouterr()
+        grants.clear()
+        # Now nothing recorded: the derived ta 404 must not warn at all.
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta={"schema": cs.CLASSROOM_SCHEMA_V1, "short_name": "cs"},
+            assignments=self.ASSIGNMENTS, service_token="tok",
+        )
+        assert "::warning::" not in capsys.readouterr().err
+        assert {team for team, _, _, _ in grants} == {"classroom50-cs-hta"}
 
     def test_grants_private_in_org_template_skips_public_and_out_of_org(self, monkeypatch):
         grants = self._capture_grants(monkeypatch)
@@ -3914,6 +4006,73 @@ class TestGrantClassroomTeamAccess:
         assert grants == []
         assert known_read["hit"] is False  # no bulk read for an empty team
 
+    def test_no_populated_staff_team_warns_instead_of_silent_success(self, monkeypatch, capsys):
+        # Discussion #768: every TA was promoted, leaving the ta team empty, and
+        # the hta team was never recorded and doesn't exist. The pass grants
+        # nothing, which used to look exactly like a healthy run. It must say so.
+        grants = self._capture_grants(monkeypatch)
+
+        def fake_members(api_url, org, team_slug, token):
+            if team_slug == "classroom50-cs":
+                return ["alice", "bob"]
+            if team_slug == "classroom50-cs-ta":
+                return []
+            raise cs.urllib.error.HTTPError(url="u", code=404, msg="no", hdrs=None, fp=None)
+
+        monkeypatch.setattr(cs, "list_team_member_logins", fake_members)
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
+        )
+        assert grants == []
+        out, err = capsys.readouterr()
+        assert "::warning::cs: no staff access was granted" in err
+        assert "classroom50-cs-ta" in err and "classroom50-cs-hta" in err
+        assert "gh teacher staff add cs50 cs" in err
+        # Per-team reasons on stdout so the log explains the verdict.
+        assert "'classroom50-cs-ta' (ta) has no members" in out
+        assert "no hta team recorded" in out
+
+    def test_no_warning_when_some_staff_team_is_populated(self, monkeypatch, capsys):
+        grants = self._capture_grants(monkeypatch)
+        stub_team_members_by_slug(
+            monkeypatch,
+            {"classroom50-cs": ["alice"], "classroom50-cs-ta": [], "classroom50-cs-hta": ["prof"]},
+        )
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta=self.META_TA_HTA, assignments=self.ASSIGNMENTS, service_token="tok",
+        )
+        assert grants
+        assert "::warning::" not in capsys.readouterr().err
+
+    def test_no_targets_does_not_warn_about_staff(self, monkeypatch, capsys):
+        # Nobody has accepted and there is no private template: there is nothing
+        # to grant, which is not a staffing problem.
+        self._capture_grants(monkeypatch)
+        stub_team_members_by_slug(monkeypatch, {"classroom50-cs": [], "classroom50-cs-ta": []})
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
+        )
+        assert "::warning::" not in capsys.readouterr().err
+
+    def test_populated_team_always_prints_a_summary_line(self, monkeypatch, capsys):
+        # An idempotent re-run grants nothing new; the log still names the team
+        # so "no output" never means "no staff access".
+        monkeypatch.setattr(cs, "known_team_repos", lambda *a, **k: None)
+        monkeypatch.setattr(cs, "grant_team_repo", lambda *a, **k: False)
+        stub_team_members_by_slug(
+            monkeypatch, {"classroom50-cs": ["alice"], "classroom50-cs-ta": ["ta1"]}
+        )
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
+        )
+        out, err = capsys.readouterr()
+        assert "cs: classroom50-cs-ta needed no new pull grant (2 target repo(s) checked)" in out
+        assert "::warning::" not in err
+
     def test_empty_team_skip_is_per_slug_not_all_or_nothing(self, monkeypatch):
         # ta is empty, hta is populated: the hta team still gets its grants.
         grants = self._capture_grants(monkeypatch)
@@ -3934,7 +4093,8 @@ class TestGrantClassroomTeamAccess:
 
     def test_non_404_skippable_staff_read_skips_that_team(self, monkeypatch, capsys):
         # A 422 (not 401/403/599/throttle) reading staff membership is SKIPPABLE:
-        # skip that team for the run without failing, and don't grant.
+        # skip that team for the run without failing, and don't grant it. The
+        # other staff team is unaffected.
         grants = self._capture_grants(monkeypatch)
 
         def fake_members(api_url, org, team_slug, token):
@@ -3947,7 +4107,7 @@ class TestGrantClassroomTeamAccess:
             api_url="https://api.github.com", org="cs50", classroom_short="cs",
             classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
         )
-        assert grants == []
+        assert {team for team, _, _, _ in grants} == {"classroom50-cs-hta"}
         assert "::warning::" in capsys.readouterr().err
 
     def test_hard_error_on_staff_read_propagates(self, monkeypatch):
@@ -4000,7 +4160,7 @@ class TestGrantClassroomTeamAccess:
             api_url="https://api.github.com", org="cs50", classroom_short="cs",
             classroom_meta=self.META, assignments=self.ASSIGNMENTS, service_token="tok",
         )
-        assert grants == []
+        assert "classroom50-cs-ta" not in {team for team, _, _, _ in grants}
         assert "::warning::" in capsys.readouterr().err
 
     # --- per-assignment scoping (change 2) ---
@@ -4408,7 +4568,9 @@ class TestPassesSkipMissingRepos:
     ASSIGNMENTS = TestGrantThrottled.ASSIGNMENTS
 
     def test_grant_pass_only_touches_existing_repos(self, monkeypatch):
-        monkeypatch.setattr(cs, "list_team_member_logins", lambda *a, **k: ["alice", "bob"])
+        stub_team_members_by_slug(
+            monkeypatch, {"classroom50-cs": ["alice", "bob"], "classroom50-cs-ta": ["ta1"]}
+        )
         monkeypatch.setattr(cs, "known_team_repos", lambda *a, **k: None)
         seen: list[str] = []
 

--- a/cli/gh-teacher/skeleton_tests/test_probe_token.py
+++ b/cli/gh-teacher/skeleton_tests/test_probe_token.py
@@ -246,14 +246,25 @@ def test_team_members_403_fails(monkeypatch):
 # Scope checks — staff-team visibility (collect-time grant target) ------------
 
 
-def test_resolve_staff_team_slugs_present_and_absent():
-    meta = {"teams": {"ta": {"id": 2, "slug": "classroom50-cs1-ta"}, "teacher": {"id": 1, "slug": "classroom50-cs1-teacher"}}}
-    assert pt.resolve_staff_team_slugs(meta) == {
-        "ta": "classroom50-cs1-ta",
+def test_resolve_staff_team_slugs_recorded_and_derived():
+    meta = {"teams": {"ta": {"id": 2, "slug": "classroom50-cs1-ta-1"}, "teacher": {"id": 1, "slug": "classroom50-cs1-teacher"}}}
+    # Recorded slugs win verbatim; the unrecorded hta falls back to the derived
+    # slug, mirroring collect_scores.py so the probe reads what the grant targets.
+    assert pt.resolve_staff_team_slugs(meta, "cs1") == {
+        "ta": "classroom50-cs1-ta-1",
         "teacher": "classroom50-cs1-teacher",
+        "hta": "classroom50-cs1-hta",
     }
-    assert pt.resolve_staff_team_slugs({}) == {}
-    assert pt.resolve_staff_team_slugs({"teams": {"ta": {"id": 2}}}) == {}
+    assert pt.resolve_staff_team_slugs({}, "cs1") == {
+        role: f"classroom50-cs1-{role}" for role in pt.STAFF_ROLES
+    }
+    assert pt.resolve_staff_team_slugs({"teams": {"ta": {"id": 2}}}, "cs1")["ta"] == "classroom50-cs1-ta"
+
+
+def test_staff_roles_mirror_collect_scores():
+    from conftest import collect_scores as cs
+
+    assert pt.STAFF_ROLES == cs.STAFF_ROLES
 
 
 def test_staff_team_visible_ok(monkeypatch):

--- a/web/src/github-core/mutations.test.ts
+++ b/web/src/github-core/mutations.test.ts
@@ -760,6 +760,109 @@ describe("validateServiceToken", () => {
       /Enter a token/,
     )
   })
+
+  // The "All repositories" probe (discussion #768): a token scoped to selected
+  // repositories reads classroom50 fine and 404s on every student repo. With
+  // the teacher's client supplied, the token must also read one other private
+  // org repo; only a 404 there is a verdict.
+  describe("repository access probe", () => {
+    const okToken = (probeResult: () => Promise<unknown>) =>
+      mockTokenClient((path) => {
+        if (path === "/repos/acme/classroom50") {
+          return Promise.resolve({ permissions: { push: true, admin: true } })
+        }
+        if (path === "/orgs/acme/members?per_page=1") {
+          return Promise.resolve([])
+        }
+        if (path === "/repos/acme/cs-hw1-alice") return probeResult()
+        throw new Error(`unexpected path ${path}`)
+      })
+    const teacherWith = (repos: { name: string }[] | Error) => {
+      const request = vi.fn().mockImplementation((path: string) => {
+        expect(path).toMatch(/^\/orgs\/acme\/repos\?type=private/)
+        return repos instanceof Error
+          ? Promise.reject(repos)
+          : Promise.resolve(repos)
+      })
+      return { request } as unknown as ReturnType<typeof createGitHubClient>
+    }
+
+    it("passes when the token reads another private repo", async () => {
+      const request = okToken(() => Promise.resolve({ name: "cs-hw1-alice" }))
+      await expect(
+        validateServiceToken(
+          "github_pat_x",
+          "acme",
+          teacherWith([{ name: "classroom50" }, { name: "cs-hw1-alice" }]),
+        ),
+      ).resolves.toBeUndefined()
+      expect(request).toHaveBeenCalledWith("/repos/acme/cs-hw1-alice")
+    })
+
+    it("rejects a token scoped to selected repositories (404 on another repo)", async () => {
+      okToken(() => Promise.reject(apiError(404)))
+      await expect(
+        validateServiceToken(
+          "github_pat_x",
+          "acme",
+          teacherWith([{ name: "classroom50" }, { name: "cs-hw1-alice" }]),
+        ),
+      ).rejects.toThrow(/All repositories.*|acme\/cs-hw1-alice/)
+    })
+
+    it("never probes with classroom50 itself, whatever its casing", async () => {
+      const request = okToken(() => Promise.resolve({}))
+      await expect(
+        validateServiceToken(
+          "github_pat_x",
+          "acme",
+          teacherWith([{ name: "Classroom50" }]),
+        ),
+      ).resolves.toBeUndefined()
+      // Only the baseline config-repo read and members probe ran; no third
+      // read against the config repo under another casing.
+      expect(request).toHaveBeenCalledTimes(2)
+      expect(request).not.toHaveBeenCalledWith("/repos/acme/Classroom50")
+    })
+
+    it("has nothing to prove when the org has no other private repo", async () => {
+      const request = okToken(() => Promise.reject(apiError(404)))
+      await expect(
+        validateServiceToken("github_pat_x", "acme", teacherWith([])),
+      ).resolves.toBeUndefined()
+      expect(request).not.toHaveBeenCalledWith("/repos/acme/cs-hw1-alice")
+    })
+
+    it("is inconclusive when the teacher's listing fails or the probe 403s/500s", async () => {
+      okToken(() => Promise.reject(apiError(404)))
+      await expect(
+        validateServiceToken(
+          "github_pat_x",
+          "acme",
+          teacherWith(new TypeError("Failed to fetch")),
+        ),
+      ).resolves.toBeUndefined()
+
+      for (const status of [403, 500]) {
+        okToken(() => Promise.reject(apiError(status)))
+        await expect(
+          validateServiceToken(
+            "github_pat_x",
+            "acme",
+            teacherWith([{ name: "cs-hw1-alice" }]),
+          ),
+        ).resolves.toBeUndefined()
+      }
+    })
+
+    it("skips the probe entirely without a teacher client", async () => {
+      const request = okToken(() => Promise.reject(apiError(404)))
+      await expect(
+        validateServiceToken("github_pat_x", "acme"),
+      ).resolves.toBeUndefined()
+      expect(request).toHaveBeenCalledTimes(2)
+    })
+  })
 })
 
 // gitBlobSha must match `git hash-object` so a skeleton file's bundled content

--- a/web/src/github-core/mutations/secrets.ts
+++ b/web/src/github-core/mutations/secrets.ts
@@ -38,11 +38,14 @@ export async function encryptSecret(publicKey: string, secret: string) {
  *
  * Caveat: GET /repos/{org}/classroom50 proves access to the config repo, not the
  * student repos the workflows touch (fine-grained PATs don't expose their repo
- * selection via the API). Hence the UI requires "All repositories".
+ * selection via the API). Hence the UI requires "All repositories", and when
+ * `teacherClient` is supplied the token is also made to read one other private
+ * org repo (see assertTokenReachesOtherRepos).
  */
 export async function validateServiceToken(
   token: string,
   org: string | undefined,
+  teacherClient?: GitHubClient,
 ) {
   if (!org) throw new Error("org must be specified to validate a service token")
 
@@ -158,6 +161,49 @@ export async function validateServiceToken(
     }
     // Inconclusive (401/5xx/network) — proceed; the repo read already proved the
     // token valid.
+  }
+
+  if (teacherClient) {
+    await assertTokenReachesOtherRepos(tokenClient, teacherClient, org)
+  }
+}
+
+// The config-repo read proves nothing about the student repos: a token scoped
+// to "Only select repositories" (with classroom50 selected) passes every check
+// above, then 404s on every student repo, which surfaces weeks later as a
+// collect-time 403 on the first staff-team grant. The teacher's own client
+// picks a private org repo other than classroom50 (one they can see, so a token
+// they own with All repositories sees it too) and the token reads it. Only a
+// 404 is a verdict; no other private repo means nothing to prove, and any other
+// failure is inconclusive (the probe-token workflow is the exhaustive check).
+async function assertTokenReachesOtherRepos(
+  tokenClient: GitHubClient,
+  teacherClient: GitHubClient,
+  org: string,
+) {
+  let repos: { name: string }[]
+  try {
+    repos = await teacherClient.request<{ name: string }[]>(
+      `/orgs/${encodeURIComponent(org)}/repos?type=private&sort=created&direction=asc&per_page=10`,
+    )
+  } catch {
+    return
+  }
+  const probe = repos.find(
+    (r) => r.name.toLowerCase() !== CONFIG_REPO.toLowerCase(),
+  )
+  if (!probe) return
+  try {
+    await tokenClient.request(
+      `/repos/${encodeURIComponent(org)}/${encodeURIComponent(probe.name)}`,
+    )
+  } catch (err) {
+    if (err instanceof GitHubAPIError && err.status === 404) {
+      throw new Error(
+        `This token can read ${org}/${CONFIG_REPO} but not ${org}/${probe.name}, so its Repository access is limited to selected repositories (or its Resource owner isn't ${org}). Collecting scores reads every student repository and grants staff teams access to them. Create the token again with Resource owner = ${org} and Repository access = All repositories, keeping the same permissions.`,
+        { cause: err },
+      )
+    }
   }
 }
 

--- a/web/src/hooks/mutations/useSaveServiceToken.test.ts
+++ b/web/src/hooks/mutations/useSaveServiceToken.test.ts
@@ -62,6 +62,22 @@ describe("useSaveServiceToken", () => {
     expect(seeded?.secretName).toBe("CLASSROOM50_SERVICE_TOKEN")
   })
 
+  it("hands the teacher's client to validation so the repo-access probe can run", async () => {
+    const queryClient = freshClient()
+    const { result } = renderHook(() => useSaveServiceToken(ORG), {
+      wrapper: wrapperWith(queryClient),
+    })
+
+    result.current.mutate({ serviceToken: "ghp_token" })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(validateServiceToken).toHaveBeenCalledWith(
+      "ghp_token",
+      ORG,
+      expect.objectContaining({ request: expect.any(Function) }),
+    )
+  })
+
   it("uses the same key useGetServiceTokenStatus reads, defaulting a missing org to ''", async () => {
     const queryClient = freshClient()
     const { result } = renderHook(() => useSaveServiceToken(undefined), {

--- a/web/src/hooks/mutations/useSaveServiceToken.ts
+++ b/web/src/hooks/mutations/useSaveServiceToken.ts
@@ -52,7 +52,7 @@ export function useSaveServiceToken(org: string | undefined) {
       expiresInDays,
       tokenName,
     }: SaveServiceTokenInput) => {
-      await validateServiceToken(serviceToken, org)
+      await validateServiceToken(serviceToken, org, client)
       await putRepoSecret(
         client,
         org,


### PR DESCRIPTION
## Summary

Follows up on [discussion #768](https://github.com/foundation50/classroom50/discussions/768) (TAs have no access to student repositories) and the TA side of [#677](https://github.com/foundation50/classroom50/discussions/677). The reporter's collect run first failed with a 403 on the staff-team grant, then "succeeded" after every TA was promoted to head TA, and the TAs still had no access. Three things in the code let that happen, and this PR fixes them.

**1. The grant pass could exit 0 having granted nothing.** `grant_classroom_team_access` skipped an empty staff team and a missing `teams` role silently, so "the TA team is empty and the HTA team isn't recorded" produced the same output as a healthy run. The pass now prints a line per staff team (granted N, needed no new grant, has no members, or not recorded and absent on GitHub) and emits a `::warning::` when student repos exist but no head-TA or TA team has members, naming the team slugs and the roster page / `gh teacher staff add` fix.

**2. `resolve_staff_team_slugs` had no derived-slug fallback.** The student team falls back to `classroom50-<short>` when `classroom.json` lacks a slug, and the web falls back to `classroom50-<short>-<role>` for staff teams, but the script returned `{}` for any role not recorded under `teams`. A classroom whose `teams` block predates the `hta` role (or was never written) therefore had its HTA team created and populated by the web, and collect never granted to it. The script (and `probe_token.py`, which mirrors it) now derives the slug for every role in `STAFF_ROLES` when it isn't recorded; a recorded slug stays authoritative. A 404 on a derived team is quiet (nothing said it would exist), a 404 on a recorded team still warns. `list_enrolled_logins` gets the same treatment, so an unrecorded head TA who accepted an assignment is polled.

**3. Token validation couldn't tell "All repositories" from "Only select repositories".** Both the web and CLI validators assert `permissions.admin` on `org/classroom50` only, so a PAT scoped to just that repo passed and then 403'd on every student repo at collect time, which matches the reporter rotating the token and still failing. The web `validateServiceToken` now takes the teacher's client, picks a private org repo other than `classroom50` from their listing, and reads it as the pasted token; the CLI's `ValidateTokenVerbose` does the same with the caller's client. Only a 404 there rejects the token (with a message naming the unreadable repo and the All repositories fix); no other private repo means nothing to prove, and any other failure is inconclusive and warns toward the probe-token workflow. The collect 403 hint and the `rotate-service-token` help now mention Repository access as well as Administration.

Not in this PR (tracked separately): persisting a lazily created staff team ref into `classroom.json` from the web, and the owner-side assignments-list vs Submissions-page count mismatch from #677.

Orgs pick up the new scripts through the existing skeleton drift banner / `gh teacher init` refresh.

## Test plan

- [x] `python3 -m pytest cli/gh-teacher/skeleton_tests` (959 pass; new: derived vs recorded slug resolution and Go-contract slug parity, quiet derived-404 vs warning recorded-404 in both the grant pass and enrolled-login polling, the no-populated-team warning with its per-team reasons, no warning when a team is populated or there are no targets, always-present per-team summary line, legacy `classroom.json` without `teams` grants via the derived TA team; probe_token mirror and `STAFF_ROLES` parity)
- [x] `python3 -m pytest cli/gh-teacher/autograders_tests` (430 pass), `ruff check --select E4,E7,E9,F` on the scripts
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run`, `golangci-lint fmt --diff` in `cli/gh-teacher` (new `TestValidateRepoScope`: all-repositories pass, selected-repositories 404 rejection, config repo never used as the probe, nothing to prove with no other private repo, inconclusive on listing failure / probe 403 / 5xx)
- [x] `npm run check` in `web/` (tsc, eslint, prettier, arch:validate, 380 files / 4950 tests; new `validateServiceToken` repository-access probe cases and the hook handing over the teacher client)
- [ ] Manual: on a dev org, set a token with Repository access = Only select repositories (classroom50 selected) in Settings → Service token and confirm it is rejected with the All repositories message; set an All repositories token and confirm it saves
- [ ] Manual: on a dev org, empty the TA team, run Collect scores, and confirm the run log shows the "no staff access was granted" warning