### PR TITLE
fix(cli): name every required permission when the config repo read is refused

### DIFF
--- a/cli/gh-teacher/internal/servicetoken/servicetoken.go
+++ b/cli/gh-teacher/internal/servicetoken/servicetoken.go
@@ -108,9 +108,11 @@ func SecretExists(client githubapi.Client, owner, repo string) (bool, error) {
 }
 
 // RequiredTokenPermissions is the fine-grained token configuration collection
-// and regrade need, as the one sentence every rejection shares (the rotate
-// help's bullet list and collect_scores.py's grant hint are pinned to it by
-// test), so a permission added in one place cannot go missing from another.
+// and regrade need, as the one sentence every permission-shaped rejection
+// quotes (the 401 and the Members-only 403 name their own single cause). The
+// rotate help's bullet list is pinned to it by test, and collect_scores.py's
+// grant hint to the two settings a grant failure can mean, so a permission
+// added in one place cannot go missing from another.
 const RequiredTokenPermissions = "Repository access = All repositories, " +
 	"Repository permissions Contents: Read and write, Actions: Read and write, " +
 	"and Administration: Read and write, and Organization permissions Members: Read"
@@ -178,7 +180,7 @@ func validateTokenWithClient(tokenClient githubapi.Client, org string, out io.Wr
 		case cliutil.IsHTTPStatus(err, http.StatusUnauthorized):
 			return fmt.Errorf("the supplied token is invalid, expired, or revoked (401). Create a fresh fine-grained PAT and try again")
 		case cliutil.IsHTTPStatus(err, http.StatusNotFound), cliutil.IsHTTPStatus(err, http.StatusForbidden):
-			return fmt.Errorf("the supplied token can't read %s/%s. Create a fine-grained PAT with Resource owner = %q, Repository access = All repositories, and Repository permissions -> Contents: Read and write AND Actions: Read and write AND Administration: Read and write (regrade re-runs autograde workflow runs; collect grants staff teams repo access). If your org requires PAT approval and you are not an org owner, an owner must approve it first (owners' tokens are auto-approved). Underlying error: %v", org, configrepo.ConfigRepoName, org, err)
+			return fmt.Errorf("the supplied token can't read %s/%s. Create a fine-grained PAT with Resource owner = %q and %s (regrade re-runs autograde workflow runs; collect grants staff teams repo access). If your org requires PAT approval and you are not an org owner, an owner must approve it first (owners' tokens are auto-approved). Underlying error: %v", org, configrepo.ConfigRepoName, org, RequiredTokenPermissions, err)
 		default:
 			return fmt.Errorf("couldn't verify the token against %s/%s: %w", org, configrepo.ConfigRepoName, err)
 		}

--- a/cli/gh-teacher/internal/servicetoken/servicetoken_test.go
+++ b/cli/gh-teacher/internal/servicetoken/servicetoken_test.go
@@ -314,8 +314,9 @@ func TestProvisionServiceSecret_PutStatus(t *testing.T) {
 }
 
 // The rotate command's help spells the token requirements as a bullet list and
-// every rejection quotes RequiredTokenPermissions; both must name the same
-// settings, or a permission added to one is invisible in the other.
+// the permission-shaped rejections quote RequiredTokenPermissions; both must
+// name the same settings, or a permission added to one is invisible in the
+// other.
 func TestRotateHelpNamesEveryRequiredTokenPermission(t *testing.T) {
 	// The help wraps at ~70 columns, so a phrase may straddle a line break.
 	long := strings.Join(strings.Fields(NewRotateCmd().Long), " ")

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/collect_scores.py
@@ -750,8 +750,8 @@ class RepoIndex:
     def prefetch(self, repo_names: Iterable[str]) -> None:
         """Tell the index which names the caller is about to ask about, so it can
         resolve them in one parallel batch (and choose probing over the listing
-        when that is cheaper). Optional: `contains` and `is_private` answer
-        without it, one request per unseen name in probe mode."""
+        when that is cheaper). Optional: `contains`, `facts` and `is_private`
+        answer without it, one request per unseen name in probe mode."""
         names = list(dict.fromkeys(name.lower() for name in repo_names))
         if self._load(names) is not None or self._probe_state is None:
             return
@@ -840,9 +840,8 @@ class RepoIndex:
 
     def _complete_listing(self) -> dict[str, RepoFacts] | None:
         """Leave probe mode by reading the rest of the listing. Probed answers
-        are kept: a name found by probe is in the org whether or not it lands on
-        a page (a repo created mid-walk shifts the pages). A soft failure leaves
-        the listing unknown, like a failed first read."""
+        are kept (see _ProbeState.known). A soft failure leaves the listing
+        unknown, like a failed first read."""
         probe = self._probe_state
         assert probe is not None
         rest = self._soft_read(
@@ -1469,8 +1468,8 @@ def build_entry_row(
     detail ONLY inside `submissions` (newest first). `owner` is the stable
     per-bucket key (repo owner from the <classroom>-<assignment>-<username>
     formula), invariant across re-collects even when a group's member set
-    changes, so apply_updates replaces the entry in place. For a group entry
-    `member_usernames` sits right after `owner`. `_assignment` / `_type` are
+    changes, so apply_updates replaces the entry in place. For a group or team
+    entry `member_usernames` sits right after `owner`. `_assignment` / `_type` are
     transport-only hints for apply_updates (bucket slug + type), stripped on
     store."""
     entry_row: dict[str, Any] = {
@@ -1517,7 +1516,7 @@ def collect_classroom(
     """Return (validated result payloads for every (student, assignment) pair,
     count of assignments whose only submissions were rejected by validation,
     slug -> mode map of the assignments actually walked, slug -> (mode, detected
-    records) for assignments that skip grading).
+    records, visited owners) for every walked assignment).
     Per-repo failures warn and skip; hard failures (auth 401/403; network 599)
     propagate and main() converts them to exit 1. The second tuple element lets
     main() distinguish a mode-flip-induced empty result (which has its own loud
@@ -1776,9 +1775,7 @@ def collect_classroom(
                     mode_flip_repos.append(repo_name)
                 continue
 
-            # Who the entry credits (see attribute_submission_members). Resolved
-            # BEFORE building the entry so `member_usernames` sits right after
-            # `owner` in the written JSON key order.
+            # A skipped repo keeps its prior entry (see MemberAttribution.skipped).
             attribution = attribute_submission_members(
                 api_url, org, classroom_short, slug, repo_name, username,
                 is_team=is_team, is_group=is_group,
@@ -2296,8 +2293,8 @@ def grant_classroom_team_access(
     if not populated_teams:
         # Every staff team absent AND unrecorded means nothing was ever set up
         # (a solo teacher, or a classroom before its first TA): a notice, since
-        # there is nothing to fix. A team that exists but is empty is the
-        # misconfiguration the warning is for.
+        # there is nothing to fix. Anything else (an empty team, a recorded team
+        # that is missing, a failed read) is worth the warning.
         message = warn_no_staff_to_grant(classroom_short, org, grant_teams)
         if len(absent_teams) == len(grant_teams):
             emit_notice(message)
@@ -2314,7 +2311,9 @@ def warn_no_staff_to_grant(
     staff team to grant them to. Without it, "every TA was moved to a team the
     pass can't see" exits 0 exactly like a healthy run, and the teacher learns
     the TAs have no access only when they ask. The caller picks the level: a
-    warning when some team exists but is empty, a notice when none was set up."""
+    notice only when every staff team is both unrecorded and absent on GitHub
+    (nothing was ever set up); otherwise a warning, because a team exists but is
+    empty, a recorded team is missing, or a team read failed."""
     slugs = ", ".join(team.slug for _, team, _ in grant_teams)
     return (
         f"{classroom_short}: no staff access was granted because no head-TA or TA "
@@ -3569,7 +3568,7 @@ def _org_repos_page_url(api_url: str, org: str) -> Callable[[int], str]:
     )
 
 
-def list_org_repos(api_url: str, org: str, token: str) -> dict[str, bool]:
+def list_org_repos(api_url: str, org: str, token: str) -> dict[str, RepoFacts]:
     """Lowercased name -> RepoFacts for every repo in `org` the token can
     see, walking pagination in parallel. Hits GET /orgs/{org}/repos.
 

--- a/cli/gh-teacher/skeleton_tests/test_contract_parity.py
+++ b/cli/gh-teacher/skeleton_tests/test_contract_parity.py
@@ -3,9 +3,10 @@
 The scripts are standalone (each is copied into a classroom repo and run by a
 workflow), so they cannot import cli/shared or the web. Every constant they
 share with Go and TypeScript is spelled by hand, and this module reads the
-other sides' source to pin each spelling. The Go leg lives in
-init_skeleton_test.go (TestStaffRolesParity_GoVsPythonVsWeb); this is the
-Python leg plus the guidance text the three surfaces each phrase themselves.
+other sides' source to pin each spelling. The Go legs live in
+init_skeleton_test.go (TestStaffRolesParity_GoVsPythonVsWeb and
+TestStaffTeamSlugParity_GoVsPython); this is the Python leg plus the guidance
+text the three surfaces each phrase themselves.
 """
 
 from __future__ import annotations
@@ -77,9 +78,9 @@ class TestStaffTeamSlug:
             assert pt.resolve_staff_team_slugs({}, "cs")[role] == expected
 
 
-# The four settings a service token needs. Each surface below phrases them in
-# its own voice; every phrase must appear in each, or a permission added to one
-# goes missing from another.
+# The settings a service token needs. The Go constant and the rotate help must
+# name all of them; the collect grant hint names only the two a grant 401/403
+# can mean (see the tests below).
 TOKEN_PERMISSION_PHRASES = (
     "All repositories",
     "Contents: Read and write",

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -11,10 +11,11 @@ import { cx } from "./cx"
 
 // The canonical button. Wraps daisyUI `btn` so the ~160 inline sites share one
 // prop->class mapping instead of hand-ordered modifier strings. Color/size are
-// props; icon-only buttons pick a `shape`; `loading` renders the accessible
-// Spinner inside and makes the button inert WITHOUT semantically disabling it
-// (aria-disabled + click guard — a native `disabled` would drop keyboard focus
-// mid-action, per Primer's loading guidance). A trailing `className` escape
+// props; icon-only buttons pick a `shape`; `loading` renders a spinner inside
+// (the accessible Spinner beside the children, or a decorative one when
+// `busyLabel` replaces them) and makes the button inert WITHOUT semantically
+// disabling it (aria-disabled + click guard — a native `disabled` would drop
+// keyboard focus mid-action, per Primer's loading guidance). A trailing `className` escape
 // hatch stays for the per-site layout utilities (`w-full`, `join-item`,
 // `self-start`, ...). `ref` is a plain prop (React 19) so sites that manage
 // focus can still reach the underlying element.

--- a/web/src/components/ui/ExternalLink.tsx
+++ b/web/src/components/ui/ExternalLink.tsx
@@ -6,7 +6,7 @@ import { cx } from "./cx"
 // A text link that opens off-site in a new tab: the daisyUI `link` recipe, the
 // `target`/`rel` pair that a new tab needs, and the trailing external-link
 // glyph, so the ~20 hand-written `<a className="link" target="_blank">` sites
-// converge on one shape. In-app navigation is the router's `Link`, not this.
+// can converge on one shape. In-app navigation is the router's `Link`, not this.
 export type ExternalLinkProps = Omit<
   AnchorHTMLAttributes<HTMLAnchorElement>,
   "target" | "rel" | "children"

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -248,7 +248,8 @@ export async function editAssignment(
   // can never rename an assignment, regardless of what the caller passed.
   editedAssignment.slug = targetAssignment.slug
 
-  // A caller that renders no lock control (input.locked undefined) must not
+  // An input with no lock decision (input.locked undefined: no lock control, or
+  // a toggle left as it was seeded) must not
   // silently unlock; only an explicit decision changes the stored state.
   const wasLocked = Boolean(targetAssignment.locked)
   if (input.locked === undefined && wasLocked) {

--- a/web/src/github-core/mutations/workflowDispatch.ts
+++ b/web/src/github-core/mutations/workflowDispatch.ts
@@ -53,8 +53,8 @@ async function openDispatch(
   const ref = repo.default_branch || DEFAULT_BRANCH
   return {
     sinceRunId: baseline.workflow_runs?.[0]?.id ?? null,
-    // A workflow with no declared inputs is dispatched with none: GitHub 422s
-    // an `inputs` key on a workflow that declares nothing.
+    // A workflow with no declared inputs is dispatched with no `inputs` key at
+    // all, as probe-token always was.
     post: (inputs) =>
       client
         .request(`${base}/dispatches`, {

--- a/web/src/github-core/queries/shared.ts
+++ b/web/src/github-core/queries/shared.ts
@@ -2,10 +2,11 @@ import { GitHubAPIError } from "../errors"
 import { logger } from "@/lib/logger"
 import { LOG_SCOPE_QUERIES } from "@/lib/logScopes"
 
-// Shared leaf primitives for the read sub-modules: the scoped logger, the
-// fresh-repo retry loop, and the per-repo read concurrency cap. Kept in a leaf
-// (imports only ../errors + lib) so every read module can depend on it without
-// forming a cycle.
+// Shared leaf primitives for github-core reads (the query sub-modules and
+// paginate): the scoped logger, the retry loop with its fresh-repo and
+// rate-limit policies, and the per-repo read slot. Kept in a leaf (imports only
+// ../errors + lib) so every read module can depend on it without forming a
+// cycle.
 export const log = logger.scope(LOG_SCOPE_QUERIES)
 
 // Max simultaneous per-repo reads. Bounded so a large class doesn't fan out
@@ -71,9 +72,10 @@ export function withGithubReadSlot<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 // Retry-After ceiling: a real secondary-limit backoff is usually ~60s, but a
-// client fan-out shouldn't hang a page that long. Cap the wait so one throttled
-// repo can't stall the batch; beyond this the read surfaces as an error the UI
-// reports rather than an indefinite spinner.
+// client fan-out shouldn't hang a page that long. retryOnRateLimit clamps its
+// one wait to this and retries anyway; withTransientRetry (paginate.ts) gives
+// the page up instead, so the UI reports an error rather than an indefinite
+// spinner.
 export const MAX_RATE_LIMIT_WAIT_MS = 8000
 
 export type RetryOptions = {
@@ -90,8 +92,8 @@ export type RetryOptions = {
   onRetry?: (attempt: number, waitMs: number) => void
 }
 
-// The one retry loop under every GitHub read retry: fresh-repo lag, a rate
-// limit, a transient page failure. Each caller supplies only its policy.
+// The one retry loop under every github-core read retry: fresh-repo lag, a
+// rate limit, a transient page failure. Each caller supplies only its policy.
 export async function withRetry<T>(
   fn: () => Promise<T>,
   options: RetryOptions,

--- a/web/src/hooks/useAssignmentRepos.ts
+++ b/web/src/hooks/useAssignmentRepos.ts
@@ -13,7 +13,8 @@ type Args = {
   assignment: string
   // Logins whose `<classroom>-<assignment>-<login>` repos the caller looks up.
   // `undefined` means the names are not derivable (a shared-repo assignment, or
-  // the roster hasn't loaded), so the whole org listing is read instead.
+  // a roster the caller could not derive them from; see
+  // assignmentRepoCandidateLogins), so the whole org listing is read instead.
   logins: readonly string[] | undefined
   enabled?: boolean
 }
@@ -26,9 +27,10 @@ type Args = {
 // latestAssignmentPush, ...) read unchanged.
 //
 // The scoped read shares its cache with the full listing in both directions: a
-// fresh full listing answers it without a request, and a scoped read that ended
-// up walking the whole org (a large roster) is stored under the full-listing
-// key too, so the assignments page does not walk the org again.
+// fresh full listing answers it without a request (except on a manual
+// `refetch`, which marks that listing stale first), and a scoped read that
+// ended up walking the whole org (a large roster) is stored under the
+// full-listing key too, so the assignments page does not walk the org again.
 export function useAssignmentRepos({
   org,
   classroom,

--- a/web/src/hooks/useGitHubOperation.ts
+++ b/web/src/hooks/useGitHubOperation.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react"
 import type { GitHubWorkflowRun } from "@/github-core/types"
 
 // Lifecycle phase of a tracked workflow_dispatch operation, shared by every
-// dispatch-and-track hook (collect scores, regrade).
+// dispatch-and-track hook (collect scores, regrade, probe token).
 export type OperationPhase =
   "idle" | "dispatching" | "running" | "completed" | "failed" | "timeout"
 

--- a/web/src/hooks/useStaffCapabilities.ts
+++ b/web/src/hooks/useStaffCapabilities.ts
@@ -6,10 +6,11 @@ import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
 // surface (toolbar, actions menu, row actions, table) reads the same verdicts
 // instead of re-deriving them from the role in six places.
 //
-// Two tiers. Workflow dispatches (Collect now, Regrade all, per-row regrade,
-// lock, delete) POST to the config repo's Actions API, which needs `push`
-// there: the teacher and head-TA teams have it, a TA has `pull` and would 403.
-// `authorAssignments` is exactly that write tier. Org ownership gates only what
+// Two tiers. Workflow dispatches (Collect now, Regrade all, per-row regrade)
+// POST to the config repo's Actions API and the assignments.json writes (lock,
+// delete) commit to it; both need `push` there: the teacher and head-TA teams
+// have it, a TA has `pull` and would 403. `authorAssignments` is exactly that
+// write tier. Org ownership gates only what
 // needs repo ADMIN (bulk access/features/visibility, Open all PRs, the template
 // grant). Reading student repos needs neither: the overlays run for every staff
 // viewer with the VIEWER's token, and a repo they lack access to reads as 404,

--- a/web/src/hooks/useTestServiceToken.ts
+++ b/web/src/hooks/useTestServiceToken.ts
@@ -21,9 +21,10 @@ const PROBE_BACKOFF_INTERVAL_MS = 12000
 
 /**
  * Dispatches probe-token.yaml (the read-only service-token health check) and
- * tracks the run via useGitHubOperation, then reads the finished run's
+ * tracks the run via useGitHubOperation, then reads a FAILED run's
  * annotations, which is where the probe reports which scope checks failed and
- * how to fix them. Registers with the Actions banner like every dispatch.
+ * how to fix them (a passing run emits only a notice the result never shows,
+ * so it is not read). Registers with the Actions banner like every dispatch.
  */
 const useTestServiceToken = (org: string | undefined) => {
   const client = useGitHubClient()

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -177,8 +177,8 @@ const AssignmentsTable = ({
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const { data: scoresData } = useGetScores(org, classroom)
-  // Org repo list, for the group-row denominator (accepted groups = group
-  // repos that exist). Shared react-query cache with the submissions page.
+  // Org repo list, for every row's Accepted count (this assignment's repos that
+  // exist). Shared react-query cache with the submissions page.
   const { data: orgRepos } = useGetOrgRepos(org)
   // Sibling slugs guard group-repo attribution against a slug-extending
   // sibling ("hw1-bonus" under "hw1") — derived from the full list so a

--- a/web/src/pages/orgSettings/ServiceTokenTestResult.tsx
+++ b/web/src/pages/orgSettings/ServiceTokenTestResult.tsx
@@ -109,9 +109,9 @@ export default function ServiceTokenTestResult({
     </Button>
   ) : null
 
-  // Every outcome but a failed RUN is one sentence in one tone; the table keeps
-  // a new outcome to a row. A failed run is the one shape with structure (the
-  // probe's own verdict list), rendered below.
+  // Every outcome but a failed RUN is one sentence in one tone, so simpleOutcome
+  // keeps a new outcome to one branch. A failed run is the one shape with
+  // structure (the probe's own verdict list), rendered below.
   const simple = simpleOutcome({ phase, failure, error })
   if (simple) {
     return (

--- a/web/src/pages/submissions/DataFreshness.tsx
+++ b/web/src/pages/submissions/DataFreshness.tsx
@@ -15,8 +15,8 @@ import { SubmissionFreshnessLine } from "@/components/SubmissionFreshnessLine"
 // stale data look authoritative, and give the user a direct way to refresh it.
 //
 // For a viewer who can dispatch the collect (teacher, head TA) the button reads
-// "Collect now" in every state — the same string the Manage hub's collect action
-// uses, because it is the same dispatch. A TA has read-only config-repo access
+// "Collect now" (and "Collecting…" while the run is in flight) — the same
+// strings the Manage hub's collect action uses, because it is the same dispatch. A TA has read-only config-repo access
 // and can't dispatch, so their button is "Refresh" (re-read what a teacher
 // collected) with a note on who to ask.
 //

--- a/web/src/pages/submissions/dashboard.ts
+++ b/web/src/pages/submissions/dashboard.ts
@@ -1649,12 +1649,10 @@ export function showCheckingAccepted(args: {
   )
 }
 
+// See assignmentFunnelCounts for what each count means.
 export type AssignmentFunnelCounts = {
-  // Graded `entries` plus the bucket's `detected` list, united by owner.
   submitted: number
-  // This assignment's existing repos; undefined while the repo list loads.
   accepted: number | undefined
-  // No collect has walked this bucket yet, which is NOT "nobody submitted".
   notCollected: boolean
 }
 


### PR DESCRIPTION
## Summary

A comment-accuracy sweep over the fourteen PRs merged from the 1.42.0 review (#840 to #853), checked against the code as it now stands on `main`. One finding was a real gap, the rest are comments.

- **Product copy (the `fix`):** `servicetoken.go`'s config-repo 403 rejection still hand-spelled its permission list and omitted `Members: Read`, exactly the drift `RequiredTokenPermissions` (#853) exists to prevent. It now quotes the constant. The 401 and the Members-only 403 keep their own single-cause wording on purpose; the constant's doc comment and the parity test's comment now say so instead of claiming "every rejection".

- **Comments that described behavior the code no longer has:** `Button` header (`loading` now renders a decorative spinner under `busyLabel`); `useGitHubOperation` (probe-token also uses it); `useAssignmentRepos` (manual `refetch` bypasses the cached-listing shortcut; `logins: undefined` also means an unknown or failed roster); `useTestServiceToken` (annotations are read only for a failed run); `useStaffCapabilities` (lock and delete are assignments.json commits, not workflow dispatches); `createEdit` (an undefined `locked` now means "no lock decision", since the form does render a control); `queries/shared.ts` header and `MAX_RATE_LIMIT_WAIT_MS` (two consumers with different semantics); `DataFreshness` header; `AssignmentsTable` org-repos comment (Accepted is computed for every row); `collect_scores.py`: `list_org_repos` return annotation, `collect_classroom` return description, `prefetch` accessor list, `build_entry_row` ("group or team"), the notice-vs-warning rule in the grant pass (the warning also covers a missing recorded team and a failed read); `test_contract_parity.py` ("four" settings that are five; two Go legs).

- **Duplicated or unverifiable:** the `AssignmentFunnelCounts` field comments restated the function's paragraphs; the "repo created mid-walk" rationale appeared on both `_ProbeState.known` and `_complete_listing`; the `collect_classroom` call-site comment restated a constraint `build_entry_row`'s signature now enforces; `workflowDispatch` asserted GitHub 422s an `inputs` key on a no-input workflow, which nothing in the repo establishes, so it now just states what is sent; `ServiceTokenTestResult` called an if-chain a table; `ExternalLink` claimed the ~20 sites had converged when one has.

## Test plan

- [x] `go vet`, `go test ./internal/servicetoken/` (the 403 message is still matched by its `strings.Contains` tests), `gofmt`
- [x] `pytest cli/gh-teacher/skeleton_tests` 987 passed; `ruff check` clean
- [x] `tsc -b`, `eslint` (no new warnings), `prettier` on the web files