### PR TITLE
feat(web): add a Test token button to the service token settings

### DIFF
--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -105,8 +105,10 @@ export {
 export {
   triggerScoreCollection,
   triggerRegrade,
+  triggerProbeToken,
   rerunFailedRun,
   CollectInputsUnsupportedError,
+  ProbeWorkflowMissingError,
 } from "./mutations/workflowDispatch"
 export {
   addRepoCollaborator,

--- a/web/src/github-core/mutations/workflowDispatch.test.ts
+++ b/web/src/github-core/mutations/workflowDispatch.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from "vitest"
 import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
 import {
   CollectInputsUnsupportedError,
+  ProbeWorkflowMissingError,
+  triggerProbeToken,
   triggerScoreCollection,
 } from "./workflowDispatch"
 import type { GitHubClient } from "../client"
@@ -288,5 +290,80 @@ describe("triggerScoreCollection display-name inputs", () => {
       ),
     ).rejects.toBeInstanceOf(GitHubAPIError)
     expect(dispatchBodies(request)).toHaveLength(1)
+  })
+})
+
+const notFound = () =>
+  new GitHubAPIError({
+    status: 404,
+    url: "https://api.github.com/x",
+    message: "Not Found",
+    body: { message: "Not Found" },
+    rateLimit: noRateLimit,
+  })
+
+// The probe has no inputs, so the only dispatch-side failure worth naming is
+// the workflow itself being absent from the org's classroom50 repo.
+describe("triggerProbeToken", () => {
+  it("dispatches probe-token.yaml with just the ref and returns the baseline", async () => {
+    const { client, request } = makeClient(() => ({}))
+
+    const result = await triggerProbeToken(client, "acme")
+
+    expect(result.sinceRunId).toBe(41)
+    const dispatchCall = request.mock.calls.find(([url]) =>
+      (url as string).endsWith("/dispatches"),
+    )
+    expect(dispatchCall?.[0]).toContain("/actions/workflows/probe-token.yaml/")
+    expect(dispatchCall?.[1]).toEqual({ method: "POST", body: { ref: "main" } })
+  })
+
+  it("maps a 404 on the dispatch to ProbeWorkflowMissingError", async () => {
+    const { client } = makeClient(() => {
+      throw notFound()
+    })
+    await expect(triggerProbeToken(client, "acme")).rejects.toBeInstanceOf(
+      ProbeWorkflowMissingError,
+    )
+  })
+
+  it("maps a 404 on the baseline runs read to ProbeWorkflowMissingError", async () => {
+    // GitHub 404s the runs listing of a workflow file that doesn't exist, so
+    // the verdict is known before any POST is attempted.
+    const request = vi.fn<(url: string) => Promise<unknown>>((url) => {
+      if (url.endsWith("/repos/acme/classroom50")) {
+        return Promise.resolve({ default_branch: "main" })
+      }
+      if (url.includes("/runs?")) return Promise.reject(notFound())
+      return Promise.resolve({})
+    })
+    const client = { request } as unknown as GitHubClient
+
+    await expect(triggerProbeToken(client, "acme")).rejects.toBeInstanceOf(
+      ProbeWorkflowMissingError,
+    )
+    expect(
+      request.mock.calls.some(([url]) => url.endsWith("/dispatches")),
+    ).toBe(false)
+  })
+
+  it("leaves other dispatch failures untouched", async () => {
+    const { client } = makeClient(() => {
+      throw new GitHubAPIError({
+        status: 403,
+        url: "https://api.github.com/x",
+        message: "Forbidden",
+        body: null,
+        rateLimit: noRateLimit,
+      })
+    })
+    const err = await triggerProbeToken(client, "acme").catch((e) => e)
+    expect(err).toBeInstanceOf(GitHubAPIError)
+    expect(err).not.toBeInstanceOf(ProbeWorkflowMissingError)
+  })
+
+  it("requires an org", async () => {
+    const { client } = makeClient(() => ({}))
+    await expect(triggerProbeToken(client, undefined)).rejects.toThrow(/org/)
   })
 })

--- a/web/src/github-core/mutations/workflowDispatch.ts
+++ b/web/src/github-core/mutations/workflowDispatch.ts
@@ -1,11 +1,28 @@
 import type { GitHubClient } from "../client"
-import { is422UnexpectedInputs } from "../errors"
+import { GitHubAPIError, is422UnexpectedInputs } from "../errors"
 import { getRepo } from "../repoReads"
-import { COLLECT_SCORES_WORKFLOW, REGRADE_WORKFLOW } from "../workflows"
+import {
+  COLLECT_SCORES_WORKFLOW,
+  PROBE_TOKEN_WORKFLOW,
+  REGRADE_WORKFLOW,
+} from "../workflows"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { logger } from "@/lib/logger"
 
 const logWorkflows = logger.scope("github:workflows")
+
+// The org's classroom50 repo has no probe-token.yaml (its skeleton predates the
+// workflow), so GitHub 404'd the workflow. The view maps this to "update the
+// workflow files first" rather than a generic dispatch failure.
+export class ProbeWorkflowMissingError extends Error {
+  constructor(cause: unknown) {
+    super(
+      "probe-token.yaml is not in the config repo; the org's workflow files are out of date",
+    )
+    this.name = "ProbeWorkflowMissingError"
+    this.cause = cause
+  }
+}
 
 // The org's collect-scores.yaml predates the `assignment` dispatch input, so
 // GitHub rejected the scoped dispatch with a 422 ("Unexpected inputs"). The
@@ -193,6 +210,52 @@ export async function triggerRegrade(
     owner: owner ?? "(all)",
     sinceRunId,
   })
+  return { sinceRunId }
+}
+
+/**
+ * Dispatches the classroom50 repo's `probe-token.yaml` workflow, the read-only
+ * check that exercises every scope the service token needs. No inputs.
+ *
+ * Returns `sinceRunId` like the other dispatchers so the caller can bind to its
+ * own run. A 404 on the workflow (baseline read or dispatch) means the org's
+ * skeleton predates probe-token.yaml and surfaces as ProbeWorkflowMissingError.
+ */
+export async function triggerProbeToken(
+  client: GitHubClient,
+  org: string | undefined,
+): Promise<{ sinceRunId: number | null }> {
+  if (!org) throw new Error("org must be specified to probe the service token")
+
+  const workflowBase = `/repos/${org}/${CONFIG_REPO}/actions/workflows/${PROBE_TOKEN_WORKFLOW}`
+  const rethrowMissingWorkflow = (err: unknown): never => {
+    if (err instanceof GitHubAPIError && err.isNotFound) {
+      throw new ProbeWorkflowMissingError(err)
+    }
+    throw err
+  }
+
+  const [repo, baseline] = await Promise.all([
+    getRepo(client, org, CONFIG_REPO),
+    client
+      .request<{ workflow_runs: { id: number }[] }>(
+        `${workflowBase}/runs?event=workflow_dispatch&per_page=1`,
+      )
+      .catch(rethrowMissingWorkflow),
+  ])
+  if (!repo) {
+    throw new Error(
+      `${org}/${CONFIG_REPO} not found; run setup for this org first`,
+    )
+  }
+  const ref = repo.default_branch || DEFAULT_BRANCH
+  const sinceRunId = baseline.workflow_runs?.[0]?.id ?? null
+
+  await client
+    .request(`${workflowBase}/dispatches`, { method: "POST", body: { ref } })
+    .catch(rethrowMissingWorkflow)
+
+  logWorkflows.info("dispatched probe-token", { org, sinceRunId })
   return { sinceRunId }
 }
 

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -128,6 +128,8 @@ export {
   getServiceTokenStatus,
   getCollectScoresRunAfterId,
   getRegradeRunAfterId,
+  getProbeTokenRunAfterId,
+  getRunAnnotations,
   getLastCollectScoresRun,
   SERVICE_TOKEN_SECRET_NAME,
   SERVICE_TOKEN_EXPIRES_AT_VAR,
@@ -136,4 +138,5 @@ export {
   classifyServiceTokenExpiry,
   type ServiceTokenStatus,
   type ServiceTokenExpiry,
+  type RunAnnotation,
 } from "./queries/releaseRunReads"

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -184,6 +184,18 @@ export const githubKeys = {
   serviceToken: (owner: string) =>
     [...githubKeys.all, "serviceToken", owner] as const,
 
+  // The probe-token dispatch tracker; sinceRunId binds the poll to one dispatch.
+  probeTokenRun: (owner: string, sinceRunId: number | null) =>
+    [
+      ...githubKeys.all,
+      "probe-token-run",
+      owner,
+      sinceRunId ?? "none",
+    ] as const,
+
+  runAnnotations: (owner: string, runId: number) =>
+    [...githubKeys.all, "run-annotations", owner, runId] as const,
+
   skeletonDrift: (owner: string) =>
     [...githubKeys.all, "skeletonDrift", owner] as const,
 

--- a/web/src/github-core/queries/releaseRunReads.test.ts
+++ b/web/src/github-core/queries/releaseRunReads.test.ts
@@ -5,6 +5,7 @@ import {
   classifyServiceTokenExpiry,
   getCollectScoresRunAfterId,
   getLastCollectScoresRun,
+  getRunAnnotations,
   getServiceTokenStatus,
   latestSubmitReleaseAndCount,
   latestSubmitReleaseWithAssets,
@@ -327,5 +328,64 @@ describe("getLastCollectScoresRun", () => {
     expect(run?.id).toBe(5)
     const url = String(request.mock.calls[0][0])
     expect(url).toContain("status=success")
+  })
+})
+
+// A run's workflow-command annotations (`::error::` etc.) hang off each job's
+// check run, so the read is the jobs list followed by one annotations call per
+// job. The probe-token verdict is delivered this way.
+describe("getRunAnnotations", () => {
+  const clientWith = (
+    jobs: { id: number }[],
+    annotations: Record<
+      number,
+      { annotation_level: string; message: string | null }[]
+    >,
+  ) => {
+    const request = vi.fn((url: string) => {
+      if (url.includes("/actions/runs/77/jobs")) {
+        return Promise.resolve({ jobs })
+      }
+      const m = /check-runs\/(\d+)\/annotations/.exec(url)
+      if (m) return Promise.resolve(annotations[Number(m[1])] ?? [])
+      return Promise.reject(new Error(`unexpected ${url}`))
+    })
+    return { client: { request } as unknown as GitHubClient, request }
+  }
+
+  it("flattens every job's annotations in job order and normalizes the level", async () => {
+    const { client, request } = clientWith([{ id: 1 }, { id: 2 }], {
+      1: [{ annotation_level: "notice", message: "probe PASSED" }],
+      2: [
+        { annotation_level: "failure", message: "  probe FAILED: 2 checks  " },
+        { annotation_level: "warning", message: "slow" },
+        { annotation_level: "weird", message: "?" },
+      ],
+    })
+
+    const out = await getRunAnnotations(client, "acme", 77)
+
+    expect(out).toEqual([
+      { level: "notice", message: "probe PASSED" },
+      { level: "failure", message: "probe FAILED: 2 checks" },
+      { level: "warning", message: "slow" },
+      { level: "notice", message: "?" },
+    ])
+    expect(String(request.mock.calls[0][0])).toContain(
+      "/repos/acme/classroom50/actions/runs/77/jobs",
+    )
+  })
+
+  it("drops annotations with no message and returns [] for a silent run", async () => {
+    const { client } = clientWith([{ id: 1 }], {
+      1: [
+        { annotation_level: "failure", message: null },
+        { annotation_level: "failure", message: "   " },
+      ],
+    })
+    expect(await getRunAnnotations(client, "acme", 77)).toEqual([])
+
+    const { client: noJobs } = clientWith([], {})
+    expect(await getRunAnnotations(noJobs, "acme", 77)).toEqual([])
   })
 })

--- a/web/src/github-core/queries/releaseRunReads.ts
+++ b/web/src/github-core/queries/releaseRunReads.ts
@@ -4,7 +4,11 @@ import type { GitHubClient } from "../client"
 import type { GitHubRelease, GitHubWorkflowRun } from "../types"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubAPIError, tolerateGitHubError } from "../errors"
-import { COLLECT_SCORES_WORKFLOW, REGRADE_WORKFLOW } from "../workflows"
+import {
+  COLLECT_SCORES_WORKFLOW,
+  PROBE_TOKEN_WORKFLOW,
+  REGRADE_WORKFLOW,
+} from "../workflows"
 import { githubKeys } from "./keys"
 
 // The submission-tag convention written by the autograde runner: each graded
@@ -372,6 +376,65 @@ export async function getRegradeRunAfterId(
     signal,
     REGRADE_WORKFLOW,
   )
+}
+
+export async function getProbeTokenRunAfterId(
+  client: GitHubClient,
+  org: string,
+  sinceRunId: number | null,
+  signal?: AbortSignal,
+): Promise<GitHubWorkflowRun | null> {
+  return getDispatchRunAfterId(
+    client,
+    org,
+    sinceRunId,
+    signal,
+    PROBE_TOKEN_WORKFLOW,
+  )
+}
+
+// One workflow-command annotation (`::error::`, `::warning::`, `::notice::`)
+// a run's job emitted, as GitHub attaches it to the job's check run.
+export type RunAnnotation = {
+  level: "failure" | "warning" | "notice"
+  message: string
+}
+
+// The annotations every job of a completed run emitted, in job order. Each
+// Actions job is a check run, so this is the jobs list followed by one
+// annotations read per job. Probe-token's verdict (the failed check names and
+// the fix) is delivered this way; a run that emitted none yields [].
+export async function getRunAnnotations(
+  client: GitHubClient,
+  org: string,
+  runId: number,
+  signal?: AbortSignal,
+): Promise<RunAnnotation[]> {
+  const repo = `/repos/${encodeURIComponent(org)}/${CONFIG_REPO}`
+  const { jobs } = await client.request<{ jobs: { id: number }[] }>(
+    `${repo}/actions/runs/${runId}/jobs?per_page=100`,
+    { method: "GET", signal },
+  )
+  const perJob = await Promise.all(
+    jobs.map((job) =>
+      client.request<{ annotation_level: string; message: string | null }[]>(
+        `${repo}/check-runs/${job.id}/annotations?per_page=100`,
+        {
+          method: "GET",
+          signal,
+        },
+      ),
+    ),
+  )
+  return perJob.flat().flatMap((a) => {
+    const message = a.message?.trim()
+    if (!message) return []
+    const level =
+      a.annotation_level === "failure" || a.annotation_level === "warning"
+        ? a.annotation_level
+        : "notice"
+    return [{ level, message }]
+  })
 }
 
 // The most recent *successful* collect-scores run (manual or scheduled), or null if

--- a/web/src/github-core/workflows.ts
+++ b/web/src/github-core/workflows.ts
@@ -5,3 +5,8 @@ export const COLLECT_SCORES_WORKFLOW = "collect-scores.yaml"
 // workflow. Grading then happens asynchronously inside the student repos, so a
 // follow-up collect-scores run refreshes the gradebook.
 export const REGRADE_WORKFLOW = "regrade.yaml"
+
+// The read-only service-token health check in <org>/classroom50. Dispatched
+// with no inputs; it exercises every scope the token needs and reports each as
+// a workflow annotation, which is how the settings page shows the result.
+export const PROBE_TOKEN_WORKFLOW = "probe-token.yaml"

--- a/web/src/hooks/useTestServiceToken.test.tsx
+++ b/web/src/hooks/useTestServiceToken.test.tsx
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { createElement, type PropsWithChildren } from "react"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) }
+})
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({}),
+}))
+
+const register = vi.fn()
+vi.mock("@/context/actions/ActionActivityProvider", () => ({
+  useActionActivityRegistry: () => ({ register }),
+}))
+
+const getRunAnnotations = vi.fn()
+vi.mock("@/github-core/queries", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/github-core/queries")>()
+  return {
+    ...actual,
+    getRunAnnotations: (...args: unknown[]) => getRunAnnotations(...args),
+  }
+})
+
+// The tracker primitive is driven by the test: each render reads the phase and
+// run the test placed here, so the hook's derived state can be pinned.
+type FakeOperation = {
+  phase: string
+  failure: "dispatch" | "run" | null
+  run: { id: number; html_url: string } | undefined
+  error: unknown
+}
+let operation: FakeOperation
+let capturedConfig: {
+  storageKey: string | null
+  resetKey: string
+  onDispatched?: (s: { sinceRunId: number | null }) => void
+}
+const trigger = vi.fn()
+vi.mock("@/hooks/useGitHubOperation", () => ({
+  useGitHubOperation: (config: typeof capturedConfig) => {
+    capturedConfig = config
+    return { trigger, ...operation }
+  },
+}))
+
+import useTestServiceToken from "./useTestServiceToken"
+
+const wrapper = ({ children }: PropsWithChildren) =>
+  createElement(
+    QueryClientProvider,
+    {
+      client: new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      }),
+    },
+    children,
+  )
+
+const idle: FakeOperation = {
+  phase: "idle",
+  failure: null,
+  run: undefined,
+  error: null,
+}
+
+describe("useTestServiceToken", () => {
+  it("keys tracking per org and registers the run with the banner", () => {
+    operation = idle
+    renderHook(() => useTestServiceToken("acme"), { wrapper })
+
+    expect(capturedConfig.storageKey).toBe("cl50:probe-token:acme")
+    expect(capturedConfig.resetKey).toBe("acme")
+
+    capturedConfig.onDispatched?.({ sinceRunId: 41 })
+    expect(register).toHaveBeenCalledWith({
+      org: "acme",
+      label: "actionsBanner.workflow.probeToken",
+      anchor: {
+        kind: "sinceRunId",
+        workflow: "probe-token.yaml",
+        sinceRunId: 41,
+      },
+    })
+  })
+
+  it("disables tracking without an org", () => {
+    operation = idle
+    renderHook(() => useTestServiceToken(undefined), { wrapper })
+    expect(capturedConfig.storageKey).toBeNull()
+  })
+
+  it("refuses a second dispatch while one is in flight", () => {
+    operation = { ...idle, phase: "running" }
+    const { result } = renderHook(() => useTestServiceToken("acme"), {
+      wrapper,
+    })
+    expect(result.current.inFlight).toBe(true)
+    result.current.test()
+    expect(trigger).not.toHaveBeenCalled()
+
+    operation = idle
+    const second = renderHook(() => useTestServiceToken("acme"), { wrapper })
+    second.result.current.test()
+    expect(trigger).toHaveBeenCalledTimes(1)
+  })
+
+  it("reads the run's annotations only once it has concluded", async () => {
+    getRunAnnotations.mockResolvedValue([
+      { level: "failure", message: "probe FAILED" },
+    ])
+    operation = {
+      phase: "running",
+      failure: null,
+      run: {
+        id: 77,
+        html_url: "https://github.com/acme/classroom50/actions/runs/77",
+      },
+      error: null,
+    }
+    const running = renderHook(() => useTestServiceToken("acme"), { wrapper })
+    expect(running.result.current.annotations).toBeUndefined()
+    expect(getRunAnnotations).not.toHaveBeenCalled()
+
+    operation = { ...operation, phase: "failed", failure: "run" }
+    const failed = renderHook(() => useTestServiceToken("acme"), { wrapper })
+    await waitFor(() =>
+      expect(failed.result.current.annotations).toEqual([
+        { level: "failure", message: "probe FAILED" },
+      ]),
+    )
+    expect(getRunAnnotations).toHaveBeenCalledWith(
+      expect.anything(),
+      "acme",
+      77,
+      expect.anything(),
+    )
+  })
+
+  it("does not read annotations for a rejected dispatch", () => {
+    getRunAnnotations.mockClear()
+    operation = {
+      phase: "failed",
+      failure: "dispatch",
+      run: undefined,
+      error: new Error("nope"),
+    }
+    const { result } = renderHook(() => useTestServiceToken("acme"), {
+      wrapper,
+    })
+    expect(result.current.annotations).toBeUndefined()
+    expect(getRunAnnotations).not.toHaveBeenCalled()
+  })
+
+  it("falls back to [] when the annotations read fails, so the run link still shows", async () => {
+    getRunAnnotations.mockRejectedValue(new Error("403"))
+    operation = {
+      phase: "completed",
+      failure: null,
+      run: {
+        id: 78,
+        html_url: "https://github.com/acme/classroom50/actions/runs/78",
+      },
+      error: null,
+    }
+    const { result } = renderHook(() => useTestServiceToken("acme"), {
+      wrapper,
+    })
+    await waitFor(() => expect(result.current.annotations).toEqual([]))
+  })
+})

--- a/web/src/hooks/useTestServiceToken.ts
+++ b/web/src/hooks/useTestServiceToken.ts
@@ -1,0 +1,95 @@
+import { useQuery } from "@tanstack/react-query"
+import { useTranslation } from "react-i18next"
+
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
+import { triggerProbeToken } from "@/github-core/mutations"
+import { PROBE_TOKEN_WORKFLOW } from "@/github-core/workflows"
+import {
+  getProbeTokenRunAfterId,
+  getRunAnnotations,
+  githubKeys,
+} from "@/github-core/queries"
+import { useGitHubOperation } from "./useGitHubOperation"
+
+// The probe is a handful of GETs, so a run that hasn't finished in a few
+// minutes is stuck in the Actions queue, not working.
+const PROBE_TIMEOUT_MS = 5 * 60 * 1000
+const PROBE_INTERVAL_MS = 4000
+const PROBE_BACKOFF_AFTER_MS = 45 * 1000
+const PROBE_BACKOFF_INTERVAL_MS = 12000
+
+/**
+ * Dispatches probe-token.yaml (the read-only service-token health check) and
+ * tracks the run via useGitHubOperation, then reads the finished run's
+ * annotations, which is where the probe reports which scope checks failed and
+ * how to fix them. Registers with the Actions banner like every dispatch.
+ */
+const useTestServiceToken = (org: string | undefined) => {
+  const client = useGitHubClient()
+  const { register } = useActionActivityRegistry()
+  const { t } = useTranslation()
+
+  const { trigger, phase, failure, run, error } = useGitHubOperation({
+    storageKey: org ? `cl50:probe-token:${org}` : null,
+    queryKey: (sinceRunId) => githubKeys.probeTokenRun(org ?? "", sinceRunId),
+    resetKey: org ?? "",
+    dispatch: () => triggerProbeToken(client, org),
+    findRun: (sinceRunId, signal) =>
+      getProbeTokenRunAfterId(client, org ?? "", sinceRunId, signal),
+    timeoutMs: PROBE_TIMEOUT_MS,
+    intervalMs: PROBE_INTERVAL_MS,
+    backoffAfterMs: PROBE_BACKOFF_AFTER_MS,
+    backoffIntervalMs: PROBE_BACKOFF_INTERVAL_MS,
+    onDispatched: (result) => {
+      if (!org) return
+      register({
+        org,
+        label: t("actionsBanner.workflow.probeToken"),
+        anchor: {
+          kind: "sinceRunId",
+          workflow: PROBE_TOKEN_WORKFLOW,
+          sinceRunId: result.sinceRunId,
+        },
+      })
+    },
+  })
+
+  // Annotations exist only once the run has concluded; a run that passed emits
+  // a single notice, a failed one the error naming the checks that did not pass.
+  const finished =
+    phase === "completed" || (phase === "failed" && failure === "run")
+  const annotations = useQuery({
+    queryKey: githubKeys.runAnnotations(org ?? "", run?.id ?? 0),
+    queryFn: ({ signal }) =>
+      getRunAnnotations(client, org ?? "", run?.id ?? 0, signal),
+    enabled: Boolean(org && run?.id && finished),
+    staleTime: Infinity,
+    // The run link is the fallback, so a failed read isn't worth retrying.
+    retry: false,
+  })
+
+  const inFlight = phase === "dispatching" || phase === "running"
+
+  return {
+    test: () => {
+      if (inFlight) return
+      trigger()
+    },
+    phase,
+    failure,
+    run,
+    error,
+    inFlight,
+    // undefined while loading or when the run isn't finished; [] when the run
+    // emitted nothing (or the annotations read failed, since the run link still
+    // gives the teacher the full log).
+    annotations: finished
+      ? annotations.isError
+        ? []
+        : annotations.data
+      : undefined,
+  }
+}
+
+export default useTestServiceToken

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -146,6 +146,7 @@
       "collectScoresClassroom": "Collecting scores for every assignment in \"{{classroom}}\"",
       "collectScoresAssignment": "Collecting scores for \"{{assignment}}\" in \"{{classroom}}\"",
       "regrade": "Regrading",
+      "probeToken": "Testing the service token",
       "generic": "GitHub Actions workflow"
     }
   },
@@ -2020,7 +2021,20 @@
       "validating": "Validating…",
       "saveButton": "Save token",
       "saved": "Service token saved.",
-      "savedNoMetadata": "Service token saved, but its expiry and name couldn't be recorded. The health chip may show \"expiry not tracked\" until you save again."
+      "savedNoMetadata": "Service token saved, but its expiry and name couldn't be recorded. The health chip may show \"expiry not tracked\" until you save again.",
+      "test": {
+        "button": "Test token",
+        "help": "Runs a read-only check in your classroom50 repository that exercises every permission the token needs, including the ones that can't be verified when you save it.",
+        "running": "Testing…",
+        "passed": "The token has every permission Classroom 50 needs.",
+        "failedTitle": "The token is missing permissions.",
+        "failedLoading": "Reading the check results…",
+        "failedNoDetails": "The check didn't report which permissions are missing. Open the run to see the log.",
+        "failedNext": "Create a new token with the required permissions, then use Set a new token to save it.",
+        "startFailed": "Couldn't start the token check: {{reason}}",
+        "workflowMissing": "This organization's workflow files don't include the token check yet. <updateLink>Update the workflow files</updateLink>, then test again.",
+        "timeout": "The check is taking longer than expected. Open the run to see the result when it finishes."
+      }
     },
     "audit": {
       "detail": {

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -17,6 +17,7 @@ import { useSafeSubmit } from "@/hooks/useSafeSubmit"
 import { useSaveServiceToken } from "@/hooks/mutations/useSaveServiceToken"
 import { useRenameServiceToken } from "@/hooks/mutations/useRenameServiceToken"
 import useGetServiceTokenStatus from "@/hooks/useGetServiceTokenStatus"
+import useTestServiceToken from "@/hooks/useTestServiceToken"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
 import {
   useHashSectionHighlight,
@@ -31,6 +32,7 @@ import RerunOrgSetup from "@/pages/orgSettings/RerunOrgSetup"
 import TeardownSection from "@/pages/orgSettings/TeardownSection"
 import TeamCreationSection from "@/pages/orgSettings/TeamCreationSection"
 import SettingsSection from "@/pages/orgSettings/SettingsSection"
+import ServiceTokenTestResult from "@/pages/orgSettings/ServiceTokenTestResult"
 import { githubOrgSettingsUrl } from "@/util/orgUrl"
 import { WIKI_URL } from "@/version"
 import { errorText } from "@/types/localizedMessage"
@@ -457,6 +459,9 @@ export const OrgSettingsPane = ({ highlighted }: { highlighted?: boolean }) => {
 
   const saveMutation = useSaveServiceToken(org)
   const renameMutation = useRenameServiceToken(org)
+  // The full-scope check runs in the org's Actions, since the save-time
+  // validation can only prove what the config repo reveals about the token.
+  const tokenTest = useTestServiceToken(org)
 
   const [modalOpen, setModalOpen] = useState(false)
   // Advisory-metadata warning from the last save, shown as a banner in this
@@ -548,10 +553,26 @@ export const OrgSettingsPane = ({ highlighted }: { highlighted?: boolean }) => {
                 </span>
               )}
             </span>
-            <Button variant="outline" size="sm" onClick={openModal}>
-              {t("orgSettings.serviceToken.rotateButton")}
-            </Button>
+            <span className="inline-flex flex-wrap items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                loading={tokenTest.inFlight}
+                loadingLabel={t("orgSettings.serviceToken.test.running")}
+                title={t("orgSettings.serviceToken.test.help")}
+                onClick={tokenTest.test}
+              >
+                {tokenTest.inFlight
+                  ? t("orgSettings.serviceToken.test.running")
+                  : t("orgSettings.serviceToken.test.button")}
+              </Button>
+              <Button variant="outline" size="sm" onClick={openModal}>
+                {t("orgSettings.serviceToken.rotateButton")}
+              </Button>
+            </span>
           </div>
+
+          <ServiceTokenTestResult state={tokenTest} />
 
           {!expiresDate && (
             <span className="inline-flex items-center gap-2 text-sm text-warning">

--- a/web/src/pages/orgSettings/ServiceTokenTestResult.test.tsx
+++ b/web/src/pages/orgSettings/ServiceTokenTestResult.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+
+// Assert on stable i18n keys, not English copy. Trans renders its key so the
+// link-bearing message is still findable.
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, string>) =>
+        opts ? `${key}:${JSON.stringify(opts)}` : key,
+    }),
+    Trans: ({ i18nKey }: { i18nKey: string }) => <span>{i18nKey}</span>,
+  }
+})
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    Link: ({ children }: { children?: React.ReactNode }) => (
+      <a href="#rerun-org-setup">{children}</a>
+    ),
+  }
+})
+
+import ServiceTokenTestResult from "./ServiceTokenTestResult"
+import { ProbeWorkflowMissingError } from "@/github-core/mutations"
+
+type State = Parameters<typeof ServiceTokenTestResult>[0]["state"]
+
+const run = {
+  id: 77,
+  html_url: "https://github.com/acme/classroom50/actions/runs/77",
+} as unknown as NonNullable<State["run"]>
+
+const state = (over: Partial<State>): State =>
+  ({
+    test: vi.fn(),
+    phase: "idle",
+    failure: null,
+    run: undefined,
+    error: null,
+    inFlight: false,
+    annotations: undefined,
+    ...over,
+  }) as State
+
+afterEach(cleanup)
+
+describe("ServiceTokenTestResult", () => {
+  it("renders nothing before a result exists (the button and banner carry progress)", () => {
+    for (const phase of ["idle", "dispatching", "running"] as const) {
+      const { container } = render(
+        <ServiceTokenTestResult state={state({ phase, inFlight: true })} />,
+      )
+      expect(container.innerHTML).toBe("")
+      cleanup()
+    }
+  })
+
+  it("shows the pass verdict with a link to the run", () => {
+    render(
+      <ServiceTokenTestResult
+        state={state({ phase: "completed", run, annotations: [] })}
+      />,
+    )
+    expect(
+      screen.getByText("orgSettings.serviceToken.test.passed"),
+    ).toBeTruthy()
+    expect(
+      screen.getByRole("link", { name: /viewRun/ }).getAttribute("href"),
+    ).toBe(run.html_url)
+  })
+
+  it("lists the probe's failure annotations and what to do next", () => {
+    render(
+      <ServiceTokenTestResult
+        state={state({
+          phase: "failed",
+          failure: "run",
+          run,
+          annotations: [
+            { level: "notice", message: "ignored" },
+            { level: "failure", message: "probe FAILED: Members: Read" },
+          ],
+        })}
+      />,
+    )
+    expect(screen.getByRole("alert")).toBeTruthy()
+    expect(
+      screen.getByText("orgSettings.serviceToken.test.failedTitle"),
+    ).toBeTruthy()
+    expect(screen.getByText("probe FAILED: Members: Read")).toBeTruthy()
+    expect(screen.queryByText("ignored")).toBeNull()
+    expect(
+      screen.getByText("orgSettings.serviceToken.test.failedNext"),
+    ).toBeTruthy()
+  })
+
+  it("says the details are loading, then falls back when the run emitted none", () => {
+    render(
+      <ServiceTokenTestResult
+        state={state({ phase: "failed", failure: "run", run })}
+      />,
+    )
+    expect(
+      screen.getByText("orgSettings.serviceToken.test.failedLoading"),
+    ).toBeTruthy()
+    cleanup()
+
+    render(
+      <ServiceTokenTestResult
+        state={state({ phase: "failed", failure: "run", run, annotations: [] })}
+      />,
+    )
+    expect(
+      screen.getByText("orgSettings.serviceToken.test.failedNoDetails"),
+    ).toBeTruthy()
+  })
+
+  it("points an org without the workflow at the setup section", () => {
+    render(
+      <ServiceTokenTestResult
+        state={state({
+          phase: "failed",
+          failure: "dispatch",
+          error: new ProbeWorkflowMissingError(new Error("404")),
+        })}
+      />,
+    )
+    expect(
+      screen.getByText("orgSettings.serviceToken.test.workflowMissing"),
+    ).toBeTruthy()
+    // A missing workflow is a setup gap, not an error the teacher caused.
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("names the reason when the dispatch itself was rejected", () => {
+    render(
+      <ServiceTokenTestResult
+        state={state({
+          phase: "failed",
+          failure: "dispatch",
+          error: new Error("Forbidden"),
+        })}
+      />,
+    )
+    expect(screen.getByRole("alert").textContent).toContain(
+      "orgSettings.serviceToken.test.startFailed",
+    )
+  })
+
+  it("keeps the run link on a timeout", () => {
+    render(<ServiceTokenTestResult state={state({ phase: "timeout", run })} />)
+    expect(
+      screen.getByText("orgSettings.serviceToken.test.timeout"),
+    ).toBeTruthy()
+    expect(screen.getByRole("link", { name: /viewRun/ })).toBeTruthy()
+  })
+})

--- a/web/src/pages/orgSettings/ServiceTokenTestResult.tsx
+++ b/web/src/pages/orgSettings/ServiceTokenTestResult.tsx
@@ -1,0 +1,121 @@
+import { Link } from "@tanstack/react-router"
+import { Trans, useTranslation } from "react-i18next"
+
+import { Alert, Button, cx } from "@/components/ui"
+import { LinkExternalIcon } from "@/components/ui/icons"
+import { ProbeWorkflowMissingError } from "@/github-core/mutations"
+import type { RunAnnotation } from "@/github-core/queries"
+import type useTestServiceToken from "@/hooks/useTestServiceToken"
+import { errorText } from "@/types/localizedMessage"
+
+type TestState = ReturnType<typeof useTestServiceToken>
+
+// DOM anchor of the Re-run org setup section (see RerunOrgSetup), where an org
+// whose workflow files predate probe-token.yaml gets them.
+const RERUN_ORG_SETUP_ANCHOR = "rerun-org-setup"
+
+// The messages worth relaying from a finished probe run: the failure verdict
+// (which checks did not pass, and the fix). Notices only restate "passed".
+const failureMessages = (annotations: RunAnnotation[] | undefined) =>
+  (annotations ?? []).filter((a) => a.level === "failure").map((a) => a.message)
+
+// The outcome of the last "Test token" run, below the token row. In-flight
+// progress is not shown here: the button spins and the Actions banner carries
+// the run. What stays is what the banner can't say: pass/fail with the probe's
+// own verdict, a rejected dispatch, and this client's poll timeout.
+export default function ServiceTokenTestResult({
+  state,
+  className,
+}: {
+  state: TestState
+  className?: string
+}) {
+  const { t } = useTranslation()
+  const { phase, failure, run, error, annotations } = state
+  if (phase === "idle" || phase === "dispatching" || phase === "running") {
+    return null
+  }
+
+  const viewRun = run?.html_url ? (
+    <Button
+      href={run.html_url}
+      target="_blank"
+      rel="noreferrer"
+      variant="ghost"
+      size="xs"
+      className="ms-auto shrink-0"
+    >
+      {t("actionsBanner.viewRun")}
+      <LinkExternalIcon aria-hidden="true" className="size-3.5" />
+    </Button>
+  ) : null
+
+  if (phase === "completed") {
+    return (
+      <Alert tone="success" className={cx("text-sm", className)}>
+        <span>{t("orgSettings.serviceToken.test.passed")}</span>
+        {viewRun}
+      </Alert>
+    )
+  }
+
+  if (phase === "timeout") {
+    return (
+      <Alert tone="warning" className={cx("text-sm", className)}>
+        <span>{t("orgSettings.serviceToken.test.timeout")}</span>
+        {viewRun}
+      </Alert>
+    )
+  }
+
+  // phase === "failed"
+  if (failure === "dispatch") {
+    if (error instanceof ProbeWorkflowMissingError) {
+      return (
+        <Alert tone="warning" className={cx("text-sm", className)}>
+          <span>
+            <Trans
+              i18nKey="orgSettings.serviceToken.test.workflowMissing"
+              components={{
+                updateLink: (
+                  <Link className="link" to="." hash={RERUN_ORG_SETUP_ANCHOR} />
+                ),
+              }}
+            />
+          </span>
+        </Alert>
+      )
+    }
+    return (
+      <Alert tone="error" className={cx("text-sm", className)}>
+        {t("orgSettings.serviceToken.test.startFailed", {
+          reason: errorText(t, error),
+        })}
+      </Alert>
+    )
+  }
+
+  const details = failureMessages(annotations)
+  return (
+    <Alert tone="error" className={cx("text-sm", className)}>
+      <div className="flex min-w-0 flex-col gap-2">
+        <p className="font-semibold">
+          {t("orgSettings.serviceToken.test.failedTitle")}
+        </p>
+        {annotations === undefined ? (
+          <span>{t("orgSettings.serviceToken.test.failedLoading")}</span>
+        ) : details.length > 0 ? (
+          <ul className="list-disc space-y-1 ps-5">
+            {details.map((message) => (
+              <li key={message}>{message}</li>
+            ))}
+          </ul>
+        ) : (
+          <span>{t("orgSettings.serviceToken.test.failedNoDetails")}</span>
+        )}
+        <span>{t("orgSettings.serviceToken.test.failedNext")}</span>
+      </div>
+      {viewRun}
+    </Alert>
+  )
+}

--- a/web/src/util/actionActivity.ts
+++ b/web/src/util/actionActivity.ts
@@ -181,4 +181,5 @@ export const WORKFLOW_LABEL_KEY: Record<string, string> = {
   "publish-pages.yaml": "actionsBanner.workflow.publishPages",
   "collect-scores.yaml": "actionsBanner.workflow.collectScores",
   "regrade.yaml": "actionsBanner.workflow.regrade",
+  "probe-token.yaml": "actionsBanner.workflow.probeToken",
 }

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -193,7 +193,9 @@ template.
 ### 7. Verify the service token
 
 After `init`/`rotate`, or when collect/regrade returns 401/403, run the
-read-only probe:
+read-only probe. In the web app, open the organization settings page and use
+**Test token** in the **Service token** section; the result shows in place.
+From the CLI:
 
 ```sh
 gh workflow run probe-token.yaml --repo <org>/classroom50

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -90,6 +90,26 @@ Classroom 50 stores it as the `CLASSROOM50_SERVICE_TOKEN` secret in your
 Classroom 50 sends you to GitHub to create the token, then you paste it back
 into the form to finish setup.
 
+#### Test the token
+
+Saving a token checks what it can prove from the `classroom50` repository
+and one other repository. The permissions that only matter once collection
+reads your classroom teams and re-runs workflows (organization **Members:
+Read**, **Actions**, and whether the token can see each staff team) are checked
+by a read-only workflow in your organization. On the organization settings
+page, the **Service token** section has a **Test token** button that runs it
+and shows the verdict in place:
+
+- a pass means the token has every permission Classroom 50 needs
+- a failure lists the permissions the check found missing, with a **View run**
+  link to the full log; create a new token with those permissions and use
+  **Set a new token** to save it
+
+Run it after setting or rotating a token, or when a collect or regrade run
+fails with a 401 or 403. The check only reads, so it's safe to run at any time.
+If the button reports that the workflow is missing, the organization's workflow
+files predate it: use **Re-run org setup** on the same page to update them.
+
 ### Member team creation
 
 Group assignments where students form their own groups work by letting the


### PR DESCRIPTION
## Summary

Follows up on [discussion #768](https://github.com/foundation50/classroom50/discussions/768), where a teacher rotated the service token twice and still couldn't tell why collection kept failing. The exhaustive check already exists (`probe-token.yaml`, a read-only workflow that exercises every scope the token needs), but the only way to run it was `gh workflow run probe-token.yaml --repo <org>/classroom50` and then reading the Actions log. This adds it to the place teachers already look.

**Settings → Service token → Test token.** Next to **Set a new token**, a **Test token** button dispatches `probe-token.yaml` in the org's `classroom50` repo, spins while the run is in flight (the app-wide Actions banner carries the run, labeled "Testing the service token", with its own View run link), and then shows the verdict in place:

- **Pass:** "The token has every permission Classroom 50 needs." with a View run link.
- **Fail:** the probe's own `::error::` annotation, which names the checks that did not pass and the fix, plus what to do next (create a new token, then Set a new token). Falls back to "open the run" if the run emitted no annotation.
- **Workflow missing:** an org whose skeleton predates `probe-token.yaml` gets a warning linking to the **Re-run org setup** section on the same page instead of a raw 404.
- **Dispatch rejected / poll timeout:** the reason, or a pointer to the run.

**Plumbing, all on existing patterns.**

- `triggerProbeToken` in `github-core/mutations/workflowDispatch.ts`, modeled on `triggerRegrade` (no inputs). A 404 on the workflow's runs listing or dispatch becomes `ProbeWorkflowMissingError`, checked before any POST when the listing already 404s.
- `getProbeTokenRunAfterId` (the shared oldest-run-past-baseline locator) and a new `getRunAnnotations` read (`/actions/runs/{id}/jobs` then `/check-runs/{job}/annotations`, flattened to `{ level, message }`). This is the first place the app reads a run's annotations; it is how the probe reports per-scope results.
- `useTestServiceToken` wraps `useGitHubOperation` like `useTriggerRegrade`, registers with the Actions banner, and reads annotations only once the run has concluded (never for a rejected dispatch; a failed read yields `[]` so the run link still shows).
- `ServiceTokenTestResult` renders the outcomes; `OrgSettingsPage` owns the hook and the button. `WORKFLOW_LABEL_KEY` gains `probe-token.yaml` so a probe dispatched from the CLI is labeled in the banner too.
- New `githubKeys.probeTokenRun` / `runAnnotations`; copy under `orgSettings.serviceToken.test.*` and `actionsBanner.workflow.probeToken`.

**Wiki.** Web Teacher Guide gets a "Test the token" subsection; GitHub Integration §7 mentions the button alongside the `gh` command.

The probe runs whatever `probe_token.py` the org's repo has, so orgs get the derived-slug fallback from #835 only after refreshing their skeleton; the button itself works against any org that has `probe-token.yaml`.

## Test plan

- [x] `npm run check` in `web/` (tsc, eslint, prettier, arch:validate, 382 files / 4963 tests) and `audit_i18n.py --strict`
- [x] New tests: `triggerProbeToken` (ref-only body, 404 on dispatch and on the baseline listing map to `ProbeWorkflowMissingError` with no POST attempted, other errors untouched, org required); `getRunAnnotations` (multi-job flatten in order, level normalization, blank messages dropped, silent run yields `[]`); `useTestServiceToken` (per-org keys, banner registration, no double dispatch in flight, annotations read only after conclusion and never for a rejected dispatch, read failure falls back to `[]`); `ServiceTokenTestResult` (nothing rendered mid-flight, pass with run link, failure list with next step, loading and no-details fallbacks, workflow-missing warning is not `role="alert"`, dispatch reason, timeout keeps the link)
- [ ] Manual: on a dev org with a healthy token, click Test token; the button spins, the banner shows "Testing the service token…", and the section shows the pass verdict with a working View run link
- [ ] Manual: set a token missing Organization → Members: Read, test again; the failure lists that check
- [ ] Manual: on an org whose `classroom50` predates `probe-token.yaml`, the button reports the missing workflow and the link lands on Re-run org setup
