### PR TITLE
ci(translate): raise the per-language job timeout to 60 minutes

### DIFF
--- a/.github/workflows/translate-locales.yaml
+++ b/.github/workflows/translate-locales.yaml
@@ -88,12 +88,13 @@ jobs:
   # so a lagging language catches up), then upload its pack for open-pr to
   # collect. fail-fast: false so one failure doesn't sink the rest. A full
   # retranslation is ~50 sequential model calls (large sections are split to
-  # fit one response), and the patch-then-full self-heal path runs both, so
-  # the timeout has to cover roughly two full passes.
+  # fit one response) and takes ~35 min for a dense script such as Hebrew; the
+  # patch-then-full self-heal path runs a large patch pass (~13 min) on top,
+  # so the timeout has to cover both with margin.
   translate:
     needs: matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Why

In [run 33759703656](https://github.com/foundation50/classroom50/actions/runs/33759703656), the first run after #870, 18 of 19 languages produced a pack. `he` was the exception: it hit the 45 minute job timeout with two sections left.

The batching worked as intended (7 patch batches and 45 full-mode calls, no truncation). What blew the budget was the self-heal path stacking up: the patch pass took 13 minutes, then its last batch failed on a one-off model slip (a trailing comma in the JSON), so the workflow fell back to a full retranslation, which takes about 32 minutes for a dense script like Hebrew. 13 + 32 is over 45.

## What

Raise `timeout-minutes` on the `translate` job from 45 to 60 and update the comment with the measured numbers.
