### PR TITLE
fix(cli): make collect warnings reflect what the run found

### DIFF
--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -431,7 +431,16 @@ def main() -> int:
             if not assignment_filter or s == assignment_filter
         ]
         assignment_count = len(collectable_slugs)
-        if assignment_count and not updates and not mode_flip_assignments:
+        # A detected record proves the token reads the student repos (and that
+        # someone pushed), so the token hint below would contradict the run's
+        # own data; "0 graded" with pushes pending is the autograder's business.
+        anything_detected = any(records for _, records, _ in detected.values())
+        if (
+            assignment_count
+            and not updates
+            and not mode_flip_assignments
+            and not anything_detected
+        ):
             emit_warning(
                 f"{classroom_short}: collected 0 submissions across "
                 f"{assignment_count} assignment(s). If you expected submissions, "
@@ -486,7 +495,11 @@ def main() -> int:
             # "never collected" (absent key) — popping it here would make a real
             # collect that found no submitters look like no collect at all.
             bucket["detected"] = merged
-            if bucket.get("detected") != before:
+            # Compared against the prior LIST, not the raw key: writing [] into a
+            # bucket that never had the key is bookkeeping, not a change, and
+            # would otherwise count once per bucket on the first run after an
+            # upgrade.
+            if merged != prior:
                 n_changes += 1
         try:
             save_scores(scores_path, scores)
@@ -1004,6 +1017,23 @@ def list_enrolled_logins(
     return _dedupe_logins(logins), {u.strip().lower() for u in student_logins}
 
 
+def parse_due(
+    classroom_short: str, slug: str, entry: dict[str, Any]
+) -> datetime.datetime | None:
+    """The assignment's `due` as a datetime, or None when absent or malformed.
+    A malformed value warns ONCE here: lateness silently absent would otherwise
+    be indistinguishable from "no due date set". Parse once per assignment and
+    hand the result to whatever needs it (see SubmissionDetector)."""
+    due_raw = entry.get("due")
+    due = parse_rfc3339(due_raw) if due_raw else None
+    if due_raw and due is None:
+        emit_warning(
+            f"{classroom_short}/{slug}: due = {due_raw!r} is not an RFC 3339 "
+            f"timestamp with timezone; skipping late-marking for this assignment"
+        )
+    return due
+
+
 class SubmissionDetector:
     """Per-repo submission detection for one assignment, shared by the
     no_autograder path (every repo) and the autograded path (repos with no
@@ -1025,6 +1055,9 @@ class SubmissionDetector:
         entry: dict[str, Any],
         service_token: str,
         roster_logins: set[str],
+        # Already parsed by the caller (parse_due), which owns the one warning
+        # for a malformed value.
+        due: datetime.datetime | None,
     ) -> None:
         self._api_url = api_url
         self._org = org
@@ -1037,16 +1070,7 @@ class SubmissionDetector:
         self._mode = "tag" if entry.get("submission_mode") == "tag" else "every-push"
         raw_tags = entry.get("submission_tags")
         self._tags = [t for t in (raw_tags or []) if isinstance(t, str) and t]
-
-        due_raw = entry.get("due")
-        self._due = parse_rfc3339(due_raw) if due_raw else None
-        if due_raw and self._due is None:
-            # Same advisory warning as the graded path — lateness silently absent
-            # would otherwise be indistinguishable from "no due date set".
-            emit_warning(
-                f"{classroom_short}/{slug}: due = {due_raw!r} is not an RFC 3339 "
-                f"timestamp with timezone; skipping late-marking for this assignment"
-            )
+        self._due = due
 
     def detect(self, username: str, repo_name: str) -> tuple[dict[str, Any] | None, bool]:
         try:
@@ -1136,6 +1160,7 @@ def collect_detected(
         entry=entry,
         service_token=service_token,
         roster_logins=roster_logins,
+        due=parse_due(classroom_short, slug, entry),
     )
     # team_usernames arrives already case-insensitively deduped (the
     # list_enrolled_logins union), so each repo is polled exactly once.
@@ -1307,13 +1332,7 @@ def collect_classroom(
             )
             continue
 
-        due_raw = entry.get("due")
-        due = parse_rfc3339(due_raw) if due_raw else None
-        if due_raw and due is None:
-            emit_warning(
-                f"{classroom_short}/{slug}: due = {due_raw!r} is not an RFC 3339 "
-                f"timestamp with timezone; skipping late-marking for this assignment"
-            )
+        due = parse_due(classroom_short, slug, entry)
 
         raw_mode = entry.get("mode")
         assignment_type = normalize_assignment_type(raw_mode)
@@ -1360,6 +1379,7 @@ def collect_classroom(
             entry=entry,
             service_token=service_token,
             roster_logins=roster_logins,
+            due=due,
         )
         detected_records: list[dict[str, Any]] = []
         detected_visited: set[str] = set()
@@ -2011,8 +2031,11 @@ def grant_classroom_team_access(
         return
 
     # Which teams the pass could work with, so the tail can tell "nothing to
-    # grant" (no populated staff team) from "already granted" (all idempotent).
+    # grant" (no populated staff team) from "already granted" (all idempotent),
+    # and "no staff team was ever set up" (all absent and unrecorded) from "a
+    # staff team exists but is empty".
     populated_teams: list[str] = []
+    absent_teams: list[str] = []
     for role, staff_team, permission in grant_teams:
         team_slug = staff_team.slug
         # Read this staff team's members to skip it when empty (see docstring).
@@ -2029,6 +2052,7 @@ def grant_classroom_team_access(
             if classify(exc) is not SKIPPABLE:
                 raise
             if exc.code == 404 and not staff_team.recorded:
+                absent_teams.append(team_slug)
                 print(
                     f"{classroom_short}: no {role} team recorded in classroom.json and "
                     f"{team_slug!r} does not exist on GitHub; nothing to grant for that role."
@@ -2099,7 +2123,15 @@ def grant_classroom_team_access(
             )
 
     if not populated_teams:
-        emit_warning(warn_no_staff_to_grant(classroom_short, org, grant_teams))
+        # Every staff team absent AND unrecorded means nothing was ever set up
+        # (a solo teacher, or a classroom before its first TA): a notice, since
+        # there is nothing to fix. A team that exists but is empty is the
+        # misconfiguration the warning is for.
+        message = warn_no_staff_to_grant(classroom_short, org, grant_teams)
+        if len(absent_teams) == len(grant_teams):
+            emit_notice(message)
+        else:
+            emit_warning(message)
 
 
 def warn_no_staff_to_grant(
@@ -2110,7 +2142,8 @@ def warn_no_staff_to_grant(
     """The verdict for a grant pass that found student repos but no populated
     staff team to grant them to. Without it, "every TA was moved to a team the
     pass can't see" exits 0 exactly like a healthy run, and the teacher learns
-    the TAs have no access only when they ask."""
+    the TAs have no access only when they ask. The caller picks the level: a
+    warning when some team exists but is empty, a notice when none was set up."""
     slugs = ", ".join(team.slug for _, team, _ in grant_teams)
     return (
         f"{classroom_short}: no staff access was granted because no head-TA or TA "
@@ -3974,6 +4007,10 @@ def emit_error(message: str) -> None:
 
 def emit_warning(message: str) -> None:
     print(f"::warning::{message}", file=sys.stderr)
+
+
+def emit_notice(message: str) -> None:
+    print(f"::notice::{message}", file=sys.stderr)
 
 
 # Entry point ----------------------------------------------------------------

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -1977,6 +1977,27 @@ class TestLateness:
         # Lateness is marked per submission, inside the row's submissions list.
         assert results[0]["submissions"][0]["late"] is True
 
+    def test_malformed_due_warns_exactly_once_per_autograded_assignment(
+        self, monkeypatch, capsys
+    ):
+        # The graded path and the push detector both need the parsed due date;
+        # the warning for a bad value must not be emitted once by each.
+        monkeypatch.setattr(cs, "all_submit_releases", lambda *a, **k: [])
+        monkeypatch.setattr(cs, "detect_repo_submissions", lambda *a, **k: [])
+        stub_team_members(monkeypatch, ["alice"])
+
+        cs.collect_classroom(
+            api_url="https://api.github.com",
+            org="cs50",
+            classroom_short="cs-principles",
+            classroom_meta={},
+            assignments={"assignments": [{"slug": "hello", "due": "2026-09-15"}]},
+            service_token="token",
+        )
+
+        err = capsys.readouterr().err
+        assert err.count("is not an RFC 3339 timestamp with timezone") == 1
+
 
 # roster.csv header lockstep --------------------------------------------------
 
@@ -2827,6 +2848,62 @@ class TestMain:
 
         assert cs.main() == 0
         assert "::warning::" not in capsys.readouterr().err
+
+    def test_no_token_hint_when_pushes_were_detected_but_none_graded(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # Zero graded entries with detected pushes is the autograder not having
+        # published yet, not a token that can't read the repos: detection just
+        # read them. The re-scope hint would contradict the run's own data.
+        write_minimal_classroom(tmp_path)
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
+        monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
+        detected = {
+            "hello": ("individual", [{"owner": "alice", "count": 2}], {"alice"})
+        }
+        monkeypatch.setattr(
+            cs,
+            "collect_classroom",
+            lambda **kwargs: ([], 0, {"hello": "individual"}, detected),
+        )
+
+        assert cs.main() == 0
+        err = capsys.readouterr().err
+        assert "collected 0 submissions" not in err
+        assert "rotate-service-token" not in err
+
+    def test_first_empty_detected_list_is_not_counted_as_a_change(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # A bucket written before detection existed has no `detected` key; the
+        # first run after an upgrade writes [] into it. That is bookkeeping, not
+        # an updated submission, so the summary must not count it.
+        write_minimal_classroom(tmp_path)
+        scores_path = tmp_path / "cs-principles" / "scores.json"
+        scores_path.write_text(
+            json.dumps(
+                {
+                    "schema": cs.SCORES_SCHEMA_V1,
+                    "assignments": {"hello": {"type": "individual", "entries": []}},
+                }
+            )
+        )
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("GITHUB_REPOSITORY_OWNER", "cs50")
+        monkeypatch.setenv("CLASSROOM50_SERVICE_TOKEN", "token")
+        detected = {"hello": ("individual", [], {"alice"})}
+        monkeypatch.setattr(
+            cs,
+            "collect_classroom",
+            lambda **kwargs: ([], 0, {"hello": "individual"}, detected),
+        )
+
+        assert cs.main() == 0
+        out = capsys.readouterr().out
+        assert "0 updated submission(s)" in out
+        written = json.loads(scores_path.read_text())
+        assert written["assignments"]["hello"]["detected"] == []
 
     def test_warns_when_zero_collected_but_assignments_exist(self, tmp_path, monkeypatch, capsys):
         # Team-driven collection: an empty roster no longer means
@@ -4248,6 +4325,30 @@ class TestGrantClassroomTeamAccess:
         # Per-team reasons on stdout so the log explains the verdict.
         assert "'classroom50-cs-ta' (ta) has no members" in out
         assert "no hta team recorded" in out
+
+    def test_no_staff_team_at_all_is_a_notice_not_a_warning(self, monkeypatch, capsys):
+        # A solo teacher: nothing under `teams`, and neither derived staff team
+        # exists on GitHub. Nothing is misconfigured, so this must not paint a
+        # yellow annotation on every collect; the verdict is still printed as a
+        # notice so a teacher who does expect TAs can find it.
+        grants = self._capture_grants(monkeypatch)
+
+        def fake_members(api_url, org, team_slug, token):
+            if team_slug == "classroom50-cs":
+                return ["alice", "bob"]
+            raise cs.urllib.error.HTTPError(url="u", code=404, msg="no", hdrs=None, fp=None)
+
+        monkeypatch.setattr(cs, "list_team_member_logins", fake_members)
+        cs.grant_classroom_team_access(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            classroom_meta={"schema": cs.CLASSROOM_SCHEMA_V1, "short_name": "cs"},
+            assignments=self.ASSIGNMENTS, service_token="tok",
+        )
+        assert grants == []
+        out, err = capsys.readouterr()
+        assert "::warning::" not in err
+        assert "::notice::cs: no staff access was granted" in err
+        assert "no ta team recorded" in out and "no hta team recorded" in out
 
     def test_no_warning_when_some_staff_team_is_populated(self, monkeypatch, capsys):
         grants = self._capture_grants(monkeypatch)


### PR DESCRIPTION
## Summary

Four `collect_scores.py` follow-ups from the 1.42.0 release review (#830). No behavior change to what is graded or written, only to what the run says about it.

- **Every collect warned for a classroom with no staff teams.** #835 made `resolve_staff_team_slugs` always return the derived `hta`/`ta` slugs, so a solo teacher's classroom hit the "404 and not recorded" branch for both roles and `warn_no_staff_to_grant` painted a `::warning::` on every run. The grant pass now tracks which roles were absent-and-unrecorded: when that is all of them, nothing was ever set up and the verdict is a `::notice::`; when a staff team exists but is empty (the discussion #768 case), it stays a `::warning::`. New `emit_notice` helper.
- **First run after upgrade inflated "updated submission(s)".** Writing `detected: []` into a bucket that never had the key compared `[] != None` and counted once per bucket. It now compares against the prior list.
- **The "collected 0 submissions... token lacks read access" hint contradicted the run's own data.** Zero graded entries with detected pushes means the autograder has not published, and detection just proved the token reads the repos. The hint is now suppressed when anything was detected.
- **A malformed `due` warned twice per autograded assignment**: once in `collect_classroom`, once in `SubmissionDetector.__init__`. `parse_due` now owns the parse and the warning; both detector construction sites pass the parsed value in.

## Test plan

- [x] New: no-staff-team-at-all is a notice; the existing empty-team case still asserts `::warning::`
- [x] New: first empty `detected` write prints `0 updated submission(s)`
- [x] New: detected pushes with zero graded entries emit no token hint
- [x] New: malformed `due` warns exactly once for an autograded assignment
- [x] `pytest cli/gh-teacher/skeleton_tests` 969 passed; `ruff check --select E4,E7,E9,F` clean