### PR TITLE
fix(web): small follow-ups on the submissions and settings pages

### DIFF
--- a/web/src/hooks/useTestServiceToken.test.tsx
+++ b/web/src/hooks/useTestServiceToken.test.tsx
@@ -157,11 +157,32 @@ describe("useTestServiceToken", () => {
     expect(getRunAnnotations).not.toHaveBeenCalled()
   })
 
-  it("falls back to [] when the annotations read fails, so the run link still shows", async () => {
-    getRunAnnotations.mockRejectedValue(new Error("403"))
+  it("does not read annotations for a run that passed", async () => {
+    // A green run's only annotation is a "passed" notice the result never
+    // shows, so the read (jobs list plus one call per job) is skipped.
+    getRunAnnotations.mockClear()
     operation = {
       phase: "completed",
       failure: null,
+      run: {
+        id: 79,
+        html_url: "https://github.com/acme/classroom50/actions/runs/79",
+      },
+      error: null,
+    }
+    const { result } = renderHook(() => useTestServiceToken("acme"), {
+      wrapper,
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(result.current.annotations).toBeUndefined()
+    expect(getRunAnnotations).not.toHaveBeenCalled()
+  })
+
+  it("falls back to [] when the annotations read fails, so the run link still shows", async () => {
+    getRunAnnotations.mockRejectedValue(new Error("403"))
+    operation = {
+      phase: "failed",
+      failure: "run",
       run: {
         id: 78,
         html_url: "https://github.com/acme/classroom50/actions/runs/78",

--- a/web/src/hooks/useTestServiceToken.ts
+++ b/web/src/hooks/useTestServiceToken.ts
@@ -55,15 +55,15 @@ const useTestServiceToken = (org: string | undefined) => {
     },
   })
 
-  // Annotations exist only once the run has concluded; a run that passed emits
-  // a single notice, a failed one the error naming the checks that did not pass.
-  const finished =
-    phase === "completed" || (phase === "failed" && failure === "run")
+  // Annotations are read only for a run that FAILED: that is where the probe
+  // names the checks that did not pass and the fix. A passing run emits only a
+  // "passed" notice the result never shows, so its read is skipped.
+  const failedRun = phase === "failed" && failure === "run"
   const annotations = useQuery({
     queryKey: githubKeys.runAnnotations(org ?? "", run?.id ?? 0),
     queryFn: ({ signal }) =>
       getRunAnnotations(client, org ?? "", run?.id ?? 0, signal),
-    enabled: Boolean(org && run?.id && finished),
+    enabled: Boolean(org && run?.id && failedRun),
     staleTime: Infinity,
     // The run link is the fallback, so a failed read isn't worth retrying.
     retry: false,
@@ -81,10 +81,10 @@ const useTestServiceToken = (org: string | undefined) => {
     run,
     error,
     inFlight,
-    // undefined while loading or when the run isn't finished; [] when the run
+    // undefined while loading or unless the run failed; [] when the run
     // emitted nothing (or the annotations read failed, since the run link still
     // gives the teacher the full log).
-    annotations: finished
+    annotations: failedRun
       ? annotations.isError
         ? []
         : annotations.data

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2788,6 +2788,7 @@
       "staleHelp": "New pushes since the last collection. Collect now to grade the newest work.",
       "collectHelp": "Collect now to grade the latest pushes.",
       "refreshLabel": "Refresh",
+      "refreshing": "Refreshing…",
       "refreshHelp": "Re-read the latest collected submission data and live repository status.",
       "collectRestricted": "Only teachers and head TAs can collect scores. Ask one to run a collection to grade the latest pushes."
     },

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -155,7 +155,10 @@ export const TeacherAssignmentsView = ({
   const canAuthor = can("authorAssignments", { classroomRole: myRole })
   // Only an org owner's repo list covers every repo; a non-owner sees the
   // repos their staff team was granted, so the Accepted column is a lower bound.
-  const { isOwner } = useIsOrgOwner()
+  // Asserted while the role still resolves so an owner never flashes the
+  // non-owner wording on load.
+  const { isOwner, isPending: ownerPending } = useIsOrgOwner()
+  const acceptanceComplete = isOwner || ownerPending
   const emptyRoster = useEmptyRosterWarning(org, classroom)
 
   const [query, setQuery] = useState("")
@@ -308,7 +311,7 @@ export const TeacherAssignmentsView = ({
           }
           archived={archived}
           canAuthor={canAuthor}
-          acceptanceComplete={isOwner}
+          acceptanceComplete={acceptanceComplete}
           sort={sort}
           onSortChange={setSort}
           // Replay the row entrance on filter/sort changes; search is excluded

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -180,10 +180,15 @@ const SubmissionsPageContent = () => {
   // VIEWER's token, and a repo they lack access to reads as 404, which both
   // fan-outs already treat as "not accepted" (collect grants the staff teams
   // per-repo read as it runs, so those repos appear after the next collect).
-  const { isOwner } = useIsOrgOwner()
+  const { isOwner, isPending: ownerPending } = useIsOrgOwner()
+  // Whether the org repo list covers every repo. Asserted while the role is
+  // still resolving too: a confirmed owner would otherwise flash the non-owner
+  // "you can see" wording for a moment on every load.
+  const acceptanceComplete = isOwner || ownerPending
   const {
     data: scoresData,
     refetch: refetchScores,
+    isRefetching: scoresRefetching,
     isError: scoresError,
     error: scoresErrorObj,
   } = useGetScores(org, classroom)
@@ -281,6 +286,7 @@ const SubmissionsPageContent = () => {
     data: orgRepos,
     isLoading: orgReposLoading,
     isPending: orgReposPending,
+    isRefetching: orgReposRefetching,
     refetch: refetchOrgRepos,
   } = useAssignmentRepos({
     org: org ?? "",
@@ -1516,7 +1522,7 @@ const SubmissionsPageContent = () => {
           onSortChange={setSort}
           isGroup={isGroupFlavor}
           acceptedAvailable={acceptedAvailable}
-          acceptanceComplete={isOwner}
+          acceptanceComplete={acceptanceComplete}
           passingAvailable={passingEnabled}
           sections={sections}
           onShare={() => setAcceptOpen(true)}
@@ -1537,6 +1543,10 @@ const SubmissionsPageContent = () => {
                 lastCollectedLabel={lastCollectedLabel}
                 stale={snapshotStale}
                 collecting={collecting}
+                refreshing={
+                  !canDispatchWorkflows &&
+                  (scoresRefetching || orgReposRefetching)
+                }
                 errorCount={liveErrorCount}
                 canCollect={canDispatchWorkflows}
                 // Stays mounted while collecting: the button IS the in-page
@@ -1557,6 +1567,11 @@ const SubmissionsPageContent = () => {
                         // Button's `loading` already swallows the click; this
                         // is the re-entrancy latch behind it.
                         if (collecting) return
+                        if (
+                          !canDispatchWorkflows &&
+                          (scoresRefetching || orgReposRefetching)
+                        )
+                          return
                         if (canDispatchWorkflows) {
                           collectScores.collect()
                         } else {
@@ -1783,7 +1798,7 @@ const SubmissionsPageContent = () => {
           acceptedUsernames={acceptedAvailable ? acceptedSet : undefined}
           // Only an owner sees every org repo; a non-owner's list is the repos
           // they were granted, so an absence is "not visible", not "not accepted".
-          acceptanceComplete={isOwner}
+          acceptanceComplete={acceptanceComplete}
           thresholdFraction={thresholdFraction}
           filtered={hasActiveFilter}
           onClearFilters={clearFilters}

--- a/web/src/pages/orgSettings/ServiceTokenTestResult.tsx
+++ b/web/src/pages/orgSettings/ServiceTokenTestResult.tsx
@@ -106,8 +106,10 @@ export default function ServiceTokenTestResult({
           <span>{t("orgSettings.serviceToken.test.failedLoading")}</span>
         ) : details.length > 0 ? (
           <ul className="list-disc space-y-1 ps-5">
-            {details.map((message) => (
-              <li key={message}>{message}</li>
+            {details.map((message, index) => (
+              // The probe may repeat a message (one per failed check), so the
+              // text alone is not a stable key.
+              <li key={`${index}-${message}`}>{message}</li>
             ))}
           </ul>
         ) : (

--- a/web/src/pages/submissions/DataFreshness.test.tsx
+++ b/web/src/pages/submissions/DataFreshness.test.tsx
@@ -146,6 +146,26 @@ describe("DataFreshness", () => {
       expect(onRefresh).toHaveBeenCalledTimes(1)
     })
 
+    it("spins and reads 'Refreshing…' while its re-reads are in flight", async () => {
+      // No workflow phase changes for a TA, so the re-reads themselves drive
+      // the feedback; the click is swallowed meanwhile like a collect.
+      const onRefresh = vi.fn()
+      render(
+        <DataFreshness
+          {...base}
+          canCollect={false}
+          refreshing
+          onRefresh={onRefresh}
+        />,
+      )
+      const btn = screen.getByRole("button")
+      expect(btn.textContent).toContain("submissions.freshness.refreshing")
+      expect(btn.textContent).not.toContain("submissions.collect.active")
+      expect(btn.getAttribute("aria-busy")).toBe("true")
+      await userEvent.click(btn)
+      expect(onRefresh).not.toHaveBeenCalled()
+    })
+
     it("explains who can collect, and only for that viewer", () => {
       const { rerender } = render(
         <DataFreshness {...base} canCollect={false} />,

--- a/web/src/pages/submissions/DataFreshness.tsx
+++ b/web/src/pages/submissions/DataFreshness.tsx
@@ -35,6 +35,10 @@ export type DataFreshnessProps = {
   // in-page progress indicator: it spins, reads "Collecting…", and goes inert
   // (but stays focusable) until the run settles.
   collecting: boolean
+  // The read-only Refresh variant's re-reads are in flight. Same treatment as
+  // `collecting`, reading "Refreshing…": a TA gets feedback for the click even
+  // though no workflow phase changes for them.
+  refreshing?: boolean
   // Collect (canCollect) or re-read (otherwise) the submission data. Omitted
   // when neither applies (e.g., empty roster) — then no button renders.
   onRefresh?: () => void
@@ -50,11 +54,16 @@ export function DataFreshness({
   lastCollectedLabel,
   stale,
   collecting,
+  refreshing = false,
   onRefresh,
   canCollect = true,
   errorCount = 0,
 }: DataFreshnessProps) {
   const { t } = useTranslation()
+  const busy = collecting || refreshing
+  const busyLabel = collecting
+    ? t("submissions.collect.active")
+    : t("submissions.freshness.refreshing")
 
   return (
     <div className="flex flex-col items-start gap-1">
@@ -71,8 +80,8 @@ export function DataFreshness({
           <Button
             variant="ghost"
             size="sm"
-            loading={collecting}
-            loadingLabel={t("submissions.collect.active")}
+            loading={busy}
+            loadingLabel={busyLabel}
             onClick={onRefresh}
             className="text-base-content/70"
             title={
@@ -81,8 +90,8 @@ export function DataFreshness({
                 : t("submissions.freshness.refreshHelp")
             }
           >
-            {collecting ? (
-              t("submissions.collect.active")
+            {busy ? (
+              busyLabel
             ) : (
               <>
                 <SyncIcon aria-hidden="true" className="size-4" />


### PR DESCRIPTION
## Summary

Four small items from the 1.42.0 release review (#830), all in the web app.

- **TA Refresh had no progress feedback.** `DataFreshness` only spun on the collect phase, which a TA never changes. It now takes a `refreshing` prop (the scores and org-repo re-reads in flight) and reads "Refreshing…" for the read-only variant, with the same swallowed-click behavior as a collect. New key `submissions.freshness.refreshing`.
- **Owners flashed the non-owner acceptance wording.** `acceptanceComplete={isOwner}` is fail-closed, so while the org role resolved every owner briefly saw the "you can see" tooltip and labels. Both `SubmissionsPage` and `AssignmentsPage` now assert completeness while the role is still pending (`isOwner || isPending`).
- **A passing token probe still read its annotations.** `useTestServiceToken` fetched jobs plus one annotations call per job for a completed run whose only annotation is a "passed" notice the result never renders. The read is now gated on a failed run.
- **Duplicate probe messages collided as React keys** in `ServiceTokenTestResult`; keyed by index and message.

## Test plan

- [x] `DataFreshness.test.tsx`: refreshing state spins, reads "Refreshing…", swallows the click
- [x] `useTestServiceToken.test.tsx`: no annotations read for a completed run; failed run still reads them; read failure still falls back to `[]`
- [x] `audit_i18n.py --strict` PASS, `tsc -b`, `eslint`, `prettier`