### PR TITLE
test: pin cross-language contract mirrors

### DIFF
--- a/cli/gh-teacher/init_skeleton_test.go
+++ b/cli/gh-teacher/init_skeleton_test.go
@@ -1276,3 +1276,79 @@ func TestRateLimitMarkersParity_GoVsInlinePython(t *testing.T) {
 		}
 	}
 }
+
+// TestStaffRolesParity_GoVsPythonVsWeb pins the STAFF_ROLES tuple the two
+// embedded scripts hand-mirror, and the web's STAFF_ROLES literal, to
+// contract.StaffRoles in value AND order. A role added to one side but not the
+// others would leave that side's staff team unread by the grant pass or unshown
+// on the roster, silently.
+func TestStaffRolesParity_GoVsPythonVsWeb(t *testing.T) {
+	var goRoles []string
+	for _, role := range contract.StaffRoles {
+		goRoles = append(goRoles, string(role))
+	}
+
+	quoteRE := regexp.MustCompile(`"([^"]+)"`)
+	readRoles := func(src, name string, declRE *regexp.Regexp) []string {
+		m := declRE.FindStringSubmatch(src)
+		if m == nil {
+			t.Fatalf("%s no longer declares STAFF_ROLES where this parity check reads it", name)
+		}
+		var got []string
+		for _, q := range quoteRE.FindAllStringSubmatch(m[1], -1) {
+			got = append(got, q[1])
+		}
+		return got
+	}
+
+	files, err := skeletonFiles("main")
+	if err != nil {
+		t.Fatalf("skeletonFiles: %v", err)
+	}
+	pyRE := regexp.MustCompile(`(?m)^STAFF_ROLES = \(([^)]*)\)`)
+	for _, name := range []string{"collect_scores.py", "probe_token.py"} {
+		script, ok := files[".github/scripts/"+name]
+		if !ok {
+			t.Fatalf("%s missing from skeleton", name)
+		}
+		if got := readRoles(script, name, pyRE); !reflect.DeepEqual(got, goRoles) {
+			t.Errorf("%s STAFF_ROLES = %q, want contract.StaffRoles %q (value and order)", name, got, goRoles)
+		}
+	}
+
+	webSrc, err := os.ReadFile(filepath.Join("..", "..", "web", "src", "types", "classroom.ts"))
+	if err != nil {
+		t.Fatalf("read web classroom.ts: %v", err)
+	}
+	webRE := regexp.MustCompile(`export const STAFF_ROLES: readonly StaffRole\[\] = \[([^\]]*)\]`)
+	if got := readRoles(string(webSrc), "web/src/types/classroom.ts", webRE); !reflect.DeepEqual(got, goRoles) {
+		t.Errorf("web STAFF_ROLES = %q, want contract.StaffRoles %q (value and order)", got, goRoles)
+	}
+}
+
+// TestStaffTeamSlugParity_GoVsPython pins the derived staff team slug shape
+// `classroom50-<short>-<role>` in both scripts to contract.StaffTeamSlug. The
+// scripts are standalone, so each spells the f-string itself; a drift here
+// means the grant pass and the probe look up a team that does not exist and
+// read "no TAs".
+func TestStaffTeamSlugParity_GoVsPython(t *testing.T) {
+	want := contract.StaffTeamSlug("cs", contract.RoleTA)
+	if want != "classroom50-cs-ta" {
+		t.Fatalf("contract.StaffTeamSlug shape changed to %q; update the Python scripts and this test together", want)
+	}
+	files, err := skeletonFiles("main")
+	if err != nil {
+		t.Fatalf("skeletonFiles: %v", err)
+	}
+	// Either spelling of the prefix, then `-{classroom_short}-{role}`.
+	slugRE := regexp.MustCompile(`f"(?:classroom50|\{CONFIG_REPO\})-\{classroom_short\}-\{role\}"`)
+	for _, name := range []string{"collect_scores.py", "probe_token.py"} {
+		script, ok := files[".github/scripts/"+name]
+		if !ok {
+			t.Fatalf("%s missing from skeleton", name)
+		}
+		if !slugRE.MatchString(script) {
+			t.Errorf("%s no longer derives the staff team slug as classroom50-<short>-<role>; keep it byte-equal to contract.StaffTeamSlug", name)
+		}
+	}
+}

--- a/cli/gh-teacher/internal/servicetoken/servicetoken.go
+++ b/cli/gh-teacher/internal/servicetoken/servicetoken.go
@@ -107,6 +107,14 @@ func SecretExists(client githubapi.Client, owner, repo string) (bool, error) {
 	return true, nil
 }
 
+// RequiredTokenPermissions is the fine-grained token configuration collection
+// and regrade need, as the one sentence every rejection shares (the rotate
+// help's bullet list and collect_scores.py's grant hint are pinned to it by
+// test), so a permission added in one place cannot go missing from another.
+const RequiredTokenPermissions = "Repository access = All repositories, " +
+	"Repository permissions Contents: Read and write, Actions: Read and write, " +
+	"and Administration: Read and write, and Organization permissions Members: Read"
+
 // ValidateTokenVerbose confirms a service token can do what the pipeline needs:
 // Contents Read+Write in the org (collect reads, regrade pushes submit/* tags),
 // Administration: write (collect grants staff teams repo access via PUT
@@ -178,14 +186,14 @@ func validateTokenWithClient(tokenClient githubapi.Client, org string, out io.Wr
 	// Token can read the repo, but regrade needs Contents: write to push
 	// submit/* tags. A read-only PAT reports push == false; reject it.
 	if !repo.Permissions.Push {
-		return fmt.Errorf("the supplied token can read %s/%s but lacks write access (Contents: write): collecting scores needs read, but regrading needs to push submit/* tags to student repos. Re-create the fine-grained personal access token with Resource owner = %q, Repository access = All repositories, and Repository permissions -> Contents: Read and write, Actions: Read and write, and Administration: Read and write (regrade re-runs student autograde workflow runs; collect grants staff teams repo access)", org, configrepo.ConfigRepoName, org)
+		return fmt.Errorf("the supplied token can read %s/%s but lacks write access (Contents: write): collecting scores needs read, but regrading needs to push submit/* tags to student repos. Re-create the fine-grained personal access token with Resource owner = %q and %s (regrade re-runs student autograde workflow runs; collect grants staff teams repo access)", org, configrepo.ConfigRepoName, org, RequiredTokenPermissions)
 	}
 
 	// Contents is proven, but collect grants staff teams repo access, needing
 	// Administration (not implied by Contents); reject an admin-less PAT here
 	// rather than as a collect-time 403 on the first grant.
 	if !repo.Permissions.Admin {
-		return fmt.Errorf("the supplied token can read and write %s/%s but lacks admin access (Administration: write): collecting scores grants staff teams (TAs, for example) read access to student repos, which needs the Administration permission. Re-create the fine-grained personal access token with Resource owner = %q, Repository access = All repositories, and Repository permissions -> Contents: Read and write, Actions: Read and write, and Administration: Read and write", org, configrepo.ConfigRepoName, org)
+		return fmt.Errorf("the supplied token can read and write %s/%s but lacks admin access (Administration: write): collecting scores grants staff teams (TAs, for example) read access to student repos, which needs the Administration permission. Re-create the fine-grained personal access token with Resource owner = %q and %s", org, configrepo.ConfigRepoName, org, RequiredTokenPermissions)
 	}
 
 	// Contents is proven, but collection is team-driven: it lists the
@@ -240,7 +248,7 @@ func validateRepoScopeWithClients(tokenClient, teacher githubapi.Client, org str
 	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(org), url.PathEscape(probe))
 	if err := tokenClient.Get(path, nil); err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusNotFound) {
-			return fmt.Errorf("the supplied token can read %s/%s but not %s/%s, so it is scoped to selected repositories (or its Resource owner isn't %q). Collecting scores reads every student repo and grants staff teams access to them. Re-create the fine-grained personal access token with Resource owner = %q and Repository access = All repositories, keeping Contents: Read and write, Actions: Read and write, Administration: Read and write, and Organization permissions -> Members: Read", org, configrepo.ConfigRepoName, org, probe, org, org)
+			return fmt.Errorf("the supplied token can read %s/%s but not %s/%s, so it is scoped to selected repositories (or its Resource owner isn't %q). Collecting scores reads every student repo and grants staff teams access to them. Re-create the fine-grained personal access token with Resource owner = %q and %s", org, configrepo.ConfigRepoName, org, probe, org, org, RequiredTokenPermissions)
 		}
 		_, _ = fmt.Fprintf(out, "Warning: couldn't confirm the token's Repository access setting by reading %s/%s (%v). Proceeding; if the token is scoped to selected repositories, collection can't reach student repos. Run the `probe-token` workflow to verify.\n", org, probe, err)
 	}

--- a/cli/gh-teacher/internal/servicetoken/servicetoken_test.go
+++ b/cli/gh-teacher/internal/servicetoken/servicetoken_test.go
@@ -312,3 +312,25 @@ func TestProvisionServiceSecret_PutStatus(t *testing.T) {
 		})
 	}
 }
+
+// The rotate command's help spells the token requirements as a bullet list and
+// every rejection quotes RequiredTokenPermissions; both must name the same
+// settings, or a permission added to one is invisible in the other.
+func TestRotateHelpNamesEveryRequiredTokenPermission(t *testing.T) {
+	// The help wraps at ~70 columns, so a phrase may straddle a line break.
+	long := strings.Join(strings.Fields(NewRotateCmd().Long), " ")
+	for _, phrase := range []string{
+		"All repositories",
+		"Contents: Read and write",
+		"Actions: Read and write",
+		"Administration: Read and write",
+		"Members: Read",
+	} {
+		if !strings.Contains(RequiredTokenPermissions, phrase) {
+			t.Errorf("RequiredTokenPermissions no longer names %q", phrase)
+		}
+		if !strings.Contains(long, phrase) {
+			t.Errorf("rotate-service-token help no longer names %q; keep it in step with RequiredTokenPermissions", phrase)
+		}
+	}
+}

--- a/cli/gh-teacher/skeleton_tests/test_contract_parity.py
+++ b/cli/gh-teacher/skeleton_tests/test_contract_parity.py
@@ -1,0 +1,141 @@
+"""Parity of the cross-tool contract literals the embedded scripts hand-mirror.
+
+The scripts are standalone (each is copied into a classroom repo and run by a
+workflow), so they cannot import cli/shared or the web. Every constant they
+share with Go and TypeScript is spelled by hand, and this module reads the
+other sides' source to pin each spelling. The Go leg lives in
+init_skeleton_test.go (TestStaffRolesParity_GoVsPythonVsWeb); this is the
+Python leg plus the guidance text the three surfaces each phrase themselves.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+from conftest import _load_module, _SCRIPTS_DIR
+from conftest import collect_scores as cs
+from conftest import materialize_tests as mt
+from conftest import probe_token as pt
+
+runner = _load_module("runner", _SCRIPTS_DIR / "runner.py")
+
+_REPO_ROOT = _SCRIPTS_DIR.parents[4]
+_CONTRACT_GO = _REPO_ROOT / "cli" / "shared" / "contract" / "contract.go"
+_SERVICETOKEN_GO = (
+    _REPO_ROOT / "cli" / "gh-teacher" / "internal" / "servicetoken" / "servicetoken.go"
+)
+_TEST_CMD_GO = (
+    _REPO_ROOT / "cli" / "gh-teacher" / "internal" / "assignmentcmd" / "test_cmd.go"
+)
+_WEB_CLASSROOM_TS = _REPO_ROOT / "web" / "src" / "types" / "classroom.ts"
+
+
+def _go_staff_roles() -> list[str]:
+    """contract.StaffRoles in declaration order, resolved through the Role*
+    constants so the test reads wire strings, not Go identifiers."""
+    src = _CONTRACT_GO.read_text()
+    values = dict(re.findall(r'(Role\w+)\s+StaffRole\s*=\s*"([a-z]+)"', src))
+    block = re.search(r"var StaffRoles = \[\]StaffRole\{([^}]*)\}", src)
+    assert block, "contract.StaffRoles literal not found in contract.go"
+    return [values[name] for name in re.findall(r"Role\w+", block.group(1))]
+
+
+def _web_staff_roles() -> list[str]:
+    src = _WEB_CLASSROOM_TS.read_text()
+    block = re.search(
+        r"export const STAFF_ROLES: readonly StaffRole\[\] = \[([^\]]*)\]", src
+    )
+    assert block, "web STAFF_ROLES literal not found in classroom.ts"
+    return re.findall(r'"([a-z]+)"', block.group(1))
+
+
+class TestStaffRoles:
+    def test_scripts_match_go_in_value_and_order(self):
+        go = _go_staff_roles()
+        assert list(cs.STAFF_ROLES) == go
+        assert list(pt.STAFF_ROLES) == go
+
+    def test_web_matches_go_in_value_and_order(self):
+        assert _web_staff_roles() == _go_staff_roles()
+
+
+class TestStaffTeamSlug:
+    def test_both_scripts_derive_the_contract_shape(self):
+        # contract.StaffTeamSlug: ConfigRepoName + "-" + short + "-" + role.
+        src = _CONTRACT_GO.read_text()
+        body = re.search(
+            r"func StaffTeamSlug\(shortName string, role StaffRole\) string \{\n\s*return ([^\n]+)\n\}",
+            src,
+        )
+        assert body and body.group(1).replace(" ", "") == (
+            'ConfigRepoName+"-"+shortName+"-"+string(role)'
+        ), "contract.StaffTeamSlug shape changed; update both scripts and this test"
+        for role in cs.STAFF_ROLES:
+            expected = f"classroom50-cs-{role}"
+            assert cs.staff_team_slug("cs", role) == expected
+            assert pt.resolve_staff_team_slugs({}, "cs")[role] == expected
+
+
+# The four settings a service token needs. Each surface below phrases them in
+# its own voice; every phrase must appear in each, or a permission added to one
+# goes missing from another.
+TOKEN_PERMISSION_PHRASES = (
+    "All repositories",
+    "Contents: Read and write",
+    "Actions: Read and write",
+    "Administration: Read and write",
+    "Members: Read",
+)
+
+
+class TestTokenPermissionGuidance:
+    def _go_constant(self) -> str:
+        src = _SERVICETOKEN_GO.read_text()
+        block = re.search(
+            r"const RequiredTokenPermissions = ((?:\s*\"[^\"]*\"\s*\+?)+)", src
+        )
+        assert block, "RequiredTokenPermissions not found in servicetoken.go"
+        return "".join(re.findall(r'"([^"]*)"', block.group(1)))
+
+    def test_go_constant_names_every_setting(self):
+        text = self._go_constant()
+        for phrase in TOKEN_PERMISSION_PHRASES:
+            assert phrase in text
+
+    def test_collect_grant_hint_names_the_settings_it_can_fix(self, monkeypatch, capsys):
+        # The grant-failure hint names what a 401/403 on the staff grant means:
+        # the token cannot reach the student repos, or cannot administer them.
+        # Reuses the Go constant's spellings so the two never disagree.
+        src = pathlib.Path(cs.__file__).read_text()
+        hint = re.search(r"grant_hint = \(\n((?:\s*f?\"[^\"]*\"\n)+)", src)
+        assert hint, "grant_hint literal not found in collect_scores.py"
+        text = "".join(re.findall(r'"([^"]*)"', hint.group(1)))
+        for phrase in ("All repositories", "Administration: Read and write"):
+            assert phrase in text
+            assert phrase in self._go_constant()
+
+
+class TestHandWrittenTestsGuidance:
+    """runner.py, materialize_tests.py and `gh teacher assignment test` each
+    tell a teacher not to commit tests.json by hand and where tests belong.
+    Pin the shared facts so one surface cannot start pointing elsewhere."""
+
+    def _texts(self) -> dict[str, str]:
+        mt_src = pathlib.Path(mt.__file__).read_text()
+        mt_warning = re.search(
+            r'print\(f"::warning::\{target\}: replaced by the tests((?:[^)]|\n)*?)\)', mt_src
+        )
+        assert mt_warning, "materialize_tests.py hand-committed tests.json warning not found"
+        return {
+            "runner": runner.HAND_WRITTEN_TESTS_HINT,
+            "materialize_tests": mt_warning.group(0),
+            "test_cmd.go": _TEST_CMD_GO.read_text(),
+        }
+
+    def test_every_surface_says_tests_json_is_generated_and_where_tests_live(self):
+        for name, text in self._texts().items():
+            flat = " ".join(text.split())
+            assert "tests.json" in flat, name
+            assert "generate" in flat, name
+            assert "gh teacher assignment test" in flat or "assignment test" in flat, name


### PR DESCRIPTION
## Summary

From the 1.42.0 release review (#830): several contract literals are hand-mirrored across Go, the two standalone Python scripts and the web with nothing pinning them to each other (unlike the existing `TestRateLimitMarkersParity_GoVsInlinePython`). Based on `main`; no product behavior changes beyond one shared Go constant.

- **`STAFF_ROLES` parity, value and order.** Go `TestStaffRolesParity_GoVsPythonVsWeb` reads `collect_scores.py`, `probe_token.py` and `web/src/types/classroom.ts` against `contract.StaffRoles`; Python `test_contract_parity.py` reads `contract.go` and `classroom.ts` from the other side, so a drift fails whichever suite runs first.
- **Staff team slug shape.** `TestStaffTeamSlugParity_GoVsPython` pins both scripts' f-strings to `contract.StaffTeamSlug`'s `classroom50-<short>-<role>`; the Python leg checks `staff_team_slug` and `probe_token.resolve_staff_team_slugs` produce it for every role.
- **Token-permission guidance.** `servicetoken.go` spelled the required settings three times in three rejection errors and once more in the rotate help. The three errors now quote one `RequiredTokenPermissions` constant; `TestRotateHelpNamesEveryRequiredTokenPermission` pins the help's bullet list to it, and the Python leg pins `collect_scores.py`'s grant hint to the same spellings.
- **Hand-written `tests.json` hint.** `runner.py`, `materialize_tests.py` and `gh teacher assignment test` each say tests.json is generated and where tests belong; the Python leg pins those shared facts across all three.

Scripts stay self-contained (no cross-imports), so this is parity-by-test rather than a shared module, matching the repo's existing approach.

## Test plan

- [x] `go test ./...` in `cli/gh-teacher` (new tests included), `golangci-lint run` 0 issues, `gofmt` clean
- [x] `pytest cli/gh-teacher/skeleton_tests` 971 passed (6 new); `ruff check` clean