### PR TITLE
refactor(web): expose inFlight from useGitHubOperation and a busy Button recipe

### DIFF
--- a/web/src/components/ui/Button.test.tsx
+++ b/web/src/components/ui/Button.test.tsx
@@ -73,6 +73,28 @@ describe("Button", () => {
     expect(onClick).not.toHaveBeenCalled()
   })
 
+  it("swaps its content for busyLabel while loading, with a decorative spinner", () => {
+    const { rerender } = render(
+      <Button busyLabel="Collecting…">Collect</Button>,
+    )
+    expect(screen.getByRole("button", { name: "Collect" })).toBeTruthy()
+
+    rerender(
+      <Button loading busyLabel="Collecting…">
+        Collect
+      </Button>,
+    )
+    const btn = screen.getByRole("button", { name: "Collecting…" })
+    // The visible text is the announcement: no children, no second sr-only
+    // label for a screen reader to read the same word twice.
+    expect(btn.textContent).toBe("Collecting…")
+    expect(btn.querySelector(".loading")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    )
+    expect(btn.querySelector("[role=status]")).toBeNull()
+    expect(btn.getAttribute("aria-busy")).toBe("true")
+  })
+
   it("does not fire onClick when disabled", async () => {
     const onClick = vi.fn()
     render(

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -5,7 +5,7 @@ import type {
   Ref,
 } from "react"
 
-import { Spinner } from "@/components/Spinner"
+import { InlineSpinner, Spinner } from "@/components/Spinner"
 
 import { cx } from "./cx"
 
@@ -75,7 +75,13 @@ type CommonProps = {
   shape?: ButtonShape
   active?: boolean
   loading?: boolean
+  // Screen-reader label for the spinner while `loading`; the children stay
+  // visible beside it. Use when the visible text does not change.
   loadingLabel?: string
+  // The button's whole visible content while `loading` ("Collecting…"),
+  // REPLACING the children. The text is the announcement, so the spinner is
+  // decorative: no second sr-only label to read the same word twice.
+  busyLabel?: string
   children?: ReactNode
 }
 
@@ -105,6 +111,7 @@ export function Button({
   active = false,
   loading = false,
   loadingLabel,
+  busyLabel,
   className,
   children,
   as,
@@ -127,12 +134,18 @@ export function Button({
     className,
   )
 
-  const inner = (
-    <>
-      {loading && <Spinner size={SPINNER_SIZE[size]} label={loadingLabel} />}
-      {children}
-    </>
-  )
+  const inner =
+    loading && busyLabel !== undefined ? (
+      <>
+        <InlineSpinner size={SPINNER_SIZE[size]} />
+        {busyLabel}
+      </>
+    ) : (
+      <>
+        {loading && <Spinner size={SPINNER_SIZE[size]} label={loadingLabel} />}
+        {children}
+      </>
+    )
 
   // Render an <a> when the caller asked for one (via `as="a"` or an `href`).
   // Anchors can't be natively `disabled`, so a loading/disabled anchor drops

--- a/web/src/hooks/useGitHubOperation.ts
+++ b/web/src/hooks/useGitHubOperation.ts
@@ -242,5 +242,12 @@ export function useGitHubOperation(config: GitHubOperationConfig) {
     failure,
     run,
     error: mutation.error ?? runQuery.error,
+    inFlight: isOperationInFlight(phase),
   }
+}
+
+// Whether a dispatch is underway: the POST is pending or the run has not
+// settled. The one predicate behind every "busy" button and re-entrancy latch.
+export function isOperationInFlight(phase: OperationPhase): boolean {
+  return phase === "dispatching" || phase === "running"
 }

--- a/web/src/hooks/useTestServiceToken.test.tsx
+++ b/web/src/hooks/useTestServiceToken.test.tsx
@@ -42,13 +42,23 @@ let capturedConfig: {
   onDispatched?: (s: { sinceRunId: number | null }) => void
 }
 const trigger = vi.fn()
-vi.mock("@/hooks/useGitHubOperation", () => ({
-  useGitHubOperation: (config: typeof capturedConfig) => {
-    capturedConfig = config
-    return { trigger, ...operation }
-  },
-}))
+vi.mock("@/hooks/useGitHubOperation", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/hooks/useGitHubOperation")>()
+  return {
+    ...actual,
+    useGitHubOperation: (config: typeof capturedConfig) => {
+      capturedConfig = config
+      return {
+        trigger,
+        ...operation,
+        inFlight: actual.isOperationInFlight(operation.phase as OperationPhase),
+      }
+    },
+  }
+})
 
+import type { OperationPhase } from "@/hooks/useGitHubOperation"
 import useTestServiceToken from "./useTestServiceToken"
 
 const wrapper = ({ children }: PropsWithChildren) =>

--- a/web/src/hooks/useTestServiceToken.ts
+++ b/web/src/hooks/useTestServiceToken.ts
@@ -30,7 +30,7 @@ const useTestServiceToken = (org: string | undefined) => {
   const { register } = useActionActivityRegistry()
   const { t } = useTranslation()
 
-  const { trigger, phase, failure, run, error } = useGitHubOperation({
+  const { trigger, phase, failure, run, error, inFlight } = useGitHubOperation({
     storageKey: org ? `cl50:probe-token:${org}` : null,
     queryKey: (sinceRunId) => githubKeys.probeTokenRun(org ?? "", sinceRunId),
     resetKey: org ?? "",
@@ -68,8 +68,6 @@ const useTestServiceToken = (org: string | undefined) => {
     // The run link is the fallback, so a failed read isn't worth retrying.
     retry: false,
   })
-
-  const inFlight = phase === "dispatching" || phase === "running"
 
   return {
     test: () => {

--- a/web/src/hooks/useTriggerRegrade.ts
+++ b/web/src/hooks/useTriggerRegrade.ts
@@ -55,7 +55,7 @@ const useTriggerRegrade = (target: RegradeTarget) => {
 
   const key = targetKey(target)
 
-  const { trigger, phase, run, error } = useGitHubOperation({
+  const { trigger, phase, run, error, inFlight } = useGitHubOperation({
     storageKey: isComplete(target) ? `cl50:regrade:${key}` : null,
     queryKey: (sinceRunId) =>
       githubKeys.regradeRun(
@@ -95,7 +95,6 @@ const useTriggerRegrade = (target: RegradeTarget) => {
 
   // Publish in-flight state to the page coordinator so "Regrade all", every
   // per-row tracker, and "Collect now" share one mutual-exclusion signal.
-  const inFlight = phase === "dispatching" || phase === "running"
   const { setInFlight } = coordinator
   useEffect(() => {
     setInFlight(key, inFlight)
@@ -112,6 +111,7 @@ const useTriggerRegrade = (target: RegradeTarget) => {
     phase,
     run,
     error,
+    inFlight,
     // True while ANY regrade (this one, another row, or "Regrade all") is in
     // flight — callers disable collect/regrade controls page-wide.
     anyRegrading: coordinator.anyInFlight,

--- a/web/src/hooks/useTriggerScoreCollection.ts
+++ b/web/src/hooks/useTriggerScoreCollection.ts
@@ -75,7 +75,7 @@ const useTriggerScoreCollection = (
   const scopeSuffix = scope
     ? `:${scope.classroom}${scope.assignment ? `:${scope.assignment}` : ""}`
     : ""
-  const { trigger, phase, failure, run, error } = useGitHubOperation({
+  const { trigger, phase, failure, run, error, inFlight } = useGitHubOperation({
     timeoutMs: scope && !scope.assignment ? SWEEP_TIMEOUT_MS : undefined,
     storageKey: org ? `cl50:collect-scores:${org}${scopeSuffix}` : null,
     queryKey: (sinceRunId) =>
@@ -98,7 +98,7 @@ const useTriggerScoreCollection = (
     },
   })
 
-  return { collect: trigger, phase, failure, run, error }
+  return { collect: trigger, phase, failure, run, error, inFlight }
 }
 
 export default useTriggerScoreCollection

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -558,13 +558,11 @@ export const OrgSettingsPane = ({ highlighted }: { highlighted?: boolean }) => {
                 variant="outline"
                 size="sm"
                 loading={tokenTest.inFlight}
-                loadingLabel={t("orgSettings.serviceToken.test.running")}
+                busyLabel={t("orgSettings.serviceToken.test.running")}
                 title={t("orgSettings.serviceToken.test.help")}
                 onClick={tokenTest.test}
               >
-                {tokenTest.inFlight
-                  ? t("orgSettings.serviceToken.test.running")
-                  : t("orgSettings.serviceToken.test.button")}
+                {t("orgSettings.serviceToken.test.button")}
               </Button>
               <Button variant="outline" size="sm" onClick={openModal}>
                 {t("orgSettings.serviceToken.rotateButton")}

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -1133,13 +1133,11 @@ const SubmissionsPageContent = () => {
   const regrading = regradeAll.anyRegrading
   // Whether "Regrade all" specifically is mid-dispatch, for its own
   // spinner/label (distinct from the page-wide `regrading` gate).
-  const regradeAllActive =
-    regradeAll.phase === "dispatching" || regradeAll.phase === "running"
+  const regradeAllActive = regradeAll.inFlight
   const { data: lastRun } = useGetLastCollectScoresRun(org)
   const collectWorkflowUrl = `https://github.com/${org}/${CONFIG_REPO}/actions/workflows/${COLLECT_SCORES_WORKFLOW}`
   const regradeWorkflowUrl = `https://github.com/${org}/${CONFIG_REPO}/actions/workflows/${REGRADE_WORKFLOW}`
-  const collecting =
-    collectScores.phase === "dispatching" || collectScores.phase === "running"
+  const collecting = collectScores.inFlight
 
   // Which action the single "View …" link points at and which status strip (if
   // any) shows. Running takes precedence; else most recently finished; else

--- a/web/src/pages/assignments/ClassroomCollectButton.tsx
+++ b/web/src/pages/assignments/ClassroomCollectButton.tsx
@@ -64,7 +64,7 @@ export function ClassroomCollectButton({
     { classroom },
     { classroom: classroomName },
   )
-  const busy = collect.phase === "dispatching" || collect.phase === "running"
+  const busy = collect.inFlight
   // A sweep is a heavier dispatch than the per-assignment collect (it walks
   // every assignment, and Actions minutes scale with the classroom), so the
   // click confirms before dispatching instead of firing straight away.
@@ -219,7 +219,7 @@ export function ClassroomCollectButton({
           variant="ghost"
           size="sm"
           loading={busy}
-          loadingLabel={t("submissions.collect.active")}
+          busyLabel={t("submissions.collect.active")}
           disabled={emptyRoster}
           title={
             emptyRoster
@@ -228,14 +228,8 @@ export function ClassroomCollectButton({
           }
           onClick={() => setConfirmOpen(true)}
         >
-          {busy ? (
-            t("submissions.collect.active")
-          ) : (
-            <>
-              <SyncIcon aria-hidden="true" className="size-4" />
-              {t("assignments.collect.label")}
-            </>
-          )}
+          <SyncIcon aria-hidden="true" className="size-4" />
+          {t("assignments.collect.label")}
         </Button>
       </SubmissionFreshnessLine>
 

--- a/web/src/pages/orgSettings/ServiceTokenTestResult.tsx
+++ b/web/src/pages/orgSettings/ServiceTokenTestResult.tsx
@@ -31,8 +31,8 @@ export default function ServiceTokenTestResult({
   className?: string
 }) {
   const { t } = useTranslation()
-  const { phase, failure, run, error, annotations } = state
-  if (phase === "idle" || phase === "dispatching" || phase === "running") {
+  const { phase, failure, run, error, annotations, inFlight } = state
+  if (phase === "idle" || inFlight) {
     return null
   }
 

--- a/web/src/pages/submissions/DataFreshness.tsx
+++ b/web/src/pages/submissions/DataFreshness.tsx
@@ -61,9 +61,6 @@ export function DataFreshness({
 }: DataFreshnessProps) {
   const { t } = useTranslation()
   const busy = collecting || refreshing
-  const busyLabel = collecting
-    ? t("submissions.collect.active")
-    : t("submissions.freshness.refreshing")
 
   return (
     <div className="flex flex-col items-start gap-1">
@@ -73,15 +70,18 @@ export function DataFreshness({
       >
         {onRefresh && (
           // A quiet ghost button in both states, so the freshness line doesn't
-          // outshout the search/filter controls beside it in the toolbar. The
-          // same loading recipe as ClassroomCollectButton: `loading` swallows
-          // clicks and announces the busy state, so no `disabled` (which would
-          // drop keyboard focus mid-action).
+          // outshout the search/filter controls beside it in the toolbar.
+          // `loading` swallows clicks and `busyLabel` is the in-place progress
+          // text, so no `disabled` (which would drop keyboard focus mid-action).
           <Button
             variant="ghost"
             size="sm"
             loading={busy}
-            loadingLabel={busyLabel}
+            busyLabel={
+              collecting
+                ? t("submissions.collect.active")
+                : t("submissions.freshness.refreshing")
+            }
             onClick={onRefresh}
             className="text-base-content/70"
             title={
@@ -90,16 +90,10 @@ export function DataFreshness({
                 : t("submissions.freshness.refreshHelp")
             }
           >
-            {busy ? (
-              busyLabel
-            ) : (
-              <>
-                <SyncIcon aria-hidden="true" className="size-4" />
-                {canCollect
-                  ? t("submissions.collect.label")
-                  : t("submissions.freshness.refreshLabel")}
-              </>
-            )}
+            <SyncIcon aria-hidden="true" className="size-4" />
+            {canCollect
+              ? t("submissions.collect.label")
+              : t("submissions.freshness.refreshLabel")}
           </Button>
         )}
       </SubmissionFreshnessLine>

--- a/web/src/pages/submissions/SubmissionsRowActions.tsx
+++ b/web/src/pages/submissions/SubmissionsRowActions.tsx
@@ -113,13 +113,12 @@ const ActiveRegradeButton = ({
   displayName?: string
 }) => {
   const { t } = useTranslation()
-  const { regrade, phase, anyRegrading } = useTriggerRegrade({
+  const { regrade, phase, anyRegrading, inFlight } = useTriggerRegrade({
     org,
     classroom,
     assignment,
     owner,
   })
-  const inFlight = phase === "dispatching" || phase === "running"
   // Disable while ANY regrade (this row, another, or "Regrade all") is in flight:
   // trackers share one regrade.yaml run list and bind by monotonic id, so a
   // single outstanding dispatch keeps the binding unambiguous.


### PR DESCRIPTION
## Summary

Refactor from the 1.42.0 release review (#830). Stacked on #844 (it touches the same `DataFreshness` and `useTestServiceToken` code), so GitHub retargets it to `main` once that merges.

- **`inFlight` comes from the operation.** `useGitHubOperation` now returns `inFlight` (and exports `isOperationInFlight(phase)`), and `useTriggerScoreCollection`, `useTriggerRegrade` and `useTestServiceToken` pass it through. The seven hand-written `phase === "dispatching" || phase === "running"` predicates in hooks and pages are gone.
- **One busy-button recipe.** `DataFreshness`, `ClassroomCollectButton` and the Test token button each did `loading={busy} loadingLabel={X}` plus `{busy ? X : children}`, which also announced the busy word twice (the Spinner's sr-only label and the visible text). `Button` gains an opt-in `busyLabel`: while `loading` it replaces the children with that text and renders the spinner decoratively (`InlineSpinner`), so the visible text is the single announcement. The existing `loadingLabel` behavior (spinner beside unchanged children) is untouched for its ~50 callers.

## Test plan

- [x] New `Button` test: `busyLabel` swaps content, spinner is `aria-hidden`, no `role=status`, `aria-busy` set
- [x] `DataFreshness`, `ClassroomCollectButton`, `OrgSettingsPage`, `ServiceTokenTestResult`, `SubmissionsRowActions` and all hook tests green (793 tests)
- [x] `tsc -b`, `eslint` (no new warnings), `prettier`