### PR TITLE
fix(cli): stop grading the accept commit of a template-less assignment

### DIFF
--- a/cli/gh-teacher/autograders_tests/test_runner.py
+++ b/cli/gh-teacher/autograders_tests/test_runner.py
@@ -493,6 +493,40 @@ class TestIsAcceptanceCommit:
         _git(repo, "commit", "-q", "-m", "Accept x/y (and sneak in a README)")
         assert ag.is_acceptance_commit(repo, self._head(repo)) is False
 
+    def test_init_shim_accept_editing_seeded_readme_grades(self, tmp_path):
+        # The realistic sneak on a template-less repo: the student amends the
+        # accept commit and writes their work into the auto_init README, which
+        # turns the expected D into an M against the seeded parent -> grade.
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "main")
+        (repo / "README.md").write_text("# seeded by auto_init\n")
+        _git(repo, "add", "-A"); _git(repo, "commit", "-q", "-m", "Initial commit")
+        (repo / ag.ACCEPT_MARKER_PATH).write_text("classroom: x\n")
+        (repo / "README.md").write_text("# my write-up\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "Initialize .classroom50.yaml and autograde workflow")
+        assert ag.is_acceptance_commit(repo, self._head(repo)) is False
+
+    def test_setup_only_guard_malformed_path_listing_grades(self, tmp_path, monkeypatch):
+        # A status with no path (an even field count) means git's output was
+        # truncated; pairing would drop it silently and could skip real work,
+        # so the guard fails open instead.
+        repo = tmp_path / "repo"
+        shas = _make_repo(repo, ["Initial commit", ACCEPT])
+        real_run = subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):
+            if (isinstance(cmd, (list, tuple)) and "show" in cmd
+                    and "--name-status" in cmd):
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout=f"A\0{ag.ACCEPT_MARKER_PATH}\0D\0", stderr="",
+                )
+            return real_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert ag.is_acceptance_commit(repo, shas[1]) is False
+
     def test_setup_only_guard_git_error_grades(self, tmp_path, monkeypatch):
         # The accept commit is the tip, but reading its touched paths
         # errors -> fail open (grade) rather than skip on partial info.

--- a/cli/gh-teacher/autograders_tests/test_runner.py
+++ b/cli/gh-teacher/autograders_tests/test_runner.py
@@ -461,6 +461,38 @@ class TestIsAcceptanceCommit:
         _git(repo, "commit", "-q", "-m", "Initialize .classroom50.yaml and autograde workflow")
         assert ag.is_acceptance_commit(repo, self._head(repo)) is True
 
+    def test_init_shim_accept_deleting_seeded_readme_is_acceptance(self, tmp_path):
+        # Regression (#628 follow-up): a template-less (init_shim) accept
+        # creates the repo with auto_init, which seeds a README, and removes
+        # it in the same accept commit. That deletion is setup, not work: the
+        # guard must not fail open and grade the accept (which produced a
+        # phantom "1 commit, 0/10" submission before any student push).
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "main")
+        (repo / "README.md").write_text("# seeded by auto_init\n")
+        _git(repo, "add", "-A"); _git(repo, "commit", "-q", "-m", "Initial commit")
+        (repo / ag.ACCEPT_MARKER_PATH).write_text("classroom: x\n")
+        wf = repo / ".github" / "workflows"
+        wf.mkdir(parents=True)
+        (wf / "autograde.yaml").write_text("name: Autograde\n")
+        _git(repo, "rm", "-q", "README.md")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "Initialize .classroom50.yaml and autograde workflow")
+        assert ag.is_acceptance_commit(repo, self._head(repo)) is True
+
+    def test_accept_commit_adding_readme_grades(self, tmp_path):
+        # The README allowance is deletion-only: an accept commit that ADDS
+        # (or edits) a README carries student work, so it fails open -> grade.
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "main")
+        (repo / ag.ACCEPT_MARKER_PATH).write_text("classroom: x\n")
+        (repo / "README.md").write_text("# my write-up\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "Accept x/y (and sneak in a README)")
+        assert ag.is_acceptance_commit(repo, self._head(repo)) is False
+
     def test_setup_only_guard_git_error_grades(self, tmp_path, monkeypatch):
         # The accept commit is the tip, but reading its touched paths
         # errors -> fail open (grade) rather than skip on partial info.
@@ -472,7 +504,7 @@ class TestIsAcceptanceCommit:
             # Only the `git show` path-listing fails; _baseline_scan's
             # earlier calls succeed so we reach the guard.
             if (isinstance(cmd, (list, tuple)) and "show" in cmd
-                    and "--name-only" in cmd):
+                    and "--name-status" in cmd):
                 return subprocess.CompletedProcess(cmd, 128, stdout="", stderr="boom")
             return real_run(cmd, *args, **kwargs)
 
@@ -545,7 +577,7 @@ class TestIsShimUpdateCommit:
 
         def fake_run(cmd, *args, **kwargs):
             if (isinstance(cmd, (list, tuple)) and cmd[0] == "git"
-                    and "--name-only" in cmd):
+                    and "--name-status" in cmd):
                 return subprocess.CompletedProcess(cmd, 128, stdout="", stderr="boom")
             return real_run(cmd, *args, **kwargs)
 

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
@@ -171,9 +171,11 @@ ACCEPT_COMMIT_PATHS = frozenset(
 
 # Paths the accept commit may DELETE (never add or modify): an init_shim accept
 # creates the repo with auto_init, which seeds a README the assignment contract
-# says must not exist, so the same commit removes it. Mirrors
-# classroomcfg.SeededReadmePath -- keep in lockstep. Deletion-only, so a tip
-# accept commit that ADDS a README (a student's amended work) still grades.
+# says must not exist, so the same commit removes it. Both accept clients
+# hand-mirror the path: classroomcfg.SeededReadmePath (gh-student) and the
+# init_shim deletePaths in web/src/domain/assignments/accept.ts -- keep in
+# lockstep. Deletion-only, so a tip accept commit that ADDS or EDITS a README
+# (a student's amended work) still grades.
 ACCEPT_COMMIT_DELETED_PATHS = frozenset({"README.md"})
 
 # Paths a teacher-side submission-mode shim retrofit touches: exactly the shim,
@@ -674,11 +676,12 @@ def is_acceptance_commit(workspace: pathlib.Path, head_sha: str) -> bool:
     empty head_sha, or no accept commit.
 
     Final guard: the tip accept commit must touch ONLY the known setup paths
-    (`ACCEPT_COMMIT_PATHS`). A student can rewrite history so the marker commit
-    is the tip yet carries real work (amend + force-push, or a squash); skipping
-    it would silently drop gradeable work, so an accept commit touching anything
-    outside the setup set fails open (grade). A git error reading its paths also
-    fails open.
+    (`ACCEPT_COMMIT_PATHS`), plus at most a deletion of a path in
+    `ACCEPT_COMMIT_DELETED_PATHS`. A student can rewrite history so the marker
+    commit is the tip yet carries real work (amend + force-push, or a squash);
+    skipping it would silently drop gradeable work, so an accept commit touching
+    anything outside the setup set fails open (grade). A git error reading its
+    paths also fails open.
     """
     if not head_sha:
         return False
@@ -754,6 +757,12 @@ def _commit_touches_only(
         if changed.returncode != 0:
             return False
         fields = changed.stdout.split("\0")
+        # Well-formed output is status/path pairs plus a trailing empty field,
+        # so an even length means a dangling status. zip would silently drop
+        # it, and a dropped entry errs toward a false skip, so treat it as
+        # uninspectable instead.
+        if len(fields) % 2 == 0:
+            return False
         entries = [
             (status, path)
             for status, path in zip(fields[0::2], fields[1::2])

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
@@ -169,6 +169,13 @@ ACCEPT_COMMIT_PATHS = frozenset(
     }
 )
 
+# Paths the accept commit may DELETE (never add or modify): an init_shim accept
+# creates the repo with auto_init, which seeds a README the assignment contract
+# says must not exist, so the same commit removes it. Mirrors
+# classroomcfg.SeededReadmePath -- keep in lockstep. Deletion-only, so a tip
+# accept commit that ADDS a README (a student's amended work) still grades.
+ACCEPT_COMMIT_DELETED_PATHS = frozenset({"README.md"})
+
 # Paths a teacher-side submission-mode shim retrofit touches: exactly the shim,
 # nothing else. Such a commit carries `[skip ci]` so the workflow normally
 # never fires; is_shim_update_commit is the backstop for environments that
@@ -683,11 +690,15 @@ def is_acceptance_commit(workspace: pathlib.Path, head_sha: str) -> bool:
 
 def _accept_commit_is_setup_only(workspace: pathlib.Path, head_sha: str) -> bool:
     """True only when every path the commit touches is in the known setup set
-    (`ACCEPT_COMMIT_PATHS`). Fails open (False -> grade) on any git error or an
-    empty path list, so a commit we can't fully inspect is treated as a
-    submission rather than silently skipped.
+    (`ACCEPT_COMMIT_PATHS`), or is a deletion of a path in
+    `ACCEPT_COMMIT_DELETED_PATHS` (the auto_init README an init_shim accept
+    removes). Fails open (False -> grade) on any git error or an empty path
+    list, so a commit we can't fully inspect is treated as a submission rather
+    than silently skipped.
     """
-    return _commit_touches_only(workspace, head_sha, ACCEPT_COMMIT_PATHS)
+    return _commit_touches_only(
+        workspace, head_sha, ACCEPT_COMMIT_PATHS, ACCEPT_COMMIT_DELETED_PATHS
+    )
 
 
 def is_shim_update_commit(workspace: pathlib.Path, head_sha: str) -> bool:
@@ -714,12 +725,15 @@ def is_shim_update_commit(workspace: pathlib.Path, head_sha: str) -> bool:
 
 
 def _commit_touches_only(
-    workspace: pathlib.Path, head_sha: str, allowed: frozenset[str]
+    workspace: pathlib.Path,
+    head_sha: str,
+    allowed: frozenset[str],
+    allowed_deletions: frozenset[str] = frozenset(),
 ) -> bool:
-    """True only when every path the commit touches is in `allowed`. Fails
-    open (False -> grade) on any git error or an empty path list, so a commit
-    we can't fully inspect is treated as a submission rather than silently
-    skipped.
+    """True only when every path the commit touches is in `allowed`, or is a
+    DELETION of a path in `allowed_deletions`. Fails open (False -> grade) on
+    any git error or an empty path list, so a commit we can't fully inspect is
+    treated as a submission rather than silently skipped.
     """
 
     def git(*args: str) -> subprocess.CompletedProcess[str]:
@@ -729,19 +743,28 @@ def _commit_touches_only(
         )
 
     try:
-        # Names of every path the commit changed vs its parent (root commit:
-        # vs the empty tree). -r recurses, --no-renames keeps paths literal,
-        # -z NUL-delimits so unusual filenames survive.
+        # Status + name of every path the commit changed vs its parent (root
+        # commit: vs the empty tree). -r recurses, --no-renames keeps paths
+        # literal (and statuses to A/M/D/T), -z NUL-delimits so unusual
+        # filenames survive: the stream alternates status, path, status, path.
         changed = git(
-            "show", "--no-renames", "--name-only", "--format=", "-r", "-z",
+            "show", "--no-renames", "--name-status", "--format=", "-r", "-z",
             head_sha,
         )
         if changed.returncode != 0:
             return False
-        paths = [p for p in changed.stdout.split("\0") if p]
-        if not paths:
+        fields = changed.stdout.split("\0")
+        entries = [
+            (status, path)
+            for status, path in zip(fields[0::2], fields[1::2])
+            if path
+        ]
+        if not entries:
             return False
-        return all(p in allowed for p in paths)
+        return all(
+            path in allowed or (status == "D" and path in allowed_deletions)
+            for status, path in entries
+        )
     except (OSError, subprocess.SubprocessError):
         return False
 


### PR DESCRIPTION
Every accept of a template-less (`init_shim`) assignment has been producing a phantom graded submission ("1 commit, 0/10") before the student pushes anything. Surfaced while testing #875 on a team assignment, where the count chip read 3 commits but the modal listed 2.

## Root cause

`runner.py --detect-acceptance` skips grading when the tip commit is the accept commit and touches only the known setup paths (`.classroom50.yaml`, `.github/workflows/autograde.yaml`); anything else fails open and grades, so a student who amends real work into the accept commit isn't silently skipped.

#628 changed the `init_shim` accept to delete GitHub's `auto_init` `README.md` in the same commit, but the runner's `ACCEPT_COMMIT_PATHS` allow-list wasn't updated. `git show --name-only` lists the deletion too, so the guard fails open, the autograder runs on the accept commit, and it publishes a `submit/*` release that `collect_scores.py` then counts as a submission. Templated assignments are unaffected (no seeded README to remove).

## Fix

- New `ACCEPT_COMMIT_DELETED_PATHS = {"README.md"}`, honored only for a **deletion**. An accept commit that adds or edits a README still fails open and grades, so the anti-skip safeguard is intact.
- `_commit_touches_only` switches from `--name-only` to `--name-status` so it can tell a `D` from an `A`/`M`. With `--no-renames` every entry is exactly one status and one path.

## Rollout and existing data

- The workflow fetches `runner.py` from the org's Pages site, so existing classrooms pick this up once their skeleton is synced and `publish-pages` reruns. New classrooms get it immediately.
- Already-accepted template-less repos keep their phantom `submit/*` release, so their collected count stays one too high until that release and tag are deleted (the next collect then drops it). A follow-up could make the collector ignore a release whose commit is the baseline, at the cost of one extra read per repo.

## Testing

- New tests: an init_shim accept commit that deletes the seeded README is acceptance; an accept commit that adds a README grades. Existing git-error fail-open tests updated for the new flag.
- `pytest cli/gh-teacher/autograders_tests` (432) and `pytest cli/gh-teacher/skeleton_tests` (987) pass; `ruff check --select E4,E7,E9,F` passes.
- Reproduced on `classroom50-summer-dev`: the accept commit of a team repo touched `.classroom50.yaml`, `autograde.yaml`, and `README.md`, and has a `submit/…-<accept sha>` release.
