### PR TITLE
fix(cli): stop blaming the service token when the Actions budget cap fails

### DIFF
--- a/cli/gh-teacher/init.go
+++ b/cli/gh-teacher/init.go
@@ -57,15 +57,15 @@ func initCmd() *cobra.Command {
 			"    history, process listings, and CI logs.\n" +
 			"  - Create a fine-grained personal access token with Resource\n" +
 			"    owner = your organization, Repository access = All repositories,\n" +
-			"    Contents: Read and write, Actions: Read and write, and\n" +
-			"    Organization permissions -> Members: Read and Administration:\n" +
-			"    Read and write. Student repos are created on demand, so an\n" +
+			"    Contents: Read and write, Actions: Read and write,\n" +
+			"    Administration: Read and write, and Organization permissions ->\n" +
+			"    Members: Read. Student repos are created on demand, so an\n" +
 			"    \"Only select repositories\" scope silently misses them.\n" +
 			"  - Why each permission: Contents read collects scores; Contents\n" +
 			"    write pushes submit/* tags; Actions write re-runs autograde\n" +
-			"    workflows when regrading; Members read lists the classroom\n" +
-			"    team (collection is team-driven); Organization Administration\n" +
-			"    sets the $0 Actions spending cap.\n" +
+			"    workflows when regrading; Administration write lets collection\n" +
+			"    grant staff teams read access to student repos; Members read\n" +
+			"    lists the classroom team (collection is team-driven).\n" +
 			"  - init validates the token before storing it. A re-run leaves an\n" +
 			"    already-configured token untouched; replace it with\n" +
 			"    `gh teacher rotate-service-token <org>`.\n" +

--- a/cli/gh-teacher/init_repo.go
+++ b/cli/gh-teacher/init_repo.go
@@ -257,7 +257,7 @@ func ensureOrgActionsBudgetCap(client githubapi.Client, out, errOut io.Writer, o
 
 	budgets, err := githubapi.ListOrgBudgets(client, org)
 	if err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: %s: couldn't read org billing budgets (%v); this usually means the token lacks Organization permissions -> Administration: Read, or the org/plan doesn't expose budgets. Set a $0 GitHub Actions budget by hand at %s to hard-stop paid Actions minutes.\n",
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: couldn't read org billing budgets (%v); billing is probably managed at the enterprise level, or the plan doesn't expose organization budgets. Set a $0 GitHub Actions budget by hand at %s to hard-stop paid Actions minutes.\n",
 			org, err, settingsURL)
 		return "unreadable"
 	}
@@ -277,7 +277,7 @@ func ensureOrgActionsBudgetCap(client githubapi.Client, out, errOut io.Writer, o
 	status, err := githubapi.CreateOrgActionsBudgetCap(client, org)
 	if err != nil {
 		if cliutil.IsHTTPStatus(err, http.StatusForbidden) {
-			_, _ = fmt.Fprintf(errOut, "Warning: %s: couldn't create the $0 Actions budget cap (%v); add Organization permissions -> Administration: Read and write to your token, or create the $0 GitHub Actions budget by hand at %s.\n",
+			_, _ = fmt.Fprintf(errOut, "Warning: %s: couldn't create the $0 Actions budget cap (%v); GitHub refused the write, which usually means billing is managed at the enterprise level. Create the $0 GitHub Actions budget by hand at %s.\n",
 				org, err, settingsURL)
 			return "failed"
 		}

--- a/cli/gh-teacher/init_summary.go
+++ b/cli/gh-teacher/init_summary.go
@@ -138,9 +138,9 @@ func (s *initSummary) renderHuman(u *ui.UI) {
 	case "warn":
 		u.Item("actions budget cap: a budget over $%d is set and was left as-is; lower it to $0 to hard-stop paid Actions minutes", orgpolicy.BudgetWarnThreshold)
 	case "unreadable":
-		u.Item("actions budget cap: couldn't verify (token lacks Organization Administration: Read); set a $0 Actions budget by hand")
+		u.Item("actions budget cap: couldn't verify (billing not readable for this org); set a $0 Actions budget by hand")
 	case "failed":
-		u.Item("actions budget cap: couldn't be created (token needs Organization Administration: Read and write); set a $0 Actions budget by hand")
+		u.Item("actions budget cap: couldn't be created (GitHub refused the write); set a $0 Actions budget by hand")
 	}
 
 	// 2b. Informational notes (plan/policy caveats that aren't actions).


### PR DESCRIPTION
## Summary

`gh teacher init --help` told teachers the service token needs **Organization permissions -> Administration: Read and write** "to set the $0 Actions spending cap", and the two budget-cap warnings plus the end-of-run summary repeated it. The cap is created with the teacher's own `gh` client (`init.go` passes `client` to `ensureOrgActionsBudgetCap`), never the service token, so adding that permission changes nothing. The canonical `RequiredTokenPermissions`, the web token URL, and `rotate-service-token --help` never listed it either.

This aligns the CLI copy with the code and with the web app's equivalent message:

- The help's permission list now matches `RequiredTokenPermissions` exactly, including the repository **Administration: Read and write** it previously omitted (collection uses it to grant staff teams repository access).
- The "couldn't read budgets" and "couldn't create the cap" warnings and the summary lines name the real causes (enterprise-managed billing or a plan without organization budgets, or GitHub refusing the write) instead of a token permission.

Found during the wiki audit in #862; the wiki already documents the correct permission set.

## Type of change

- [x] Bug fix

## Checklist

- [x] `go build ./... && go test ./... && golangci-lint run` in `cli/gh-teacher` (and `golangci-lint fmt --diff` clean)
- [x] No cross-binary contract change.
- [x] The wiki already reflects the corrected permission list.
- [x] Conventional Commits.