### PR TITLE
docs(wiki): document the GitHub proxy and add a Privacy and FERPA section

### DIFF
--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -413,6 +413,17 @@ token still has every permission it needs, use **Test token** under **Service
 token** in the organization's **Settings**. See
 [the service-token setup](CLI-Teacher-Guide#create-the-service-token).
 
+### Is Classroom 50 FERPA compliant? Where does student data go?
+
+Classroom 50 has no server or database, so it holds no student data to be
+compliant about. Everything lives in your GitHub organization, and your
+browser or machine talks to GitHub directly, with one exception: browser
+sign-in and repository downloads pass through a small stateless proxy that
+stores nothing. Compliance therefore depends on your institution's agreement
+with GitHub and on how much identifying data you put on GitHub. For the full
+picture, including practices that keep student data off GitHub, see
+[Privacy and FERPA](GitHub-Integration#privacy-and-ferpa).
+
 ## Roadmap
 
 Some capabilities from GitHub Classroom aren't available today, including

--- a/wiki/GitHub-Integration.md
+++ b/wiki/GitHub-Integration.md
@@ -296,22 +296,42 @@ browser itself must reach these hosts.
 
 ### The GitHub proxy
 
-A browser can't do everything GitHub requires directly, so the web app sends two
-operations through a small proxy. It defaults to the Fifty Foundation Cloudflare
-Worker at `classroom50.fifty-foundation.workers.dev`:
+Two GitHub endpoints refuse cross-origin requests from a browser, so the web
+app sends those two operations, and only those two, through a small proxy. It
+defaults to the Fifty Foundation Cloudflare Worker at
+`classroom50.fifty-foundation.workers.dev`:
 
 1. **OAuth sign-in**, both the browser redirect flow and the device-code flow.
-   Exchanging the login code for an access token needs the OAuth client secret,
-   which can't be shipped in browser JavaScript. The proxy holds the secret and
-   performs the exchange.
+   GitHub's token endpoint sends no CORS headers, and exchanging the login code
+   for an access token needs the OAuth client secret, which can't be shipped in
+   browser JavaScript. The proxy holds the secret and performs the exchange.
 2. **Repository downloads.** GitHub's archive endpoint redirects to
    `codeload.github.com`, which doesn't send the CORS headers a browser needs to
    follow the redirect. The proxy follows it server-side and streams the zip
    back.
 
+The proxy is stateless: it keeps no copy of tokens or downloaded files, holds
+nothing between requests, and accepts requests only from the Classroom 50 web
+app's own origins. What passes through it:
+
+| Operation | What the proxy handles |
+|---|---|
+| Sign-in | The one-time login code from GitHub and the access token GitHub returns for it. |
+| Repository download | Your access token, used for that one request, and the zip archive as it streams to your browser. |
+
+Both limits are GitHub's, not design choices, and the proxy exists only until
+GitHub lifts them. [Issue #877](https://github.com/foundation50/classroom50/issues/877)
+tracks the workaround and the upstream work: the
+[single page app support for GitHub Apps](https://github.com/github/roadmap/issues/1153)
+item on the GitHub roadmap would remove the sign-in half, and the download half
+waits on CORS support for `codeload.github.com`
+([octokit/rest.js#3](https://github.com/octokit/rest.js/issues/3)).
+
 The proxy is configurable: set `VITE_GITHUB_PROXY_BASE` at build time to point
-the app at your own proxy instead of the default worker. Everything else the web
-app does talks to `api.github.com` directly and doesn't involve the proxy.
+the app at your own proxy instead of the default worker (the source is
+[`cloudflare_worker.js`](https://github.com/foundation50/classroom50/blob/main/cloudflare_worker.js)).
+Everything else the web app does talks to `api.github.com` directly and doesn't
+involve the proxy, and the `gh teacher` and `gh student` CLIs never use it.
 
 ### If the proxy domain is blocked
 
@@ -337,6 +357,47 @@ Some networks can't allow `workers.dev`. When the proxy is unreachable:
 - **A fuller fix:** host the proxy yourself on a domain your network already
   allows and point `VITE_GITHUB_PROXY_BASE` at it. This restores both the normal
   sign-in and repository downloads.
+
+---
+
+## Privacy and FERPA
+
+Classroom 50 doesn't collect, store, or process student records. It has no
+server, database, or account system of its own, so there is no Classroom 50
+data to request, export, or delete. Every classroom record (roster, assignment
+repositories, scores, feedback) lives in your GitHub organization under your
+organization's own access controls, and Classroom 50 acts on it only with a
+token you or your students grant. If your institution needs a data processing
+agreement, the party to that agreement is GitHub; see the
+[GitHub Data Protection Agreement](https://github.com/customer-terms/github-data-protection-agreement).
+
+How each surface reaches GitHub:
+
+| Surface | Where data goes |
+|---|---|
+| Web app | Your browser talks to `api.github.com` directly. Sign-in and repository downloads pass through the stateless proxy described in [The GitHub proxy](#the-github-proxy); signing in with a personal access token skips the proxy entirely. |
+| `gh teacher` and `gh student` | Your machine talks to GitHub directly. The CLIs never use the proxy. |
+| Autograding and score collection | Run in GitHub Actions inside your organization, and results are stored in your organization's repositories. |
+
+Classroom 50 can't make a course FERPA compliant on its own: compliance depends
+on how your institution and GitHub handle the data. What you can control is how
+much student data reaches GitHub in the first place:
+
+- **Pseudonymous accounts.** Students don't need to give GitHub a real name or a
+  school email. Let them use a pseudonym, and keep the mapping from pseudonym to
+  student in your institution's own systems.
+- **Roster contents.** The roster holds only the columns you give it, and only a
+  GitHub username or id is required. Leave out names, and use `section` labels
+  that don't identify anyone. Inviting by email sends that address to GitHub as
+  an organization invitation. See [Roster CSV fields](Web-Teacher-Guide#roster-csv-fields).
+- **A small teacher role.** Organization owners can reach every repository.
+  Keep that group small and use the head TA and TA roles for graders. See
+  [Staff, TAs, and Multiple Teachers](Staff-TAs-and-Multiple-Teachers).
+- **End-of-term cleanup.** Archive or delete student repositories when the
+  course ends. See [End of term](Course-Lifecycle-and-End-of-Term#end-of-term).
+
+This section describes how Classroom 50 handles data; it isn't legal advice.
+Confirm your obligations with your institution's privacy office.
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -35,7 +35,9 @@ assignment run at the time you perform them and record the resulting state.
 Teachers therefore stay more involved in administration than they would with a
 hosted service.
 
-For the full model, see [How Classroom 50 Works](How-Classroom-50-Works).
+For the full model, see [How Classroom 50 Works](How-Classroom-50-Works). For
+where student data lives and what leaves your browser, including FERPA
+considerations, see [Privacy and FERPA](GitHub-Integration#privacy-and-ferpa).
 
 ## What you can do
 

--- a/wiki/Known-Limitations.md
+++ b/wiki/Known-Limitations.md
@@ -155,6 +155,13 @@ briefly fail or show stale data; wait a minute and retry.
   and a student in the same organization. What you can do is gated by your
   org and classroom role after sign-in, not by your token's scopes; see
   [Permissions and access](GitHub-Integration#permissions-and-access).
+- **Fully proxy-free web app.** Two GitHub endpoints refuse cross-origin
+  requests from a browser (the OAuth token exchange and repository archive
+  downloads), so those two operations pass through a small stateless proxy
+  until GitHub lifts the limits
+  ([#877](https://github.com/foundation50/classroom50/issues/877) tracks
+  the upstream work). Everything else already goes straight to GitHub; see
+  [The GitHub proxy](GitHub-Integration#the-github-proxy).
 
 Classroom 50 is open source and actively developed; if one of these matters
 to your course, share your use case in

--- a/wiki/Staff-TAs-and-Multiple-Teachers.md
+++ b/wiki/Staff-TAs-and-Multiple-Teachers.md
@@ -108,7 +108,9 @@ pull requests in bulk, is owner-only.)
 Because TAs and head TAs are ordinary organization members, graders don't
 need owner rights to do their work. If your institution's privacy rules (such
 as FERPA) require limiting who holds administrative access to student data,
-keep the teacher role small and use head TA and TA for everyone else.
+keep the teacher role small and use head TA and TA for everyone else. For
+where student data lives and what leaves the browser, see
+[Privacy and FERPA](GitHub-Integration#privacy-and-ferpa).
 
 ## Staff who are also students (dual roles)
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -47,18 +47,21 @@ Workarounds:
 
 ### "Couldn't reach the sign-in service"
 
-Browser sign-in routes the OAuth exchange through a small Cloudflare Worker,
-and this message ("Couldn't reach the sign-in service. It may be down. Check
-your connection and try again.") means your browser couldn't reach it. Two
-causes:
+Browser sign-in routes the OAuth exchange through a small Cloudflare Worker
+(see [The GitHub proxy](GitHub-Integration#the-github-proxy) for what it does
+and why), and this message ("Couldn't reach the sign-in service. It may be
+down. Check your connection and try again.") means your browser couldn't reach
+it. Two causes:
 
 - **You're offline.** Check your connection; the app shows a separate
   "You appear to be offline" notice when it can tell.
 - **A school or corporate filter blocks the proxy.** Ask IT to allow the
   domains in
   [Network and allowed domains](GitHub-Integration#network-and-allowed-domains),
-  or select **Sign in with token** to sign in with a personal access token,
-  which skips the proxy entirely.
+  or sign in with a personal access token, which skips the proxy entirely: on
+  the sign-in card, click **Other sign-in methods**, then click **Use a
+  personal access token (classic)** or **Use a personal access token
+  (fine-grained)**.
 
 ### `redirect_uri is not associated with this application`
 


### PR DESCRIPTION
Teachers asking about FERPA had nowhere to point them: the wiki said "no server" in several places but never consolidated where student data lives, what passes through the Cloudflare Worker, or why the Worker exists at all.

## What changed

- **GitHub Integration, The GitHub proxy**: explains why each of the two operations is proxied (GitHub's token endpoint sends no CORS headers and requires the client secret; `codeload.github.com` sends no CORS headers), states the Worker is stateless and origin-restricted, adds a table of exactly what transits it, links #877 and both upstream trackers (github/roadmap#1153, octokit/rest.js#3), and notes the CLIs never use it.
- **GitHub Integration, new Privacy and FERPA section**: no server or database, so no Classroom 50 data to request or delete; GitHub is the party to any data processing agreement (links the GitHub Data Protection Agreement); a per-surface table of where data goes (web app, CLIs, Actions); four practices that reduce what student data reaches GitHub (pseudonymous accounts, minimal roster columns, small teacher role, end-of-term cleanup), each linking to the existing page that covers it.
- **FAQ**: new "Is Classroom 50 FERPA compliant? Where does student data go?" entry pointing at the section.
- **Known Limitations**: new "Fully proxy-free web app" bullet tracking #877.
- **Troubleshooting**: "Couldn't reach the sign-in service" links the proxy section and fixes the stale **Sign in with token** instruction to the actual path (**Other sign-in methods**, then **Use a personal access token…**), matching `en.json`.
- **Staff, TAs, and Multiple Teachers** and **Home**: link the existing FERPA mention and the "How it works" intro to the new section.

## Checks

- Follows `docs/github-docs-writing-style.md`: no em dashes, no "please"/"just"/Latin abbreviations, sentence-case headers, bolded list leads as parallel noun phrases, tables for parallel content.
- All new `Page#anchor` links resolve against existing headers.

Tracks #877.
