### PR TITLE
fix(web): free read slots during probe retries and stop retrying definitive pages

### DIFF
--- a/web/src/github-core/paginate.test.ts
+++ b/web/src/github-core/paginate.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from "vitest"
 
-import { lastPageNumber, PAGE_FETCH_CONCURRENCY, paginateAll } from "./paginate"
+import {
+  lastPageNumber,
+  PAGE_FETCH_CONCURRENCY,
+  paginateAll,
+  paginateFirstPage,
+  paginateRemaining,
+} from "./paginate"
 import type { GitHubClient, GitHubRequestOptions } from "./client"
 import { GitHubAPIError } from "./errors"
 
@@ -265,6 +271,49 @@ describe("paginateAll", () => {
       paginateAll(client, makePath, { retryPages: true }),
     ).rejects.toMatchObject({ status: 404 })
     expect(requested.filter((p) => p === 2)).toHaveLength(1)
+  })
+
+  it("does not retry a 4xx that a re-request cannot change", async () => {
+    // 409 (empty repo), 422 (validation) and 451 (DMCA) are not in the
+    // definitive-role set but retrying them only burns the backoff budget.
+    for (const status of [409, 422, 451]) {
+      const { client, requested } = fakeClient({
+        pages: { 1: pageOf(1) },
+        last: 2,
+        failures: { 2: [apiError(status)] },
+      })
+      await expect(
+        paginateAll(client, makePath, { retryPages: true }),
+      ).rejects.toMatchObject({ status })
+      expect(requested.filter((p) => p === 2)).toHaveLength(1)
+    }
+  })
+
+  it("aborts the remaining pages when the caller had already aborted", async () => {
+    // Page 1 resolved before the abort landed; the walk must not start pages
+    // 2..N with a live signal just because the abort listener was added late.
+    const controller = new AbortController()
+    const seen: AbortSignal[] = []
+    const request = vi.fn(
+      async (path: string, options?: GitHubRequestOptions) => {
+        if (options?.signal) seen.push(options.signal)
+        options?.onHeaders?.(new Headers({ link: linkHeader(3) }))
+        return pageOf(Number(/[?&]page=(\d+)/.exec(path)?.[1] ?? 1))
+      },
+    )
+    const first = await paginateFirstPage<{ id: number }>(
+      { request } as unknown as GitHubClient,
+      makePath,
+      { signal: controller.signal },
+    )
+    controller.abort()
+    await paginateRemaining(
+      { request } as unknown as GitHubClient,
+      makePath,
+      first,
+      { signal: controller.signal },
+    ).catch(() => undefined)
+    expect(seen.slice(1).every((s) => s.aborted)).toBe(true)
   })
 
   it("gives up after the retry budget", async () => {

--- a/web/src/github-core/paginate.ts
+++ b/web/src/github-core/paginate.ts
@@ -1,5 +1,5 @@
 import type { GitHubClient } from "./client"
-import { GitHubAPIError, isDefinitiveGitHubStatus } from "./errors"
+import { GitHubAPIError } from "./errors"
 import { logger } from "@/lib/logger"
 import { LOG_SCOPE_QUERIES } from "@/lib/logScopes"
 import { mapWithConcurrency } from "@/util/concurrency"
@@ -98,6 +98,7 @@ export async function paginateRemaining<T>(
   // are aborted rather than left to finish (and retry) for nothing.
   const walk = new AbortController()
   const onCallerAbort = () => walk.abort(options.signal?.reason)
+  if (options.signal?.aborted) onCallerAbort()
   options.signal?.addEventListener("abort", onCallerAbort, { once: true })
   const pageOptions = { ...options, signal: walk.signal }
   const pages = Array.from({ length: lastPage - 1 }, (_, i) => i + 2)
@@ -168,8 +169,9 @@ export function lastPageNumber(linkHeader: string | null): number | null {
 }
 
 // Retry one read on transient failures (5xx, short rate limit, timeout,
-// network). Definitive statuses (401/403/404), caller aborts, and a rate limit
-// longer than MAX_RATE_LIMIT_WAIT_MS propagate at once.
+// network). Every other GitHub status (401/403/404, and a 409/422/451 a
+// re-request cannot change), caller aborts, and a rate limit longer than
+// MAX_RATE_LIMIT_WAIT_MS propagate at once.
 export async function withTransientRetry<T>(
   fn: () => Promise<T>,
   signal: AbortSignal | undefined,
@@ -205,7 +207,7 @@ function retryWaitMs(err: unknown, attempt: number): number | null {
 
 function isTransientPageError(err: unknown): boolean {
   if (err instanceof GitHubAPIError) {
-    return err.isRateLimited || !isDefinitiveGitHubStatus(err.status)
+    return err.isRateLimited || err.status >= 500
   }
   // A timeout (`TimeoutError` DOMException) or network failure.
   return !(err instanceof DOMException && err.name === "AbortError")

--- a/web/src/github-core/queries/repoRefReads.test.ts
+++ b/web/src/github-core/queries/repoRefReads.test.ts
@@ -221,6 +221,39 @@ describe("getOrgRepos / getAssignmentRepos", () => {
     }
   })
 
+  it("aborts the sibling probes once one fails for good", async () => {
+    const seenSignals: AbortSignal[] = []
+    const request = vi.fn(
+      async (path: string, options?: GitHubRequestOptions) => {
+        if (/[?&]page=1\b/.test(path)) {
+          options?.onHeaders?.(
+            new Headers({
+              link: `<${LIST}&page=2>; rel="next", <${LIST}&page=10>; rel="last"`,
+            }),
+          )
+          return [{ name: "a", private: true }]
+        }
+        if (options?.signal) seenSignals.push(options.signal)
+        if (path.endsWith("/cs-hw1-bob")) throw apiError(401)
+        // carol's probe is slow; it should be aborted, not completed.
+        await new Promise((_, reject) => {
+          options?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          )
+        })
+        return { name: "cs-hw1-carol", private: true }
+      },
+    )
+    await expect(
+      getAssignmentRepos({ request } as unknown as GitHubClient, "acme", [
+        "cs-hw1-bob",
+        "cs-hw1-carol",
+      ]),
+    ).rejects.toMatchObject({ status: 401 })
+    expect(seenSignals).toHaveLength(2)
+    expect(seenSignals.every((s) => s.aborted)).toBe(true)
+  })
+
   it("resolves null when the org itself 404s", async () => {
     const request = vi.fn().mockRejectedValue(notFound())
     await expect(

--- a/web/src/github-core/queries/repoRefReads.ts
+++ b/web/src/github-core/queries/repoRefReads.ts
@@ -174,21 +174,9 @@ export async function getAssignmentRepos(
         ].filter((name) => !onFirstPage.has(name))
         // Same rule as the collect script: never more requests than the pages.
         if (unresolved.length <= first.lastPage - 1) {
-          const probed = await mapWithConcurrency(
-            unresolved,
-            REPO_READ_CONCURRENCY,
-            (name) =>
-              withGithubReadSlot(() =>
-                withTransientRetry(
-                  () => getRepo(client, owner, name, signal),
-                  signal,
-                ),
-              ),
-          )
+          const probed = await probeRepos(client, owner, unresolved, signal)
           return {
-            repos: first.items.concat(
-              probed.filter((repo): repo is GitHubRepo => repo !== null),
-            ),
+            repos: first.items.concat(probed),
             complete: false,
           }
         }
@@ -200,6 +188,42 @@ export async function getAssignmentRepos(
     },
     { repos: null, complete: false },
   )
+}
+
+// The candidate repos that exist, read by exact name. Mirrors paginateRemaining:
+// one probe failing definitively ends the fan-out and aborts its siblings, and
+// the retry waits outside the read slot so a throttled probe does not hold one
+// of the few slots while it sleeps.
+async function probeRepos(
+  client: GitHubClient,
+  owner: string,
+  names: readonly string[],
+  signal: AbortSignal | undefined,
+): Promise<GitHubRepo[]> {
+  const fanOut = new AbortController()
+  const onCallerAbort = () => fanOut.abort(signal?.reason)
+  if (signal?.aborted) onCallerAbort()
+  signal?.addEventListener("abort", onCallerAbort, { once: true })
+  try {
+    const probed = await mapWithConcurrency(
+      names,
+      REPO_READ_CONCURRENCY,
+      (name) =>
+        withTransientRetry(
+          () =>
+            withGithubReadSlot(() =>
+              getRepo(client, owner, name, fanOut.signal),
+            ),
+          fanOut.signal,
+        ),
+    )
+    return probed.filter((repo): repo is GitHubRepo => repo !== null)
+  } catch (err) {
+    fanOut.abort(err)
+    throw err
+  } finally {
+    signal?.removeEventListener("abort", onCallerAbort)
+  }
 }
 
 // Open PRs on a student/group repo. The autograde workflow opens one Feedback


### PR DESCRIPTION
## Summary

Follow-ups to the parallel pagination and repo probing from #829, found in the 1.42.0 release review (#830).

- **Probe retries held a read slot.** `getAssignmentRepos` nested `withGithubReadSlot(() => withTransientRetry(...))`, so a probe waiting out a short rate limit (up to 8s) or a 5xx backoff occupied one of the 8 global per-repo read slots while sleeping; eight throttled probes stalled every other per-repo read on the page. The nesting is now `withTransientRetry(() => withGithubReadSlot(...))`, so the slot is released during the wait.
- **Sibling probes kept running after a definitive failure.** `paginateRemaining` aborts pages in flight once one page fails for good; the probe fan-out did not. It now runs under its own `AbortController` linked to the caller's signal, mirroring the page walk.
- **Already-aborted caller signal was ignored** in `paginateRemaining`: `addEventListener("abort")` never fires for a signal that is already aborted, so pages 2..N would have started with a live signal. One guard line.
- **`withTransientRetry` retried 409/422/451.** Only 401/403/404 were treated as definitive, so a 4xx that a re-request cannot change burned the 3-attempt backoff (~1.5s). Transient now means rate limit, 5xx, timeout or network only.

## Test plan

- [x] `paginate.test.ts`: no retry on 409/422/451; already-aborted caller aborts the remaining pages
- [x] `repoRefReads.test.ts`: one probe failing with 401 aborts its slow sibling; existing retry/absent/probe tests unchanged
- [x] `useAssignmentRepos.test.tsx` still green
- [x] `tsc -b`, `eslint`, `prettier --check` on the changed files