### PR TITLE
fix(web): read the full org listing on a roster error and re-read repos on Refresh

### DIFF
--- a/web/src/hooks/useAssignmentRepos.test.tsx
+++ b/web/src/hooks/useAssignmentRepos.test.tsx
@@ -211,4 +211,31 @@ describe("useAssignmentRepos", () => {
       ),
     )
   })
+
+  it("re-reads on a manual refetch even when a fresh full listing is cached", async () => {
+    // Refresh / Collect now call refetch. The shortcut to a fresh full listing
+    // must not swallow that: the user asked for GitHub's current answer.
+    const { probed } = serveOrg({ lastPage: 20, existing: ["cs101-hw1-alice"] })
+    const client = makeClient()
+    client.setQueryData(githubKeys.orgRepos("acme"), [])
+    const { result } = renderHook(
+      () => useAssignmentRepos({ ...base, logins: ["alice"] }),
+      { wrapper: wrapper(client) },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(probed).toEqual([])
+
+    await result.current.refetch()
+    expect(probed).toEqual(["cs101-hw1-alice"])
+    await waitFor(() =>
+      expect(result.current.data?.map((r) => r.name)).toContain(
+        "cs101-hw1-alice",
+      ),
+    )
+    // The full listing was only marked stale, not re-walked.
+    expect(request).not.toHaveBeenCalledWith(
+      expect.stringMatching(/page=2/),
+      expect.anything(),
+    )
+  })
 })

--- a/web/src/hooks/useAssignmentRepos.ts
+++ b/web/src/hooks/useAssignmentRepos.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useCallback, useMemo } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { useGitHubClient } from "@/context/github/GitHubProvider"
@@ -87,5 +87,21 @@ export function useAssignmentRepos({
   })
   const fullQuery = useGetOrgRepos(org, enabled && !scoped)
 
-  return scoped ? scopedQuery : fullQuery
+  // A manual refresh must reach GitHub. The scoped queryFn answers from a
+  // fresh full listing, so mark that listing invalidated first (without
+  // refetching its own observers) and the shortcut steps aside; the full
+  // query's own refetch already re-walks.
+  const refetchScoped = scopedQuery.refetch
+  const refetch = useCallback(
+    async (...args: Parameters<typeof refetchScoped>) => {
+      await queryClient.invalidateQueries({
+        queryKey: githubKeys.orgRepos(org),
+        refetchType: "none",
+      })
+      return refetchScoped(...args)
+    },
+    [queryClient, org, refetchScoped],
+  )
+
+  return scoped ? { ...scopedQuery, refetch } : fullQuery
 }

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -267,15 +267,17 @@ const SubmissionsPageContent = () => {
   // `latestPush` isn't frozen at page load (else a push after load never flips
   // the freshness line to "Out of date").
   // For an individual assignment the repo names are derivable from the enrolled
-  // roster, so the read is scoped to them and can skip walking a large org. An
-  // UNKNOWN roster has no names to derive, so it reads the full listing rather
-  // than probing an empty candidate set (which would stop at page one).
+  // roster, so the read is scoped to them and can skip walking a large org.
+  // When they are not (see assignmentRepoCandidateLogins) it reads the full
+  // listing rather than probing a partial candidate set, which would stop at
+  // page one.
   const candidateLogins = useMemo(
     () =>
-      studentRosterKnown
-        ? assignmentRepoCandidateLogins(isGroupFlavor, teamRows)
-        : undefined,
-    [studentRosterKnown, isGroupFlavor, teamRows],
+      assignmentRepoCandidateLogins(isGroupFlavor, teamRows, {
+        rosterKnown: studentRosterKnown,
+        rosterError,
+      }),
+    [studentRosterKnown, rosterError, isGroupFlavor, teamRows],
   )
   const {
     data: orgRepos,

--- a/web/src/pages/submissions/dashboard.test.ts
+++ b/web/src/pages/submissions/dashboard.test.ts
@@ -2635,6 +2635,22 @@ describe("assignmentRepoCandidateLogins", () => {
   it("is undefined for a shared-repo assignment", () => {
     expect(assignmentRepoCandidateLogins(true, [teamRow()])).toBeUndefined()
   })
+
+  it("is undefined when the roster is not known to this viewer", () => {
+    expect(
+      assignmentRepoCandidateLogins(false, [teamRow()], { rosterKnown: false }),
+    ).toBeUndefined()
+  })
+
+  it("is undefined when the roster read failed, even with staff rows loaded", () => {
+    // A members-read error leaves the staff rows in place. Scoping to those
+    // would make page one of the org the whole truth for acceptance and
+    // freshness, so the page falls back to the full listing instead.
+    const rows = [teamRow({ username: "Prof", roles: ["teacher"] })]
+    expect(
+      assignmentRepoCandidateLogins(false, rows, { rosterError: true }),
+    ).toBeUndefined()
+  })
 })
 
 describe("orgReposReadEnabled", () => {

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -1601,14 +1601,20 @@ export function paginationRange(
 // Logins whose `<classroom>-<assignment>-<login>` repo the submissions page
 // looks up, for the roster-scoped org repo read (useAssignmentRepos). Every
 // enrolled row counts, students and staff alike (a staff member who accepted is
-// a gradee too). `undefined` for a shared-repo assignment: a team repo's
-// `group-<n>` segment is not derivable from any login, so the page reads the
-// whole listing instead.
+// a gradee too). `undefined` means the names are not derivable and the page
+// reads the whole listing instead:
+//   - a shared-repo assignment: a team repo's `group-<n>` segment comes from no
+//     login;
+//   - a roster this viewer cannot see (`rosterKnown` false);
+//   - a roster read that failed (`rosterError`): its rows are whatever staff
+//     loaded, and scoping to those would report page one of the org as truth.
 export function assignmentRepoCandidateLogins(
   isGroupFlavor: boolean,
   teamRows: readonly TeamRosterRow[],
+  roster: { rosterKnown?: boolean; rosterError?: boolean } = {},
 ): string[] | undefined {
-  if (isGroupFlavor) return undefined
+  const { rosterKnown = true, rosterError = false } = roster
+  if (isGroupFlavor || !rosterKnown || rosterError) return undefined
   return teamRows
     .filter((row) => row.state === "enrolled")
     .map((row) => row.username)


### PR DESCRIPTION
## Summary

Two follow-ups to the roster-scoped org repo read from #829, found in the 1.42.0 release review (#830).

- **Roster error degraded the read to page one.** `useTeamRoster` only marks the student roster unknown when the members read *succeeds* with `[]` for a non-owner; on a members *error* `studentRosterKnown` stayed `true`, so `candidateLogins` was just the staff rows and `getAssignmentRepos` returned page 1 plus a few probes. `latestAssignmentPush`, `acceptedUsernames` and the public-repo badges were then computed from the oldest 100 repos of the org. `assignmentRepoCandidateLogins` now takes the roster state and returns `undefined` (full listing) when the roster is unknown or its read failed, and the page passes both flags.

- **Manual Refresh / Collect now did not re-read repos.** The scoped `queryFn` answers from a fresh full listing (under 5 minutes, not invalidated), and `refetch()` went through that shortcut, so after visiting Assignments a Refresh on Submissions never reached GitHub. For a TA there is no collect completion to invalidate it. The hook now wraps `refetch` to mark `orgRepos(org)` invalidated (`refetchType: "none"`, so the listing's own observers are not re-walked) before the scoped read runs.

## Test plan

- [x] `useAssignmentRepos.test.tsx`: manual refetch probes GitHub even with a fresh full listing cached, and does not re-walk the listing
- [x] `dashboard.test.ts`: `assignmentRepoCandidateLogins` is `undefined` for an unknown roster and for a failed roster read with staff rows loaded
- [x] `tsc -b`, `eslint`, `prettier --check` on the changed files