### PR TITLE
docs(wiki): cover the include-staff toggle and per-commit authors on team submissions

### DIFF
--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -340,6 +340,11 @@ roles and be graded as a student. For how the app behaves with a dual-role
 account, see
 [Staff who are also students](Staff-TAs-and-Multiple-Teachers#staff-who-are-also-students-dual-roles).
 
+To try an assignment without enrolling yourself, accept it as staff. Your
+repository appears on the submissions page with your role badge, and the
+assignments table counts it once you turn on **Include teaching staff** next
+to **Collect all**.
+
 One caveat: as an **organization owner** you keep `admin` on your own assignment
 repository (GitHub won't let an owner reduce their own access to `write`), so it
 won't match a real student's `write`-level setup. To test the exact student

--- a/wiki/Staff-TAs-and-Multiple-Teachers.md
+++ b/wiki/Staff-TAs-and-Multiple-Teachers.md
@@ -130,7 +130,10 @@ GitHub teams are the authority for enrollment and role; the `role` column in
   the snapshot updating, not a change to enrollment.
 - **Submissions** list any account with a student enrollment as a student. A
   pure-staff account appears in submissions only once it has accepted an
-  assignment repository.
+  assignment repository; its row shows the staff role badge, and the
+  assignments table leaves it out of the **Accepted** and **Submitted** counts
+  unless **Include teaching staff** is on. For more information, see
+  [Collect the whole classroom](Web-Teacher-Guide#collect-the-whole-classroom).
 - **Unenroll** drops only the student side (the roster row and student-team
   membership); the staff role stays.
 

--- a/wiki/Web-Student-Guide.md
+++ b/wiki/Web-Student-Guide.md
@@ -190,7 +190,8 @@ many submissions you've made, and when you last submitted. The row's actions
 open your repository on GitHub, list your submissions (**View submissions**),
 and, once a submission has been graded, open the latest result
 (**View autograder details**). In the submissions list, each graded submission
-has a **View score** link.
+has a **View score** link. On a group assignment, the list also names the
+teammate who made each commit.
 
 The **Assignments** page offers the same views: **View my submission**, or on a
 group assignment **View group submission** and **View group**.

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -903,10 +903,11 @@ Each row shows a student's (or group's) latest submission plus its full history
 and links to the repository, the commit, the feedback pull request
 (**View feedback PR** on the row; its manage dialog carries the same link as
 **Review**), and the Release (**View autograder details**). A row whose work
-was pushed after the last collection shows **Pending** until you collect. For
-where every result lives (per-test breakdowns, past attempts, grading a
-specific commit, and who submitted), see
-[Reading results](Autograding-Basics#reading-results).
+was pushed after the last collection shows **Pending** until you collect. On a
+group assignment, each entry in the history also names the member who made the
+commit, so you can tell one teammate's work from another's. For where every
+result lives (per-test breakdowns, past attempts, grading a specific commit,
+and who submitted), see [Reading results](Autograding-Basics#reading-results).
 
 On a group assignment, rows are titled by group name, and a **Members** column
 shows each group's live member count; click it to open the group's manage
@@ -935,6 +936,17 @@ as **Pending** on the assignment's submissions page, so the two views agree. A
 student who pushed but whose autograder run failed or never ran counts as
 submitted here; their score arrives once the autograder publishes a result and
 the assignment is collected again.
+
+The **Accepted** and **Submitted** columns count enrolled students only, so a
+repository that a teacher, head TA, or TA accepted to try the assignment is
+left out of both. To count teaching staff alongside students, turn on
+**Include teaching staff** next to **Collect all**. The toggle is a preference
+for this browser and applies to every classroom you view; while it's on, the
+classroom header shows how many staff are counted so the columns add up. Before
+any student is enrolled, the columns read **No students yet**, and the tooltip
+notes how many staff repositories the toggle would count. On the submissions
+page, a staff member's row shows their role badge in place of a student's, so
+a test run is never mistaken for a student's work.
 
 Because the run walks every assignment's repositories, it takes longer than a
 single-assignment collection and uses more GitHub Actions minutes, so


### PR DESCRIPTION
Documents the two user-visible web features in the pending 1.44.0 release ([#869](https://github.com/foundation50/classroom50/pull/869)). The three fixes in that release (language picker refresh, budget-cap wording, template-less accept-commit skip) already match what the wiki says, so no page changes for them.

**Include teaching staff toggle (#871)**

- `Web-Teacher-Guide.md`, Collect the whole classroom: the **Accepted** and **Submitted** columns count enrolled students only; **Include teaching staff** next to **Collect all** widens them; per-browser preference; header staff count; **No students yet** state; staff rows badged on the submissions page.
- `Staff-TAs-and-Multiple-Teachers.md`, dual roles: a pure-staff account's repository is badged and left out of the counts unless the toggle is on, with a link to the guide.
- `FAQ.md`, "As a teacher, can I test an assignment as a student?": mentions the staff-accept path as an alternative to enrolling yourself.

**Who made each commit in a team's submissions (#875)**

- `Web-Teacher-Guide.md`, View submissions: history entries on a group assignment name the member who made the commit.
- `Web-Student-Guide.md`, View your submissions: same, from the student side.

Follows `docs/github-docs-writing-style.md` (sentence case, bold UI labels reproduced exactly, no em dashes, cross-references in the standard "For more information, see" form).