### PR TITLE
feat(web): show who made each commit in a team's submissions

### DIFF
--- a/web/src/components/submissions/SubmissionDetailsModal.tsx
+++ b/web/src/components/submissions/SubmissionDetailsModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import {
   GitCommitIcon,
   MarkGithubIcon,
+  PersonIcon,
   RepoIcon,
   TagIcon,
 } from "@/components/ui/icons"
@@ -12,8 +13,10 @@ import { Button, Modal, MonoLtr } from "@/components/ui"
 // One row in the submission-details list. `kind` picks the icon and action
 // label ("View tag" vs "View commit"); `href` is the already-built, safe GitHub
 // link (omit to render the row inert). `sublabel` is a secondary line such as
-// the submission time; `releaseHref` adds a "View grade" link. `count` is how
-// many submissions the row represents (1 for a single tag/commit; N for a glob
+// the submission time; `releaseHref` adds a "View grade" link. `author` names
+// who made a commit (set only for a team's shared repo, where it disambiguates
+// members); `avatarUrl` is an already-guarded URL. `count` is how many
+// submissions the row represents (1 for a single tag/commit; N for a glob
 // group that bundles N tags into one row), so the modal header count matches
 // the row's count chip even when a group renders as one row.
 export type SubmissionDetailItem = {
@@ -23,6 +26,7 @@ export type SubmissionDetailItem = {
   sublabel?: string
   href?: string
   releaseHref?: string
+  author?: { label: string; avatarUrl?: string }
   count: number
 }
 
@@ -152,9 +156,48 @@ export function SubmissionDetailsModal({
                   <MonoLtr className="truncate font-medium">
                     {item.label}
                   </MonoLtr>
-                  {item.sublabel ? (
-                    <span className="truncate text-xs text-base-content/60">
-                      {item.sublabel}
+                  {item.author || item.sublabel ? (
+                    <span className="flex min-w-0 items-center gap-x-1.5 text-xs text-base-content/60">
+                      {item.author ? (
+                        <span
+                          className="inline-flex min-w-0 items-center gap-1"
+                          title={t("submissions.details.commitBy", {
+                            author: item.author.label,
+                          })}
+                        >
+                          {item.author.avatarUrl ? (
+                            <img
+                              src={item.author.avatarUrl}
+                              alt=""
+                              className="size-4 shrink-0 rounded-full"
+                            />
+                          ) : (
+                            <PersonIcon
+                              aria-hidden="true"
+                              className="size-3.5 shrink-0"
+                            />
+                          )}
+                          <span className="sr-only">
+                            {t("submissions.details.commitBy", {
+                              author: item.author.label,
+                            })}
+                          </span>
+                          <span aria-hidden="true" className="truncate">
+                            {item.author.label}
+                          </span>
+                        </span>
+                      ) : null}
+                      {item.sublabel ? (
+                        <span
+                          className={
+                            item.author
+                              ? "truncate before:me-1.5 before:text-base-content/30 before:content-['·']"
+                              : "truncate"
+                          }
+                        >
+                          {item.sublabel}
+                        </span>
+                      ) : null}
                     </span>
                   ) : null}
                 </span>

--- a/web/src/components/submissions/submissionDetailItems.test.tsx
+++ b/web/src/components/submissions/submissionDetailItems.test.tsx
@@ -38,9 +38,58 @@ describe("commitDetailItems", () => {
     expect(items[1].href).toBeUndefined()
     expect(items[1].releaseHref).toBeUndefined()
   })
+
+  it("omits the author unless asked (an individual repo's author is the student)", () => {
+    const commits = [
+      {
+        key: "c",
+        author: { login: "alice", avatarUrl: "https://avatars/alice" },
+      },
+    ]
+    expect(commitDetailItems(commits, t)[0].author).toBeUndefined()
+    expect(
+      commitDetailItems(commits, t, { showAuthors: true })[0].author,
+    ).toEqual({ label: "alice", avatarUrl: "https://avatars/alice" })
+  })
+
+  it("names an unlinked commit by its git author, without an avatar", () => {
+    const [item] = commitDetailItems(
+      [{ key: "c", author: { name: "Alice Git" } }],
+      t,
+      { showAuthors: true },
+    )
+    expect(item.author).toEqual({ label: "Alice Git", avatarUrl: undefined })
+  })
+
+  it("guards the avatar URL and skips an authorless commit", () => {
+    const items = commitDetailItems(
+      [
+        { key: "a", author: { login: "alice", avatarUrl: "javascript:x" } },
+        { key: "b" },
+      ],
+      t,
+      { showAuthors: true },
+    )
+    expect(items[0].author).toEqual({ label: "alice", avatarUrl: undefined })
+    expect(items[1].author).toBeUndefined()
+  })
 })
 
 describe("buildSubmissionDetailItems", () => {
+  it("labels pushes with their author on a shared repo", () => {
+    const items = buildSubmissionDetailItems(
+      {
+        tags: [],
+        commits: [{ key: "c", author: { login: "bob" } }],
+        showAuthors: true,
+      },
+      "every-push",
+      "acme",
+      "cs101-hw1-group-1",
+      t,
+    )
+    expect(items[0].author?.label).toBe("bob")
+  })
   it("uses tag entries in tag mode", () => {
     const items = buildSubmissionDetailItems(
       {

--- a/web/src/components/submissions/submissionDetailItems.ts
+++ b/web/src/components/submissions/submissionDetailItems.ts
@@ -4,7 +4,10 @@ import {
   jumpableTagEntries,
   resolveSubmissionMode,
 } from "@/domain/assignments/submissionDetection"
-import type { DetectedSubmission } from "@/domain/assignments/submissionDetection"
+import type {
+  CommitAuthor,
+  DetectedSubmission,
+} from "@/domain/assignments/submissionDetection"
 import { repoTagsUrl } from "@/util/orgUrl"
 import { safeHttpUrl } from "@/util/url"
 import { formatSubmissionDateTime } from "@/util/formatDate"
@@ -19,12 +22,14 @@ type Translate = (key: string, opts?: Record<string, unknown>) => string
 // A normalized push (default-branch commit) submission, mode-agnostic across the
 // two views: the teacher maps its collected scores.json attempts to this shape,
 // the student maps its live default-branch commits. `commitHref`/`releaseHref`
-// are raw (possibly unsafe) URLs — the builder guards them.
+// are raw (possibly unsafe) URLs — the builder guards them. `author` is who made
+// the commit, when the source knows (live commits do; collected attempts don't).
 export type PushSubmission = {
   key: string
   commitHref?: string | null
   datetime?: string
   releaseHref?: string | null
+  author?: CommitAuthor
 }
 
 // A normalized tag submission collected in scores.json — the FALLBACK tag
@@ -97,9 +102,13 @@ export function collectedTagDetailItems(
 // Map normalized push submissions to details-modal items, newest first (the
 // caller supplies them newest-first, matching both the collected history and
 // GitHub's default commit order). Numbered #N…#1 so the newest reads highest.
+// `showAuthors` attaches who made each commit: on for a team's shared repo,
+// where the members' commits need telling apart; off for an individual repo,
+// where the author is always the student.
 export function commitDetailItems(
   commits: PushSubmission[],
   t: Translate,
+  { showAuthors = false }: { showAuthors?: boolean } = {},
 ): SubmissionDetailItem[] {
   return commits.map((commit, i) => ({
     key: commit.key,
@@ -110,8 +119,22 @@ export function commitDetailItems(
       : undefined,
     href: safeHttpUrl(commit.commitHref),
     releaseHref: safeHttpUrl(commit.releaseHref),
+    author: showAuthors ? detailItemAuthor(commit.author) : undefined,
     count: 1,
   }))
+}
+
+// The modal's author chip: the login when GitHub linked the commit to an
+// account (with its avatar), else the git author name, else nothing.
+function detailItemAuthor(
+  author: CommitAuthor | undefined,
+): SubmissionDetailItem["author"] {
+  const label = author?.login ?? author?.name
+  if (!label) return undefined
+  return {
+    label,
+    avatarUrl: author?.login ? safeHttpUrl(author.avatarUrl) : undefined,
+  }
 }
 
 // The one type-aware item builder both views use: tag entries in tag mode, push
@@ -120,15 +143,18 @@ export function commitDetailItems(
 // unit), so the unused side is simply empty. In tag mode, when the detection
 // overlay is empty (a viewer without it) but collected tag submissions exist,
 // fall back to those so the modal never contradicts a positive count chip.
+// `showAuthors` (a team repo) labels each push with who made it.
 export function buildSubmissionDetailItems(
   {
     tags,
     commits,
     collectedTags = [],
+    showAuthors = false,
   }: {
     tags: DetectedSubmission[]
     commits: PushSubmission[]
     collectedTags?: CollectedTagSubmission[]
+    showAuthors?: boolean
   },
   mode: SubmissionMode | undefined,
   org: string,
@@ -136,7 +162,7 @@ export function buildSubmissionDetailItems(
   t: Translate,
 ): SubmissionDetailItem[] {
   if (resolveSubmissionMode(mode) !== "tag") {
-    return commitDetailItems(commits, t)
+    return commitDetailItems(commits, t, { showAuthors })
   }
   const detected = tagDetailItems(tags, org, repo, t)
   return detected.length > 0

--- a/web/src/domain/assignments/submissionDetection.test.ts
+++ b/web/src/domain/assignments/submissionDetection.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest"
 
 import {
+  commitAuthor,
   detectBranchSubmissions,
   detectTagSubmissions,
   detectedSubmissionCount,
@@ -49,6 +50,50 @@ describe("detectBranchSubmissions", () => {
     const detected = detectBranchSubmissions([commit("baseline")], "baseline")
     expect(detected).toEqual([])
     expect(detectedSubmissionCount(detected)).toBe(0)
+  })
+
+  it("carries who made each commit so a group's members can be told apart", () => {
+    const linked: GitHubCommit = {
+      ...commit("c2"),
+      author: { login: "alice", avatar_url: "https://avatars/alice" },
+    }
+    const detected = detectBranchSubmissions([linked, commit("c1")], "base")
+    expect(detected[0].author).toEqual({
+      login: "alice",
+      name: undefined,
+      avatarUrl: "https://avatars/alice",
+    })
+    expect(detected[1].author).toBeUndefined()
+  })
+})
+
+describe("commitAuthor", () => {
+  it("prefers the linked GitHub account, with its avatar", () => {
+    expect(
+      commitAuthor({
+        ...commit("c"),
+        commit: { message: "c", author: { name: "Alice Git" } },
+        author: { login: "alice", avatar_url: "https://avatars/alice" },
+      }),
+    ).toEqual({
+      login: "alice",
+      name: "Alice Git",
+      avatarUrl: "https://avatars/alice",
+    })
+  })
+
+  it("falls back to the git author name for an unlinked commit", () => {
+    expect(
+      commitAuthor({
+        ...commit("c"),
+        commit: { message: "c", author: { name: "Alice Git" } },
+        author: null,
+      }),
+    ).toEqual({ login: undefined, name: "Alice Git", avatarUrl: undefined })
+  })
+
+  it("is absent when the commit names nobody", () => {
+    expect(commitAuthor(commit("c"))).toBeUndefined()
   })
 
   // Regression: on a TEMPLATED assignment the accept commit (the baseline) sits

--- a/web/src/domain/assignments/submissionDetection.ts
+++ b/web/src/domain/assignments/submissionDetection.ts
@@ -21,13 +21,35 @@ import { SUBMISSION_MODES, type SubmissionMode } from "@/types/classroom"
 // a commit sha); `sha` points at the underlying commit when known. `datetime`
 // is the submission's ISO time when the source carries one: branch-mode
 // commits always do, canonical submit/* tags encode it in the name, and
-// milestone tags get it filled by a per-commit lookup in the fan-out.
+// milestone tags get it filled by a per-commit lookup in the fan-out. `author`
+// is who made a branch-mode commit, so a group's members can be told apart.
 export type DetectedSubmission = {
   kind: "commit" | "tag" | "tag-group"
   label: string
   count: number
   sha?: string
   datetime?: string
+  author?: CommitAuthor
+}
+
+// Who made a commit: the linked GitHub account when GitHub resolves one, else
+// the git author name (an unlinked email, or a commit made in a web editor
+// under another identity). Absent when the commit carries neither.
+export type CommitAuthor = {
+  login?: string
+  name?: string
+  avatarUrl?: string
+}
+
+export function commitAuthor(commit: GitHubCommit): CommitAuthor | undefined {
+  const login = commit.author?.login
+  const name = commit.commit.author?.name
+  if (!login && !name) return undefined
+  return {
+    login: login || undefined,
+    name: name || undefined,
+    avatarUrl: commit.author?.avatar_url || undefined,
+  }
 }
 
 // A glob pattern uses any Actions tag-filter metacharacter; an exact pattern is
@@ -93,6 +115,7 @@ export function detectBranchSubmissions(
     count: 1,
     sha: c.sha,
     datetime: c.commit.committer?.date ?? c.commit.author?.date,
+    author: commitAuthor(c),
   }))
 }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2777,6 +2777,7 @@
       "viewGrade": "View score",
       "unavailable": "Unavailable",
       "pushEntry": "Commit #{{number}}",
+      "commitBy": "Committed by {{author}}",
       "tagEntry": "Submission #{{number}}",
       "emptyEveryPush": "No commits on the default branch yet. The repository still exists, so open it to see the code.",
       "emptyTag": "No tagged submissions yet. The repository still exists, so open its tags to see submissions as they arrive.",

--- a/web/src/pages/StudentSubmissionPage.tsx
+++ b/web/src/pages/StudentSubmissionPage.tsx
@@ -29,6 +29,7 @@ import { safeHttpUrl } from "@/util/url"
 import type { GitHubCommit, GitHubRelease } from "@/github-core/types"
 import { SUBMISSION_TAG_PREFIX } from "@/github-core/queries/releaseRunReads"
 import {
+  commitAuthor,
   submissionModeCountKey,
   latestDetectedAt,
 } from "@/domain/assignments/submissionDetection"
@@ -98,6 +99,7 @@ const toPushSubmissions = (
     commitHref: commit.html_url,
     datetime: commit.commit.committer?.date ?? commit.commit.author?.date,
     releaseHref: releaseHrefBySha.get(commit.sha.slice(0, 7)),
+    author: commitAuthor(commit),
   }))
 }
 
@@ -241,8 +243,14 @@ const SubmissionBody = ({
   const latestReleaseHref = safeHttpUrl(releases?.[0]?.html_url)
   const commitSubmissions = toPushSubmissions(pushSubmissions, releases)
 
+  // A team repo lists who made each push, so members can tell their commits
+  // apart; on an individual repo the author is always the viewer.
   const detailItems: SubmissionDetailItem[] = buildSubmissionDetailItems(
-    { tags: taggedSubmissions, commits: commitSubmissions },
+    {
+      tags: taggedSubmissions,
+      commits: commitSubmissions,
+      showAuthors: isTeamMode,
+    },
     submissionMode,
     org,
     repoName,

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -984,6 +984,84 @@ describe("SubmissionsTable submission details modal", () => {
     )
   })
 
+  it("names who made each detected push on a team row, but not on an individual row", async () => {
+    const user = userEvent.setup()
+    const detectedEntries = [
+      {
+        kind: "commit" as const,
+        label: "bbb2222",
+        count: 1,
+        sha: "bbb2222",
+        author: { login: "alice", avatarUrl: "https://avatars/alice" },
+      },
+      {
+        kind: "commit" as const,
+        label: "aaa1111",
+        count: 1,
+        sha: "aaa1111",
+        author: { name: "Bob Git" },
+      },
+    ]
+    const teamView = render(
+      <SubmissionsTable
+        {...baseProps}
+        assignmentMode="every-push"
+        isGroup
+        isTeam
+        teamsSettled
+        teamsByOwner={
+          new Map<string, GroupTeamRef>([
+            [
+              "group-1",
+              { slug: "classroom50-group-x-1", id: 1, n: 1, name: "Rocket" },
+            ],
+          ])
+        }
+        scores={[
+          scoreRow({
+            owner: "group-1",
+            usernames: ["alice", "bob"],
+            submissionCount: 2,
+            submissions: [],
+            detectedEntries,
+          }),
+        ]}
+        acceptedUsernames={new Set(["alice", "bob"])}
+      />,
+    )
+    await user.click(
+      screen.getByRole("button", { name: "submissions.type.countEveryPush" }),
+    )
+    // Linked account: avatar + login. Unlinked commit: the git author name.
+    const byLines = screen.getAllByText("submissions.details.commitBy")
+    expect(byLines).toHaveLength(2)
+    expect(screen.getByText("alice")).toBeTruthy()
+    expect(screen.getByText("Bob Git")).toBeTruthy()
+    teamView.unmount()
+
+    // The same detected entries on an individual row stay author-less: the
+    // author is always the student, so it would only add noise.
+    render(
+      <SubmissionsTable
+        {...baseProps}
+        assignmentMode="every-push"
+        scores={[
+          scoreRow({
+            submissionCount: 2,
+            submissions: [],
+            detectedEntries,
+          }),
+        ]}
+        acceptedUsernames={new Set(["alice"])}
+      />,
+    )
+    await user.click(
+      screen.getByRole("button", { name: "submissions.type.countEveryPush" }),
+    )
+    expect(screen.queryByText("submissions.details.commitBy")).toBeNull()
+    expect(screen.queryByText("Bob Git")).toBeNull()
+  })
+
   it("shows the empty state with a tags link when a tag-mode row has no submissions", async () => {
     const user = userEvent.setup()
     render(

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -157,12 +157,15 @@ type OverrideModalRow = {
 // A viewer without the detection overlay (a non-owner, or the owner before
 // detection resolves) falls back to the collected `submissions`, so the modal
 // never shows a false "no submissions" state beside a positive count chip.
+// A team row labels each detected push with who made it (the collected
+// fallback carries no author).
 function buildDetailItems(
   row: SubmissionRow,
   mode: SubmissionMode,
   org: string,
   repo: string,
   t: (key: string, opts?: Record<string, unknown>) => string,
+  { isTeam = false }: { isTeam?: boolean } = {},
 ): SubmissionDetailItem[] {
   const detectedCommits = (row.detectedEntries ?? []).filter(
     (e) => e.kind === "commit",
@@ -185,6 +188,7 @@ function buildDetailItems(
             ? (releaseByCommit.get(e.sha) ??
               releaseByCommit.get(e.sha.slice(0, 7)))
             : undefined,
+          author: e.author,
         }))
       : row.submissions.map((s, i) => ({
           key: `${s.datetime}-${s.commit}-${i}`,
@@ -205,7 +209,12 @@ function buildDetailItems(
   )
 
   return buildSubmissionDetailItems(
-    { tags: row.detectedEntries ?? [], commits, collectedTags },
+    {
+      tags: row.detectedEntries ?? [],
+      commits,
+      collectedTags,
+      showAuthors: isTeam,
+    },
     mode,
     org,
     repo,
@@ -610,6 +619,7 @@ const SubmissionsTable = ({
           org,
           repo,
           t,
+          { isTeam },
         ),
       })
     // The row's primary action: the manage-submission modal. Shared by the


### PR DESCRIPTION
Implements the suggestion in https://github.com/foundation50/classroom50/discussions/786#discussioncomment-18250457: in a Teams-based group assignment, the submissions modal now shows who made each commit, so a group's members can tell their pushes apart.

## What changes

- Each commit row in the submission details modal shows the committer's GitHub avatar and login under the "Commit #N" label, before the date. An unlinked commit (no GitHub account resolved) falls back to the git author name with a person icon. A commit with neither renders as before.
- Applies to both views of a team assignment: the student's "Your group's submissions" modal and the teacher's per-group modal on the submissions page. Individual and legacy group assignments are unchanged, since there the author is always the student.
- Accessible label: "Committed by {{author}}" (sr-only and title), new key `submissions.details.commitBy`.

## How

The GitHub commits API already returns the linked account per commit and `GitHubCommit.author` already typed it; it just wasn't carried through. `detectBranchSubmissions` now attaches a `CommitAuthor` to each detected commit, `PushSubmission` carries it to the shared item builder, and `buildSubmissionDetailItems` takes a `showAuthors` flag that both views set from team mode. Avatar URLs go through `safeHttpUrl` like every other href.

## Known gap

Rows served from the collected `scores.json` history (the brief window before the live detection read resolves) carry no author, so they show the date only. Covering that would mean recording the author in `scores.json`, which is a separate schema change.

## Testing

- Unit tests for `commitAuthor`, the `showAuthors` switch, the git-name fallback, and avatar URL guarding.
- Teacher table test: a team row shows both a linked login and a git-name fallback; an individual row with the same detected entries shows no author.
- `npm run check` passes (tsc, eslint, prettier, arch:validate, vitest); `audit_i18n.py --strict` passes.
- Verified against a real team assignment on a local dev server (teacher view).
