### PR TITLE
docs(wiki): document the 1.42.x collect and autograder behavior changes

### DIFF
--- a/wiki/Advanced-Autograding.md
+++ b/wiki/Advanced-Autograding.md
@@ -47,8 +47,9 @@ The runner provides:
 
 - **Environment variables:** `CLASSROOM`, `ASSIGNMENT`, `SUBMISSION_TAG`,
   `PAGES_BASE_URL`, `USERNAME`/`OWNER`, `ASSIGNMENT_TYPE`, `COMMIT_URL`,
-  `RELEASE_URL`, `REVIEW_URL`, `CLASSROOM50_BUNDLE_DIR` (the directory the
-  entrypoint was extracted to), and all standard `GITHUB_*`.
+  `RELEASE_URL`, `REVIEW_URL`, `CLASSROOM50_BUNDLE_DIR` (the assignment's
+  extracted bundle folder, also when the entrypoint is the classroom default),
+  and all standard `GITHUB_*`.
 - **Working directory:** the student's checkout (relative paths resolve to
   student code).
 - **Sibling files:** anything else under `CLASSROOM/autograders/ASSIGNMENT/` is
@@ -176,6 +177,11 @@ default that grades every assignment without its own autograder or tests. With n
 `--from`, it installs a diagnostic stub (echoes the environment, emits a vacuous
 pass) — useful for verifying the pipeline. Inspect it with `autograder show`, and
 delete it outright with `autograder remove`.
+
+The default runs from the runtime directory, not from the assignment's bundle, so
+read per-assignment fixtures through `$CLASSROOM50_BUNDLE_DIR` rather than
+`Path(__file__).parent`. It points at `CLASSROOM/autograders/ASSIGNMENT/` when
+that folder was published, and at the runtime directory otherwise.
 
 ## The `result.json` contract
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -823,7 +823,25 @@ token problem, so don't rotate the token for it:
 Also check the assignment itself: with autograding paused or a tag-mode
 assignment no one has submitted to, there are no results to collect.
 
+The warning is skipped when the run detected pushes that the autograder has not
+graded yet: reading those repositories proves the token works, and the gap is
+the autograder's (see ["The collection run did not complete successfully."](#the-collection-run-did-not-complete-successfully)).
+
 See the [service-token setup](GitHub-Integration#4-fine-grained-pat-for-score-collection).
+
+### `collect-scores` says "no staff access was granted"
+
+Collection grants the head TA and TA teams read access to student repositories
+as it runs, and reports when it had nobody to grant it to. The level tells you
+whether anything needs fixing:
+
+- A **notice** means the classroom has no staff team at all: nothing in
+  `classroom.json` names one and none exists on GitHub. A solo teacher can
+  ignore it. It stops once you add a TA on the roster page or with
+  `gh teacher staff add <org> <classroom> <username> --role ta`.
+- A **warning** means a staff team exists but has no members, or a team
+  recorded in `classroom.json` is missing or couldn't be read. Check each TA's
+  role on the roster page, then run collection again.
 
 ### "The collection run did not complete successfully."
 

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -841,7 +841,9 @@ organization owners.
 The **Actions** menu at the top of the submissions page operates on the whole
 assignment:
 
-- **Metrics** — summary statistics for the assignment.
+- **Metrics** — summary statistics of the collected scores. Shown only for
+  empty-repository assignments; every other assignment shows live status in
+  the table instead.
 - **Open all Feedback PRs** — review each student's feedback pull request in
   turn.
 - **Collect now** — trigger a score collection scoped to this assignment.


### PR DESCRIPTION
## Summary

Wiki follow-ups for behavior that changed in the 1.42.0 review PRs (#840 to #853, #855). Publishes to the GitHub wiki from `wiki/` on merge.

- **Advanced-Autograding:** `CLASSROOM50_BUNDLE_DIR` was described as "the directory the entrypoint was extracted to". Since #847 it is the assignment's extracted bundle folder even when the entrypoint is the classroom default, which lives beside the bundle; the classroom-default section now says to read fixtures through the env var rather than `Path(__file__).parent`, and what it points at when no bundle was published.
- **Web-Teacher-Guide:** the Actions menu listed **Metrics** unconditionally. It is only offered for empty-repository assignments (every other assignment shows live status in the table instead), which #831 made true for every staff role and was confirmed as intended in the review.
- **Troubleshooting:** two `collect-scores` log messages teachers will now see:
  - the "collected 0 submissions" warning is skipped when the run detected ungraded pushes (#845), so the section says why;
  - a new section on "no staff access was granted", explaining the notice (no staff team exists, nothing to fix) versus the warning (a team exists but is empty, or a recorded team is missing or unreadable) introduced in #845.

Checked and already accurate: the service-token permission tables (GitHub-Integration, gh-teacher), the `--locked` and `assignment lock` docs, the TA **Refresh** description in Staff-TAs-and-Multiple-Teachers, and the hand-written `tests.json` guidance.

## Test plan

- [x] Rendered locally as Markdown; the intra-page anchor for the new cross-reference matches the existing heading