### PR TITLE
fix(cli): document and check the tools self-hosted autograde runners need

### DIFF
--- a/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
@@ -1001,17 +1001,10 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends ${{ needs.setup.outputs.apt }}
 
-      # GitHub-hosted images ship all of these, but a self-hosted runner or a
-      # custom container image may not (issue #863: `gh` is the usual gap).
-      # Without this check the job grades fine and then dies in the commit
-      # status / release steps with a bare `gh: command not found`. Runs after
-      # the toolchain steps so a setup-python-provided python3 counts.
-      #
-      # Only tools whose absence already fails the job are fatal here. git is
-      # a warning: actions/checkout falls back to a REST download without it
-      # and runner.py degrades on purpose (no review diff link, timestamps
-      # fall back to now, allowed_files enforcement skipped), so a git-less
-      # runner that grades today keeps grading.
+      # Fail early with a clear message instead of `gh: command not found`
+      # after grading (issue #863). Placed after the toolchain steps so a
+      # setup-python-provided python3 counts. Only tools whose absence already
+      # fails the job are fatal; runner.py degrades on purpose without git.
       - name: Check runner tools
         run: |
           set -euo pipefail

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
@@ -1006,16 +1006,26 @@ jobs:
       # Without this check the job grades fine and then dies in the commit
       # status / release steps with a bare `gh: command not found`. Runs after
       # the toolchain steps so a setup-python-provided python3 counts.
+      #
+      # Only tools whose absence already fails the job are fatal here. git is
+      # a warning: actions/checkout falls back to a REST download without it
+      # and runner.py degrades on purpose (no review diff link, timestamps
+      # fall back to now, allowed_files enforcement skipped), so a git-less
+      # runner that grades today keeps grading.
       - name: Check runner tools
         run: |
           set -euo pipefail
+          WIKI="https://github.com/foundation50/classroom50/wiki/Advanced-Autograding#the-runtime-block"
           MISSING=()
-          for TOOL in git curl python3 gh; do
+          for TOOL in curl python3 gh; do
             command -v "$TOOL" >/dev/null 2>&1 || MISSING+=("$TOOL")
           done
           if (( ${#MISSING[@]} > 0 )); then
-            echo "::error::This runner is missing tools the grade job needs: ${MISSING[*]}. Install them on the self-hosted runner or in the container image, then re-run. See https://github.com/foundation50/classroom50/wiki/Advanced-Autograding#the-runtime-block"
+            echo "::error::This runner is missing tools the grade job needs: ${MISSING[*]}. Install them on the self-hosted runner or in the container image, then re-run. See $WIKI"
             exit 1
+          fi
+          if ! command -v git >/dev/null 2>&1; then
+            echo "::warning::git is not installed on this runner. Grading continues, but allowed_files is not enforced, the review diff link is missing, and submission timestamps fall back to the grading time. Install git to restore them. See $WIKI"
           fi
 
       # === Run runner.py (which execs the autograder) ===

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/autograde-runner.yaml
@@ -1001,6 +1001,23 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends ${{ needs.setup.outputs.apt }}
 
+      # GitHub-hosted images ship all of these, but a self-hosted runner or a
+      # custom container image may not (issue #863: `gh` is the usual gap).
+      # Without this check the job grades fine and then dies in the commit
+      # status / release steps with a bare `gh: command not found`. Runs after
+      # the toolchain steps so a setup-python-provided python3 counts.
+      - name: Check runner tools
+        run: |
+          set -euo pipefail
+          MISSING=()
+          for TOOL in git curl python3 gh; do
+            command -v "$TOOL" >/dev/null 2>&1 || MISSING+=("$TOOL")
+          done
+          if (( ${#MISSING[@]} > 0 )); then
+            echo "::error::This runner is missing tools the grade job needs: ${MISSING[*]}. Install them on the self-hosted runner or in the container image, then re-run. See https://github.com/foundation50/classroom50/wiki/Advanced-Autograding#the-runtime-block"
+            exit 1
+          fi
+
       # === Run runner.py (which execs the autograder) ===
       # runner.py is fetched fresh every run so updates to the
       # runner-side bootstrap propagate without editing this file.

--- a/wiki/Advanced-Autograding.md
+++ b/wiki/Advanced-Autograding.md
@@ -303,12 +303,14 @@ in its image) before pointing an assignment at it:
 
 - `bash`: every grade step runs with `shell: bash`. Present on any Linux or
   macOS host; it matters for minimal container images.
-- `git`: `runner.py` reads the submission's history with it (`actions/checkout`
-  alone falls back to a REST download without `git`, which has no history).
 - `curl`: fetches `runner.py` from your classroom's Pages site.
 - `python3` with `pip`: runs `runner.py`, which installs `pytest` on demand.
 - The [GitHub CLI (`gh`)](https://cli.github.com/): posts the commit status,
   publishes the submission release, and opens the feedback pull request.
+- `git`, strongly recommended: `runner.py` reads the submission's history
+  with it. Grading still runs without it, but `allowed_files` is not
+  enforced, the review diff link is missing, and submission timestamps fall
+  back to the grading time. The grade job warns when it's absent.
 
 `gh` is the one most often missed. It needs no login on the runner: each step
 that calls it sets `GH_TOKEN` to the job's own `GITHUB_TOKEN`. The **Check
@@ -335,9 +337,9 @@ must provide one. If it doesn't, set `python` in the same `runtime` block and
 the `setup-python` action installs it inside the container.
 
 Every grade step runs inside the container, so the image also needs the other
-tools listed under self-hosted runners above: `bash`, `git`, `curl`, and the
-GitHub CLI (`gh`). Base images such as `gcc` or `python` don't include `gh`;
-add it to your Dockerfile.
+tools listed under self-hosted runners above: `bash`, `curl`, the GitHub CLI
+(`gh`), and ideally `git`. Base images such as `gcc` or `python` don't include
+`gh`; add it to your Dockerfile.
 
 </details>
 

--- a/wiki/Advanced-Autograding.md
+++ b/wiki/Advanced-Autograding.md
@@ -296,6 +296,25 @@ those into the runner image; `runner.py` still installs `pytest` /
 `pytest-json-report` on demand. Detection uses `runner.environment`, so keep
 the runner agent (v2.294.0 or later) up to date.
 
+**Self-hosted runners must supply the grading tools too.** GitHub-hosted
+images preinstall them, but the Actions runner agent installs none of them, so
+the runner has only what you put there. Make sure these are on the runner (or
+in its image) before pointing an assignment at it:
+
+- `bash`: every grade step runs with `shell: bash`. Present on any Linux or
+  macOS host; it matters for minimal container images.
+- `git`: `runner.py` reads the submission's history with it (`actions/checkout`
+  alone falls back to a REST download without `git`, which has no history).
+- `curl`: fetches `runner.py` from your classroom's Pages site.
+- `python3` with `pip`: runs `runner.py`, which installs `pytest` on demand.
+- The [GitHub CLI (`gh`)](https://cli.github.com/): posts the commit status,
+  publishes the submission release, and opens the feedback pull request.
+
+`gh` is the one most often missed. It needs no login on the runner: each step
+that calls it sets `GH_TOKEN` to the job's own `GITHUB_TOKEN`. The **Check
+runner tools** step in the grade job fails early and lists everything missing,
+so you can fix the runner in one pass.
+
 </details>
 
 <details>
@@ -314,6 +333,11 @@ error. `image` is required and injection-checked; `user` accepts
 The grade job runs `runner.py` with the container's `python3`, so the image
 must provide one. If it doesn't, set `python` in the same `runtime` block and
 the `setup-python` action installs it inside the container.
+
+Every grade step runs inside the container, so the image also needs the other
+tools listed under self-hosted runners above: `bash`, `git`, `curl`, and the
+GitHub CLI (`gh`). Base images such as `gcc` or `python` don't include `gh`;
+add it to your Dockerfile.
 
 </details>
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -248,7 +248,9 @@ and what each one trades away.
 Yes. Set `runs-on` in the assignment's runtime to your self-hosted labels (for
 example `["self-hosted", "gpu"]`). Self-hosted runners keep their own
 toolchains, so Classroom 50 skips managed toolchain setup on them. Provision
-what your assignments need in the runner image. See
+what your assignments need in the runner image, plus the tools the grade job
+itself calls: `git`, `curl`, `python3`, and the GitHub CLI (`gh`), which
+GitHub-hosted runners preinstall but the runner agent doesn't install. See
 [The `runtime` block](Advanced-Autograding#the-runtime-block).
 
 ### Can the autograder show students *why* a test failed?

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -249,7 +249,7 @@ Yes. Set `runs-on` in the assignment's runtime to your self-hosted labels (for
 example `["self-hosted", "gpu"]`). Self-hosted runners keep their own
 toolchains, so Classroom 50 skips managed toolchain setup on them. Provision
 what your assignments need in the runner image, plus the tools the grade job
-itself calls: `git`, `curl`, `python3`, and the GitHub CLI (`gh`), which
+itself calls: `curl`, `python3`, the GitHub CLI (`gh`), and `git`, which
 GitHub-hosted runners preinstall but the runner agent doesn't install. See
 [The `runtime` block](Advanced-Autograding#the-runtime-block).
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -787,6 +787,17 @@ this used to mean a missing `pytest`; the built-in autograder now installs
   your tests import there. See the
   [Python recipe](Autograder-Recipes#python).
 
+### `gh: command not found` or "Check runner tools" fails on a self-hosted runner
+
+The grade job itself needs a few programs besides your assignment's toolchain:
+`git`, `curl`, `python3`, and the GitHub CLI (`gh`), which posts the commit
+status and publishes the submission release. GitHub-hosted runners preinstall
+all of them; a self-hosted runner or a custom `container` image has only what
+you installed, and `gh` is the usual gap. Install the missing ones on the
+runner and re-run the workflow. The **Check runner tools** step lists
+everything missing at once. See
+[Custom and self-hosted runners](Advanced-Autograding#the-runtime-block).
+
 ### `tests.json is a bare test array` or `tests.json is not a JSON object` in the grading log
 
 Every submission ends as an error, and the **Grade details** step says the

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -790,12 +790,13 @@ this used to mean a missing `pytest`; the built-in autograder now installs
 ### `gh: command not found` or "Check runner tools" fails on a self-hosted runner
 
 The grade job itself needs a few programs besides your assignment's toolchain:
-`git`, `curl`, `python3`, and the GitHub CLI (`gh`), which posts the commit
-status and publishes the submission release. GitHub-hosted runners preinstall
-all of them; a self-hosted runner or a custom `container` image has only what
-you installed, and `gh` is the usual gap. Install the missing ones on the
-runner and re-run the workflow. The **Check runner tools** step lists
-everything missing at once. See
+`curl`, `python3`, and the GitHub CLI (`gh`), which posts the commit status
+and publishes the submission release. GitHub-hosted runners preinstall all of
+them; a self-hosted runner or a custom `container` image has only what you
+installed, and `gh` is the usual gap. Install the missing ones on the runner
+and re-run the workflow. The **Check runner tools** step lists everything
+missing at once, and warns (without failing) when `git` is absent, since
+grading then runs without `allowed_files` enforcement or a review diff link. See
 [Custom and self-hosted runners](Advanced-Autograding#the-runtime-block).
 
 ### `tests.json is a bare test array` or `tests.json is not a JSON object` in the grading log


### PR DESCRIPTION
Grading on a self-hosted runner used to succeed and then die in the commit-status and release steps with a bare `gh: command not found`, because the grade job shells out to `gh`, `curl`, `python3`, and `git` and nothing said so. The wiki now lists those tools (and why each is needed) for self-hosted runners and custom `container` images, and the grade job gets a **Check runner tools** step that fails before grading with one error line naming every missing tool and linking the wiki section.

Fixes #863

## Design decisions

- The check runs unconditionally rather than gated on `runner.environment == 'self-hosted'`, because a custom `container` image on a hosted runner has the same gap (every step runs inside the image, and images like `gcc` or `python` don't include `gh`). On a hosted runner it costs four `command -v` calls.
- It sits after the toolchain steps so a `setup-python`-installed `python3` inside a container counts.
- Only tools whose absence already fails the job are fatal: `curl`, `python3`, `gh`. A missing `git` is a `::warning::`, not a failure. `actions/checkout` falls back to a REST download without git and `runner.py` deliberately degrades at every git call site (no review diff link, timestamps fall back to grading time, `allowed_files` enforcement skipped), so a git-less runner that grades today keeps grading. The warning names what degrades so the teacher can decide. This PR therefore adds no new requirement the **Grade details** step didn't already have.

## Verification

- Every factual claim in the docs was checked against GitHub's contexts reference, the "Running jobs in a container" doc, the Ubuntu 24.04 runner-image manifest, the actions/checkout README, the gh environment manual, and the `gcc` Dockerfile.
- The check step was run locally in three states: all tools present (exit 0), `gh` missing (exit 1 with the `::error::` line), and only `git` missing (exit 0 with the `::warning::` line).
- `go test` for the skeleton/init tests passes; the workflow YAML still parses.
