### PR TITLE
fix(web): keep a concurrent lock when saving unrelated assignment edits

### DIFF
--- a/web/src/pages/assignments/EditAssignmentForm.test.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.test.tsx
@@ -236,7 +236,10 @@ it("saves directly (no confirm) when accepted but no provisioning setting change
   expect(document.querySelector("dialog[open]")).toBeNull()
 })
 
-it("passes the lock toggle through the edit boundary", () => {
+it("sends locked as undefined when the toggle was not flipped", () => {
+  // The form was seeded when it opened; a lock applied since (row action,
+  // CLI, co-teacher) must survive a save that never touched the toggle, so an
+  // unchanged toggle asks editAssignment to carry the STORED state forward.
   submittedOverrides = { locked: false }
   render(
     <EditAssignmentForm
@@ -253,10 +256,9 @@ it("passes the lock toggle through the edit boundary", () => {
     />,
   )
   fireEvent.click(screen.getByRole("button", { name: "submit" }))
-  expect(mutateAsync).toHaveBeenCalledWith(
-    expect.objectContaining({ locked: false }),
-    expect.any(Object),
-  )
+  expect(mutateAsync).toHaveBeenCalledTimes(1)
+  const [input] = mutateAsync.mock.calls[0]
+  expect(input).toHaveProperty("locked", undefined)
 })
 
 it("confirms a lock even when no students have accepted, listing the lock item", async () => {
@@ -342,6 +344,8 @@ it("saves a locked assignment that stays locked without a prompt", () => {
   fireEvent.click(screen.getByRole("button", { name: "submit" }))
   expect(mutateAsync).toHaveBeenCalledTimes(1)
   expect(document.querySelector("dialog[open]")).toBeNull()
+  const [input] = mutateAsync.mock.calls[0]
+  expect(input).toHaveProperty("locked", undefined)
 })
 
 it("confirms a visibility or permission change only once students accepted", () => {

--- a/web/src/pages/assignments/EditAssignmentForm.tsx
+++ b/web/src/pages/assignments/EditAssignmentForm.tsx
@@ -137,6 +137,15 @@ const EditAssignmentForm = ({
             defaultValues={assignmentToFormValues(defaultData)}
             onSubmit={async (values) => {
               const shape = deriveFormShape(values)
+              // Only an explicit flip of the toggle is written. An unchanged
+              // toggle sends undefined so editAssignment carries the STORED
+              // state forward: the form was seeded when it opened, and a lock
+              // applied since (row action, CLI, co-teacher) must not be
+              // undone by a save that never touched it.
+              const locked =
+                values.locked === Boolean(defaultData.locked)
+                  ? undefined
+                  : values.locked
               const input = {
                 name: values.name,
                 mode: values.mode,
@@ -145,7 +154,7 @@ const EditAssignmentForm = ({
                 description: values.description,
                 due_date: values.due_date,
                 available_from_date: values.available_from_date,
-                locked: values.locked,
+                locked,
                 max_group_size: values.max_group_size,
                 team_formation: values.team_formation,
                 feedback_pr: values.feedback_pr,
@@ -208,7 +217,7 @@ const EditAssignmentForm = ({
                   gradingMode: values.grading_choice,
                   student_permission: values.student_permission || undefined,
                   repo_visibility: values.repo_visibility,
-                  locked: values.locked,
+                  locked,
                 },
                 acceptedCount,
               )


### PR DESCRIPTION
## Summary

- `EditAssignmentForm` sent `locked: values.locked` on every save. The toggle is seeded when the form opens, so a lock applied since (row action, `gh teacher assignment lock`, a co-teacher) was overwritten by any unrelated save: `editAssignment` saw `wasLocked=true`, `input.locked=false`, wrote the entry unlocked, and the `needsTeamGrant && !nowLocked` path re-granted the student team's read on a private template. In 1.41.0 `locked` was `"preserved"` and this could not happen.

- The form now sends `locked: undefined` when the toggle equals its seeded baseline, so `editAssignment` carries the stored state forward (the existing "edit with no lock decision carries the stored lock forward" domain test pins that path) and only an explicit flip is written. `editImpactSummary` gets the same value, so the confirm dialog still lists lock/unlock only for a real flip.

Found in the 1.42.0 release review (#830).

## Test plan

- [x] `EditAssignmentForm.test.tsx`: unchanged toggle sends `locked: undefined` (both unlocked and stays-locked cases); false-to-true flip still sends `true` and confirms
- [x] `tsc -b`, `eslint`, `prettier --check` on the changed files