### PR TITLE
fix(web): list a student's repos newest first again

### DIFF
--- a/web/src/components/org/OrgRepos.test.tsx
+++ b/web/src/components/org/OrgRepos.test.tsx
@@ -109,4 +109,23 @@ describe("OrgRepos", () => {
       screen.queryByRole("heading", { name: "cs101-a1-sibling" }),
     ).toBeNull()
   })
+
+  it("lists the newest repo first even though the listing arrives oldest first", () => {
+    getOrgRepos.mockReturnValue({
+      data: [
+        { ...repo("cs-a1-first", "write"), created_at: "2026-01-01T00:00:00Z" },
+        {
+          ...repo("cs-a2-second", "write"),
+          created_at: "2026-02-01T00:00:00Z",
+        },
+        { ...repo("cs-a3-third", "write"), created_at: "2026-03-01T00:00:00Z" },
+      ],
+    })
+
+    render(<OrgRepos org="acme" classroom="cs" />)
+
+    expect(
+      screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent),
+    ).toEqual(["cs-a3-third", "cs-a2-second", "cs-a1-first"])
+  })
 })

--- a/web/src/components/org/OrgRepos.tsx
+++ b/web/src/components/org/OrgRepos.tsx
@@ -30,6 +30,7 @@ import useDotClassroom50 from "@/hooks/useDotClassroom50"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
 import { useClassroomSecret } from "@/hooks/useStudentClassrooms"
 import { EnterDiv } from "@/lib/motionComponents"
+import { sortReposNewestFirst } from "@/util/repoOrder"
 
 const RepoCard = ({ org, repo }: { org: string; repo: GitHubRepo }) => {
   const { t } = useTranslation()
@@ -234,7 +235,11 @@ export const OrgRepos = ({
 
   if (!repos) return <></>
 
-  let writableRepos = repos.filter((repo) => repo.permissions?.push)
+  // The listing arrives oldest first (see sortReposNewestFirst); a student
+  // expects their latest assignment at the top.
+  let writableRepos = sortReposNewestFirst(repos).filter(
+    (repo) => repo.permissions?.push,
+  )
   if (classroom) {
     // Classroom repos are `<classroom>-<assignment>-<user>`, so require the
     // trailing "-" to avoid matching a sibling classroom whose name extends

--- a/web/src/util/repoOrder.test.ts
+++ b/web/src/util/repoOrder.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+
+import { sortReposNewestFirst } from "./repoOrder"
+
+describe("sortReposNewestFirst", () => {
+  it("orders by created_at descending without mutating the input", () => {
+    const repos = [
+      { name: "old", created_at: "2026-01-01T00:00:00Z" },
+      { name: "new", created_at: "2026-03-01T00:00:00Z" },
+      { name: "mid", created_at: "2026-02-01T00:00:00Z" },
+    ]
+    expect(sortReposNewestFirst(repos).map((r) => r.name)).toEqual([
+      "new",
+      "mid",
+      "old",
+    ])
+    expect(repos.map((r) => r.name)).toEqual(["old", "new", "mid"])
+  })
+
+  it("keeps repos without a timestamp last, in their original order", () => {
+    const repos = [
+      { name: "a" },
+      { name: "new", created_at: "2026-03-01T00:00:00Z" },
+      { name: "b" },
+      { name: "old", created_at: "2026-01-01T00:00:00Z" },
+    ]
+    expect(sortReposNewestFirst(repos).map((r) => r.name)).toEqual([
+      "new",
+      "old",
+      "a",
+      "b",
+    ])
+  })
+})

--- a/web/src/util/repoOrder.ts
+++ b/web/src/util/repoOrder.ts
@@ -1,0 +1,16 @@
+import type { GitHubRepo } from "@/github-core/types"
+
+// Newest repo first, GitHub's own default for a repo listing. The org listing
+// is walked oldest-first so pages stay stable while they are fetched in
+// parallel, so a view that shows the list to a person sorts it back. Repos
+// without a timestamp keep their relative order at the end.
+export function sortReposNewestFirst<T extends Pick<GitHubRepo, "created_at">>(
+  repos: readonly T[],
+): T[] {
+  return [...repos].sort((a, b) => {
+    if (!a.created_at || !b.created_at) {
+      return Number(!a.created_at) - Number(!b.created_at)
+    }
+    return b.created_at.localeCompare(a.created_at)
+  })
+}


### PR DESCRIPTION
## Summary

- #829 changed the org repo walk to `sort=created&direction=asc` so a repo created while pages 2..N are in flight lands after them instead of shifting every page. Every dashboard consumer of that listing is order-independent, but `OrgRepos` renders the student's repo cards straight from it, so the student "your repos" view flipped from newest-first (GitHub's default) to oldest-first.
- Adds `sortReposNewestFirst` in `util/repoOrder.ts` (repos without `created_at` stay last in their original order) and applies it in `OrgRepos` before filtering. `StudentAssignmentList` only builds a name set from the same listing, so it needs nothing.

Found in the 1.42.0 release review (#830).

## Test plan

- [x] `repoOrder.test.ts`: descending order, no input mutation, missing timestamps last
- [x] `OrgRepos.test.tsx`: cards render newest first from an oldest-first listing
- [x] `tsc -b`, `eslint`, `prettier --check`, `arch:validate`