### PR TITLE
ci(translate): batch locale translations to fit the model output cap

### DIFF
--- a/.github/workflows/translate-locales.yaml
+++ b/.github/workflows/translate-locales.yaml
@@ -86,11 +86,14 @@ jobs:
 
   # Patch + gate each language in parallel (each diffs against its own marker,
   # so a lagging language catches up), then upload its pack for open-pr to
-  # collect. fail-fast: false so one failure doesn't sink the rest.
+  # collect. fail-fast: false so one failure doesn't sink the rest. A full
+  # retranslation is ~50 sequential model calls (large sections are split to
+  # fit one response), and the patch-then-full self-heal path runs both, so
+  # the timeout has to cover roughly two full passes.
   translate:
     needs: matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/test_translate_locales.py
+++ b/scripts/test_translate_locales.py
@@ -28,6 +28,7 @@ import translate_locales
 from translate_locales import (
     build_nested_from_keys,
     check_key_parity,
+    chunk_keys,
     compute_diff,
     delete_nested,
     extract_text,
@@ -36,7 +37,9 @@ from translate_locales import (
     invoke_model,
     parse_model_json,
     plural_group_keys,
+    plural_stem,
     set_nested,
+    translate_full,
     translate_keys,
 )
 
@@ -196,6 +199,98 @@ class TestExtractText:
     def test_raises_when_content_missing(self):
         with pytest.raises(ValueError):
             extract_text({})
+
+    def test_raises_when_truncated_at_max_tokens(self):
+        # A cut-off response is unterminated JSON; name the cause instead of
+        # letting json.loads report an opaque "Unterminated string".
+        payload = {"stop_reason": "max_tokens", "content": [{"text": '{"a": "unterm'}]}
+        with pytest.raises(ValueError, match="max_tokens"):
+            extract_text(payload)
+
+    def test_accepts_end_turn_stop_reason(self):
+        payload = {"stop_reason": "end_turn", "content": [{"text": "ok"}]}
+        assert extract_text(payload) == "ok"
+
+
+def _base_of(n: int, prefix: str = "sec", plural_every: int = 0) -> dict:
+    """A flat section of `n` ~60-char leaves; every `plural_every`th is a plural pair."""
+    section: dict = {}
+    for i in range(n):
+        if plural_every and i % plural_every == 0:
+            section[f"k{i}_one"] = f"one {i} " + "x" * 40
+            section[f"k{i}_other"] = f"other {i} " + "x" * 40
+        else:
+            section[f"k{i}"] = f"value {i} " + "x" * 40
+    return {prefix: section}
+
+
+class TestPluralStem:
+    @pytest.mark.parametrize("suffix", translate_locales.PLURAL_SUFFIXES)
+    def test_strips_each_plural_suffix(self, suffix):
+        assert plural_stem(f"nav.count{suffix}") == "nav.count"
+
+    def test_leaves_non_plural_key_alone(self):
+        assert plural_stem("nav.title") == "nav.title"
+
+
+class TestChunkKeys:
+    def test_small_input_is_one_batch_in_order(self):
+        base = _base_of(5)
+        keys = list(flatten(base))
+        assert chunk_keys(base, keys, max_chars=100_000) == [keys]
+
+    def test_every_batch_fits_budget_and_covers_every_key_once(self):
+        base = _base_of(200)
+        keys = list(flatten(base))
+        budget = 2_000
+        batches = chunk_keys(base, keys, max_chars=budget)
+        assert len(batches) > 1
+        assert [k for b in batches for k in b] == keys
+        for batch in batches:
+            rendered = json.dumps(build_nested_from_keys(base, batch), ensure_ascii=False, indent=2)
+            assert len(rendered) <= budget
+
+    def test_plural_siblings_never_straddle_a_batch_boundary(self):
+        base = _base_of(120, plural_every=3)
+        keys = list(flatten(base))
+        batches = chunk_keys(base, keys, max_chars=1_500)
+        assert len(batches) > 1
+        for batch in batches:
+            stems = [plural_stem(k) for k in batch if k != plural_stem(k)]
+            for stem in set(stems):
+                assert f"{stem}_one" in batch and f"{stem}_other" in batch
+
+    def test_lone_group_over_budget_gets_its_own_batch(self):
+        # A single plural group that can't fit is still emitted whole rather
+        # than split or dropped.
+        base = {"s": {"a": "x", "big_one": "y" * 500, "big_other": "z" * 500, "b": "w"}}
+        batches = chunk_keys(base, list(flatten(base)), max_chars=200)
+        assert batches == [["s.a"], ["s.big_one", "s.big_other"], ["s.b"]]
+
+    def test_empty_keys_yield_no_batches(self):
+        assert chunk_keys({"s": {"a": "x"}}, [], max_chars=100) == []
+
+    def test_real_en_json_sections_all_fit_default_budget(self):
+        # The regression this guards: sections that outgrew one response got
+        # truncated. Every batch of the real file must fit the default budget
+        # and keep plural groups intact.
+        from pathlib import Path
+
+        base_path = Path(__file__).resolve().parent.parent / "web" / "src" / "locales" / "en.json"
+        base = json.loads(base_path.read_text(encoding="utf-8"))
+        budget = translate_locales.DEFAULT_MAX_CHUNK_CHARS
+        for section, value in base.items():
+            keys = list(flatten({section: value}))
+            batches = chunk_keys(base, keys, budget)
+            assert [k for b in batches for k in b] == keys
+            for batch in batches:
+                rendered = json.dumps(build_nested_from_keys(base, batch), ensure_ascii=False, indent=2)
+                # A lone oversized plural group may exceed; none exist in en.json.
+                assert len(rendered) <= budget, f"{section}: batch of {len(batch)} keys is {len(rendered)} chars"
+                stems = {plural_stem(k) for k in batch if k != plural_stem(k)}
+                for stem in stems:
+                    siblings = [k for k in keys if plural_stem(k) == stem]
+                    assert all(s in batch for s in siblings), f"{stem} split across batches"
 
 
 class TestFlatten:
@@ -362,6 +457,143 @@ class TestTranslateKeys:
         )
         result = translate_keys(None, "model", "prompt", "ja", base, base_raw, ["nav.a", "nav.b"])
         assert flatten(result) == {"nav.a": "翻訳a", "nav.b": "翻訳b"}
+
+    def test_batches_a_large_backlog_and_merges_every_batch(self, monkeypatch):
+        # The regression: 900+ changed keys in one call truncated at max_tokens.
+        base = _base_of(150)
+        keys = list(flatten(base))
+        monkeypatch.setattr(translate_locales, "DEFAULT_MAX_CHUNK_CHARS", 2_000)
+        calls: list[int] = []
+
+        def fake_invoke(_client, _model, _system, message):
+            requested = _requested_block(message)
+            calls.append(len(flatten(requested)))
+            return json.dumps(_echo_translate(requested))
+
+        monkeypatch.setattr(translate_locales, "invoke_model", fake_invoke)
+        result = translate_keys(None, "model", "prompt", "de", base, json.dumps(base), keys)
+        assert len(calls) > 1
+        assert sum(calls) == len(keys)
+        assert flatten(result) == {k: f"[de] {v}" for k, v in flatten(base).items()}
+
+    def test_fails_fast_on_the_first_bad_batch(self, monkeypatch):
+        base = _base_of(150)
+        keys = list(flatten(base))
+        monkeypatch.setattr(translate_locales, "DEFAULT_MAX_CHUNK_CHARS", 2_000)
+        calls = 0
+
+        def fake_invoke(_client, _model, _system, message):
+            nonlocal calls
+            calls += 1
+            return "{}"  # drops every requested key
+
+        monkeypatch.setattr(translate_locales, "invoke_model", fake_invoke)
+        assert translate_keys(None, "model", "prompt", "de", base, json.dumps(base), keys) is None
+        assert calls == 1
+
+
+def _requested_block(message: str) -> dict:
+    """The JSON the prompt asks to translate: the second fenced block (the first
+    is the full-file context)."""
+    blocks = message.split("```json\n")
+    return json.loads(blocks[2].split("\n```", 1)[0])
+
+
+def _echo_translate(obj: dict, code: str = "de") -> dict:
+    """Fake translation: prefix every leaf so tests can tell output from input."""
+    out: dict = {}
+    for key, value in flatten(obj).items():
+        set_nested(out, key, f"[{code}] {value}")
+    return out
+
+
+class TestTranslateFull:
+    @pytest.fixture(autouse=True)
+    def _small_budget(self, monkeypatch):
+        monkeypatch.setattr(translate_locales, "DEFAULT_MAX_CHUNK_CHARS", 2_000)
+
+    def _install_echo(self, monkeypatch, messages: list[str]):
+        def fake_invoke(_client, _model, _system, message):
+            messages.append(message)
+            return json.dumps(_echo_translate(_requested_block(message)))
+
+        monkeypatch.setattr(translate_locales, "invoke_model", fake_invoke)
+
+    def test_splits_a_large_section_into_parts_and_reassembles_it(self, monkeypatch):
+        base = {**_base_of(3, "small"), **_base_of(150, "big", plural_every=5)}
+        messages: list[str] = []
+        self._install_echo(monkeypatch, messages)
+
+        result = translate_full(None, "model", "prompt", "de", base, json.dumps(base), {})
+
+        assert flatten(result) == {k: f"[de] {v}" for k, v in flatten(base).items()}
+        assert list(result) == ["small", "big"]
+        # `small` fits one call with no part label; `big` is split and labelled.
+        small_msgs = [m for m in messages if '"small" subtree' in m]
+        big_msgs = [m for m in messages if '"big" subtree' in m]
+        assert len(small_msgs) == 1 and "part 1 of" not in small_msgs[0]
+        assert len(big_msgs) > 1
+        assert all(f"part {i} of {len(big_msgs)}" in m for i, m in enumerate(big_msgs, start=1))
+
+    def test_existing_translation_is_scoped_to_the_part_and_keeps_extra_plurals(self, monkeypatch):
+        base = _base_of(150, "big", plural_every=5)
+        current = _echo_translate(base, "pl")
+        # A community-added Polish form on one plural group; en.json has no _few.
+        set_nested(current, "big.k0_few", "[pl] few")
+        messages: list[str] = []
+        self._install_echo(monkeypatch, messages)
+
+        translate_full(None, "model", "prompt", "pl", base, json.dumps(base), current)
+
+        for message in messages:
+            requested = set(flatten(_requested_block(message)))
+            existing_block = message.split("```json\n")[3].split("\n```", 1)[0]
+            existing = set(flatten(json.loads(existing_block)))
+            # Every existing key shown is either requested or a plural sibling of one.
+            assert all(k in requested or plural_stem(k) in {plural_stem(r) for r in requested} for k in existing)
+            if "big.k0_one" in requested:
+                assert "big.k0_few" in existing
+            else:
+                assert "big.k0_few" not in existing
+
+    def test_first_time_generation_has_no_existing_block(self, monkeypatch):
+        base = _base_of(3)
+        messages: list[str] = []
+        self._install_echo(monkeypatch, messages)
+        translate_full(None, "model", "prompt", "de", base, json.dumps(base), {})
+        assert len(messages) == 1
+        assert "There is no existing translation" in messages[0]
+        assert messages[0].count("```json\n") == 2
+
+    def test_accepts_bare_section_object(self, monkeypatch):
+        base = {"nav": {"a": "x"}}
+        monkeypatch.setattr(translate_locales, "invoke_model", lambda *a, **k: '{"a": "übersetzt"}')
+        assert translate_full(None, "model", "prompt", "de", base, json.dumps(base), {}) == {
+            "nav": {"a": "übersetzt"}
+        }
+
+    def test_returns_none_when_a_part_drops_a_key(self, monkeypatch):
+        base = _base_of(150)
+
+        def fake_invoke(_client, _model, _system, message):
+            requested = _requested_block(message)
+            translated = _echo_translate(requested)
+            first = next(iter(translated["sec"]))
+            del translated["sec"][first]
+            return json.dumps(translated)
+
+        monkeypatch.setattr(translate_locales, "invoke_model", fake_invoke)
+        assert translate_full(None, "model", "prompt", "de", base, json.dumps(base), {}) is None
+
+    def test_returns_none_and_names_truncation(self, monkeypatch, capsys):
+        base = _base_of(3)
+        monkeypatch.setattr(
+            translate_locales,
+            "invoke_model",
+            lambda *a, **k: (_ for _ in ()).throw(ValueError("truncated at max_tokens=32000")),
+        )
+        assert translate_full(None, "model", "prompt", "de", base, json.dumps(base), {}) is None
+        assert "max_tokens" in capsys.readouterr().err
 
 
 class TestMainPatchMode:

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -14,9 +14,10 @@ survive across runs, and it's cheap. Diff keys come from the caller (see
 locale_diff.py). With no diff (or no current pack to patch), it falls back to a
 full section-by-section translation so new languages still work.
 
-Chunking (a section per call, or the changed subset in one call) keeps each
-response small enough to avoid truncation and never splits a fragment/plural
-sibling group; the full English file rides along as terminology context.
+Every call translates a batch of keys sized to fit the model's output budget
+(see BEDROCK_MAX_CHUNK_CHARS): a small section or changed subset goes in one
+call, a large one is split into several. A plural sibling group is never split
+across batches; the full English file rides along as terminology context.
 
 Usage (patch mode — CI): --changed-keys / --removed-keys are JSON lists of
 dotted keys added/modified / removed in en.json.
@@ -60,9 +61,15 @@ from botocore.exceptions import (
 # schema. Overridable via BEDROCK_ANTHROPIC_VERSION.
 ANTHROPIC_VERSION = os.environ.get("BEDROCK_ANTHROPIC_VERSION", "bedrock-2023-05-31")
 
-# Bounds one response. We translate a single section per call, so this only
-# needs to fit the largest section; kept generous. Overridable.
-DEFAULT_MAX_TOKENS = int(os.environ.get("BEDROCK_MAX_TOKENS", "20000"))
+# Bounds one response. Overridable.
+DEFAULT_MAX_TOKENS = int(os.environ.get("BEDROCK_MAX_TOKENS", "32000"))
+
+# Upper bound on the English JSON (chars) translated per call. A translation can
+# run ~20% longer than its English, and dense scripts (CJK, Arabic, Hebrew) cost
+# ~1.5 chars per output token, so this keeps every response far under
+# DEFAULT_MAX_TOKENS; a response that still hits the cap is caught by
+# extract_text rather than surfacing as a truncated-JSON parse error.
+DEFAULT_MAX_CHUNK_CHARS = int(os.environ.get("BEDROCK_MAX_CHUNK_CHARS", "16000"))
 
 MAX_ATTEMPTS = 5
 BASE_BACKOFF_SECONDS = 2.0
@@ -205,6 +212,40 @@ def build_nested_from_keys(base: dict, keys: list[str]) -> dict:
     return out
 
 
+def plural_stem(key: str) -> str:
+    """Strip an i18next plural suffix so every form of one message shares a stem."""
+    for suffix in PLURAL_SUFFIXES:
+        if key.endswith(suffix):
+            return key[: -len(suffix)]
+    return key
+
+
+def chunk_keys(base: dict, keys: list[str], max_chars: int) -> list[list[str]]:
+    """Split dotted `keys`, in order, into batches whose English JSON fits `max_chars`.
+
+    Plural siblings (`x_one`, `x_other`, ...) always share a batch: the prompt
+    asks the model to add the forms a language needs, which it can only do when
+    it sees the whole group. A lone group over budget gets a batch of its own.
+    """
+    groups: dict[str, list[str]] = {}
+    for key in keys:
+        groups.setdefault(plural_stem(key), []).append(key)
+
+    def rendered_size(subset: list[str]) -> int:
+        return len(json.dumps(build_nested_from_keys(base, subset), ensure_ascii=False, indent=2))
+
+    batches: list[list[str]] = []
+    batch: list[str] = []
+    for group in groups.values():
+        if batch and rendered_size(batch + group) > max_chars:
+            batches.append(batch)
+            batch = []
+        batch.extend(group)
+    if batch:
+        batches.append(batch)
+    return batches
+
+
 def build_keys_message(
     code: str,
     base_full_raw: str,
@@ -247,13 +288,20 @@ def build_section_message(
     base_full_raw: str,
     section_base_raw: str,
     section_current_raw: str | None,
+    part: tuple[int, int] | None = None,
 ) -> str:
-    """Build the user turn for translating one top-level section.
+    """Build the user turn for translating one top-level section, or one part of it.
 
     The full English file rides along as read-only context for terminology
-    consistency, but only the current section is translated and returned.
-    Chunking by top-level section never splits a fragment/plural sibling group.
+    consistency, but only the keys shown are translated and returned. `part` is
+    (index, total) when the section was split to fit the per-call budget.
     """
+    scope = f'the "{section}" subtree of the file above'
+    if part is not None:
+        scope = (
+            f'part {part[0]} of {part[1]} of the "{section}" subtree of the file '
+            "above (only the keys shown here)"
+        )
     parts = [
         f"Target locale code: {code}",
         "",
@@ -263,8 +311,7 @@ def build_section_message(
         base_full_raw.strip(),
         "```",
         "",
-        f'SECTION TO TRANSLATE — the "{section}" subtree of the file above. '
-        "Translate its VALUES into the target locale:",
+        f"SECTION TO TRANSLATE — {scope}. Translate its VALUES into the target locale:",
         "```json",
         section_base_raw.strip(),
         "```",
@@ -272,7 +319,7 @@ def build_section_message(
     if section_current_raw is not None:
         parts += [
             "",
-            f'EXISTING TRANSLATION of the "{section}" section — may contain human '
+            "EXISTING TRANSLATION of the keys shown above — may contain human "
             "corrections. Preserve values that are still correct for the current "
             "English; only change values whose English source changed, and add any "
             "keys missing here:",
@@ -283,14 +330,14 @@ def build_section_message(
     else:
         parts += [
             "",
-            f'There is no existing translation for the "{section}" section — '
-            "produce a complete first translation of every value in it.",
+            "There is no existing translation for the keys shown above — "
+            "produce a complete first translation of every value.",
         ]
     parts += [
         "",
         f'Return ONLY the translated "{section}" object as a single JSON object '
         f'whose top-level key is "{section}", with exactly the same keys and '
-        "nesting as the section shown. Return only the JSON — no markdown fences, "
+        "nesting as shown. Return only the JSON — no markdown fences, "
         "no commentary.",
     ]
     return "\n".join(parts)
@@ -345,7 +392,17 @@ def invoke_model(client, model_id: str, system_prompt: str, user_message: str) -
 
 
 def extract_text(payload: dict) -> str:
-    """Pull the assistant text out of an Anthropic Messages response payload."""
+    """Pull the assistant text out of an Anthropic Messages response payload.
+
+    A response cut off at max_tokens is unusable (its JSON is unterminated), so
+    reject it here with a message that names the real cause; otherwise it would
+    surface downstream as an opaque JSON parse error.
+    """
+    if payload.get("stop_reason") == "max_tokens":
+        raise ValueError(
+            f"Bedrock response was truncated at max_tokens={DEFAULT_MAX_TOKENS}; "
+            "lower BEDROCK_MAX_CHUNK_CHARS or raise BEDROCK_MAX_TOKENS"
+        )
     content = payload.get("content")
     if isinstance(content, list):
         chunks = [c.get("text", "") for c in content if isinstance(c, dict)]
@@ -389,49 +446,63 @@ def translate_full(
 ) -> dict | None:
     """Translate the whole file, one top-level section per call.
 
+    A section over the per-call budget is split into parts (see chunk_keys).
     Preserves good existing values, retranslates changed English, fills missing
     keys. Used for first-time generation and recovery. Returns the translated
-    dict, or None if any section failed (caller turns that into a non-zero exit).
+    dict, or None if any part failed (caller turns that into a non-zero exit).
     """
     translated: dict = {}
+    current_flat = flatten(current)
     for section, section_value in base.items():
-        section_base_obj: dict = {section: section_value}
-        section_base_raw = json.dumps(section_base_obj, ensure_ascii=False, indent=2)
-        section_current_raw: str | None = None
-        if section in current:
-            section_current_raw = json.dumps(
-                {section: current[section]}, ensure_ascii=False, indent=2
+        batches = chunk_keys(base, list(flatten({section: section_value})), DEFAULT_MAX_CHUNK_CHARS)
+        for index, batch in enumerate(batches, start=1):
+            part = (index, len(batches)) if len(batches) > 1 else None
+            label = f"section '{section}'" + (f" part {index}/{len(batches)}" if part else "")
+            batch_base_raw = json.dumps(
+                build_nested_from_keys(base, batch), ensure_ascii=False, indent=2
             )
 
-        message = build_section_message(
-            code, section, base_raw, section_base_raw, section_current_raw
-        )
+            # Show the pack's existing values for these keys, including extra
+            # plural forms alongside them (community-added, to be preserved).
+            batch_current_raw: str | None = None
+            stems = {plural_stem(key) for key in batch}
+            existing = [key for key in current_flat if plural_stem(key) in stems]
+            if existing:
+                batch_current_raw = json.dumps(
+                    build_nested_from_keys(current, existing), ensure_ascii=False, indent=2
+                )
 
-        eprint(f"[{code}] invoking {model_id} for section '{section}' ...")
-        try:
-            text = invoke_model(client, model_id, system_prompt, message)
-            section_result = parse_model_json(text)
-        except json.JSONDecodeError as err:
-            eprint(f"[{code}] section '{section}' returned invalid JSON: {err}")
-            return None
-        except Exception as err:  # noqa: BLE001 - surface any Bedrock failure per-language
-            eprint(f"[{code}] section '{section}' failed: {err}")
-            return None
-
-        # Accept either { "<section>": {...} } or the bare section object.
-        if list(section_result.keys()) == [section]:
-            section_result = section_result[section]
-
-        # Fail on the offending section rather than after the whole file.
-        section_missing = check_key_parity(section_base_obj, {section: section_result})
-        if section_missing:
-            eprint(
-                f"[{code}] section '{section}' is missing "
-                f"{len(section_missing)} key(s); first few: {section_missing[:5]}"
+            message = build_section_message(
+                code, section, base_raw, batch_base_raw, batch_current_raw, part
             )
-            return None
 
-        translated[section] = section_result
+            eprint(f"[{code}] invoking {model_id} for {label} ...")
+            try:
+                text = invoke_model(client, model_id, system_prompt, message)
+                result = parse_model_json(text)
+            except json.JSONDecodeError as err:
+                eprint(f"[{code}] {label} returned invalid JSON: {err}")
+                return None
+            except Exception as err:  # noqa: BLE001 - surface any Bedrock failure per-language
+                eprint(f"[{code}] {label} failed: {err}")
+                return None
+
+            # Accept either { "<section>": {...} } or the bare section object.
+            if list(result.keys()) != [section]:
+                result = {section: result}
+
+            # Fail on the offending part rather than after the whole file.
+            result_flat = flatten(result)
+            missing = sorted(set(batch) - set(result_flat))
+            if missing:
+                eprint(
+                    f"[{code}] {label} is missing {len(missing)} key(s); "
+                    f"first few: {missing[:5]}"
+                )
+                return None
+
+            for key, value in result_flat.items():
+                set_nested(translated, key, value)
 
     return translated
 
@@ -447,33 +518,44 @@ def translate_keys(
 ) -> dict | None:
     """Translate only `changed_keys` (dotted) and return them as a nested dict.
 
-    One call for the whole subset — it's just the changed English, which stays
-    well under the token budget. Returns None on failure or if the model dropped
-    any requested key (caller turns that into a non-zero exit).
+    Batched to the per-call budget: a long-unpublished language can have a
+    backlog of changed English far larger than one response holds. Returns None
+    on failure or if the model dropped any requested key (caller turns that into
+    a non-zero exit).
     """
-    subset = build_nested_from_keys(base, changed_keys)
-    subset_raw = json.dumps(subset, ensure_ascii=False, indent=2)
-    message = build_keys_message(code, base_raw, subset_raw)
+    batches = chunk_keys(base, changed_keys, DEFAULT_MAX_CHUNK_CHARS)
+    eprint(
+        f"[{code}] invoking {model_id} for {len(changed_keys)} changed key(s) "
+        f"in {len(batches)} batch(es) ..."
+    )
+    result: dict = {}
+    for index, batch in enumerate(batches, start=1):
+        label = f"changed-keys batch {index}/{len(batches)} ({len(batch)} key(s))"
+        subset_raw = json.dumps(build_nested_from_keys(base, batch), ensure_ascii=False, indent=2)
+        message = build_keys_message(code, base_raw, subset_raw)
 
-    eprint(f"[{code}] invoking {model_id} for {len(changed_keys)} changed key(s) ...")
-    try:
-        text = invoke_model(client, model_id, system_prompt, message)
-        result = parse_model_json(text)
-    except json.JSONDecodeError as err:
-        eprint(f"[{code}] changed-keys response was invalid JSON: {err}")
-        return None
-    except Exception as err:  # noqa: BLE001 - surface any Bedrock failure per-language
-        eprint(f"[{code}] changed-keys translation failed: {err}")
-        return None
+        if len(batches) > 1:
+            eprint(f"[{code}] {label} ...")
+        try:
+            text = invoke_model(client, model_id, system_prompt, message)
+            batch_result = parse_model_json(text)
+        except json.JSONDecodeError as err:
+            eprint(f"[{code}] {label} response was invalid JSON: {err}")
+            return None
+        except Exception as err:  # noqa: BLE001 - surface any Bedrock failure per-language
+            eprint(f"[{code}] {label} translation failed: {err}")
+            return None
 
-    result_flat = flatten(result)
-    dropped = sorted(set(changed_keys) - set(result_flat))
-    if dropped:
-        eprint(
-            f"[{code}] changed-keys response dropped {len(dropped)} key(s); "
-            f"first few: {dropped[:5]}"
-        )
-        return None
+        batch_flat = flatten(batch_result)
+        dropped = sorted(set(batch) - set(batch_flat))
+        if dropped:
+            eprint(
+                f"[{code}] {label} response dropped {len(dropped)} key(s); "
+                f"first few: {dropped[:5]}"
+            )
+            return None
+        for key in batch:
+            set_nested(result, key, batch_flat[key])
     return result
 
 


### PR DESCRIPTION
## Why

[Run 33704483553](https://github.com/foundation50/classroom50/actions/runs/33704483553) (triggered by #858) failed 18 of 19 languages, and `zh-TW` timed out. Every failure was the same: the model's response was cut off mid-string (`Unterminated string starting at ... (char ~47000)`), so `json.loads` failed. The cut-off points line up exactly with the 20k `max_tokens` cap (~2.3 chars/token for Latin scripts, ~1.6 for CJK/Arabic/Hebrew).

`en.json` has grown to 3,231 keys / 236 KB. The `assignments` and `submissions` sections are ~43 KB of English each, and a translation runs 10-20% longer, so a single full-section response no longer fits. Patch mode hit the same wall because the language-repo markers lag `main` by a lot: the diff was 909 changed keys (1,811 for `ur`) sent as one request. The self-heal path (`--full` retranslation) then failed on the same large sections, so nothing was rescued.

## What

- **Batch every model call to a size budget.** New `chunk_keys()` greedily packs dotted keys into batches whose English JSON fits `DEFAULT_MAX_CHUNK_CHARS` (16 KB, overridable via `BEDROCK_MAX_CHUNK_CHARS`). Plural siblings (`x_one`/`x_other`/...) are grouped by stem and never split, since the prompt asks the model to add the forms a language needs and it can only do that seeing the whole group. Both `translate_full` (per section, now with a `part i of N` prompt label and the existing-translation block scoped to that part) and `translate_keys` (the changed-key backlog) use it.
- **Detect truncation explicitly.** `extract_text` now rejects a response with `stop_reason == "max_tokens"` and names the cause and the two knobs, instead of letting it surface as an opaque JSON parse error.
- **Raise `max_tokens`** from 20k to 32k as headroom.
- **Raise the `translate` job timeout** from 20 to 45 minutes. The patch-then-full self-heal path runs two passes, and a full pass is now ~47 calls on the current `en.json`.

On today's `en.json`: `assignments` splits into 4 parts, `submissions` and `students` into 3, `orgSettings` into 2, every other section stays one call. The 909-key backlog becomes ~17 batches.

## Tests

`scripts/test_translate_locales.py`: 84 pass (was 60). New coverage for `plural_stem`, `chunk_keys` (budget, order, plural integrity, oversized lone group, and a guard asserting every section of the real `en.json` batches under the default budget), truncation detection, batched `translate_keys`, and a `translate_full` suite driven by an echo fake that translates whatever block the prompt requests.

## After merging

Trigger a `workflow_dispatch` of "Translate locales" (forces full mode) so every language regenerates and its marker catches up to `main`. Catalan will publish on that same run since it has no marker yet. From then on, patch runs go back to small diffs.
