### PR TITLE
feat(cli): accept the tests.json envelope in --tests and add assignment test set

### DIFF
--- a/cli/gh-teacher/autograders_tests/test_declarative_grader.py
+++ b/cli/gh-teacher/autograders_tests/test_declarative_grader.py
@@ -403,6 +403,7 @@ class TestLoadTests:
         assert "--tests" in msg
         assert "Remove the tests.json" in msg
         assert "gh teacher assignment test add" in msg
+        assert "gh teacher assignment test set --tests" in msg
 
     def test_non_object_scalar_points_to_authoring_path(self, tmp_path):
         p = self._write(tmp_path, '"hello"')

--- a/cli/gh-teacher/internal/assignment/tests.go
+++ b/cli/gh-teacher/internal/assignment/tests.go
@@ -253,15 +253,38 @@ func validateNoControlChars(s, label string) error {
 	return nil
 }
 
-// ParseTestsFile loads and validates `--tests <path>` (`-` = stdin): a bare
-// JSON array of test specs. Empty path → (nil, nil). DisallowUnknownFields so a
-// typo'd key fails loudly.
-func ParseTestsFile(path string) ([]TestSpec, error) {
+// TestsSchemaV1 is the `schema` value of the tests.json envelope that
+// publish-pages generates and runner.py reads (schemas/tests-v1.schema.json).
+const TestsSchemaV1 = "classroom50/tests/v1"
+
+// TestsFile is the parsed content of a `--tests` file. Defaults is nil for a
+// bare array and for an envelope without `defaults`; the caller decides what
+// nil means (keep vs clear the assignment's test_defaults).
+type TestsFile struct {
+	Tests    []TestSpec
+	Defaults *TestDefaults
+	// Envelope reports which of the two accepted shapes the file used.
+	Envelope bool
+}
+
+// testsEnvelope mirrors schemas/tests-v1.schema.json, the shape of the
+// generated bundle file. Accepted on input so a teacher can round-trip that
+// file (or keep one in a course repo) instead of learning a second format.
+type testsEnvelope struct {
+	Schema   string        `json:"schema"`
+	Tests    []TestSpec    `json:"tests"`
+	Defaults *TestDefaults `json:"defaults,omitempty"`
+}
+
+// ParseTestsFile loads and validates `--tests <path>` (`-` = stdin): either a
+// bare JSON array of test specs or the generated tests.json envelope. Empty
+// path → (nil, nil). DisallowUnknownFields so a typo'd key fails loudly.
+func ParseTestsFile(path string) (*TestsFile, error) {
 	return parseTestsFileFrom(path, os.Stdin)
 }
 
 // parseTestsFileFrom is the testable seam for ParseTestsFile.
-func parseTestsFileFrom(path string, stdin io.Reader) ([]TestSpec, error) {
+func parseTestsFileFrom(path string, stdin io.Reader) (*TestsFile, error) {
 	if path == "" {
 		return nil, nil
 	}
@@ -280,22 +303,45 @@ func parseTestsFileFrom(path string, stdin io.Reader) ([]TestSpec, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read --tests %s: %w", label, err)
 	}
-	if len(bytes.TrimSpace(data)) == 0 {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
 		return nil, fmt.Errorf("--tests %s is empty", label)
 	}
-	var tests []TestSpec
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
-	if err := dec.Decode(&tests); err != nil {
-		return nil, fmt.Errorf("parse --tests %s: %w", label, err)
+	parsed := &TestsFile{}
+	switch trimmed[0] {
+	case '[':
+		if err := dec.Decode(&parsed.Tests); err != nil {
+			return nil, fmt.Errorf("parse --tests %s: %w", label, err)
+		}
+	case '{':
+		var env testsEnvelope
+		if err := dec.Decode(&env); err != nil {
+			return nil, fmt.Errorf("parse --tests %s: %w (expected a JSON array of tests, or the generated tests.json envelope with \"schema\": %q)", label, err, TestsSchemaV1)
+		}
+		if env.Schema != TestsSchemaV1 {
+			return nil, fmt.Errorf("--tests %s: \"schema\" is %q, want %q", label, env.Schema, TestsSchemaV1)
+		}
+		if env.Tests == nil {
+			return nil, fmt.Errorf("--tests %s: envelope is missing the \"tests\" array", label)
+		}
+		if env.Defaults != nil {
+			if err := ValidateTestDefaults(*env.Defaults); err != nil {
+				return nil, fmt.Errorf("--tests %s: defaults: %w", label, err)
+			}
+		}
+		parsed.Tests, parsed.Defaults, parsed.Envelope = env.Tests, env.Defaults, true
+	default:
+		return nil, fmt.Errorf("--tests %s: expected a JSON array of tests, or the generated tests.json envelope, got %q", label, string(trimmed[0]))
 	}
 	if err := expectEOF(dec); err != nil {
 		return nil, fmt.Errorf("parse --tests %s: %w", label, err)
 	}
-	if err := ValidateTests(tests); err != nil {
+	if err := ValidateTests(parsed.Tests); err != nil {
 		return nil, fmt.Errorf("--tests %s: %w", label, err)
 	}
-	return tests, nil
+	return parsed, nil
 }
 
 // UpsertTest replaces a test by Name (position-preserving) or appends it.

--- a/cli/gh-teacher/internal/assignment/tests_test.go
+++ b/cli/gh-teacher/internal/assignment/tests_test.go
@@ -271,12 +271,16 @@ func TestParseTestsFile_EmptyPathIsNoOp(t *testing.T) {
 
 func TestParseTestsFileFrom_Stdin(t *testing.T) {
 	body := `[{"name":"compiles","type":"run","run":"true","points":1}]`
-	got, err := parseTestsFileFrom("-", strings.NewReader(body))
+	parsed, err := parseTestsFileFrom("-", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("parseTestsFileFrom: %v", err)
 	}
+	got := parsed.Tests
 	if len(got) != 1 || got[0].Name != "compiles" || got[0].Type != "run" {
 		t.Errorf("stdin tests not parsed: %#v", got)
+	}
+	if parsed.Envelope || parsed.Defaults != nil {
+		t.Errorf("bare array must not report an envelope: %#v", parsed)
 	}
 }
 
@@ -290,12 +294,72 @@ func TestParseTestsFile_HappyPath(t *testing.T) {
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	got, err := ParseTestsFile(path)
+	parsed, err := ParseTestsFile(path)
 	if err != nil {
 		t.Fatalf("ParseTestsFile: %v", err)
 	}
+	got := parsed.Tests
 	if len(got) != 2 || got[0].Name != "compiles" || got[1].Comparison != "included" {
 		t.Errorf("tests not parsed: %#v", got)
+	}
+}
+
+// TestParseTestsFile_EnvelopeAccepted pins discussion #805: the generated
+// bundle tests.json (schema + tests + defaults) is valid `--tests` input, so
+// a teacher who keeps that file in a course repo can pass it straight through.
+func TestParseTestsFile_EnvelopeAccepted(t *testing.T) {
+	body := `{
+  "schema": "classroom50/tests/v1",
+  "tests": [{"name":"compiles","type":"run","run":"true","points":1}],
+  "defaults": {"failure-details": "none", "show-output": true}
+}`
+	parsed, err := parseTestsFileFrom("-", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parseTestsFileFrom: %v", err)
+	}
+	if !parsed.Envelope {
+		t.Error("envelope not reported")
+	}
+	if len(parsed.Tests) != 1 || parsed.Tests[0].Name != "compiles" {
+		t.Errorf("envelope tests not parsed: %#v", parsed.Tests)
+	}
+	if parsed.Defaults == nil || parsed.Defaults.FailureDetails != "none" || parsed.Defaults.ShowOutput == nil || !*parsed.Defaults.ShowOutput {
+		t.Errorf("envelope defaults not parsed: %#v", parsed.Defaults)
+	}
+}
+
+func TestParseTestsFile_EnvelopeWithoutDefaults(t *testing.T) {
+	body := `{"schema": "classroom50/tests/v1", "tests": []}`
+	parsed, err := parseTestsFileFrom("-", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parseTestsFileFrom: %v", err)
+	}
+	if !parsed.Envelope || parsed.Defaults != nil || parsed.Tests == nil || len(parsed.Tests) != 0 {
+		t.Errorf("expected envelope with empty non-nil tests and nil defaults, got %#v", parsed)
+	}
+}
+
+func TestParseTestsFile_EnvelopeRejections(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "wrong schema", body: `{"schema": "classroom50/tests/v2", "tests": []}`, want: `"schema" is "classroom50/tests/v2"`},
+		{name: "missing tests", body: `{"schema": "classroom50/tests/v1"}`, want: `missing the "tests" array`},
+		{name: "bad defaults", body: `{"schema": "classroom50/tests/v1", "tests": [], "defaults": {"failure-details": "loud"}}`, want: "defaults: invalid failure-details"},
+		{name: "unknown envelope key", body: `{"schema": "classroom50/tests/v1", "tests": [], "extra": 1}`, want: `unknown field "extra"`},
+		// A single test object is neither shape; the error names both.
+		{name: "single test object", body: `{"name":"t","type":"run","run":"x","points":1}`, want: "expected a JSON array of tests"},
+		{name: "scalar", body: `"tests"`, want: "expected a JSON array of tests"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseTestsFileFrom("-", strings.NewReader(tc.body))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
 	}
 }
 
@@ -439,10 +503,11 @@ func TestParseTestsFile_ShowOutputFalseRoundTrips(t *testing.T) {
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	got, err := ParseTestsFile(path)
+	parsed, err := ParseTestsFile(path)
 	if err != nil {
 		t.Fatalf("ParseTestsFile: %v", err)
 	}
+	got := parsed.Tests
 	if got[0].ShowOutput == nil || *got[0].ShowOutput {
 		t.Errorf("explicit show-output:false lost: %#v", got[0].ShowOutput)
 	}

--- a/cli/gh-teacher/internal/assignmentcmd/assignment.go
+++ b/cli/gh-teacher/internal/assignmentcmd/assignment.go
@@ -301,9 +301,16 @@ func assignmentAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			tests, err := assignment.ParseTestsFile(strings.TrimSpace(testsFile))
+			parsedTests, err := assignment.ParseTestsFile(strings.TrimSpace(testsFile))
 			if err != nil {
 				return err
+			}
+			var (
+				tests        []assignment.TestSpec
+				testDefaults *assignment.TestDefaults
+			)
+			if parsedTests != nil {
+				tests, testDefaults = parsedTests.Tests, parsedTests.Defaults
 			}
 
 			client, err := githubapi.RequireAuthClient(cmd)
@@ -328,6 +335,7 @@ func assignmentAddCmd() *cobra.Command {
 					Autograder:            autograderVal,
 					Runtime:               runtime,
 					Tests:                 tests,
+					TestDefaults:          testDefaults,
 					FeedbackPR:            feedbackPRVal,
 					EmptyRepo:             emptyRepo,
 					AllowedFiles:          allowedFiles,
@@ -355,7 +363,7 @@ func assignmentAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&teamFormation, "team-formation", "", "Who forms the groups of a team assignment: `teacher` (you create the teams) or `student` (the first student founds a team and adds teammates). Required with --mode team")
 	cmd.Flags().StringVar(&autograder, "autograder", contract.DefaultAutograderName, "Autograder workflow shim this assignment opts into; resolves to <classroom>/autograders/<name>.yaml in the classroom50 repository")
 	cmd.Flags().StringVar(&runtimeFile, "runtime", "", "Path to a JSON file describing the runtime environment (runs-on as a single label or an array of labels for self-hosted runners, python/node/java/go/rust versions, apt packages, or container image), or `-` to read from stdin. Omit for ubuntu-latest and Python 3.14")
-	cmd.Flags().StringVar(&testsFile, "tests", "", "Path to a JSON file with a bare array of declarative test specs (io/run/python), or `-` to read from stdin. Sets the assignment's `tests` block; mutually exclusive with a per-assignment autograder. See `gh teacher assignment test --help`")
+	cmd.Flags().StringVar(&testsFile, "tests", "", "Path to a JSON file of declarative test specs (io/run/python), or `-` to read from stdin: either a bare array or the generated tests.json envelope ({\"schema\": \"classroom50/tests/v1\", \"tests\": [...]}). Sets the assignment's `tests` block; mutually exclusive with a per-assignment autograder. To change only the tests on an existing assignment, use `gh teacher assignment test set`")
 	cmd.Flags().BoolVar(&feedbackPR, "feedback-pr", true, "Open one long-lived Feedback pull request per student repo so you can leave inline review comments on the full starter-to-submission diff. Accept freezes a base branch at the baseline commit and opens the PR right away, so it exists even with GitHub Actions disabled; the autograde runner then adopts and maintains it (and opens it on the first submission if accept could not). Default on; pass --feedback-pr=false to disable. Requires `gh teacher init` to have set up the org prerequisites")
 	cmd.Flags().BoolVar(&emptyRepo, "empty-repo", false, "Create truly bare student repos (no README or initial commit, no .classroom50.yaml marker, no autograde workflow) for assignments where students build the repo, including their own GitHub Actions, from scratch. Autograding and the Feedback PR are disabled. Changing this on a same-slug re-add applies only to accepts from now on (repositories students already accepted are not retrofitted; a warning is printed). Mutually exclusive with --template, --tests, --feedback-pr, --allowed-files, --pass-threshold, --submission-mode, and --submission-tag")
 	cmd.Flags().StringArrayVar(&allowedFiles, "allowed-files", nil, "Ordered .gitignore-style pattern (repeatable, order preserved) defining which files belong to the submission. Last match wins; `!` re-includes. Pass `--allowed-files '*' --allowed-files '!hello.py'` to allow only hello.py. The autograde runner removes disallowed files before grading (control files are always kept); `gh student submit` filters them too. Omit to allow every file")
@@ -658,6 +666,9 @@ type addAssignmentParams struct {
 	Autograder        string
 	Runtime           *assignment.RuntimeRef
 	Tests             []assignment.TestSpec
+	// TestDefaults comes only from a `--tests` envelope; a bare array leaves
+	// it nil.
+	TestDefaults      *assignment.TestDefaults
 	FeedbackPR        bool
 	EmptyRepo         bool
 	AllowedFiles      []string
@@ -765,6 +776,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 		Autograder:        autograder,
 		Runtime:           runtime,
 		Tests:             tests,
+		TestDefaults:      p.TestDefaults,
 		FeedbackPR:        feedbackPR,
 		EmptyRepo:         p.EmptyRepo,
 		AllowedFiles:      allowedFiles,
@@ -1089,7 +1101,7 @@ func runAssignmentAdd(client githubapi.Client, out, errOut io.Writer, p addAssig
 	}
 	if droppedTests > 0 {
 		_, _ = fmt.Fprintf(errOut,
-			"Warning: replacing %q dropped its %d declarative test(s): `assignment add` rewrites the whole entry. Pass --tests to keep them, or re-add with `gh teacher assignment test add`.\n",
+			"Warning: replacing %q dropped its %d declarative test(s): `assignment add` rewrites the whole entry. Pass --tests to keep them, or restore them with `gh teacher assignment test set`.\n",
 			slug, droppedTests)
 	}
 	if droppedTemplate != nil {

--- a/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
+++ b/cli/gh-teacher/internal/assignmentcmd/test_cmd.go
@@ -18,13 +18,13 @@ import (
 )
 
 // assignmentTestCmd is the `gh teacher assignment test` command group: add /
-// list / remove declarative tests on an assignment's `tests` block (graded by
-// runner.py, no autograder.py needed). Mutually exclusive with a per-assignment
-// autograder.py — see ensureNoPerAssignmentAutograder.
+// set / list / remove declarative tests on an assignment's `tests` block
+// (graded by runner.py, no autograder.py needed). Mutually exclusive with a
+// per-assignment autograder.py — see ensureNoPerAssignmentAutograder.
 func assignmentTestCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test",
-		Short: "Add, list, or remove declarative tests on an assignment",
+		Short: "Add, set, list, or remove declarative tests on an assignment",
 		Long: "Manage the declarative `tests` block on an assignment in\n" +
 			"<org>/classroom50/<classroom>/assignments.json.\n\n" +
 			"Each test is one of three types, mirroring GitHub Classroom's\n" +
@@ -35,14 +35,19 @@ func assignmentTestCmd() *cobra.Command {
 			"Describe tests here instead of writing an autograder script. Tests\n" +
 			"are stored on the assignment; the Publish Pages workflow generates\n" +
 			"the bundled tests.json from them, so never commit a tests.json under\n" +
-			"<classroom>/autograders/<slug>/ (that directory is for fixtures and\n" +
-			"grading scripts). See the Autograding-Basics wiki page for the\n" +
-			"field reference.\n\n" +
-			"For bulk edits (or a GUI/agent export), `gh teacher assignment\n" +
-			"add <org> <classroom> <slug> --tests <file.json>` sets the whole\n" +
-			"array at once; these subcommands edit one test at a time.",
+			"<classroom>/autograders/<slug>/. That directory is for the files\n" +
+			"tests read (fixtures and grading scripts), reached through\n" +
+			"$CLASSROOM50_BUNDLE_DIR; nothing in it is copied into the student\n" +
+			"checkout. See the Autograding-Basics wiki page for the field\n" +
+			"reference.\n\n" +
+			"`add` and `remove` edit one test at a time. `set` replaces the whole\n" +
+			"list from a file you keep outside the classroom50 repository: a bare\n" +
+			"JSON array (what `list --json` prints) or the generated tests.json\n" +
+			"envelope. `gh teacher assignment add --tests` takes the same file\n" +
+			"when creating an assignment.",
 	}
 	cmd.AddCommand(assignmentTestAddCmd())
+	cmd.AddCommand(assignmentTestSetCmd())
 	cmd.AddCommand(assignmentTestListCmd())
 	cmd.AddCommand(assignmentTestRemoveCmd())
 	return cmd
@@ -75,7 +80,8 @@ func assignmentTestAddCmd() *cobra.Command {
 			"Types:\n" +
 			"  - io: feed --input (or --input-file) on stdin, compare the\n" +
 			"    command's stdout against --expected (or --expected-file)\n" +
-			"    using --comparison (included | exact | regex).\n" +
+			"    using --comparison (included | exact | regex; required, no\n" +
+			"    default).\n" +
 			"  - run: pass only when the command's exit code matches\n" +
 			"    --exit-code (default 0).\n" +
 			"  - python: run pytest; points are split across discovered cases\n" +
@@ -84,8 +90,10 @@ func assignmentTestAddCmd() *cobra.Command {
 			"has committed alongside the assignment at\n" +
 			"<classroom>/autograders/<slug>/ in the classroom50 repository; it\n" +
 			"is bundled and read at grade time. Commands run in the student\n" +
-			"checkout; $CLASSROOM50_BUNDLE_DIR points at that directory, so a\n" +
-			"grading script can stay out of the template students receive.\n\n" +
+			"checkout, and bundled files are not copied there:\n" +
+			"$CLASSROOM50_BUNDLE_DIR points at the bundle, so a grading script\n" +
+			"stays out of the template students receive and is run as\n" +
+			"`bash \"$CLASSROOM50_BUNDLE_DIR/check.sh\"`.\n\n" +
 			"Fails if the assignment slug isn't registered yet, or if the\n" +
 			"assignment already has a hand-written per-assignment autograder\n" +
 			"(the two are mutually exclusive).",
@@ -159,7 +167,7 @@ func assignmentTestAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "io only: bundled fixture file fed on stdin")
 	cmd.Flags().StringVar(&expected, "expected", "", "io only: inline expected stdout")
 	cmd.Flags().StringVar(&expectedFile, "expected-file", "", "io only: bundled fixture file holding expected stdout")
-	cmd.Flags().StringVar(&comparison, "comparison", "", "io only: included | exact | regex")
+	cmd.Flags().StringVar(&comparison, "comparison", "", "io only, required: included | exact | regex")
 	cmd.Flags().IntVar(&timeout, "timeout", 0, "Seconds before the test fails (0 = default of 10s)")
 	cmd.Flags().IntVar(&exitCode, "exit-code", 0, "run only: required exit code (default 0); pass to require a specific code")
 	cmd.Flags().IntVar(&points, "points", 0, "Points the test is worth")
@@ -220,6 +228,125 @@ func runAssignmentTestAdd(client githubapi.Client, out io.Writer, org, classroom
 	}
 	_, _ = fmt.Fprintf(out, "%s/%s/%s: %s test %q on %s (type %s, %d pts)\n",
 		org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), action, spec.Name, slug, spec.Type, spec.Points)
+	return nil
+}
+
+func assignmentTestSetCmd() *cobra.Command {
+	var testsFile string
+	cmd := &cobra.Command{
+		Use:   "set <org> <classroom> <slug>",
+		Short: "Replace all declarative tests on an assignment from a file",
+		Long: "Replace the assignment's `tests` block with the contents of --tests,\n" +
+			"leaving every other field of the assignment as it is. Use it to keep\n" +
+			"tests in a file outside the classroom50 repository and sync them, or\n" +
+			"to restore tests that `assignment add` dropped.\n\n" +
+			"--tests accepts two shapes, the same as `gh teacher assignment add\n" +
+			"--tests`:\n" +
+			"  - A bare JSON array of tests, as `assignment test list --json`\n" +
+			"    prints. The assignment's `test_defaults` are left unchanged.\n" +
+			"  - The generated tests.json envelope ({\"schema\":\n" +
+			"    \"classroom50/tests/v1\", \"tests\": [...], \"defaults\": {...}}).\n" +
+			"    `test_defaults` is set from `defaults`, or cleared when absent.\n\n" +
+			"An empty array removes every test. Fails if the assignment slug\n" +
+			"isn't registered yet, or if the assignment has a hand-written\n" +
+			"per-assignment autograder (the two are mutually exclusive).",
+		Example: "  gh teacher assignment test set cs50-fall-2026 cs-principles hello --tests hello-tests.json\n" +
+			"  gh teacher assignment test list cs50-fall-2026 cs-principles hello --json > hello-tests.json\n" +
+			"  cat hello-tests.json | gh teacher assignment test set cs50-fall-2026 cs-principles hello --tests -",
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			org := strings.TrimSpace(args[0])
+			classroom := strings.TrimSpace(args[1])
+			slug := strings.TrimSpace(args[2])
+			if org == "" || classroom == "" || slug == "" {
+				return errors.New("org, classroom, and slug must all be non-empty")
+			}
+			if err := validate.ShortName(classroom, "classroom"); err != nil {
+				return err
+			}
+			if err := validate.ShortName(slug, "slug"); err != nil {
+				return err
+			}
+			parsed, err := assignment.ParseTestsFile(strings.TrimSpace(testsFile))
+			if err != nil {
+				return err
+			}
+			if parsed == nil {
+				return errors.New("--tests is required: a JSON file of test specs, or `-` for stdin")
+			}
+			client, err := githubapi.RequireAuthClient(cmd)
+			if err != nil {
+				return err
+			}
+			return runAssignmentTestSet(client, cmd.OutOrStdout(), org, classroom, slug, parsed)
+		},
+	}
+	cmd.Flags().StringVar(&testsFile, "tests", "", "Path to a JSON file of test specs (bare array or generated tests.json envelope), or `-` to read from stdin (required)")
+	return cmd
+}
+
+// runAssignmentTestSet replaces an existing entry's tests wholesale. Unlike
+// `assignment add`, only `tests` (and, for an envelope, `test_defaults`) change,
+// so a scripted sync can't drop the template, allowlist, or other fields.
+func runAssignmentTestSet(client githubapi.Client, out io.Writer, org, classroom, slug string, parsed *assignment.TestsFile) error {
+	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
+	if err != nil {
+		return err
+	}
+
+	build := func(parentSHA string) (map[string]string, error) {
+		if len(parsed.Tests) > 0 {
+			if err := ensureDeclarativeTestsSupported(client, org, parentSHA); err != nil {
+				return nil, err
+			}
+			if err := ensureNoPerAssignmentAutograder(client, org, classroom, slug, parentSHA); err != nil {
+				return nil, err
+			}
+		}
+		file, err := loadAssignments(client, org, classroom, parentSHA)
+		if err != nil {
+			return nil, err
+		}
+		idx, ok := assignment.FindAssignment(file.Assignments, slug)
+		if !ok {
+			return nil, fmt.Errorf("assignment %q is not registered in %s/%s/%s: run `gh teacher assignment add %s %s %s ...` first",
+				slug, org, configrepo.ConfigRepoName, assignmentsFilePath(classroom), org, classroom, slug)
+		}
+		entry := file.Assignments[idx]
+		entry.Tests = parsed.Tests
+		if len(entry.Tests) == 0 {
+			entry.Tests = nil
+		}
+		// A bare array says nothing about defaults, so keep them; an envelope
+		// is the whole picture, so its (possibly absent) defaults win.
+		if parsed.Envelope {
+			entry.TestDefaults = parsed.Defaults
+		}
+		if err := assignment.ValidateAssignmentEntry(entry); err != nil {
+			return nil, err
+		}
+		file.Assignments[idx] = entry
+		data, err := assignment.EncodeAssignments(file)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]string{assignmentsFilePath(classroom): string(data)}, nil
+	}
+
+	message := contract.PrefixCommit(fmt.Sprintf("assignment: set %d test(s) on %s/%s (gh teacher assignment test set)", len(parsed.Tests), classroom, slug))
+	if _, err := configwrite.CommitTree(client, org, configrepo.ConfigRepoName, branch, message, build); err != nil {
+		return err
+	}
+	path := fmt.Sprintf("%s/%s/%s", org, configrepo.ConfigRepoName, assignmentsFilePath(classroom))
+	switch len(parsed.Tests) {
+	case 0:
+		_, _ = fmt.Fprintf(out, "%s: removed all tests from %s\n", path, slug)
+	case 1:
+		_, _ = fmt.Fprintf(out, "%s: set 1 test on %s\n", path, slug)
+	default:
+		_, _ = fmt.Fprintf(out, "%s: set %d tests on %s\n", path, len(parsed.Tests), slug)
+	}
 	return nil
 }
 

--- a/cli/gh-teacher/internal/assignmentcmd/test_cmd_test.go
+++ b/cli/gh-teacher/internal/assignmentcmd/test_cmd_test.go
@@ -973,6 +973,147 @@ func TestRunAssignmentAdd_ExplicitEmptyTestsClearsSilently(t *testing.T) {
 	}
 }
 
+func TestRunAssignmentAdd_EnvelopeDefaultsPersist(t *testing.T) {
+	server, fix := newTestCmdServer(t, helloAssignments(""), false)
+	client := githubtest.NewTestClient(t, server)
+
+	var stdout, stderr bytes.Buffer
+	p := helloAddParams()
+	p.Tests = []assignment.TestSpec{{Name: "compiles", Type: "run", Run: "true", Points: 1}}
+	p.TestDefaults = &assignment.TestDefaults{FailureDetails: "none"}
+	if err := runAssignmentAdd(client, &stdout, &stderr, p); err != nil {
+		t.Fatalf("runAssignmentAdd: %v", err)
+	}
+	entry := decodeCommitted(t, fix).Assignments[0]
+	if entry.TestDefaults == nil || entry.TestDefaults.FailureDetails != "none" {
+		t.Errorf("test_defaults from the --tests envelope not persisted: %#v", entry.TestDefaults)
+	}
+}
+
+// helloAssignmentsWithDefaults is helloAssignments plus a test_defaults block,
+// for the `test set` keep-vs-replace checks.
+func helloAssignmentsWithDefaults(testsJSON string) string {
+	body := helloAssignments(testsJSON)
+	return strings.Replace(body, `"autograder": "default"`, `"autograder": "default",
+      "test_defaults": { "failure-details": "actual-only" }`, 1)
+}
+
+func TestRunAssignmentTestSet_ReplacesListKeepsEntry(t *testing.T) {
+	existing := `[{"name":"old","type":"run","run":"false","points":1}]`
+	server, fix := newTestCmdServer(t, helloAssignmentsWithDefaults(existing), false)
+	client := githubtest.NewTestClient(t, server)
+
+	var stdout bytes.Buffer
+	parsed := &assignment.TestsFile{Tests: []assignment.TestSpec{
+		{Name: "compiles", Type: "run", Run: "gcc -o hello hello.c", Points: 1},
+		{Name: "prints", Type: "io", Run: "./hello", Expected: "hi", Comparison: "included", Points: 2},
+	}}
+	if err := runAssignmentTestSet(client, &stdout, "o", "cs-principles", "hello", parsed); err != nil {
+		t.Fatalf("runAssignmentTestSet: %v", err)
+	}
+
+	entry := decodeCommitted(t, fix).Assignments[0]
+	if len(entry.Tests) != 2 || entry.Tests[0].Name != "compiles" || entry.Tests[1].Name != "prints" {
+		t.Errorf("committed tests = %#v, want the two new specs", entry.Tests)
+	}
+	// Unlike `assignment add`, the rest of the entry must survive untouched.
+	if entry.Template == nil || entry.Template.Repo != "hello-template" || entry.Name != "Hello" {
+		t.Errorf("test set must not touch other fields, got %#v", entry)
+	}
+	if entry.TestDefaults == nil || entry.TestDefaults.FailureDetails != "actual-only" {
+		t.Errorf("a bare array must keep test_defaults, got %#v", entry.TestDefaults)
+	}
+	if !strings.Contains(stdout.String(), "set 2 tests on hello") {
+		t.Errorf("stdout = %q, want set confirmation", stdout.String())
+	}
+}
+
+func TestRunAssignmentTestSet_EnvelopeReplacesDefaults(t *testing.T) {
+	existing := `[{"name":"old","type":"run","run":"false","points":1}]`
+	server, fix := newTestCmdServer(t, helloAssignmentsWithDefaults(existing), false)
+	client := githubtest.NewTestClient(t, server)
+
+	var stdout bytes.Buffer
+	parsed := &assignment.TestsFile{
+		Tests:    []assignment.TestSpec{{Name: "compiles", Type: "run", Run: "true", Points: 1}},
+		Defaults: &assignment.TestDefaults{FailureDetails: "none"},
+		Envelope: true,
+	}
+	if err := runAssignmentTestSet(client, &stdout, "o", "cs-principles", "hello", parsed); err != nil {
+		t.Fatalf("runAssignmentTestSet: %v", err)
+	}
+	entry := decodeCommitted(t, fix).Assignments[0]
+	if entry.TestDefaults == nil || entry.TestDefaults.FailureDetails != "none" {
+		t.Errorf("envelope defaults should replace test_defaults, got %#v", entry.TestDefaults)
+	}
+
+	// An envelope without defaults clears them: it is the whole picture.
+	server2, fix2 := newTestCmdServer(t, helloAssignmentsWithDefaults(existing), false)
+	client2 := githubtest.NewTestClient(t, server2)
+	parsed.Defaults = nil
+	if err := runAssignmentTestSet(client2, &stdout, "o", "cs-principles", "hello", parsed); err != nil {
+		t.Fatalf("runAssignmentTestSet (no defaults): %v", err)
+	}
+	if got := decodeCommitted(t, fix2).Assignments[0].TestDefaults; got != nil {
+		t.Errorf("envelope without defaults should clear test_defaults, got %#v", got)
+	}
+}
+
+func TestRunAssignmentTestSet_EmptyArrayClears(t *testing.T) {
+	existing := `[{"name":"old","type":"run","run":"false","points":1}]`
+	server, fix := newTestCmdServer(t, helloAssignments(existing), true)
+	client := githubtest.NewTestClient(t, server)
+
+	// autograderExists=true: clearing must not trip the mutual-exclusion
+	// probe, since removing tests is exactly how a teacher moves to
+	// autograder.py.
+	var stdout bytes.Buffer
+	if err := runAssignmentTestSet(client, &stdout, "o", "cs-principles", "hello", &assignment.TestsFile{Tests: []assignment.TestSpec{}}); err != nil {
+		t.Fatalf("runAssignmentTestSet: %v", err)
+	}
+	if got := decodeCommitted(t, fix).Assignments[0].Tests; len(got) != 0 {
+		t.Errorf("empty array should clear tests, got %#v", got)
+	}
+	if !strings.Contains(stdout.String(), "removed all tests from hello") {
+		t.Errorf("stdout = %q, want removed confirmation", stdout.String())
+	}
+}
+
+func TestRunAssignmentTestSet_RejectsExistingAutograder(t *testing.T) {
+	server, fix := newTestCmdServer(t, helloAssignments(""), true)
+	client := githubtest.NewTestClient(t, server)
+
+	var stdout bytes.Buffer
+	parsed := &assignment.TestsFile{Tests: []assignment.TestSpec{{Name: "compiles", Type: "run", Run: "true", Points: 1}}}
+	err := runAssignmentTestSet(client, &stdout, "o", "cs-principles", "hello", parsed)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected mutual-exclusion error, got %v", err)
+	}
+	fix.mu.Lock()
+	if fix.committed != nil || fix.refPatched {
+		t.Error("conflict must not land a commit")
+	}
+	fix.mu.Unlock()
+}
+
+func TestRunAssignmentTestSet_UnregisteredSlugFails(t *testing.T) {
+	empty := `{"schema":"classroom50/assignments/v1","assignments":[]}`
+	server, fix := newTestCmdServer(t, empty, false)
+	client := githubtest.NewTestClient(t, server)
+
+	var stdout bytes.Buffer
+	parsed := &assignment.TestsFile{Tests: []assignment.TestSpec{{Name: "compiles", Type: "run", Run: "true", Points: 1}}}
+	err := runAssignmentTestSet(client, &stdout, "o", "cs-principles", "hello", parsed)
+	if err == nil || !strings.Contains(err.Error(), "not registered") {
+		t.Fatalf("expected unregistered-slug error, got %v", err)
+	}
+	fix.mu.Lock()
+	if fix.committed != nil {
+		t.Error("unregistered slug must not land a commit")
+	}
+	fix.mu.Unlock()
+}
+
 func TestRunAssignmentTestRemove_HappyPath(t *testing.T) {
 	existing := `[
     {"name":"compiles","type":"run","run":"gcc -o hello hello.c","points":1},

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/materialize_tests.py
@@ -78,7 +78,8 @@ def materialize(root: pathlib.Path) -> int:
                 print(f"::warning::{target}: replaced by the tests stored on the "
                       f"assignment. tests.json is generated at publish time; remove "
                       f"the committed copy and manage tests with the web assignment "
-                      f"form or `gh teacher assignment test add`.")
+                      f"form, `gh teacher assignment test add`, or "
+                      f"`gh teacher assignment test set --tests FILE`.")
             payload = {"schema": TESTS_SCHEMA_V1, "tests": tests}
             # Assignment-level defaults for the per-test reporting options
             # (failure-details / show-output) ride the envelope; runner.py's

--- a/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
+++ b/cli/gh-teacher/skeleton/dotgithub/scripts/runner.py
@@ -1954,7 +1954,8 @@ HAND_WRITTEN_TESTS_HINT = (
     "Declarative tests are stored on the assignment and tests.json is generated "
     "from them when the classroom50 repository publishes. Remove the tests.json "
     "you committed under CLASSROOM/autograders/ASSIGNMENT/ and add the tests "
-    "with the web assignment form or `gh teacher assignment test add` instead.")
+    "with the web assignment form, `gh teacher assignment test add`, or "
+    "`gh teacher assignment test set --tests FILE` with that same file instead.")
 
 
 def load_tests(path: pathlib.Path) -> list[dict[str, Any]]:

--- a/cli/gh-teacher/skeleton_tests/test_materialize_tests.py
+++ b/cli/gh-teacher/skeleton_tests/test_materialize_tests.py
@@ -99,6 +99,7 @@ class TestMaterialize:
         assert "::warning::" in out
         assert "replaced by the tests stored on the assignment" in out
         assert "gh teacher assignment test add" in out
+        assert "gh teacher assignment test set --tests" in out
 
     def test_rejects_traversal_slug(self, tmp_path):
         # A hand-edited manifest with a path-traversal slug must not escape

--- a/wiki/Advanced-Autograding.md
+++ b/wiki/Advanced-Autograding.md
@@ -22,8 +22,8 @@ two scopes:
 
 Declarative tests sit between the two: the **Publish Pages** workflow generates
 them into the bundle as `CLASSROOM/autograders/ASSIGNMENT/tests.json`. You
-never create or commit that file. See
-[Where tests live](Autograding-Basics#where-tests-live).
+never create or commit that file; it is not the file you pass to the CLI's
+`--tests` flag. See [Where tests live](Autograding-Basics#where-tests-live).
 
 If none of the three exist, the runner emits a vacuous pass (score 0/0) and the
 submission still lands as a tagged Release, a valid mid-setup state.
@@ -39,7 +39,8 @@ The runner resolves the grading entrypoint in this order:
 4. None of the above: vacuous pass.
 
 To keep precedence from silently swallowing tests, the CLI refuses `assignment
-test add` / `--tests` while a per-assignment `autograder.py` exists.
+test add` / `assignment test set` / `--tests` while a per-assignment
+`autograder.py` exists.
 
 ### Contract
 

--- a/wiki/Autograding-Basics.md
+++ b/wiki/Autograding-Basics.md
@@ -96,11 +96,13 @@ gh teacher assignment test list cs50-fall-2026 cs-principles hello
 gh teacher assignment test remove cs50-fall-2026 cs-principles hello compiles
 ```
 
-To set the whole list at once, pass a file to `gh teacher assignment add ...
---tests hello-tests.json` (`--tests -` reads stdin). The file is a bare JSON
-array, the same shape `assignment test list --json` emits. Keep it anywhere
-outside the `classroom50` repository; the CLI copies its contents into the
-assignment.
+To set the whole list at once, pass a file with `gh teacher assignment test set
+... --tests hello-tests.json` (`--tests -` reads stdin). `gh teacher assignment
+add --tests` takes the same file when creating an assignment. Keep the file
+anywhere outside the `classroom50` repository; the CLI copies its contents into
+the assignment. The file is a bare JSON array, the same shape `assignment test
+list --json` prints, so `list --json > hello-tests.json` exports and `test set
+--tests hello-tests.json` imports:
 
 ```json
 [
@@ -114,13 +116,25 @@ assignment.
 ]
 ```
 
+`--tests` also accepts the generated `tests.json` envelope described next, so a
+copy of that file works as input too. With an envelope, `test set` also
+replaces the assignment's report defaults from its `defaults` block (clearing
+them when the block is absent); with a bare array it leaves them alone.
+
 #### Where tests live
 
-You never write a `tests.json` yourself. When you push to the `classroom50`
-repository, the **Publish Pages** workflow reads each assignment's tests and
-generates `CLASSROOM/autograders/ASSIGNMENT/tests.json` inside the published
-bundle, wrapped in an envelope (`schema`, `tests`, and optional `defaults`)
-that the runner checks at grade time.
+Two different files are easy to confuse:
+
+| File | Where | Shape | Who writes it |
+|---|---|---|---|
+| The `--tests` file (`hello-tests.json` above) | Anywhere outside the `classroom50` repository | A bare JSON array of tests | You |
+| `CLASSROOM/autograders/ASSIGNMENT/tests.json` | Inside the published Pages bundle | An envelope: `schema`, `tests`, and optional `defaults` | The **Publish Pages** workflow |
+
+Tests are stored on the assignment (its entry in `assignments.json`). When you
+push to the `classroom50` repository, the **Publish Pages** workflow reads each
+assignment's tests and generates the bundled `tests.json` from them, and the
+runner checks that envelope at grade time. You never write the bundled file
+yourself.
 
 Don't commit a `tests.json` to `CLASSROOM/autograders/ASSIGNMENT/` in the
 `classroom50` repository:
@@ -132,10 +146,12 @@ Don't commit a `tests.json` to `CLASSROOM/autograders/ASSIGNMENT/` in the
   [Troubleshooting](Troubleshooting#testsjson-is-a-bare-test-array-or-testsjson-is-not-a-json-object-in-the-grading-log).
 
 That directory is for the files tests read: fixtures for `input-file` and
-`expected-file`, and grading scripts students must not see. See
-[Teacher-only test files](#teacher-only-test-files). In paths and commands on
-this page, replace `CLASSROOM` with the classroom's short name and `ASSIGNMENT`
-with the assignment slug.
+`expected-file`, and grading scripts students must not see. Nothing in it is
+copied into the student's checkout; a `setup` or `run` command reaches a
+script there as `"$CLASSROOM50_BUNDLE_DIR/check.sh"`, never as `./check.sh`.
+See [Teacher-only test files](#teacher-only-test-files). In paths and commands
+on this page, replace `CLASSROOM` with the classroom's short name and
+`ASSIGNMENT` with the assignment slug.
 
 #### Test types
 
@@ -155,11 +171,11 @@ with the assignment slug.
 |---|---|
 | `name` | Required. Unique within the assignment; at most 100 UTF-8 bytes; no control characters. |
 | `type` | Required. `io`, `run`, or `python`. |
-| `run` | Required. Shell command, run in the student checkout. `$CLASSROOM50_BUNDLE_DIR` points at the assignment's bundle; see [Teacher-only test files](#teacher-only-test-files). |
+| `run` | Required. Shell command, run in the student checkout. Bundled files are not copied there; `$CLASSROOM50_BUNDLE_DIR` points at the assignment's bundle, see [Teacher-only test files](#teacher-only-test-files). |
 | `setup` | Optional pre-command (for example, compile). Non-zero exit fails the test. Same working directory and `$CLASSROOM50_BUNDLE_DIR` as `run`. |
 | `input` / `input-file` | `io` only, mutually exclusive. Inline stdin or a bundled fixture. |
 | `expected` / `expected-file` | `io` only, mutually exclusive. Must be non-empty for `included`/`regex`. |
-| `comparison` | `io` only. `included` (substring), `exact` (trimmed equality), or `regex` (Python `re.search`, multiline). |
+| `comparison` | `io` only, and required for `io` (no default). `included` (substring), `exact` (trimmed equality), or `regex` (Python `re.search`, multiline). The web form preselects `included`. |
 | `timeout` | Seconds, 1 to 600. Omit or 0 for the default of 10s. Applies to `setup` and `run` separately. |
 | `exit-code` | `run` only, 0 to 255. Omit to require 0. |
 | `points` | Required, 0 to 1000. A 0-point test does not affect the numeric score; a failure still sets the autograde status to `failure`. |
@@ -284,8 +300,11 @@ copy on every grading run, so nothing a student changes in their repository
 affects it.
 
 Every `setup` and `run` command receives the bundle's absolute path in
-`CLASSROOM50_BUNDLE_DIR`. Commands still start in the student checkout, so
-student files stay relative and teacher files go through the variable.
+`CLASSROOM50_BUNDLE_DIR`. Commands still start in the student checkout, and
+nothing from the bundle is copied there, so student files stay relative
+(`python3 add.py`) and teacher files go through the variable
+(`"$CLASSROOM50_BUNDLE_DIR/check.sh"`). A plain `bash check.sh` fails with `No
+such file or directory` because the script is not in the checkout.
 
 The following example grades a Python assignment where students implement
 `add.py` and the checks live in a script students never see. Replace `ORG` with

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -564,7 +564,7 @@ slug is too long.
 | `--team-formation teacher\|student` | Who forms a team assignment's groups: `teacher` (you create the group teams; see [Manage group teams](#manage-group-teams)) or `student` (the first student founds a group with `gh student accept --new-team`). Required with `--mode team`. |
 | `--max-group-size <N>` | Maximum group size (2 to 100). Enforced by Classroom 50 clients when groups form; advisory beyond that. |
 | `--runtime <path>` | JSON describing the autograde environment (`runs-on`, language versions, `apt`, or a `container`). Omit for ubuntu-latest and Python 3.14. See [Advanced Autograding](Advanced-Autograding#the-runtime-block). |
-| `--tests <path>` | JSON array of declarative tests (or `-` for stdin). Sets the whole `tests` block at once; add one test at a time with `assignment test add` instead. Mutually exclusive with a per-assignment `autograder.py`. |
+| `--tests <path>` | Declarative tests as a bare JSON array or the generated `tests.json` envelope (or `-` for stdin). Sets the whole `tests` block at once when creating an assignment; to change only the tests later, use `assignment test set`. Mutually exclusive with a per-assignment `autograder.py`. |
 | `--autograder <name>` | Reserved for swapping the whole reusable workflow (rare). Use `--runtime` for language toolchains. |
 | `--feedback-pr` | One long-lived feedback PR per student repo for inline review. On by default; `--feedback-pr=false` disables. |
 | `--empty-repo` | Truly bare student repos (no README, marker, or autograde workflow) for students who build everything from scratch. Disables autograding and the feedback PR. |
@@ -598,14 +598,17 @@ gh teacher assignment test add cs50-fall-2026 cs-principles hello --name compile
 gh teacher assignment test add cs50-fall-2026 cs-principles hello --name "prints hello" --type io --setup "gcc -o hello hello.c" --run ./hello --expected "Hello, world!" --comparison included --points 2
 gh teacher assignment test list cs50-fall-2026 cs-principles hello
 gh teacher assignment test remove cs50-fall-2026 cs-principles hello compiles
+gh teacher assignment test set cs50-fall-2026 cs-principles hello --tests hello-tests.json   # replace the whole list from a file
 ```
 
 `add` upserts by `--name` and is refused while the assignment has a
-hand-written `autograder.py`. Tests are stored on the assignment and bundled
-into a `tests.json` when Pages publishes, so never commit a `tests.json` under
-`<classroom>/autograders/<slug>/`. For every flag, see
-[`assignment test`](gh-teacher#assignment-test); for the field semantics, see
-[Declarative tests](Autograding-Basics#declarative-tests).
+hand-written `autograder.py`. `set` replaces every test from a file you keep
+outside the `classroom50` repository (a bare JSON array, or the generated
+`tests.json` envelope) and touches nothing else on the assignment. Tests are
+stored on the assignment and bundled into a `tests.json` when Pages publishes,
+so never commit a `tests.json` under `<classroom>/autograders/<slug>/`. For
+every flag, see [`assignment test`](gh-teacher#assignment-test); for the field
+semantics, see [Declarative tests](Autograding-Basics#declarative-tests).
 
 **Manage the classroom default autograder:**
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -800,8 +800,10 @@ there.
 1. Delete `CLASSROOM/autograders/ASSIGNMENT/tests.json` from the `classroom50`
    repository and push.
 2. Add the tests on the assignment instead: the web form's **Autograding
-   tests** section, `gh teacher assignment test add`, or `gh teacher assignment
-   add --tests FILE` with the bare-array file.
+   tests** section, `gh teacher assignment test add` for one test, or
+   `gh teacher assignment test set ORG CLASSROOM ASSIGNMENT --tests FILE` to
+   load the whole list from a file. `--tests` accepts both the bare array and
+   the envelope, so the file you deleted in step 1 works as-is.
 3. Wait for the **Publish Pages** workflow to finish, then submit as a test
    student.
 
@@ -809,6 +811,27 @@ If the assignment already had tests, the publish log also warns
 `replaced by the tests stored on the assignment`: grading works, but delete
 the committed file so the next person doesn't edit it. See
 [Where tests live](Autograding-Basics#where-tests-live).
+
+### `No such file or directory` for a script in `CLASSROOM/autograders/ASSIGNMENT/`
+
+A declarative test's `setup` or `run` command fails with something like
+`bash: check.sh: No such file or directory`, even though `check.sh` is
+committed next to the assignment's fixtures and shows up in the bundle.
+
+Commands run in the student's checkout, and nothing from the bundle is copied
+there. Only `input-file` and `expected-file` are read from the bundle for you;
+every other file is reached through the `CLASSROOM50_BUNDLE_DIR` variable.
+Change the command to go through it:
+
+```sh
+gh teacher assignment test add ORG CLASSROOM ASSIGNMENT \
+    --name "hidden checks" --type run \
+    --run 'bash "$CLASSROOM50_BUNDLE_DIR/check.sh"' --points 5
+```
+
+In the web form, enter `bash "$CLASSROOM50_BUNDLE_DIR/check.sh"` as the **Run
+command**. On a Windows runner, write `%CLASSROOM50_BUNDLE_DIR%` instead. See
+[Teacher-only test files](Autograding-Basics#teacher-only-test-files).
 
 ## Collecting scores and downloading submissions
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -40,7 +40,7 @@ per-step API and git detail; most commands that print progress also accept
 | `assignment submission-mode <org> <classroom> <slug> --tag\|--every-push` | Change when the autograder fires and retrofit existing repos' shims. |
 | `assignment lock <org> <classroom> <slug>` | Lock (or `--unlock`) an assignment against student access. |
 | `assignment feedback-pr <org> <classroom> <assignment>` | Open or repair the feedback PR on every student repo. Flags: `--user`, `-q`. |
-| `assignment test add/list/remove` | Manage an assignment's declarative tests. |
+| `assignment test add/set/list/remove` | Manage an assignment's declarative tests. |
 | `team create <org> <classroom> <assignment>` | Create a group team for a team assignment. Flags: `--name`, `--member` (repeatable). |
 | `team list <org> <classroom> <assignment>` | List a team assignment's group teams, members, and drift. |
 | `team add` / `remove <org> <classroom> <assignment> <team> <username>` | Add or remove a rostered student on a group team. |
@@ -601,7 +601,7 @@ the CLI warns that students with long usernames can't accept it.
 | `--team-formation teacher\|student` | Who forms a team assignment's groups: `teacher` (you create the group teams with [`team create`](#team-create); students not in a group can't accept) or `student` (the first student founds a group with `gh student accept --new-team` and adds teammates). Required with `--mode team`. |
 | `--max-group-size <N>` | Maximum group size (2 to 100). Enforced by Classroom 50 clients when groups form; advisory beyond that (direct GitHub-UI changes can bypass it). |
 | `--runtime <path>` | JSON runtime (`runs-on`, toolchains, `apt`, `container`). See [Advanced Autograding](Advanced-Autograding#the-runtime-block). |
-| `--tests <path>` | JSON array of declarative tests. Mutually exclusive with a per-assignment `autograder.py`. |
+| `--tests <path>` | Declarative tests as a bare JSON array or the generated `tests.json` envelope (`-` for stdin). Mutually exclusive with a per-assignment `autograder.py`. To change only the tests on an existing assignment, use [`assignment test set`](#assignment-test). |
 | `--autograder <name>` | Swap the reusable workflow (rare). Default `default`. |
 | `--feedback-pr` | One review PR per student repo. **On by default**; `--feedback-pr=false` disables. Requires the org prerequisites `gh teacher init` sets up. |
 | `--empty-repo` | Truly bare repos (no README, marker, or shim); autograding and the feedback PR are disabled; changeable on a same-slug re-add (warns; only affects future accepts); mutually exclusive with `--template`, `--tests`, `--feedback-pr`, `--allowed-files`, `--pass-threshold`, `--submission-mode`, and `--submission-tag`. |
@@ -836,6 +836,7 @@ re-running never fixes it.
 
 ```sh
 gh teacher assignment test add <org> <classroom> <slug> --name "<n>" --type {io,run,python} --run "<cmd>" [options]
+gh teacher assignment test set <org> <classroom> <slug> --tests <path>
 gh teacher assignment test list <org> <classroom> <slug> [--json] [-q]
 gh teacher assignment test remove <org> <classroom> <slug> <test-name>
 ```
@@ -843,14 +844,23 @@ gh teacher assignment test remove <org> <classroom> <slug> <test-name>
 Manage the declarative `tests` block: GitHub Classroom-style io/run/python
 checks graded with no `autograder.py`. `add` upserts by `--name`; it's refused
 while a per-assignment `autograder.py` exists, and it fails if the slug isn't
-registered yet. Commands run in the student checkout;
-`$CLASSROOM50_BUNDLE_DIR` points at the teacher-only files in
+registered yet. Commands run in the student checkout, and bundled files are
+not copied there: `$CLASSROOM50_BUNDLE_DIR` points at the teacher-only files in
 `<classroom>/autograders/<slug>/` (see
 [Teacher-only test files](Autograding-Basics#teacher-only-test-files)). See
 [Declarative tests](Autograding-Basics#declarative-tests) for fields and
 semantics and [Report options](Autograding-Basics#report-options) for what
-each failure-details level shows. For bulk edits, use
-`assignment add --tests <file.json>`.
+each failure-details level shows.
+
+**`test set`** replaces the whole test list from `--tests <path>` (`-` for
+stdin) and changes nothing else on the assignment, so it's the command for
+keeping tests in a file outside the `classroom50` repository and syncing them.
+The file is either a bare JSON array (what `test list --json` prints) or the
+generated `tests.json` envelope (`schema`, `tests`, optional `defaults`). A bare
+array leaves the assignment's `test_defaults` alone; an envelope replaces them
+from its `defaults` block, clearing them when the block is absent. An empty
+array removes every test. `assignment add --tests` takes the same file when
+creating an assignment; unlike `test set`, it rewrites the whole entry.
 
 **`test add` flags** (`--name`, `--type`, and `--run` are required):
 
@@ -864,7 +874,7 @@ each failure-details level shows. For bulk edits, use
 | `--timeout <s>` | Seconds before the test fails (`0` = the default of 10 s). |
 | `--input <text>` / `--input-file <name>` | `io` only: inline stdin, or a bundled fixture file fed on stdin. |
 | `--expected <text>` / `--expected-file <name>` | `io` only: inline expected stdout, or a bundled fixture file holding it. |
-| `--comparison included\|exact\|regex` | `io` only: how stdout is compared. |
+| `--comparison included\|exact\|regex` | `io` only, required: how stdout is compared. No default. |
 | `--exit-code <N>` | `run` only: required exit code (default `0`). |
 | `--failure-details full\|actual-only\|none` | How much failure detail students see; omit for the assignment default. |
 | `--show-output` | Include captured setup/run output in the report even when the test passes (`--show-output=false` opts one test out of a `show-output` default). |


### PR DESCRIPTION
Follow-up to the feedback on [discussion #805](https://github.com/foundation50/classroom50/discussions/805) after #834. Each point was checked against the code before changing anything.

## What was wrong

- **The generated `tests.json` envelope was a dead end as `--tests` input.** `gh teacher assignment add --tests` only decoded a bare array, so a teacher who copied the bundle file (the natural thing to do after reading the wiki) got `json: cannot unmarshal object into Go value of type []assignment.TestSpec`. This is the CLI-side mirror of the runner bug #834 fixed.
- **No way to replace an assignment's tests without rewriting the entry.** `assignment add` rebuilds everything from flags (and never carried `test_defaults`), so a scripted "sync tests from a file" loop had to re-pass the template, allowlist, and every other flag or lose them.
- **The wiki never said `comparison` is required.** It has no default anywhere (schema, Go validator, runner); only the web form preselects `included`, which is where the "seems to be include" impression came from.
- **Bundle files are not copied into the checkout**, so `bash test.sh` fails with `No such file or directory` even though `test.sh` is in the bundle. The wiki explained `$CLASSROOM50_BUNDLE_DIR` but only deep in the teacher-only files section.

## Changes

**CLI**

- `ParseTestsFile` accepts both shapes: a bare array, or `{"schema": "classroom50/tests/v1", "tests": [...], "defaults": {...}}`. A wrong schema, missing `tests`, invalid `defaults`, a single test object, or a scalar each get an error naming both accepted shapes.
- New `gh teacher assignment test set <org> <classroom> <slug> --tests <file|->`. Replaces only `tests`; with an envelope it also replaces `test_defaults` from `defaults` (clearing them when absent), with a bare array it leaves them alone. An empty array clears every test and is allowed even when `autograder.py` exists, since that is how you migrate to it. Same skeleton and `autograder.py` guards as `test add` otherwise.
- `assignment add --tests` with an envelope persists `defaults` into `test_defaults`. Its drop-warning now points at `test set` for recovery.
- Help copy: `--comparison` is "io only, required"; the `test` group help says the bundle directory is not copied into the checkout and names both files.
- The runner hint and the materialize warning also offer `test set --tests FILE`, since the file the teacher committed by mistake is now valid input.

**Wiki**

- Autograding Basics: a two-row table contrasting the `--tests` file with the generated bundle `tests.json`; the `comparison` row says required with no default; "nothing in that directory is copied into the checkout, use `$CLASSROOM50_BUNDLE_DIR`" stated in "Where tests live", the `run` field row, and "Teacher-only test files" (with the exact `No such file or directory` symptom).
- Troubleshooting: the existing `tests.json` entry points at `test set`; new entry for the script-not-found symptom.
- gh-teacher, CLI Teacher Guide, Advanced Autograding: `test set` documented and `--tests` descriptions updated.

## Not changed

Hand-editing the `tests` block in `assignments.json` directly is tolerated by the runner but not documented as a supported batch path. Left as is; a docs-only follow-up if we want to bless it.

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run` (0 issues), `gofmt` clean
- `pytest cli/gh-teacher/skeleton_tests` 987 passed, `pytest cli/gh-teacher/autograders_tests` 434 passed, ruff clean
- The parity test pinning the three "don't hand-write tests.json" surfaces still passes
- Smoke-tested the new error paths by hand: envelope now parses through to the API call, a single test object and a missing `--tests` each return the intended message
