### PR TITLE
fix(cli): hand the classroom default autograder the extracted bundle

### DIFF
--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -1049,6 +1049,12 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 	if resolved != nil {
 		templateDesc = fmt.Sprintf("template %s/%s@%s", resolved.Owner, resolved.Repo, resolved.Branch)
 	}
+	// Said on the summary line for every template kind: the stderr note below
+	// only fires for a private in-org template, and a public or absent one is
+	// still UX-locked for every student.
+	if committedLocked {
+		templateDesc += ", locked"
+	}
 	_, _ = fmt.Fprintf(out, "%s/%s/%s: %s %s (%s, autograder %s)\n",
 		org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), action, slug,
 		templateDesc, entry.Autograder)

--- a/cli/gh-teacher/internal/assignmentcmd/lock_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/lock_test.go
@@ -390,6 +390,48 @@ func TestRunAssignmentAdd_LockedFlagOnFreshAddSkipsGrant(t *testing.T) {
 	if !strings.Contains(errOut.String(), "locked") {
 		t.Errorf("expected the locked note on stderr, got %q", errOut.String())
 	}
+	if !strings.Contains(out.String(), ", locked, ") {
+		t.Errorf("expected the summary line to say the entry is locked, got %q", out.String())
+	}
+}
+
+// TestRunAssignmentAdd_LockedFlagOnPublicTemplateIsConfirmed: with a PUBLIC
+// template there is no read to withhold, so the stderr note never fires; the
+// summary line is then the only confirmation that --locked took effect.
+func TestRunAssignmentAdd_LockedFlagOnPublicTemplateIsConfirmed(t *testing.T) {
+	server, fix := newLockServer(t, lockServerConfig{
+		assignments:     lockAssignmentsBody(false),
+		classroom:       lockClassroomBody(),
+		templatePrivate: false,
+	})
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	err := runAssignmentAdd(client, &out, &errOut, addAssignmentParams{
+		Org:           "o",
+		Classroom:     "dst",
+		Slug:          "exam",
+		Name:          "Exam",
+		Tmpl:          &templateArg{Owner: "o", Repo: "hello-template"},
+		Mode:          assignment.ModeIndividual,
+		Autograder:    "default",
+		Locked:        true,
+		LockedChanged: true,
+	})
+	if err != nil {
+		t.Fatalf("runAssignmentAdd(--locked, public template): %v", err)
+	}
+	file := decodeLock(t, fix)
+	idx, ok := assignment.FindAssignment(file.Assignments, "exam")
+	if !ok || !file.Assignments[idx].Locked {
+		t.Fatalf("expected the new entry to be written locked, got %+v", file.Assignments)
+	}
+	if !strings.Contains(out.String(), ", locked, ") {
+		t.Errorf("expected the summary line to say the entry is locked, got %q", out.String())
+	}
+	if strings.Contains(errOut.String(), "was not granted read") {
+		t.Errorf("a public template has no read to withhold; got the private-template note %q", errOut.String())
+	}
 }
 
 // TestRunAssignmentAdd_LockedFlagOnReAddRevokes: `--locked` on a same-slug

--- a/cli/gh-teacher/internal/servicetoken/servicetoken.go
+++ b/cli/gh-teacher/internal/servicetoken/servicetoken.go
@@ -107,22 +107,19 @@ func SecretExists(client githubapi.Client, owner, repo string) (bool, error) {
 	return true, nil
 }
 
-// ValidateToken confirms a service token can do what the pipeline needs:
+// ValidateTokenVerbose confirms a service token can do what the pipeline needs:
 // Contents Read+Write in the org (collect reads, regrade pushes submit/* tags),
 // Administration: write (collect grants staff teams repo access via PUT
 // /orgs/{org}/teams/{slug}/repos/... — a scope not implied by Contents), AND
 // org Members: Read (collection is team-driven and lists the classroom team's
 // members — also not implied by any repository permission). Catches a
 // misconfigured PAT at provisioning time rather than as an opaque collect-time 403.
-func ValidateToken(token []byte, org string) error {
-	return ValidateTokenVerbose(token, org, nil, io.Discard)
-}
-
-// ValidateTokenVerbose is ValidateToken with a writer for advisory notes. When
-// the org-members probe is INCONCLUSIVE (401/5xx/timeout after a proven-live
-// repo read), validation still passes (fail-open) but warns to `out` so the
-// teacher knows Members: Read wasn't positively confirmed and should run the
-// `probe-token` workflow before relying on collection.
+//
+// `out` receives advisory notes. When the org-members probe is INCONCLUSIVE
+// (401/5xx/timeout after a proven-live repo read), validation still passes
+// (fail-open) but warns to `out` so the teacher knows Members: Read wasn't
+// positively confirmed and should run the `probe-token` workflow before relying
+// on collection.
 //
 // `teacher` is the caller's own authenticated client. When non-nil it is used
 // to find a private repo other than classroom50 to read as the token, which is
@@ -145,7 +142,7 @@ func ValidateTokenVerbose(token []byte, org string, teacher githubapi.Client, ou
 	return validateRepoScopeWithClients(tokenClient, teacher, org, out)
 }
 
-// validateTokenWithClient is ValidateToken's testable core: reads the config
+// validateTokenWithClient is ValidateTokenVerbose's testable core: reads the config
 // repo with a client authenticated as the token, asserts it can write contents
 // AND administer repos, then probes org members, mapping each failure mode to
 // an actionable error.

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
@@ -2381,16 +2381,25 @@ def resolve_entrypoint(
 
 def run_entrypoint(
     finalize: Finalizer, entrypoint: pathlib.Path, workspace: pathlib.Path,
+    *, bundle_dir: pathlib.Path | None = None,
 ) -> int | None:
     """Exec the entrypoint with the helper env vars and cwd at the student's
     checkout. Returns an rc (already finalized as an error) on a failed
     invocation or a non-zero autograder exit, else None to continue.
 
+    `bundle_dir` is where fetch_bundle extracted the per-assignment bundle. It
+    is what CLASSROOM50_BUNDLE_DIR names, even for the classroom DEFAULT
+    entrypoint (written beside it, not inside it), so a default autograder.py
+    can still reach a bundle that ships only fixtures. With no bundle (a 404,
+    or nothing extracted) the entrypoint's own directory is the fallback.
+
     The USERNAME / *_URL helper env vars are read off `finalize` (the identity
     carrier), matching run_declarative, rather than re-threading them through
     the signature."""
     env = dict(os.environ)
-    env[BUNDLE_DIR_ENV] = str(entrypoint.parent.resolve())
+    if bundle_dir is None or not bundle_dir.is_dir():
+        bundle_dir = entrypoint.parent
+    env[BUNDLE_DIR_ENV] = str(bundle_dir.resolve())
     env["USERNAME"] = finalize.username
     env["OWNER"] = finalize.username
     env["ASSIGNMENT_TYPE"] = finalize.assignment_type
@@ -2634,7 +2643,9 @@ def main() -> int:
         if entrypoint is None:
             return rc  # declarative grader ran, vacuous pass, or fetch error
 
-        rc = run_entrypoint(finalize, entrypoint, workspace)
+        rc = run_entrypoint(
+            finalize, entrypoint, workspace, bundle_dir=runtime_dir / assignment,
+        )
         if rc is not None:
             return rc
 

--- a/cli/gh-teacher/skeleton_tests/test_runner_bundle_dir.py
+++ b/cli/gh-teacher/skeleton_tests/test_runner_bundle_dir.py
@@ -1,0 +1,81 @@
+"""Tests for runner.run_entrypoint's CLASSROOM50_BUNDLE_DIR: the env var must
+name the extracted per-assignment bundle even when the entrypoint is the
+classroom DEFAULT autograder.py (written beside the bundle, not inside it)."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+from types import SimpleNamespace
+
+from conftest import _load_module, _SCRIPTS_DIR
+
+runner = _load_module("runner", _SCRIPTS_DIR / "runner.py")
+
+
+def _finalize() -> SimpleNamespace:
+    return SimpleNamespace(
+        username="alice",
+        assignment_type="individual",
+        commit_link="c",
+        release_link="r",
+        review_link="v",
+        error=lambda message: 1,
+    )
+
+
+def _capture_env(monkeypatch) -> dict[str, str]:
+    seen: dict[str, str] = {}
+
+    def fake_run(argv, cwd, env, check):
+        seen.update(env)
+        return subprocess.CompletedProcess(args=argv, returncode=0)
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+    return seen
+
+
+def test_default_entrypoint_gets_the_extracted_bundle(tmp_path: pathlib.Path, monkeypatch):
+    runtime_dir = tmp_path / "runtime"
+    bundle_dir = runtime_dir / "hw1"
+    bundle_dir.mkdir(parents=True)
+    (bundle_dir / "check.sh").write_text("exit 0\n")
+    entrypoint = runtime_dir / runner.ENTRYPOINT_FILENAME
+    entrypoint.write_text("")
+    env = _capture_env(monkeypatch)
+
+    rc = runner.run_entrypoint(
+        _finalize(), entrypoint, tmp_path / "ws", bundle_dir=bundle_dir,
+    )
+
+    assert rc is None
+    assert env[runner.BUNDLE_DIR_ENV] == str(bundle_dir.resolve())
+
+
+def test_no_bundle_falls_back_to_the_entrypoint_directory(tmp_path: pathlib.Path, monkeypatch):
+    # The bundle 404ed, so nothing was extracted; the classroom default still
+    # gets a real directory to point at.
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+    entrypoint = runtime_dir / runner.ENTRYPOINT_FILENAME
+    entrypoint.write_text("")
+    env = _capture_env(monkeypatch)
+
+    runner.run_entrypoint(
+        _finalize(), entrypoint, tmp_path / "ws", bundle_dir=runtime_dir / "hw1",
+    )
+
+    assert env[runner.BUNDLE_DIR_ENV] == str(runtime_dir.resolve())
+
+
+def test_per_assignment_entrypoint_is_inside_the_bundle(tmp_path: pathlib.Path, monkeypatch):
+    runtime_dir = tmp_path / "runtime"
+    bundle_dir = runtime_dir / "hw1"
+    bundle_dir.mkdir(parents=True)
+    entrypoint = bundle_dir / runner.ENTRYPOINT_FILENAME
+    entrypoint.write_text("")
+    env = _capture_env(monkeypatch)
+
+    runner.run_entrypoint(_finalize(), entrypoint, tmp_path / "ws", bundle_dir=bundle_dir)
+
+    assert env[runner.BUNDLE_DIR_ENV] == str(bundle_dir.resolve())


### PR DESCRIPTION
## Summary

Three small CLI items from the 1.42.0 release review (#830).

- **`CLASSROOM50_BUNDLE_DIR` pointed at the runtime root for the classroom default autograder.** `fetch_bundle` extracts into `runtime_dir/<assignment>/`, but the classroom default `autograder.py` is written to `runtime_dir/autograder.py`, so `run_entrypoint` set the env var to `entrypoint.parent` = the runtime root, while the README and wiki say the script receives the extracted directory. `run_entrypoint` now takes the bundle dir from `main` and falls back to the entrypoint's directory only when nothing was extracted (a 404). Per-assignment entrypoints are unaffected (they live inside the bundle).
- **`assignment add --locked` gave no confirmation for a public or absent template.** The stderr note only fires for a private in-org template. The summary line now says `, locked` for every template kind.
- **Removed the dead `servicetoken.ValidateToken`** (zero callers after #835 added the `teacher` client parameter to `ValidateTokenVerbose`); its doc comment moved onto the surviving function.

## Test plan

- [x] New `test_runner_bundle_dir.py`: default entrypoint gets the extracted bundle; no bundle falls back to the entrypoint dir; per-assignment entrypoint unchanged
- [x] New `TestRunAssignmentAdd_LockedFlagOnPublicTemplateIsConfirmed`; the fresh `--locked` test also asserts the summary line
- [x] `go build`, `go vet`, `go test`, `golangci-lint run` clean; `pytest cli/gh-teacher/skeleton_tests` 968 passed; `ruff check` clean