### PR TITLE
fix(cli): reuse the org listing when detecting pushes without a release

### DIFF
--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -628,8 +628,30 @@ def load_roster_metadata(classroom_dir: pathlib.Path) -> dict[str, dict[str, str
 # Per-classroom collection ----------------------------------------------------
 
 
+class RepoFacts(NamedTuple):
+    """What a listing (or a direct read) said about one repo, kept so a later
+    pass does not re-read the repo to learn it. `size` is GitHub's kilobyte
+    figure; 0 means the repo has no commits, so there is nothing to detect."""
+
+    private: bool
+    default_branch: str | None = None
+    size: int | None = None
+
+
+def repo_facts(repo: dict[str, Any]) -> RepoFacts:
+    """The RepoFacts of one repo object. `private` is strict (anything but the
+    boolean true reads as public, as before); the rest is optional."""
+    branch = repo.get("default_branch")
+    size = repo.get("size")
+    return RepoFacts(
+        repo.get("private") is True,
+        branch if isinstance(branch, str) and branch else None,
+        size if isinstance(size, int) and not isinstance(size, bool) else None,
+    )
+
+
 class RepoIndex:
-    """The org's repos (lowercased name -> `private`), read once per run and only
+    """The org's repos (lowercased name -> RepoFacts), read once per run and only
     when something asks.
 
     Both passes walk the (team member × assignment) product — thousands of names
@@ -659,16 +681,16 @@ class RepoIndex:
         self._api_url = api_url
         self._org = org
         self._token = token
-        self._repos: dict[str, bool] | None = None
+        self._repos: dict[str, RepoFacts] | None = None
         self._loaded = False
         self._started = 0.0
         # Probe mode: page 1 plus per-name answers. `_found` maps a name to its
-        # private flag, or None when its read failed (unknown, fails open);
-        # `_missing` holds the names that 404ed so they are not probed twice.
+        # facts, or None when its read failed (unknown, fails open); `_missing`
+        # holds the names that 404ed so they are not probed twice.
         self._probing = False
         self._last_page = 1
         self._probes_spent = 0
-        self._found: dict[str, bool | None] = {}
+        self._found: dict[str, RepoFacts | None] = {}
         self._missing: set[str] = set()
 
     def prefetch(self, repo_names: Iterable[str]) -> None:
@@ -681,7 +703,7 @@ class RepoIndex:
             return
         self._probe([name for name in names if not self._resolved(name)])
 
-    def _load(self, hint: list[str] | None = None) -> dict[str, bool] | None:
+    def _load(self, hint: list[str] | None = None) -> dict[str, RepoFacts] | None:
         """The repos, or None when the listing is unknown (unreadable, or being
         answered by probes). Reads once; a soft failure warns once and stays None.
 
@@ -717,7 +739,7 @@ class RepoIndex:
             )
             return None
 
-    def _read(self, hint: list[str] | None) -> dict[str, bool] | None:
+    def _read(self, hint: list[str] | None) -> dict[str, RepoFacts] | None:
         """One attempt at the org listing (or, given a small enough hint, its
         first page plus probes)."""
         if hint is None:
@@ -754,7 +776,7 @@ class RepoIndex:
             repos.update(rest)
         return self._listing(repos)
 
-    def _listing(self, repos: dict[str, bool] | None) -> dict[str, bool] | None:
+    def _listing(self, repos: dict[str, RepoFacts] | None) -> dict[str, RepoFacts] | None:
         """Accept a complete listing, treating empty as unknown."""
         if not repos:
             return None
@@ -764,7 +786,7 @@ class RepoIndex:
         )
         return repos
 
-    def _complete_listing(self) -> dict[str, bool] | None:
+    def _complete_listing(self) -> dict[str, RepoFacts] | None:
         """Leave probe mode by reading the rest of the listing. Probed answers
         are kept: a name found by probe is in the org whether or not it lands on
         a page (a repo created mid-walk shifts the pages). A soft failure leaves
@@ -778,7 +800,7 @@ class RepoIndex:
         if rest is None:
             self._repos = None
             return None
-        repos = {name: private for name, private in self._found.items() if private is not None}
+        repos = {name: facts for name, facts in self._found.items() if facts is not None}
         repos.update(rest)
         self._repos = self._listing(repos)
         return self._repos
@@ -799,7 +821,7 @@ class RepoIndex:
         self._found.update(found)
         self._missing.update(name for name in names if name not in found)
 
-    def _answers(self, name: str) -> dict[str, bool | None] | None:
+    def _answers(self, name: str) -> dict[str, RepoFacts | None] | None:
         """The map that holds `name`'s answer: the listing, or in probe mode the
         probe results once `name` is resolved (which may complete the listing).
         None when the listing is unknown. In probe mode an unknown name maps to
@@ -818,13 +840,18 @@ class RepoIndex:
         answers = self._answers(name)
         return answers is None or name in answers
 
-    def is_private(self, repo_name: str) -> bool | None:
-        """Whether `repo_name` is private, or None when the index can't say (the
-        listing was unreadable, or the name isn't in it). Answers from the
-        listing already read, saving the caller a per-repo request."""
+    def facts(self, repo_name: str) -> RepoFacts | None:
+        """What the listing said about `repo_name`, or None when the index can't
+        say (the listing was unreadable, or the name isn't in it). Answers from
+        the read already made, saving the caller a per-repo request."""
         name = repo_name.lower()
         answers = self._answers(name)
         return None if answers is None else answers.get(name)
+
+    def is_private(self, repo_name: str) -> bool | None:
+        """Whether `repo_name` is private, or None when the index can't say."""
+        facts = self.facts(repo_name)
+        return None if facts is None else facts.private
 
     def names(self) -> list[str] | None:
         """Every visible repo name (lowercased), or None when the listing is
@@ -1058,6 +1085,10 @@ class SubmissionDetector:
         # Already parsed by the caller (parse_due), which owns the one warning
         # for a malformed value.
         due: datetime.datetime | None,
+        # The run's RepoIndex, when the caller has one: what its listing said
+        # about a repo spares detection a request per repo (see
+        # detect_repo_submissions). None probes cold.
+        repo_index: RepoIndex | None = None,
     ) -> None:
         self._api_url = api_url
         self._org = org
@@ -1065,6 +1096,7 @@ class SubmissionDetector:
         self._slug = slug
         self._token = service_token
         self._roster_logins = roster_logins
+        self._repo_index = repo_index
         self._is_team = normalize_assignment_type(entry.get("mode")) == "team"
 
         self._mode = "tag" if entry.get("submission_mode") == "tag" else "every-push"
@@ -1073,9 +1105,18 @@ class SubmissionDetector:
         self._due = due
 
     def detect(self, username: str, repo_name: str) -> tuple[dict[str, Any] | None, bool]:
+        facts = (
+            self._repo_index.facts(repo_name) if self._repo_index is not None else None
+        )
         try:
             detections = detect_repo_submissions(
-                self._api_url, self._org, repo_name, self._token, self._mode, self._tags
+                self._api_url,
+                self._org,
+                repo_name,
+                self._token,
+                self._mode,
+                self._tags,
+                facts=facts,
             )
         except urllib.error.HTTPError as exc:
             if classify(exc) is not SKIPPABLE:
@@ -1161,6 +1202,7 @@ def collect_detected(
         service_token=service_token,
         roster_logins=roster_logins,
         due=parse_due(classroom_short, slug, entry),
+        repo_index=repo_index,
     )
     # team_usernames arrives already case-insensitively deduped (the
     # list_enrolled_logins union), so each repo is polled exactly once.
@@ -1380,6 +1422,7 @@ def collect_classroom(
             service_token=service_token,
             roster_logins=roster_logins,
             due=due,
+            repo_index=repo_index,
         )
         detected_records: list[dict[str, Any]] = []
         detected_visited: set[str] = set()
@@ -2981,17 +3024,26 @@ def detect_repo_submissions(
     token: str,
     mode: str,
     submission_tags: list[str],
+    facts: RepoFacts | None = None,
 ) -> list[dict[str, Any]]:
     """One repo's detected submissions. Branch mode reads the default branch, its
     accept-marker baseline and its commit log; tag mode reads its tags. Returns
-    [] for a repo that isn't accepted or is commitless."""
+    [] for a repo that isn't accepted or is commitless.
+
+    `facts` is what the org listing already said about the repo (RepoIndex).
+    A commitless repo is answered from it without a request, and a known
+    default branch spares the GET /repos read that only existed to learn it."""
+    if facts is not None and facts.size == 0:
+        return []
     if mode == "tag":
         tags = list_repo_tags(api_url, org, repo_name, token)
         patterns = [*submission_tags, f"{SUBMIT_TAG_PREFIX}*"]
         return detect_tag_submissions(tags, patterns)
 
-    info = get_repo(api_url, org, repo_name, token)
-    branch = (info or {}).get("default_branch")
+    branch: Any = facts.default_branch if facts is not None else None
+    if branch is None:
+        info = get_repo(api_url, org, repo_name, token)
+        branch = (info or {}).get("default_branch")
     if not isinstance(branch, str) or not branch:
         return []  # not accepted, or no commits yet
     baseline = oldest_commit_sha_for_path(
@@ -3382,7 +3434,7 @@ def _org_repos_page_url(api_url: str, org: str) -> Callable[[int], str]:
 
 
 def list_org_repos(api_url: str, org: str, token: str) -> dict[str, bool]:
-    """Lowercased name -> `private` flag for every repo in `org` the token can
+    """Lowercased name -> RepoFacts for every repo in `org` the token can
     see, walking pagination in parallel. Hits GET /orgs/{org}/repos.
 
     Read once per run — see RepoIndex, which documents why a name absent here
@@ -3397,13 +3449,13 @@ def list_org_repos(api_url: str, org: str, token: str) -> dict[str, bool]:
         token=token,
         resource_label=f"orgs/{org}/repos",
     )
-    return _repo_privacy_map(repos)
+    return _repo_facts_map(repos)
 
 
 def list_org_repos_first_page(
     api_url: str, org: str, token: str
-) -> tuple[dict[str, bool], int]:
-    """Page 1 of the org listing as (lowercased name -> private, page count).
+) -> tuple[dict[str, RepoFacts], int]:
+    """Page 1 of the org listing as (lowercased name -> RepoFacts, page count).
     A count of 1 means the map already is the whole listing. Lets RepoIndex
     learn the org's size from one request before deciding whether listing the
     rest or probing the candidate names is cheaper.
@@ -3412,31 +3464,31 @@ def list_org_repos_first_page(
     items, last = _first_page(
         _org_repos_page_url(api_url, org), api_url, token, f"orgs/{org}/repos"
     )
-    return _repo_privacy_map(items), last or 1
+    return _repo_facts_map(items), last or 1
 
 
 def list_org_repos_rest(
     api_url: str, org: str, token: str, last: int
-) -> dict[str, bool]:
+) -> dict[str, RepoFacts]:
     """Pages 2..last of the org listing, fetched in parallel. The second half
     of list_org_repos_first_page."""
     batches = _fetch_pages_parallel(
         _org_repos_page_url(api_url, org), token, range(2, last + 1)
     )
-    return _repo_privacy_map(item for batch in batches for item in batch)
+    return _repo_facts_map(item for batch in batches for item in batch)
 
 
 def probe_org_repos(
     api_url: str, org: str, names: list[str], token: str
-) -> dict[str, bool | None]:
-    """Lowercased name -> private flag for each of `names` that exists, None for
+) -> dict[str, RepoFacts | None]:
+    """Lowercased name -> RepoFacts for each of `names` that exists, None for
     a name whose read failed with a skippable error (unknown, so callers fail
     open); a 404 name is absent. Reads GET /repos/{org}/{name} in parallel.
 
     A throttle or a fatal error propagates, abandoning the probes not yet
     started, so the caller's retry sees an unresolved name rather than a wrong
     answer."""
-    def probe(name: str) -> tuple[str, bool | None, bool]:
+    def probe(name: str) -> tuple[str, RepoFacts | None, bool]:
         try:
             repo = get_repo(api_url, org, name, token)
         except urllib.error.HTTPError as exc:
@@ -3445,33 +3497,33 @@ def probe_org_repos(
             return name.lower(), None, True
         if repo is None:
             return name.lower(), None, False
-        return name.lower(), repo.get("private") is True, True
+        return name.lower(), repo_facts(repo), True
 
     if not names:
         return {}
-    found: dict[str, bool | None] = {}
+    found: dict[str, RepoFacts | None] = {}
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=min(PARALLEL_PAGE_WORKERS, len(names))
     ) as pool:
         futures = [pool.submit(probe, name) for name in names]
         try:
             for future in futures:
-                name, private, present = future.result()
+                name, facts, present = future.result()
                 if present:
-                    found[name] = private
+                    found[name] = facts
         except BaseException:
             pool.shutdown(wait=False, cancel_futures=True)
             raise
     return found
 
 
-def _repo_privacy_map(repos: Iterable[dict[str, Any]]) -> dict[str, bool]:
-    """Lowercased name -> strict-boolean `private` from repo objects."""
-    visible: dict[str, bool] = {}
+def _repo_facts_map(repos: Iterable[dict[str, Any]]) -> dict[str, RepoFacts]:
+    """Lowercased name -> RepoFacts from repo objects."""
+    visible: dict[str, RepoFacts] = {}
     for repo in repos:
         name = repo.get("name")
         if isinstance(name, str) and name:
-            visible[name.lower()] = repo.get("private") is True
+            visible[name.lower()] = repo_facts(repo)
     return visible
 
 

--- a/cli/gh-teacher/skeleton_tests/test_collect_scores.py
+++ b/cli/gh-teacher/skeleton_tests/test_collect_scores.py
@@ -1085,6 +1085,9 @@ class _FakeRepoIndex:
     def is_private(self, repo_name):
         return True
 
+    def facts(self, repo_name):
+        return None
+
 
 class TestTeamCollectClassroom:
     """The team-mode attribution suite, mirroring TestGroupCollectClassroom:
@@ -2671,6 +2674,94 @@ class TestCommitWalkEarlyStop:
         ]
 
 
+class TestDetectionReusesTheListing:
+    """detect_repo_submissions used to spend GET /repos on every probed repo to
+    learn its default branch, which the org listing (RepoIndex) had already
+    said. Early in term most accepted repos have no release yet, so that read
+    dominated the run's request budget."""
+
+    def _stub_walk(self, monkeypatch, calls):
+        monkeypatch.setattr(
+            cs, "get_repo",
+            lambda *a, **k: calls.append("get_repo") or {"default_branch": "main"},
+        )
+        monkeypatch.setattr(
+            cs, "oldest_commit_sha_for_path",
+            lambda *a, **k: calls.append("baseline") or "base",
+        )
+        monkeypatch.setattr(
+            cs, "list_default_branch_commits",
+            lambda *a, **k: calls.append("commits") or [
+                {"sha": "s1", "commit": {"committer": {"date": "2026-06-01T10:00:00Z"}}},
+                {"sha": "base"},
+            ],
+        )
+
+    def test_known_default_branch_skips_the_repo_read(self, monkeypatch):
+        calls: list[str] = []
+        self._stub_walk(monkeypatch, calls)
+        got = cs.detect_repo_submissions(
+            "https://api.github.com", "cs50", "cs-hw1-alice", "tok", "every-push", [],
+            facts=cs.RepoFacts(True, default_branch="main", size=12),
+        )
+        assert calls == ["baseline", "commits"]
+        assert [d["sha"] for d in got] == ["s1"]
+
+    def test_commitless_repo_is_answered_without_a_request(self, monkeypatch):
+        calls: list[str] = []
+        self._stub_walk(monkeypatch, calls)
+        monkeypatch.setattr(
+            cs, "list_repo_tags", lambda *a, **k: calls.append("tags") or []
+        )
+        for mode in ("every-push", "tag"):
+            assert cs.detect_repo_submissions(
+                "https://api.github.com", "cs50", "cs-hw1-alice", "tok", mode, [],
+                facts=cs.RepoFacts(True, default_branch="main", size=0),
+            ) == []
+        assert calls == []
+
+    def test_no_facts_reads_the_repo_as_before(self, monkeypatch):
+        calls: list[str] = []
+        self._stub_walk(monkeypatch, calls)
+        cs.detect_repo_submissions(
+            "https://api.github.com", "cs50", "cs-hw1-alice", "tok", "every-push", []
+        )
+        assert calls == ["get_repo", "baseline", "commits"]
+
+    def test_detector_hands_the_index_facts_to_detection(self, monkeypatch):
+        seen: dict[str, object] = {}
+
+        def fake_detect(api_url, org, repo_name, token, mode, tags, facts=None):
+            seen["facts"] = facts
+            return []
+
+        monkeypatch.setattr(cs, "detect_repo_submissions", fake_detect)
+        monkeypatch.setattr(
+            cs, "list_org_repos",
+            lambda *a, **k: {
+                "cs-hw1-alice": cs.RepoFacts(True, default_branch="trunk", size=3)
+            },
+        )
+        index = cs.RepoIndex("https://api.github.com", "cs50", "tok")
+        detector = cs.SubmissionDetector(
+            api_url="https://api.github.com", org="cs50", classroom_short="cs",
+            slug="hw1", entry={}, service_token="tok", roster_logins=set(),
+            due=None, repo_index=index,
+        )
+        detector.detect("alice", "cs-hw1-alice")
+        assert seen["facts"] == cs.RepoFacts(True, default_branch="trunk", size=3)
+
+    def test_listing_keeps_default_branch_and_size(self):
+        facts = cs.repo_facts(
+            {"name": "r", "private": True, "default_branch": "main", "size": 0}
+        )
+        assert facts == cs.RepoFacts(True, "main", 0)
+        # Anything malformed is simply unknown; `private` stays strict.
+        assert cs.repo_facts({"name": "r", "private": "yes", "size": True}) == (
+            cs.RepoFacts(False, None, None)
+        )
+
+
 # main() hard-failure handling -------------------------------------------------
 
 
@@ -3527,7 +3618,7 @@ def test_no_autograder_detection_records_no_score(monkeypatch):
 def test_no_autograder_detection_omits_non_submitters(monkeypatch):
     # A repo with nothing detected is OMITTED rather than recorded as 0, so the
     # record list is exactly the submitter set (what the progress bar counts).
-    def per_user(api_url, org, repo_name, token, mode, tags):
+    def per_user(api_url, org, repo_name, token, mode, tags, facts=None):
         return [{"sha": "c1", "datetime": "2026-06-01T10:00:00Z"}] if "alice" in repo_name else []
 
     monkeypatch.setattr(cs, "detect_repo_submissions", per_user)
@@ -3579,7 +3670,7 @@ def test_no_autograder_detection_tag_mode_reads_tags(monkeypatch):
     # detectTagSubmissions mirrors.
     seen = {}
 
-    def capture(api_url, org, repo_name, token, mode, tags):
+    def capture(api_url, org, repo_name, token, mode, tags, facts=None):
         seen["mode"] = mode
         seen["tags"] = tags
         return [{"count": 2, "datetime": "2026-06-02T10:00:00Z"}]
@@ -3614,7 +3705,7 @@ def test_no_autograder_detection_tag_mode_reads_tags(monkeypatch):
 
 def test_no_autograder_detection_skips_unreadable_repo(monkeypatch, capsys):
     # One unreadable repo warns and is skipped; it must not void the assignment.
-    def flaky(api_url, org, repo_name, token, mode, tags):
+    def flaky(api_url, org, repo_name, token, mode, tags, facts=None):
         if "bob" in repo_name:
             raise http_error(500, "Server Error")
         return [{"sha": "c1", "datetime": "2026-06-01T10:00:00Z"}]
@@ -3703,7 +3794,7 @@ def test_no_autograder_detection_tag_mode_does_not_trust_tag_times(monkeypatch):
 def test_no_autograder_detection_reports_visited_owners(monkeypatch):
     # `visited` names owners whose repo was actually read, so main() can tell a
     # failed read apart from "nothing detected" and preserve the prior record.
-    def flaky(api_url, org, repo_name, token, mode, tags):
+    def flaky(api_url, org, repo_name, token, mode, tags, facts=None):
         if "bob" in repo_name:
             raise http_error(500, "Server Error")
         return [{"sha": "c1", "datetime": "2026-06-01T10:00:00Z"}]
@@ -3775,7 +3866,7 @@ def test_autograded_assignment_detects_pushes_with_no_release(monkeypatch, capsy
     # not, and no graded entry is invented for either.
     monkeypatch.setattr(cs, "all_submit_releases", lambda *a, **k: [])
 
-    def per_user(api_url, org, repo_name, token, mode, tags):
+    def per_user(api_url, org, repo_name, token, mode, tags, facts=None):
         assert mode == "every-push"
         return (
             [
@@ -3822,7 +3913,7 @@ def test_autograded_graded_repo_is_visited_but_never_probed(monkeypatch):
         lambda *a, **k: make_result(username="alice", assignment="hw1"),
     )
     monkeypatch.setattr(
-        cs, "detect_repo_submissions", lambda a, o, repo, *rest: probed.append(repo) or []
+        cs, "detect_repo_submissions", lambda a, o, repo, *rest, **kw: probed.append(repo) or []
     )
     stub_team_members(monkeypatch, ["alice", "bob"])
 
@@ -3846,7 +3937,7 @@ def test_autograded_detection_respects_tag_mode(monkeypatch):
     monkeypatch.setattr(cs, "all_submit_releases", lambda *a, **k: [])
     seen: dict[str, object] = {}
 
-    def fake_detect(api_url, org, repo_name, token, mode, tags):
+    def fake_detect(api_url, org, repo_name, token, mode, tags, facts=None):
         seen["mode"], seen["tags"] = mode, tags
         return [{"count": 1, "datetime": "2026-06-01T10:00:00Z"}]
 
@@ -3874,7 +3965,7 @@ def test_autograded_detection_failure_keeps_prior_record(monkeypatch, capsys):
     # record from the last run instead of deleting a submitter over a 500.
     monkeypatch.setattr(cs, "all_submit_releases", lambda *a, **k: [])
 
-    def flaky(api_url, org, repo_name, token, mode, tags):
+    def flaky(api_url, org, repo_name, token, mode, tags, facts=None):
         raise http_error(500, "Server Error")
 
     monkeypatch.setattr(cs, "detect_repo_submissions", flaky)
@@ -4882,6 +4973,9 @@ class StubIndex:
     def contains(self, repo_name):
         return repo_name.lower() in self._names
 
+    def facts(self, repo_name):
+        return None
+
 
 class TestPassesSkipMissingRepos:
     META = TestGrantThrottled.META
@@ -4918,7 +5012,7 @@ class TestPassesSkipMissingRepos:
         monkeypatch.setattr(cs, "list_enrolled_logins", lambda *a, **k: (["alice", "bob"], {"alice", "bob"}))
         monkeypatch.setattr(cs, "all_submit_releases", fake_releases)
         monkeypatch.setattr(
-            cs, "detect_repo_submissions", lambda a, o, repo, *rest: probed.append(repo) or []
+            cs, "detect_repo_submissions", lambda a, o, repo, *rest, **kw: probed.append(repo) or []
         )
         _, _, _, detected = cs.collect_classroom(
             api_url="https://api.github.com", org="cs50", classroom_short="cs",
@@ -5145,7 +5239,9 @@ class TestOrgAndTeamListings:
         repos = cs.list_org_repos("https://api.github.com", "CS50", "tok")
         # The private flag rides along from the same bodies, so the grant pass
         # doesn't re-read each template. Strict boolean: a non-bool is not True.
-        assert repos == {"cs-hw1-alice": True, "cs-hw2-bob": False, "starter": False}
+        assert {n: f.private for n, f in repos.items()} == {
+            "cs-hw1-alice": True, "cs-hw2-bob": False, "starter": False
+        }
         # type=all keeps private student repos in the listing; without it the
         # index would call every private repo missing and skip its poll.
         assert "type=all" in self.seen_url and "per_page=100" in self.seen_url
@@ -5185,7 +5281,7 @@ class TestTemplatePrivacyFromTheIndex:
     def test_index_answers_privacy_without_a_per_template_read(self, monkeypatch):
         monkeypatch.setattr(
             cs, "list_org_repos",
-            lambda *a, **k: {"priv-tmpl": True, "pub-tmpl": False},
+            lambda *a, **k: {"priv-tmpl": cs.RepoFacts(True), "pub-tmpl": cs.RepoFacts(False)},
         )
         monkeypatch.setattr(
             cs, "get_repo", lambda *a, **k: pytest.fail("no per-template read expected")
@@ -5429,6 +5525,7 @@ class TestRepoIndexProbeMode:
         self, monkeypatch, *, last, page1=None, existing=(), fail=(), rest_error=None
     ):
         page1 = {"starter": False} if page1 is None else dict(page1)
+        page1 = {n: cs.RepoFacts(p) for n, p in page1.items()}
         probed: list[str] = []
         rest_reads: list[int] = []
 
@@ -5439,7 +5536,7 @@ class TestRepoIndexProbeMode:
             rest_reads.append(n)
             if rest_error is not None:
                 raise rest_error
-            return {name: False for name in existing}
+            return {name: cs.RepoFacts(False) for name in existing}
 
         def get_repo(api_url, owner, repo, token):
             probed.append(repo)
@@ -5629,6 +5726,9 @@ class TestCollectPassHintsEveryPoll:
         def is_private(self, name):
             return None
 
+        def facts(self, name):
+            return None
+
         def names(self):
             return []
 
@@ -5676,7 +5776,7 @@ class TestListOrgReposFirstPage:
 
         monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
         repos, last = cs.list_org_repos_first_page("https://api.github.com", "cs50", "tok")
-        assert repos == {"a": True} and last == 90
+        assert repos == {"a": cs.RepoFacts(True)} and last == 90
         # Oldest first: a repo created mid-walk lands after the pages in flight.
         assert "sort=created" in self.url and "direction=asc" in self.url
 
@@ -5686,7 +5786,7 @@ class TestListOrgReposFirstPage:
 
         monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
         assert cs.list_org_repos_first_page("https://api.github.com", "cs50", "tok") == (
-            {"a": False},
+            {"a": cs.RepoFacts(False)},
             1,
         )
 
@@ -5716,7 +5816,9 @@ class TestListOrgReposFirstPage:
         monkeypatch.setattr(cs, "_http_get_with_headers", fake_get)
         got = cs.list_org_repos_rest("https://api.github.com", "cs50", "tok", 4)
         assert sorted(seen) == [2, 3, 4]
-        assert got == {"r2": False, "r3": True, "r4": False}
+        assert got == {
+            "r2": cs.RepoFacts(False), "r3": cs.RepoFacts(True), "r4": cs.RepoFacts(False)
+        }
 
 
 class TestThrottleBudgetUnderConcurrency:
@@ -5774,7 +5876,7 @@ class TestProbeOrgRepos:
         got = cs.probe_org_repos(
             "https://api.github.com", "cs50", ["Priv", "pub", "gone", "blocked"], "tok"
         )
-        assert got == {"priv": True, "pub": False, "blocked": None}
+        assert got == {"priv": cs.RepoFacts(True), "pub": cs.RepoFacts(False), "blocked": None}
 
     def test_fatal_propagates(self, monkeypatch):
         def get_repo(*a, **k):


### PR DESCRIPTION
## Summary

Stacked on #845 (same `SubmissionDetector` code); GitHub will retarget to `main` when that merges.

#838 made `collect_scores.py` detect pushes in every autograded repo with no `submit/*` release, at 3+ requests per repo (`GET /repos` for the default branch, the accept-baseline walk, the commit walk). Early in term that is the dominant path: 300 students x 5 assignments at 60% accepted-but-unsubmitted is roughly +2,700 requests per run against a 5,000/hr PAT budget. The 1.42.0 review (#830) flagged it.

The cheapest correct cut, without changing what is detected:

- **`RepoIndex` keeps `default_branch` and `size` alongside `private`** (`RepoFacts`) from the listing and probe responses it already reads; `facts(name)` exposes them and `is_private` is now a view over it.
- **`detect_repo_submissions` takes the facts.** A known default branch skips the `GET /repos` read (1 of the 3 requests). A repo with `size == 0` has no commits, so it is answered `[]` with no request at all in either mode.
- `SubmissionDetector` receives the run's index and hands the facts through; with no index (listing unreadable) detection probes cold exactly as before.

Not done, deliberately: comparing `pushed_at` with the accept baseline. Accept itself pushes the marker and Feedback-PR commits, so `pushed_at` is about accept time for every non-submitter (the web documents this in `assignmentRepoPresence.ts`); it cannot tell a push from an accept. The web mirror (`useDetectedSubmissions.ts`) is unchanged.

## Test plan

- [x] New `TestDetectionReusesTheListing`: known branch skips `get_repo`; `size == 0` issues no request in either mode; no facts keeps the old three reads; the detector hands the index facts through; `repo_facts` stays strict on `private`
- [x] Existing listing/probe/index tests updated to the `RepoFacts` shape (privacy semantics unchanged)
- [x] `pytest cli/gh-teacher/skeleton_tests` 974 passed; `ruff check --select E4,E7,E9,F` clean