### PR TITLE
refactor(web): one dispatch core and one retry primitive in github-core

### DIFF
--- a/web/src/github-core/activityRuns.ts
+++ b/web/src/github-core/activityRuns.ts
@@ -1,5 +1,5 @@
 import type { GitHubClient } from "./client"
-import type { GitHubWorkflowRun } from "./types"
+import type { GitHubWorkflowRun, GitHubWorkflowRunList } from "./types"
 import { GitHubAPIError } from "./errors"
 import { CONFIG_REPO } from "@/util/configRepo"
 
@@ -29,7 +29,7 @@ async function fetchRunsPage(
   signal?: AbortSignal,
 ): Promise<GitHubWorkflowRun[]> {
   try {
-    const res = await client.request<{ workflow_runs: GitHubWorkflowRun[] }>(
+    const res = await client.request<GitHubWorkflowRunList>(
       `/repos/${encodeURIComponent(org)}/${CONFIG_REPO}/actions/runs?${query}`,
       { method: "GET", signal },
     )

--- a/web/src/github-core/mutations/secrets.ts
+++ b/web/src/github-core/mutations/secrets.ts
@@ -6,6 +6,7 @@ import { CONFIG_REPO } from "@/util/configRepo"
 import { logger } from "@/lib/logger"
 import { LOG_SCOPE_GITHUB_SETUP } from "@/lib/logScopes"
 import type { GitHubClient } from "../client"
+import type { GitHubRepo } from "../types"
 
 const logSetup = logger.scope(LOG_SCOPE_GITHUB_SETUP)
 
@@ -181,9 +182,9 @@ async function assertTokenReachesOtherRepos(
   teacherClient: GitHubClient,
   org: string,
 ) {
-  let repos: { name: string }[]
+  let repos: Pick<GitHubRepo, "name">[]
   try {
-    repos = await teacherClient.request<{ name: string }[]>(
+    repos = await teacherClient.request<Pick<GitHubRepo, "name">[]>(
       `/orgs/${encodeURIComponent(org)}/repos?type=private&sort=created&direction=asc&per_page=10`,
     )
   } catch {

--- a/web/src/github-core/mutations/workflowDispatch.ts
+++ b/web/src/github-core/mutations/workflowDispatch.ts
@@ -1,4 +1,5 @@
 import type { GitHubClient } from "../client"
+import type { GitHubWorkflowRun, GitHubWorkflowRunList } from "../types"
 import { GitHubAPIError, is422UnexpectedInputs } from "../errors"
 import { getRepo } from "../repoReads"
 import {
@@ -10,6 +11,59 @@ import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { logger } from "@/lib/logger"
 
 const logWorkflows = logger.scope("github:workflows")
+
+// The one dispatch recipe every trigger shares. The dispatch ref (the config
+// repo's default branch) and the newest dispatch run id are independent reads,
+// so they run together; the baseline must still precede the POST. Run ids are
+// monotonic, so the run this POST creates is the oldest dispatch run whose id
+// exceeds `sinceRunId` (the dispatch API itself returns no run id): no clock
+// comparison, unambiguous when dispatches race.
+//
+// `mapError` rewrites a failed baseline read or POST before it propagates
+// (probe-token turns a 404 into ProbeWorkflowMissingError); the config-repo
+// read is left alone since its "not found" is the same for every workflow.
+async function openDispatch(
+  client: GitHubClient,
+  org: string,
+  workflow: string,
+  options: { mapError?: (err: unknown) => never } = {},
+): Promise<{
+  sinceRunId: number | null
+  post: (inputs?: Record<string, string>) => Promise<unknown>
+}> {
+  const base = `/repos/${org}/${CONFIG_REPO}/actions/workflows/${workflow}`
+  const rethrow =
+    options.mapError ??
+    ((err: unknown): never => {
+      throw err
+    })
+  const [repo, baseline] = await Promise.all([
+    getRepo(client, org, CONFIG_REPO),
+    client
+      .request<GitHubWorkflowRunList<Pick<GitHubWorkflowRun, "id">>>(
+        `${base}/runs?event=workflow_dispatch&per_page=1`,
+      )
+      .catch(rethrow),
+  ])
+  if (!repo) {
+    throw new Error(
+      `${org}/${CONFIG_REPO} not found; run setup for this org first`,
+    )
+  }
+  const ref = repo.default_branch || DEFAULT_BRANCH
+  return {
+    sinceRunId: baseline.workflow_runs?.[0]?.id ?? null,
+    // A workflow with no declared inputs is dispatched with none: GitHub 422s
+    // an `inputs` key on a workflow that declares nothing.
+    post: (inputs) =>
+      client
+        .request(`${base}/dispatches`, {
+          method: "POST",
+          body: inputs === undefined ? { ref } : { ref, inputs },
+        })
+        .catch(rethrow),
+  }
+}
 
 // The org's classroom50 repo has no probe-token.yaml (its skeleton predates the
 // workflow), so GitHub 404'd the workflow. The view maps this to "update the
@@ -41,12 +95,7 @@ export class CollectInputsUnsupportedError extends Error {
 /**
  * Dispatches the classroom50 repo's `collect-scores.yaml` workflow (the same
  * job that refreshes `scores.json`) so a teacher can pull fresh
- * submissions on demand.
- *
- * Returns `sinceRunId`: the newest collect-scores dispatch run before this POST
- * (null if none). The dispatch API returns no run id, so the caller finds the
- * triggered run as the oldest dispatch run with a larger id — monotonic, so no
- * clock comparison and unambiguous when dispatches race.
+ * submissions on demand. Returns `sinceRunId` (see openDispatch).
  *
  * @param scope optional dispatch inputs narrowing the collection to one
  *   classroom, or one assignment within it; omitted collects org-wide.
@@ -65,20 +114,11 @@ export async function triggerScoreCollection(
 ): Promise<{ sinceRunId: number | null }> {
   if (!org) throw new Error("org must be specified to collect scores")
 
-  const repo = await getRepo(client, org, CONFIG_REPO)
-  if (!repo) {
-    throw new Error(
-      `${org}/${CONFIG_REPO} not found; run setup for this org first`,
-    )
-  }
-  const ref = repo.default_branch || DEFAULT_BRANCH
-
-  // Snapshot the newest dispatch run id before the POST. Run ids are monotonic,
-  // so the run this POST creates is the oldest dispatch run whose id exceeds it.
-  const baseline = await client.request<{ workflow_runs: { id: number }[] }>(
-    `/repos/${org}/${CONFIG_REPO}/actions/workflows/${COLLECT_SCORES_WORKFLOW}/runs?event=workflow_dispatch&per_page=1`,
+  const { sinceRunId, post } = await openDispatch(
+    client,
+    org,
+    COLLECT_SCORES_WORKFLOW,
   )
-  const sinceRunId = baseline.workflow_runs?.[0]?.id ?? null
 
   const inputs: Record<string, string> = {}
   if (scope) {
@@ -99,15 +139,9 @@ export async function triggerScoreCollection(
     labelInputs.assignment_name = names.assignment
   }
 
-  const dispatch = (body: Record<string, string>) =>
-    client.request(
-      `/repos/${org}/${CONFIG_REPO}/actions/workflows/${COLLECT_SCORES_WORKFLOW}/dispatches`,
-      { method: "POST", body: { ref, inputs: body } },
-    )
-
   try {
     try {
-      await dispatch({ ...inputs, ...labelInputs })
+      await post({ ...inputs, ...labelInputs })
     } catch (err) {
       // GitHub 422s on ANY undeclared input key, so an org whose workflow
       // predates the *_name inputs would otherwise lose collect entirely over
@@ -119,7 +153,7 @@ export async function triggerScoreCollection(
         "collect-scores.yaml predates the *_name inputs; retrying without",
         { org },
       )
-      await dispatch(inputs)
+      await post(inputs)
     }
   } catch (err) {
     // Only the `assignment` input is newer than the long-standing `classroom`
@@ -145,12 +179,8 @@ export async function triggerScoreCollection(
  * to re-run the autograder for an assignment — the whole assignment, or
  * a single student when `owner` is supplied. Each targeted repo re-grades its
  * current `main` HEAD; grading runs asynchronously, so the gradebook is
- * refreshed by a subsequent collect-scores run.
- *
- * Returns `sinceRunId`: the newest regrade dispatch run before this POST (null
- * if none). The dispatch API returns no run id, so the caller binds to its own
- * run as the oldest dispatch run with a larger id (monotonic — no clock needed,
- * unambiguous when dispatches race). Mirrors triggerScoreCollection.
+ * refreshed by a subsequent collect-scores run. Returns `sinceRunId` (see
+ * openDispatch).
  *
  * @param classroom required dispatch input (the regrade workflow is always
  *   classroom-scoped, unlike collect which can sweep org-wide).
@@ -172,36 +202,13 @@ export async function triggerRegrade(
   if (!classroom) throw new Error("classroom must be specified to regrade")
   if (!assignment) throw new Error("assignment must be specified to regrade")
 
-  // getRepo (for the dispatch ref) and the baseline snapshot are independent
-  // reads; run them together. The baseline must still precede the POST below —
-  // run ids are monotonic, so the run this POST creates is the oldest dispatch
-  // run whose id exceeds the snapshot.
-  const [repo, baseline] = await Promise.all([
-    getRepo(client, org, CONFIG_REPO),
-    client.request<{ workflow_runs: { id: number }[] }>(
-      `/repos/${org}/${CONFIG_REPO}/actions/workflows/${REGRADE_WORKFLOW}/runs?event=workflow_dispatch&per_page=1`,
-    ),
-  ])
-  if (!repo) {
-    throw new Error(
-      `${org}/${CONFIG_REPO} not found; run setup for this org first`,
-    )
-  }
-  const ref = repo.default_branch || DEFAULT_BRANCH
-  const sinceRunId = baseline.workflow_runs?.[0]?.id ?? null
+  const { sinceRunId, post } = await openDispatch(client, org, REGRADE_WORKFLOW)
 
   // The workflow's `owner` input is optional; only send it when scoping to a
   // single student so an empty string isn't passed as a (no-op) filter.
   const inputs: Record<string, string> = { classroom, assignment }
   if (owner) inputs.owner = owner
-
-  await client.request(
-    `/repos/${org}/${CONFIG_REPO}/actions/workflows/${REGRADE_WORKFLOW}/dispatches`,
-    {
-      method: "POST",
-      body: { ref, inputs },
-    },
-  )
+  await post(inputs)
 
   logWorkflows.info("dispatched regrade", {
     org,
@@ -215,11 +222,10 @@ export async function triggerRegrade(
 
 /**
  * Dispatches the classroom50 repo's `probe-token.yaml` workflow, the read-only
- * check that exercises every scope the service token needs. No inputs.
- *
- * Returns `sinceRunId` like the other dispatchers so the caller can bind to its
- * own run. A 404 on the workflow (baseline read or dispatch) means the org's
- * skeleton predates probe-token.yaml and surfaces as ProbeWorkflowMissingError.
+ * check that exercises every scope the service token needs. No inputs. Returns
+ * `sinceRunId` (see openDispatch). A 404 on the workflow (baseline read or
+ * dispatch) means the org's skeleton predates probe-token.yaml and surfaces as
+ * ProbeWorkflowMissingError.
  */
 export async function triggerProbeToken(
   client: GitHubClient,
@@ -227,33 +233,20 @@ export async function triggerProbeToken(
 ): Promise<{ sinceRunId: number | null }> {
   if (!org) throw new Error("org must be specified to probe the service token")
 
-  const workflowBase = `/repos/${org}/${CONFIG_REPO}/actions/workflows/${PROBE_TOKEN_WORKFLOW}`
-  const rethrowMissingWorkflow = (err: unknown): never => {
-    if (err instanceof GitHubAPIError && err.isNotFound) {
-      throw new ProbeWorkflowMissingError(err)
-    }
-    throw err
-  }
-
-  const [repo, baseline] = await Promise.all([
-    getRepo(client, org, CONFIG_REPO),
-    client
-      .request<{ workflow_runs: { id: number }[] }>(
-        `${workflowBase}/runs?event=workflow_dispatch&per_page=1`,
-      )
-      .catch(rethrowMissingWorkflow),
-  ])
-  if (!repo) {
-    throw new Error(
-      `${org}/${CONFIG_REPO} not found; run setup for this org first`,
-    )
-  }
-  const ref = repo.default_branch || DEFAULT_BRANCH
-  const sinceRunId = baseline.workflow_runs?.[0]?.id ?? null
-
-  await client
-    .request(`${workflowBase}/dispatches`, { method: "POST", body: { ref } })
-    .catch(rethrowMissingWorkflow)
+  const { sinceRunId, post } = await openDispatch(
+    client,
+    org,
+    PROBE_TOKEN_WORKFLOW,
+    {
+      mapError: (err) => {
+        if (err instanceof GitHubAPIError && err.isNotFound) {
+          throw new ProbeWorkflowMissingError(err)
+        }
+        throw err
+      },
+    },
+  )
+  await post()
 
   logWorkflows.info("dispatched probe-token", { org, sinceRunId })
   return { sinceRunId }

--- a/web/src/github-core/paginate.ts
+++ b/web/src/github-core/paginate.ts
@@ -1,10 +1,7 @@
 import type { GitHubClient } from "./client"
 import { GitHubAPIError } from "./errors"
-import { logger } from "@/lib/logger"
-import { LOG_SCOPE_QUERIES } from "@/lib/logScopes"
+import { log, MAX_RATE_LIMIT_WAIT_MS, withRetry } from "./queries/shared"
 import { mapWithConcurrency } from "@/util/concurrency"
-
-const log = logger.scope(LOG_SCOPE_QUERIES)
 
 // Hard cap (100 pages x 100/page = 10k items) so a server that ignores the
 // page param and keeps returning full pages can't loop unbounded.
@@ -16,13 +13,11 @@ const MAX_PAGES = 100
 export const PAGE_FETCH_CONCURRENCY = 8
 
 // Per-page retry: a single 15s timeout or 5xx on page 40 of 90 used to fail the
-// whole query and React Query re-walked every page from 1.
+// whole query and React Query re-walked every page from 1. A rate limit whose
+// Retry-After exceeds MAX_RATE_LIMIT_WAIT_MS is not waited out: the page fails
+// at once rather than being re-requested while GitHub is still refusing.
 const PAGE_RETRY_ATTEMPTS = 3
 const PAGE_RETRY_BASE_MS = 500
-// A rate limit whose Retry-After is longer than this is not waited out: the
-// page is failed at once rather than re-requested while GitHub is still
-// refusing (the UI reports it and the user retries later).
-const MAX_RATE_LIMIT_WAIT_MS = 8000
 
 export type PaginateOptions = {
   signal?: AbortSignal
@@ -172,25 +167,18 @@ export function lastPageNumber(linkHeader: string | null): number | null {
 // network). Every other GitHub status (401/403/404, and a 409/422/451 a
 // re-request cannot change), caller aborts, and a rate limit longer than
 // MAX_RATE_LIMIT_WAIT_MS propagate at once.
-export async function withTransientRetry<T>(
+export function withTransientRetry<T>(
   fn: () => Promise<T>,
   signal: AbortSignal | undefined,
 ): Promise<T> {
-  let lastError: unknown
-  for (let attempt = 0; attempt < PAGE_RETRY_ATTEMPTS; attempt++) {
-    try {
-      return await fn()
-    } catch (err) {
-      lastError = err
-      if (signal?.aborted || !isTransientPageError(err)) throw err
-      if (attempt === PAGE_RETRY_ATTEMPTS - 1) break
-      const waitMs = retryWaitMs(err, attempt)
-      if (waitMs === null) throw err
-      log.debug("retrying page", { attempt, waitMs })
-      await sleep(waitMs, signal)
-    }
-  }
-  throw lastError
+  return withRetry(fn, {
+    attempts: PAGE_RETRY_ATTEMPTS,
+    shouldRetry: isTransientPageError,
+    waitMs: retryWaitMs,
+    signal,
+    onRetry: (attempt, waitMs) =>
+      log.debug("retrying page", { attempt, waitMs }),
+  })
 }
 
 // How long to wait before retrying `err`, or null when the wait would exceed
@@ -211,18 +199,4 @@ function isTransientPageError(err: unknown): boolean {
   }
   // A timeout (`TimeoutError` DOMException) or network failure.
   return !(err instanceof DOMException && err.name === "AbortError")
-}
-
-function sleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort)
-      resolve()
-    }, ms)
-    const onAbort = () => {
-      clearTimeout(timer)
-      reject(signal?.reason ?? new DOMException("Aborted", "AbortError"))
-    }
-    signal?.addEventListener("abort", onAbort, { once: true })
-  })
 }

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -2,6 +2,25 @@ import type { QueryClient } from "@tanstack/react-query"
 
 import { CONFIG_REPO } from "@/util/configRepo"
 
+// The tracker key for one workflow dispatch. `scope` narrows it to the surface
+// that dispatched (a regrade is per classroom/assignment/owner so one
+// assignment's run never shows as in progress on another's page); `sinceRunId`
+// binds the poll to our own dispatch. Every dispatch tracker key is built here
+// so a new workflow needs no hand-written key.
+const dispatchRun = (
+  workflow: string,
+  owner: string,
+  scope: readonly string[],
+  sinceRunId: number | null,
+) =>
+  [
+    ...githubKeys.all,
+    `${workflow}-run`,
+    owner,
+    ...scope,
+    sinceRunId ?? "none",
+  ] as const
+
 // The cache-key factory for every github-core read. This is the leaf of the
 // queries module: every *Query sub-module imports these keys, and this file
 // imports nothing from them, so the split stays cycle-free (import-x/no-cycle).
@@ -151,19 +170,11 @@ export const githubKeys = {
     [...githubKeys.all, "csv-file", owner, repo, path, ref ?? null] as const,
 
   collectScoresRun: (owner: string, sinceRunId: number | null) =>
-    [
-      ...githubKeys.all,
-      "collect-scores-run",
-      owner,
-      sinceRunId ?? "none",
-    ] as const,
+    dispatchRun("collect-scores", owner, [], sinceRunId),
 
   lastCollectScoresRun: (owner: string) =>
     [...githubKeys.all, "last-collect-scores-run", owner] as const,
 
-  // Scoped by classroom + assignment (+ optional repo owner) so a regrade of
-  // one assignment doesn't surface as in-progress on another assignment's
-  // page; sinceRunId binds the poll to our specific dispatch.
   regradeRun: (
     owner: string,
     classroom: string,
@@ -171,27 +182,18 @@ export const githubKeys = {
     repoOwner: string | null,
     sinceRunId: number | null,
   ) =>
-    [
-      ...githubKeys.all,
-      "regrade-run",
+    dispatchRun(
+      "regrade",
       owner,
-      classroom,
-      assignment,
-      repoOwner ?? "all",
-      sinceRunId ?? "none",
-    ] as const,
+      [classroom, assignment, repoOwner ?? "all"],
+      sinceRunId,
+    ),
 
   serviceToken: (owner: string) =>
     [...githubKeys.all, "serviceToken", owner] as const,
 
-  // The probe-token dispatch tracker; sinceRunId binds the poll to one dispatch.
   probeTokenRun: (owner: string, sinceRunId: number | null) =>
-    [
-      ...githubKeys.all,
-      "probe-token-run",
-      owner,
-      sinceRunId ?? "none",
-    ] as const,
+    dispatchRun("probe-token", owner, [], sinceRunId),
 
   runAnnotations: (owner: string, runId: number) =>
     [...githubKeys.all, "run-annotations", owner, runId] as const,

--- a/web/src/github-core/queries/releaseRunReads.ts
+++ b/web/src/github-core/queries/releaseRunReads.ts
@@ -1,7 +1,13 @@
 import { queryOptions } from "@tanstack/react-query"
 
 import type { GitHubClient } from "../client"
-import type { GitHubRelease, GitHubWorkflowRun } from "../types"
+import type {
+  GitHubCheckAnnotation,
+  GitHubRelease,
+  GitHubWorkflowJob,
+  GitHubWorkflowRun,
+  GitHubWorkflowRunList,
+} from "../types"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubAPIError, tolerateGitHubError } from "../errors"
 import {
@@ -278,7 +284,7 @@ async function listLatestWorkflowRun(
   if (filters.status) params.set("status", filters.status)
   if (filters.page) params.set("page", String(filters.page))
 
-  const res = await client.request<{ workflow_runs: GitHubWorkflowRun[] }>(
+  const res = await client.request<GitHubWorkflowRunList>(
     `/repos/${org}/${CONFIG_REPO}/actions/workflows/${workflow}/runs?${params.toString()}`,
     { method: "GET", signal },
   )
@@ -411,18 +417,15 @@ export async function getRunAnnotations(
   signal?: AbortSignal,
 ): Promise<RunAnnotation[]> {
   const repo = `/repos/${encodeURIComponent(org)}/${CONFIG_REPO}`
-  const { jobs } = await client.request<{ jobs: { id: number }[] }>(
+  const { jobs } = await client.request<{ jobs: GitHubWorkflowJob[] }>(
     `${repo}/actions/runs/${runId}/jobs?per_page=100`,
     { method: "GET", signal },
   )
   const perJob = await Promise.all(
     jobs.map((job) =>
-      client.request<{ annotation_level: string; message: string | null }[]>(
+      client.request<GitHubCheckAnnotation[]>(
         `${repo}/check-runs/${job.id}/annotations?per_page=100`,
-        {
-          method: "GET",
-          signal,
-        },
+        { method: "GET", signal },
       ),
     ),
   )

--- a/web/src/github-core/queries/repoRefReads.ts
+++ b/web/src/github-core/queries/repoRefReads.ts
@@ -8,7 +8,6 @@ import type {
   GitHubRepo,
 } from "../types"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
-import { mapWithConcurrency } from "@/util/concurrency"
 import { tolerateGitHubError } from "../errors"
 import {
   PAGE_FETCH_CONCURRENCY,
@@ -19,7 +18,7 @@ import {
 } from "../paginate"
 import { getRepo } from "../repoReads"
 import { githubKeys } from "./keys"
-import { REPO_READ_CONCURRENCY, withGithubReadSlot } from "./shared"
+import { withGithubReadSlot } from "./shared"
 
 export function getBranchRefRepo(
   client: GitHubClient,
@@ -193,7 +192,9 @@ export async function getAssignmentRepos(
 // The candidate repos that exist, read by exact name. Mirrors paginateRemaining:
 // one probe failing definitively ends the fan-out and aborts its siblings, and
 // the retry waits outside the read slot so a throttled probe does not hold one
-// of the few slots while it sleeps.
+// of the few slots while it sleeps. The slot is the only bound: it already caps
+// the aggregate wire concurrency, so the fan-out starts every probe and lets
+// them queue on it.
 async function probeRepos(
   client: GitHubClient,
   owner: string,
@@ -205,10 +206,8 @@ async function probeRepos(
   if (signal?.aborted) onCallerAbort()
   signal?.addEventListener("abort", onCallerAbort, { once: true })
   try {
-    const probed = await mapWithConcurrency(
-      names,
-      REPO_READ_CONCURRENCY,
-      (name) =>
+    const probed = await Promise.all(
+      names.map((name) =>
         withTransientRetry(
           () =>
             withGithubReadSlot(() =>
@@ -216,6 +215,7 @@ async function probeRepos(
             ),
           fanOut.signal,
         ),
+      ),
     )
     return probed.filter((repo): repo is GitHubRepo => repo !== null)
   } catch (err) {

--- a/web/src/github-core/queries/shared.test.ts
+++ b/web/src/github-core/queries/shared.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
-import { retryOnRateLimit, withGithubReadSlot } from "./shared"
+import { retryOnRateLimit, withGithubReadSlot, withRetry } from "./shared"
 
 const noRateLimit: GitHubRateLimit = {
   limit: null,
@@ -29,6 +29,62 @@ const plainError = (status: number) =>
     body: null,
     rateLimit: noRateLimit,
   })
+
+describe("withRetry", () => {
+  const always = () => true
+
+  it("stops after `attempts` and rethrows the last error", async () => {
+    const fn = vi.fn().mockRejectedValue(plainError(500))
+    await expect(
+      withRetry(fn, { attempts: 3, shouldRetry: always, waitMs: () => 0 }),
+    ).rejects.toMatchObject({ status: 500 })
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it("gives up at once when waitMs returns null", async () => {
+    const fn = vi.fn().mockRejectedValue(plainError(500))
+    await expect(
+      withRetry(fn, { attempts: 3, shouldRetry: always, waitMs: () => null }),
+    ).rejects.toMatchObject({ status: 500 })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not retry once the signal is aborted, and aborts a wait in progress", async () => {
+    const controller = new AbortController()
+    const fn = vi.fn().mockRejectedValue(plainError(500))
+    const pending = withRetry(fn, {
+      attempts: 3,
+      shouldRetry: always,
+      waitMs: () => 10_000,
+      signal: controller.signal,
+    })
+    await Promise.resolve()
+    controller.abort(new DOMException("Aborted", "AbortError"))
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("reports each retry with its wait", async () => {
+    const onRetry = vi.fn()
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(plainError(500))
+      .mockRejectedValueOnce(plainError(502))
+      .mockResolvedValue("ok")
+    await expect(
+      withRetry(fn, {
+        attempts: 3,
+        shouldRetry: always,
+        waitMs: (_err, attempt) => attempt + 1,
+        onRetry,
+      }),
+    ).resolves.toBe("ok")
+    expect(onRetry.mock.calls).toEqual([
+      [0, 1],
+      [1, 2],
+    ])
+  })
+})
 
 describe("retryOnRateLimit", () => {
   it("returns the result when the call succeeds first try", async () => {

--- a/web/src/github-core/queries/shared.ts
+++ b/web/src/github-core/queries/shared.ts
@@ -74,31 +74,76 @@ export function withGithubReadSlot<T>(fn: () => Promise<T>): Promise<T> {
 // client fan-out shouldn't hang a page that long. Cap the wait so one throttled
 // repo can't stall the batch; beyond this the read surfaces as an error the UI
 // reports rather than an indefinite spinner.
-const MAX_RATE_LIMIT_WAIT_MS = 8000
+export const MAX_RATE_LIMIT_WAIT_MS = 8000
+
+export type RetryOptions = {
+  // Total attempts, including the first.
+  attempts: number
+  // Whether `err` is worth another attempt at all.
+  shouldRetry: (err: unknown) => boolean
+  // How long to wait before attempt `attempt + 1` (0-based `attempt` just
+  // failed), or null to give up on this error even though it is retryable
+  // (a rate limit longer than a page load can absorb).
+  waitMs: (err: unknown, attempt: number) => number | null
+  // Aborts the wait and stops retrying once aborted.
+  signal?: AbortSignal
+  onRetry?: (attempt: number, waitMs: number) => void
+}
+
+// The one retry loop under every GitHub read retry: fresh-repo lag, a rate
+// limit, a transient page failure. Each caller supplies only its policy.
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions,
+): Promise<T> {
+  const { attempts, shouldRetry, waitMs, signal, onRetry } = options
+  let lastError: unknown
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastError = err
+      if (signal?.aborted || !shouldRetry(err)) throw err
+      if (attempt === attempts - 1) break
+      const wait = waitMs(err, attempt)
+      if (wait === null) throw err
+      onRetry?.(attempt, wait)
+      await sleep(wait, signal)
+    }
+  }
+  throw lastError
+}
 
 // Run a GitHub read, retrying ONCE if it fails with a rate-limit (429, or a 403
 // carrying Retry-After / remaining:0). Waits the server's Retry-After (bounded),
 // falling back to a short delay when the header is absent. Non-rate-limit errors
 // propagate immediately. One retry only — a persistent throttle should surface,
 // not loop.
-export async function retryOnRateLimit<T>(fn: () => Promise<T>): Promise<T> {
-  try {
-    return await fn()
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.isRateLimited) {
-      const retryAfterMs =
-        err.rateLimit.retryAfter !== null
-          ? err.rateLimit.retryAfter * 1000
-          : 1000
-      await sleep(Math.min(retryAfterMs, MAX_RATE_LIMIT_WAIT_MS))
-      return await fn()
-    }
-    throw err
-  }
+export function retryOnRateLimit<T>(fn: () => Promise<T>): Promise<T> {
+  return withRetry(fn, {
+    attempts: 2,
+    shouldRetry: (err) => err instanceof GitHubAPIError && err.isRateLimited,
+    waitMs: (err) => {
+      const retryAfter = (err as GitHubAPIError).rateLimit.retryAfter
+      const retryAfterMs = retryAfter !== null ? retryAfter * 1000 : 1000
+      return Math.min(retryAfterMs, MAX_RATE_LIMIT_WAIT_MS)
+    },
+  })
 }
 
-export function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+// Resolve after `ms`, or reject with the signal's reason if it aborts first.
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(signal?.reason ?? new DOMException("Aborted", "AbortError"))
+    }
+    signal?.addEventListener("abort", onAbort, { once: true })
+  })
 }
 
 function isGitRepositoryEmptyError(error: unknown) {
@@ -142,28 +187,17 @@ export type FreshRepoRetryOptions = {
 // Retry `fn` while it hits fresh-repo lag. `fn` must re-read its own state each
 // attempt and may throw a synthetic error to signal non-HTTP lag (e.g., a 200
 // with a blank SHA).
-export async function withFreshRepoRetry<T>(
+export function withFreshRepoRetry<T>(
   fn: () => Promise<T>,
   options: FreshRepoRetryOptions = {},
 ): Promise<T> {
-  const attempts = options.attempts ?? 6
   const baseDelayMs = options.baseDelayMs ?? 500
   const backoffFactor = options.backoffFactor ?? 2
-  const shouldRetry = options.shouldRetry ?? isFreshRepoLagError
-
-  let lastError: unknown
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    try {
-      return await fn()
-    } catch (err) {
-      lastError = err
-      if (!shouldRetry(err) || attempt === attempts) {
-        throw err
-      }
-      log.debug("fresh-repo lag, retrying read", { attempt })
-      await sleep(baseDelayMs * backoffFactor ** (attempt - 1))
-    }
-  }
-
-  throw lastError
+  return withRetry(fn, {
+    attempts: options.attempts ?? 6,
+    shouldRetry: options.shouldRetry ?? isFreshRepoLagError,
+    waitMs: (_err, attempt) => baseDelayMs * backoffFactor ** attempt,
+    onRetry: (attempt) =>
+      log.debug("fresh-repo lag, retrying read", { attempt: attempt + 1 }),
+  })
 }

--- a/web/src/github-core/types.ts
+++ b/web/src/github-core/types.ts
@@ -289,6 +289,28 @@ export type GitHubWorkflowRun = {
   }
 }
 
+// The list-runs envelope (GET .../actions/workflows/{id}/runs and
+// .../actions/runs). Only `id` is read where the list is used as a baseline.
+export type GitHubWorkflowRunList<Run = GitHubWorkflowRun> = {
+  workflow_runs: Run[]
+}
+
+// One job of a workflow run (GET .../actions/runs/{id}/jobs). Each job is also
+// a check run, which is where its annotations live.
+export type GitHubWorkflowJob = {
+  id: number
+  name?: string
+}
+
+// One workflow-command annotation (`::error::`, `::warning::`, `::notice::`)
+// as attached to a job's check run (GET .../check-runs/{id}/annotations).
+export type GitHubCheckAnnotation = {
+  annotation_level: "notice" | "warning" | "failure" | string
+  message: string | null
+  path?: string
+  start_line?: number
+}
+
 // A commit from the REST list-commits endpoint
 // (GET /repos/{owner}/{repo}/commits). Distinct from GitHubCommitRef (the
 // git-data single-commit tree ref). Used by the org activity timeline to render


### PR DESCRIPTION
## Summary

Refactor from the 1.42.0 release review (#830). No behavior change; stacked on #843 (it rewrites the same probe block), so GitHub retargets it to `main` once that merges.

- **One dispatch recipe.** `triggerScoreCollection`, `triggerRegrade` and `triggerProbeToken` each re-implemented "read the config repo for the ref, snapshot the newest dispatch run id, POST `/dispatches`", with the same not-found message. `openDispatch(client, org, workflow, { mapError })` now owns that (ref and baseline read together, as regrade and probe already did); each trigger keeps only its input shaping and error mapping. A workflow with no declared inputs is still dispatched with `{ ref }` alone.
- **One retry loop.** `withFreshRepoRetry`, `retryOnRateLimit` (`queries/shared.ts`) and `withTransientRetry` (`paginate.ts`) were three backoff loops, two of them declaring their own `MAX_RATE_LIMIT_WAIT_MS = 8000` and their own `sleep`. `withRetry(fn, { attempts, shouldRetry, waitMs, signal, onRetry })` is the single loop; the three callers pass only their policy. `sleep` lives once in `shared.ts` and is abortable.
- **One dispatch-run key builder.** `collectScoresRun`, `regradeRun`, `probeTokenRun` all ended in `sinceRunId ?? "none"`; `dispatchRun(workflow, owner, scope, sinceRunId)` builds them, so a fourth workflow needs no hand-written key. Key values are unchanged.
- **Named response types** in `types.ts` (`GitHubWorkflowRunList`, `GitHubWorkflowJob`, `GitHubCheckAnnotation`) replace the inline shapes in `workflowDispatch.ts`, `releaseRunReads.ts`, `activityRuns.ts` and `secrets.ts`.
- **Single bound on the probe fan-out.** `probeRepos` bounded the same fan-out twice (`mapWithConcurrency` at `REPO_READ_CONCURRENCY` plus the shared semaphore); the semaphore is the bound, so the fan-out now just queues on it.

## Test plan

- [x] New `withRetry` tests: attempt budget, `waitMs === null` gives up at once, abort mid-wait, `onRetry` reporting
- [x] `vitest run src/github-core` (500 tests) plus the collect/regrade/probe hook tests unchanged and green
- [x] `tsc -b`, `eslint`, `prettier`, `arch:validate` clean