### PR TITLE
fix(web): show roster names and fit long repo names in the submissions modal

### DIFF
--- a/web/src/components/submissions/SubmissionDetailsModal.tsx
+++ b/web/src/components/submissions/SubmissionDetailsModal.tsx
@@ -8,7 +8,7 @@ import {
   TagIcon,
 } from "@/components/ui/icons"
 
-import { Button, Modal, MonoLtr } from "@/components/ui"
+import { Button, Modal, MonoLtr, cx } from "@/components/ui"
 
 // One row in the submission-details list. `kind` picks the icon and action
 // label ("View tag" vs "View commit"); `href` is the already-built, safe GitHub
@@ -81,11 +81,23 @@ export function SubmissionDetailsModal({
     dialogRef.current?.showModal()
   }, [])
 
+  // Wide enough that a typical `<classroom>-<assignment>-<owner>` repo name and
+  // a row's "View commit · View grade" actions fit on one line; a longer name
+  // wraps rather than truncating, since the name is what identifies the repo.
+  const repoClass = "mt-2 flex w-fit max-w-full items-start gap-1.5"
+  const repoName = (
+    <MonoLtr className="min-w-0 break-words text-sm">{repo}</MonoLtr>
+  )
+  // Optically aligns the 16px icon with the first 20px text line.
+  const repoIcon = (
+    <RepoIcon aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+  )
+
   return (
     <Modal
       dialogRef={dialogRef}
       onClose={onClose}
-      size="lg"
+      size="xl"
       title={<span className="block truncate">{title}</span>}
       subtitle={
         subtitle ? (
@@ -97,19 +109,19 @@ export function SubmissionDetailsModal({
     >
       {repoHref ? (
         <a
-          className="link link-hover mt-2 inline-flex w-fit max-w-full items-center gap-1.5"
+          className={cx("link link-hover", repoClass)}
           href={repoHref}
           target="_blank"
           rel="noreferrer"
           title={t("submissions.details.viewRepository")}
         >
-          <RepoIcon aria-hidden="true" className="size-4 shrink-0" />
-          <MonoLtr className="truncate text-sm">{repo}</MonoLtr>
+          {repoIcon}
+          {repoName}
         </a>
       ) : (
-        <p className="mt-2 inline-flex w-fit max-w-full items-center gap-1.5 text-base-content/50">
-          <RepoIcon aria-hidden="true" className="size-4 shrink-0" />
-          <MonoLtr className="truncate text-sm">{repo}</MonoLtr>
+        <p className={cx(repoClass, "text-base-content/50")}>
+          {repoIcon}
+          {repoName}
         </p>
       )}
 
@@ -146,13 +158,16 @@ export function SubmissionDetailsModal({
             return (
               <li
                 key={item.key}
-                className="flex items-center gap-3 rounded-box border border-base-300 bg-base-100 px-3 py-2 text-sm"
+                // The label block keeps a readable minimum, so on a narrow
+                // screen the actions wrap below it instead of squeezing the
+                // author and date down to ellipses.
+                className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-box border border-base-300 bg-base-100 px-3 py-2 text-sm"
               >
                 <Icon
                   aria-hidden="true"
                   className="size-4 shrink-0 text-base-content/70"
                 />
-                <span className="flex min-w-0 flex-col">
+                <span className="flex min-w-[10rem] flex-1 flex-col">
                   <MonoLtr className="truncate font-medium">
                     {item.label}
                   </MonoLtr>
@@ -201,30 +216,32 @@ export function SubmissionDetailsModal({
                     </span>
                   ) : null}
                 </span>
-                {item.href ? (
-                  <a
-                    className="link link-hover ms-auto inline-flex shrink-0 items-center gap-1"
-                    href={item.href}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    {actionLabel}
-                  </a>
-                ) : (
-                  <span className="ms-auto shrink-0 text-base-content/50">
-                    {t("submissions.details.unavailable")}
-                  </span>
-                )}
-                {item.releaseHref ? (
-                  <a
-                    className="link link-hover inline-flex shrink-0 items-center gap-1 text-base-content/70 before:me-1 before:text-base-content/30 before:content-['·']"
-                    href={item.releaseHref}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    {t("submissions.details.viewGrade")}
-                  </a>
-                ) : null}
+                <span className="ms-auto flex shrink-0 items-center">
+                  {item.href ? (
+                    <a
+                      className="link link-hover inline-flex items-center gap-1"
+                      href={item.href}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {actionLabel}
+                    </a>
+                  ) : (
+                    <span className="text-base-content/50">
+                      {t("submissions.details.unavailable")}
+                    </span>
+                  )}
+                  {item.releaseHref ? (
+                    <a
+                      className="link link-hover ms-3 inline-flex items-center gap-1 text-base-content/70 before:me-1 before:text-base-content/30 before:content-['·']"
+                      href={item.releaseHref}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {t("submissions.details.viewGrade")}
+                    </a>
+                  ) : null}
+                </span>
               </li>
             )
           })}

--- a/web/src/components/submissions/submissionDetailItems.test.tsx
+++ b/web/src/components/submissions/submissionDetailItems.test.tsx
@@ -61,6 +61,48 @@ describe("commitDetailItems", () => {
     expect(item.author).toEqual({ label: "Alice Git", avatarUrl: undefined })
   })
 
+  it("prefers the roster name for a linked login, falling back to the login", () => {
+    const roster: Record<string, string> = { alice: "Alice Anderson" }
+    const items = commitDetailItems(
+      [
+        {
+          key: "a",
+          author: { login: "alice", avatarUrl: "https://avatars/alice" },
+        },
+        {
+          key: "b",
+          author: { login: "bob", avatarUrl: "https://avatars/bob" },
+        },
+        // An unlinked commit has no login to resolve, so the resolver is skipped
+        // and the git author name stands.
+        { key: "c", author: { name: "Carol Git" } },
+      ],
+      t,
+      { showAuthors: true, authorName: (login) => roster[login] },
+    )
+    expect(items[0].author).toEqual({
+      label: "Alice Anderson",
+      avatarUrl: "https://avatars/alice",
+    })
+    expect(items[1].author).toEqual({
+      label: "bob",
+      avatarUrl: "https://avatars/bob",
+    })
+    expect(items[2].author).toEqual({
+      label: "Carol Git",
+      avatarUrl: undefined,
+    })
+  })
+
+  it("treats an empty resolved name as unavailable", () => {
+    const [item] = commitDetailItems(
+      [{ key: "a", author: { login: "alice" } }],
+      t,
+      { showAuthors: true, authorName: () => "" },
+    )
+    expect(item.author?.label).toBe("alice")
+  })
+
   it("guards the avatar URL and skips an authorless commit", () => {
     const items = commitDetailItems(
       [
@@ -80,15 +122,20 @@ describe("buildSubmissionDetailItems", () => {
     const items = buildSubmissionDetailItems(
       {
         tags: [],
-        commits: [{ key: "c", author: { login: "bob" } }],
+        commits: [
+          { key: "c", author: { login: "bob" } },
+          { key: "d", author: { login: "dan" } },
+        ],
         showAuthors: true,
+        authorName: (login) => (login === "bob" ? "Bob Brown" : undefined),
       },
       "every-push",
       "acme",
       "cs101-hw1-group-1",
       t,
     )
-    expect(items[0].author?.label).toBe("bob")
+    expect(items[0].author?.label).toBe("Bob Brown")
+    expect(items[1].author?.label).toBe("dan")
   })
   it("uses tag entries in tag mode", () => {
     const items = buildSubmissionDetailItems(

--- a/web/src/components/submissions/submissionDetailItems.ts
+++ b/web/src/components/submissions/submissionDetailItems.ts
@@ -99,16 +99,23 @@ export function collectedTagDetailItems(
   }))
 }
 
+// How a view labels a commit's author. `showAuthors` is on for a team's shared
+// repo, where the members' commits need telling apart, and off for an
+// individual repo, where the author is always the student. `authorName`
+// resolves a linked login to a roster name; only the teacher has a roster, so
+// the student view leaves it unset and sees logins.
+export type AuthorLabelOptions = {
+  showAuthors?: boolean
+  authorName?: (login: string) => string | undefined
+}
+
 // Map normalized push submissions to details-modal items, newest first (the
 // caller supplies them newest-first, matching both the collected history and
 // GitHub's default commit order). Numbered #N…#1 so the newest reads highest.
-// `showAuthors` attaches who made each commit: on for a team's shared repo,
-// where the members' commits need telling apart; off for an individual repo,
-// where the author is always the student.
 export function commitDetailItems(
   commits: PushSubmission[],
   t: Translate,
-  { showAuthors = false }: { showAuthors?: boolean } = {},
+  { showAuthors = false, authorName }: AuthorLabelOptions = {},
 ): SubmissionDetailItem[] {
   return commits.map((commit, i) => ({
     key: commit.key,
@@ -119,22 +126,28 @@ export function commitDetailItems(
       : undefined,
     href: safeHttpUrl(commit.commitHref),
     releaseHref: safeHttpUrl(commit.releaseHref),
-    author: showAuthors ? detailItemAuthor(commit.author) : undefined,
+    author: showAuthors
+      ? detailItemAuthor(commit.author, authorName)
+      : undefined,
     count: 1,
   }))
 }
 
-// The modal's author chip: the login when GitHub linked the commit to an
-// account (with its avatar), else the git author name, else nothing.
+// The modal's author chip. A linked account shows its roster name when the
+// view can resolve one, else the login, with its avatar either way; an unlinked
+// commit shows the git author name; a commit with neither shows nothing.
 function detailItemAuthor(
   author: CommitAuthor | undefined,
+  authorName: AuthorLabelOptions["authorName"],
 ): SubmissionDetailItem["author"] {
-  const label = author?.login ?? author?.name
-  if (!label) return undefined
-  return {
-    label,
-    avatarUrl: author?.login ? safeHttpUrl(author.avatarUrl) : undefined,
+  if (author?.login) {
+    return {
+      label: authorName?.(author.login) || author.login,
+      avatarUrl: safeHttpUrl(author.avatarUrl),
+    }
   }
+  if (!author?.name) return undefined
+  return { label: author.name, avatarUrl: undefined }
 }
 
 // The one type-aware item builder both views use: tag entries in tag mode, push
@@ -143,26 +156,27 @@ function detailItemAuthor(
 // unit), so the unused side is simply empty. In tag mode, when the detection
 // overlay is empty (a viewer without it) but collected tag submissions exist,
 // fall back to those so the modal never contradicts a positive count chip.
-// `showAuthors` (a team repo) labels each push with who made it.
+// `showAuthors` (a team repo) labels each push with who made it, by roster
+// name when `authorName` resolves one.
 export function buildSubmissionDetailItems(
   {
     tags,
     commits,
     collectedTags = [],
     showAuthors = false,
+    authorName,
   }: {
     tags: DetectedSubmission[]
     commits: PushSubmission[]
     collectedTags?: CollectedTagSubmission[]
-    showAuthors?: boolean
-  },
+  } & AuthorLabelOptions,
   mode: SubmissionMode | undefined,
   org: string,
   repo: string,
   t: Translate,
 ): SubmissionDetailItem[] {
   if (resolveSubmissionMode(mode) !== "tag") {
-    return commitDetailItems(commits, t, { showAuthors })
+    return commitDetailItems(commits, t, { showAuthors, authorName })
   }
   const detected = tagDetailItems(tags, org, repo, t)
   return detected.length > 0

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -989,10 +989,17 @@ describe("SubmissionsTable submission details modal", () => {
     const detectedEntries = [
       {
         kind: "commit" as const,
+        label: "ccc3333",
+        count: 1,
+        sha: "ccc3333",
+        author: { login: "alice", avatarUrl: "https://avatars/alice" },
+      },
+      {
+        kind: "commit" as const,
         label: "bbb2222",
         count: 1,
         sha: "bbb2222",
-        author: { login: "alice", avatarUrl: "https://avatars/alice" },
+        author: { login: "zed", avatarUrl: "https://avatars/zed" },
       },
       {
         kind: "commit" as const,
@@ -1020,22 +1027,25 @@ describe("SubmissionsTable submission details modal", () => {
         scores={[
           scoreRow({
             owner: "group-1",
-            usernames: ["alice", "bob"],
-            submissionCount: 2,
+            usernames: ["alice", "zed"],
+            submissionCount: 3,
             submissions: [],
             detectedEntries,
           }),
         ]}
-        acceptedUsernames={new Set(["alice", "bob"])}
+        acceptedUsernames={new Set(["alice", "zed"])}
       />,
     )
     await user.click(
       screen.getByRole("button", { name: "submissions.type.countEveryPush" }),
     )
-    // Linked account: avatar + login. Unlinked commit: the git author name.
+    // Linked account on the roster: its roster name. Linked account off the
+    // roster: the login. Unlinked commit: the git author name.
     const byLines = screen.getAllByText("submissions.details.commitBy")
-    expect(byLines).toHaveLength(2)
-    expect(screen.getByText("alice")).toBeTruthy()
+    expect(byLines).toHaveLength(3)
+    expect(screen.getByText("Alice A")).toBeTruthy()
+    expect(screen.queryByText("alice")).toBeNull()
+    expect(screen.getByText("zed")).toBeTruthy()
     expect(screen.getByText("Bob Git")).toBeTruthy()
     teamView.unmount()
 
@@ -1047,7 +1057,7 @@ describe("SubmissionsTable submission details modal", () => {
         assignmentMode="every-push"
         scores={[
           scoreRow({
-            submissionCount: 2,
+            submissionCount: 3,
             submissions: [],
             detectedEntries,
           }),

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -157,15 +157,18 @@ type OverrideModalRow = {
 // A viewer without the detection overlay (a non-owner, or the owner before
 // detection resolves) falls back to the collected `submissions`, so the modal
 // never shows a false "no submissions" state beside a positive count chip.
-// A team row labels each detected push with who made it (the collected
-// fallback carries no author).
+// A team row labels each detected push with who made it, by roster name when
+// the login is on the roster (the collected fallback carries no author).
 function buildDetailItems(
   row: SubmissionRow,
   mode: SubmissionMode,
   org: string,
   repo: string,
   t: (key: string, opts?: Record<string, unknown>) => string,
-  { isTeam = false }: { isTeam?: boolean } = {},
+  {
+    isTeam = false,
+    students = [],
+  }: { isTeam?: boolean; students?: Student[] } = {},
 ): SubmissionDetailItem[] {
   const detectedCommits = (row.detectedEntries ?? []).filter(
     (e) => e.kind === "commit",
@@ -214,6 +217,7 @@ function buildDetailItems(
       commits,
       collectedTags,
       showAuthors: isTeam,
+      authorName: (login) => getName(login, students),
     },
     mode,
     org,
@@ -619,7 +623,7 @@ const SubmissionsTable = ({
           org,
           repo,
           t,
-          { isTeam },
+          { isTeam, students },
         ),
       })
     // The row's primary action: the manage-submission modal. Shared by the


### PR DESCRIPTION
Follow-up to #875. Two small fixes to the submission details modal for a team assignment.

## Roster names for commit authors

The teacher's per-group modal labeled each commit with the committer's GitHub login even when the roster knows their name. The shared item builder now takes an optional `authorName(login)` resolver alongside `showAuthors`, and the teacher table passes `getName` from its roster (the same case-insensitive lookup every other name surface in the table uses). A login that isn't on the roster, or has no name recorded, falls back to the login as before. Unlinked commits still show the git author name.

The student's "Your group's submissions" modal is unchanged: students can't read the private roster, and the team-members API carries no display names, so there is no name to fall back to there.

## Long repository names

A long `<classroom>-<assignment>-<owner>` name was truncated with an ellipsis under the title. The modal is now one size wider (`xl`) and the repo name wraps instead of truncating. Names are hyphen-joined, so the wrap lands at a hyphen; `break-words` only kicks in for a hyphen-free segment longer than a line. The repo icon aligns to the first line.

While checking this at a phone width, the per-commit row was squeezing the author and date down to `R… · Sep 3, …` because the action links never yielded space. The row now wraps, so at narrow widths "View commit · View grade" drops below the label and both read in full. The two links are grouped so they always wrap together. Desktop layout is unchanged.

## Testing

- Builder unit tests: roster name preferred for a linked login, login fallback when unresolved or empty, unlinked commits skip the resolver.
- Teacher table test: a team row shows the roster name for an on-roster login, the login for an off-roster login, and the git author name for an unlinked commit; an individual row stays author-less.
- Rendered in real Chromium at 1024px and 375px with long and typical repo names.
- `npm run check` passes (tsc, eslint, prettier, arch:validate, vitest including the browser-mode a11y guards).