### PR TITLE
feat(web): complete the WCAG A/AA conformance report (VPAT)

### DIFF
--- a/web/accessibility/README.md
+++ b/web/accessibility/README.md
@@ -6,13 +6,13 @@ source of truth, rendered into several views.
 
 ## The single source
 
-| Piece                  | Where                                        | Role                                                                                                                                                              |
-| ---------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Manual verdicts**    | `accessibility/vpatVerdicts.json` (this dir) | The only hand-edited file: per-criterion human verdicts (`status`, `evidence: "manual"`, `assessed` date, `remark`).                                              |
-| **Base model**         | `src/util/a11y/vpatModel.ts`                 | The applicable WCAG 2.2 A/AA criteria + the overlay logic (`applyVerdicts`). Contrast rows are re-derived from the live audit; automated rows are set by tooling. |
-| **Assessor guidance**  | `src/util/a11y/assessmentGuidance.ts`        | The "how to test each SC" prose the `/assess` tool shows.                                                                                                         |
-| **Report renderer**    | `src/util/a11y/vpatReport.ts`                | Renders the ACR (VPAT 2.5Rev, WCAG edition) and the canonical JSON from the model.                                                                                |
-| **Automated bindings** | `src/util/a11y/vpatAutomated.ts`             | Ties each `automated` verdict to the hermetic check that establishes it.                                                                                          |
+| Piece                  | Where                                        | Role                                                                                                                                                                                                                                                                         |
+| ---------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Manual verdicts**    | `accessibility/vpatVerdicts.json` (this dir) | The only hand-edited file: per-criterion human verdicts (`status`, `evidence: "manual"`, `assessed` date, `remark`).                                                                                                                                                         |
+| **Base model**         | `src/util/a11y/vpatModel.ts`                 | Every WCAG 2.2 A/AA criterion (plus 1.4.6 and 4.1.1) + the overlay logic (`applyVerdicts`). Contrast rows are re-derived from the live audit; automated rows are set by tooling; criteria the product's design rules out are `notApplicable` with an `architectural` reason. |
+| **Assessor guidance**  | `src/util/a11y/assessmentGuidance.ts`        | The "how to test each SC" prose the `/assess` tool shows.                                                                                                                                                                                                                    |
+| **Report renderer**    | `src/util/a11y/vpatReport.ts`                | Renders the ACR (VPAT 2.5Rev, WCAG edition) and the canonical JSON from the model.                                                                                                                                                                                           |
+| **Automated bindings** | `src/util/a11y/vpatAutomated.ts`             | Ties each `automated` verdict to the hermetic check that establishes it.                                                                                                                                                                                                     |
 
 All the a11y model/report code lives under `src/util/a11y/` (a pure leaf layer —
 no app imports); the report generators live under `scripts/a11y/`. The guards
@@ -109,7 +109,15 @@ The live, no-auth report is always at `/accessibility` in the running app.
 ## Report format
 
 The ACR follows **VPAT® 2.5Rev** (the ITI industry-standard template), WCAG
-edition, kept concise: a short preamble (product, date, evaluation methods,
-conformance terms), a one-line summary, and per-principle tables with columns
-**Criterion · Level · Conformance Level · Assessed · Remarks**. The `Assessed`
-column carries each verdict's date so remarks stay focused on the finding.
+edition, kept concise: a short preamble (product, date, applicable standards,
+evaluation methods, conformance terms), a one-line summary, and per-principle
+tables with columns **Criterion · Level · Conformance Level · Assessed ·
+Remarks**. The `Assessed` column carries each verdict's date so remarks stay
+focused on the finding.
+
+The report lists **every** WCAG 2.2 Level A and AA criterion (55), so a
+reviewer can file it against WCAG 2.0, 2.1, or 2.2. Nothing is omitted: a
+criterion the product cannot trigger (captions with no media, motion actuation
+with no sensors) is marked _Not Applicable_ with the reason in its remark, and
+anything else without a verdict shows _Not Evaluated_. `vpatGuard.test.ts`
+pins the count so the list cannot silently shrink.

--- a/web/accessibility/README.md
+++ b/web/accessibility/README.md
@@ -114,8 +114,10 @@ for Authors" mandate: the "[Company] Accessibility Conformance Report" title,
 template version, Name of Product/Version, Report Date, Product Description,
 Contact Information, Notes, Evaluation Methods Used, the Applicable
 Standards/Guidelines table (WCAG 2.0, 2.1, 2.2 at Level A and AA), and the ITI
-term definitions verbatim. The version comes from the build (`release.version`
-in `vite.config.ts`, `npm_package_version` for the local generator).
+term definitions verbatim. The version is the `web-v*` release tag when the
+build has one (`release.tagVersion` in `vite.config.ts`, `VITE_APP_VERSION` for
+the generator); an untagged build names no version rather than borrowing the
+last release's.
 
 The tables use columns **Criteria · Level · Conformance Level · Assessed ·
 Remarks and Explanations**, grouped by WCAG principle (the template allows

--- a/web/accessibility/README.md
+++ b/web/accessibility/README.md
@@ -109,15 +109,30 @@ The live, no-auth report is always at `/accessibility` in the running app.
 ## Report format
 
 The ACR follows **VPAT® 2.5Rev** (the ITI industry-standard template), WCAG
-edition, kept concise: a short preamble (product, date, applicable standards,
-evaluation methods, conformance terms), a one-line summary, and per-principle
-tables with columns **Criterion · Level · Conformance Level · Assessed ·
-Remarks**. The `Assessed` column carries each verdict's date so remarks stay
-focused on the finding.
+edition. The header carries every field the template's "Essential Requirements
+for Authors" mandate: the "[Company] Accessibility Conformance Report" title,
+template version, Name of Product/Version, Report Date, Product Description,
+Contact Information, Notes, Evaluation Methods Used, the Applicable
+Standards/Guidelines table (WCAG 2.0, 2.1, 2.2 at Level A and AA), and the ITI
+term definitions verbatim. The version comes from the build (`release.version`
+in `vite.config.ts`, `npm_package_version` for the local generator).
+
+The tables use columns **Criteria · Level · Conformance Level · Assessed ·
+Remarks and Explanations**, grouped by WCAG principle (the template allows
+combining its per-level tables; numerical order is preserved within each). The
+`Assessed` column carries each verdict's date so remarks stay focused on the
+finding. Criteria added after WCAG 2.0 are marked "(2.1 and 2.2)" or "(2.2
+only)" as in the template, via `since` on the model.
 
 The report lists **every** WCAG 2.2 Level A and AA criterion (55), so a
 reviewer can file it against WCAG 2.0, 2.1, or 2.2. Nothing is omitted: a
 criterion the product cannot trigger (captions with no media, motion actuation
 with no sensors) is marked _Not Applicable_ with the reason in its remark, and
-anything else without a verdict shows _Not Evaluated_. `vpatGuard.test.ts`
-pins the count so the list cannot silently shrink.
+4.1.1 Parsing is answered _Supports_ for 2.0/2.1 as the template instructs.
+`vpatGuard.test.ts` pins the count so the list cannot silently shrink.
+
+**Not Evaluated on A/AA rows is a declared deviation.** ITI reserves that term
+for Level AAA. Until the manual assessment covers every A/AA criterion, the
+renderer adds a Notes bullet listing the pending ids as a deviation from the
+ITI terms (the template requires deviations to be declared there). Recording
+the outstanding verdicts through `/assess` removes the bullet automatically.

--- a/web/accessibility/vpatVerdicts.json
+++ b/web/accessibility/vpatVerdicts.json
@@ -195,7 +195,7 @@
     "status": "supports",
     "evidence": "manual",
     "assessed": "2026-09-05",
-    "remark": "Walked the destructive actions in the browser and cancelled each: Unenroll student opens a confirmation stating exactly what happens ('This will remove student X from the classroom... repositories will not be deleted') with Keep student / Unenroll student choices; Archive classroom opens 'Archive classroom?' with Cancel / Archive. Assignment deletion and other irreversible actions use the shared ConfirmModal, which requires typing the item name for the highest-impact ones. Roster and assignment forms can be reviewed and edited before submit. Every deletion or data change is confirmed before commit."
+    "remark": "Walked the destructive actions in the browser and cancelled each: Unenroll student opens a confirmation stating exactly what happens ('This will remove student X from the classroom... repositories will not be deleted') with Keep student / Unenroll student choices; Archive classroom opens 'Archive classroom?' with Cancel / Archive. Verified in source (not exercised in the browser): assignment deletion, classroom deletion, and group deletion use the shared ConfirmModal with type-to-confirm (the assignment slug, org/classroom slug, or group name), and bulk member removal requires a confirm phrase. Roster and assignment forms can be reviewed and edited before submit. Every deletion or data change is confirmed before commit."
   },
   "3.3.7": {
     "status": "supports",

--- a/web/accessibility/vpatVerdicts.json
+++ b/web/accessibility/vpatVerdicts.json
@@ -17,17 +17,41 @@
     "assessed": "2026-08-05",
     "remark": "guided visual + DOM-order review on the Organizations grid and the assignments table: the DOM/reading order matches the visual order (sidebar -> breadcrumb -> heading -> toolbar -> rows top-to-bottom, each row left-to-right). Card grids read left-then-right in source order; no CSS reordering scrambles the sequence."
   },
+  "1.3.3": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Scanned every instruction, empty state, help text, and alert on the organizations, classrooms, assignments, roster, members, submissions, activity, settings, accept, and assignment-settings pages for shape/size/position/color-only wording (left/right/above/below/the green one). None found: every instruction names its target (e.g. 'Upload roster', 'Refresh roster'). Interactive controls are labeled by name, not by where they sit."
+  },
+  "1.3.4": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Chromium emulation at tablet portrait (768x1024), tablet landscape (1024x768), and phone portrait (390x844) on the organizations, assignments, and student accept pages: the layout reflows in every case (sidebar collapses to a menu, toolbar wraps), no horizontal overflow, main content and headings visible. No orientation lock in CSS, no web-app manifest, and screen.orientation.lock is never called."
+  },
   "1.3.5": {
     "status": "supports",
     "evidence": "manual",
     "assessed": "2026-08-05",
     "remark": "guided review: the app collects almost no information about the user themselves — text inputs capture classroom data (org/assignment/section) or a THIRD party's details (a student's name/username/email on the roster form), for which autocomplete tokens are inappropriate. The user's own identity is delegated to GitHub OAuth/device-code. So 1.3.5 is met by not applying self-autofill where it doesn't belong."
   },
+  "1.4.1": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Reviewed the organizations, classrooms, assignments, roster, members, submissions, and activity pages in grayscale (CSS filter) and via the DOM: every status/role/grade badge carries text ('Enrolled', 'Pending invite', 'Teacher', '10/10'); the active sidebar item has a left bar plus background, not color alone, and is exposed with aria-current=page; form errors are text. Prose links in the org-details panel are green with no underline at rest but gain an underline on hover/focus and sit at about 3.1:1 against body text (G183). No information conveyed by color alone found."
+  },
   "1.4.13": {
     "status": "partially",
     "evidence": "manual",
     "assessed": "2026-08-05",
     "remark": "Manual inspection in Chromium of the tooltips on /accessibility: they are DaisyUI CSS .tooltip on non-focusable <span> elements, so they appear on mouse hover only (not keyboard focus), have no Escape-to-dismiss, and are not hoverable (CSS pseudo-content). They elaborate on already-visible values, so essential info is not lost, but the hover/focus content itself is not dismissible/hoverable/keyboard-reachable per 1.4.13."
+  },
+  "1.4.5": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Enumerated every <img> and CSS background image on ten teacher/student pages: all images are GitHub avatars (decorative alt=\"\" beside the visible name, or named 'X's avatar') and the inline SVG logo. Headings, badges, buttons, and code slugs are real text. No images of text."
   },
   "2.1.1": {
     "status": "partially",
@@ -41,6 +65,18 @@
     "assessed": "2026-08-05",
     "remark": "Manual keyboard test in Chromium of the About modal (native <dialog>): on open, focus moves into the dialog; Tab cycles only among the dialog's controls (focus stays contained across 6 presses); Escape closes it and focus returns to the triggering button. No keyboard trap; escape is always available."
   },
+  "2.2.1": {
+    "status": "partially",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Reviewed the app's time limits. Non-error toasts auto-dismiss after 6 s (DEFAULT_TOAST_MS) with no way to extend, pause, or turn the timer off; error toasts persist until dismissed; the same outcome is reflected in page state, so no data is lost. The only other limit is GitHub's device-code expiry on the login screen, which shows the countdown and lets the user request a new code. No app-side session timeout. Partially: a pause-on-hover/focus or a 'keep notifications until dismissed' setting would meet the criterion."
+  },
+  "2.2.2": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "The only moving content is loading spinners and the skeleton shimmer (progress indicators, exempt as essential) plus sub-second transitions; the activity timeline auto-refreshes only while an operation is in flight (progress of a process the user started) and stops when idle. Verified in Chromium that the shimmer is disabled under prefers-reduced-motion. Note: the in-app 'Interface motion: Off' toggle (data-reduce-motion) does not yet stop the shimmer, only the OS setting does; a follow-up."
+  },
   "2.4.1": {
     "status": "partially",
     "evidence": "manual",
@@ -52,6 +88,12 @@
     "evidence": "manual",
     "assessed": "2026-08-05",
     "remark": "guided visual + layout review: the only sticky element is the left sidebar column (0-240px), which sits beside main content rather than over it, and the top banner is position:static (not floating). No sticky top/bottom bar overlays focus, so a keyboard-focused control is never entirely hidden on the desktop layout."
+  },
+  "2.4.2": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Visited 14 routes (organizations, classrooms, members, activity, org settings, assignments, roster, classroom settings, new assignment, submissions, assignment settings, student accept, settings, accessibility): each sets a descriptive document.title of the form 'Page · Classroom 50' via useDocumentTitle, and it changes on client-side navigation. Titles name the page type but not the specific classroom or assignment; that is acceptable for 2.4.2 and the breadcrumb supplies the context."
   },
   "2.4.3": {
     "status": "supports",
@@ -65,6 +107,12 @@
     "assessed": "2026-08-05",
     "remark": "Manual keyboard + accessibility-tree pass in Chromium on the authenticated Organizations flow: all 33 visible links carry meaningful accessible names (e.g. 'Open', 'Review the service token for <org>'); no bare 'click here'/'link'/empty-name links found. Verified via the a11y tree, not a speaking screen reader."
   },
+  "2.4.5": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Every teacher page is reachable at least two ways: the persistent sidebar navigation on all routes, breadcrumbs on classroom and assignment routes (Classrooms > AP CS Principles > Assignments > Hello world), and card/row links on the organizations, classrooms, and assignments pages. The student accept/submit pages are steps in a process reached from an invite link and are exempt."
+  },
   "2.4.6": {
     "status": "supports",
     "evidence": "manual",
@@ -77,11 +125,47 @@
     "assessed": "2026-08-05",
     "remark": "Manual keyboard pass + screenshots in Chromium on the Organizations flow: tabbing through search, sort, view toggles, action buttons, card links, and open dropdown-menu items shows a visible focus indicator on each (2px solid outline, plus a background change on menu items). Native inputs/selects confirmed visually focus-ringed. Verified on the primary authenticated flow; a full per-route sweep remains."
   },
+  "2.5.1": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "No functionality requires a multipoint or path-based gesture: there are no touch, swipe, or pinch handlers in the source, and the only drag interaction (dropping a file onto the roster/upload dropzones) has a single-tap alternative (click opens the native file picker). Verified in the browser on the roster upload dialog."
+  },
+  "2.5.2": {
+    "status": "partially",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Pointer test in Chromium on classroom card links, the New classroom button, and menu triggers: pressing, dragging off the target, and releasing did not activate them (click fires on the up-event), and no element has an inline mousedown/pointerdown handler. Exception: the shared Combobox (template-repo picker, member link picker) commits the highlighted option on pointerdown, so the choice cannot be aborted by dragging off; the selection can be changed afterwards (undo), which mitigates but does not fully meet the criterion. Moving that handler to click would resolve it."
+  },
   "2.5.3": {
     "status": "partially",
     "evidence": "manual",
     "assessed": "2026-08-05",
     "remark": "Manual accessibility-tree inspection in Chromium: several controls' accessible names do not contain their visible label text — e.g. links whose visible chip reads 'No service token' / 'Expiry not tracked' are named 'Review the service token for <org>', and the account button shows the user's name visually but is named 'Account menu'. This can break voice-control ('click <visible text>')."
+  },
+  "2.5.7": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "The only drag interactions are the file dropzones (roster upload, FileDropzone). Verified on the roster Upload roster dialog: the dropzone is a role=button with tabindex=0 and the text 'Drop a file here, or click to choose'; click and Enter/Space open the native file picker, so dragging is never required. No list reordering or resizing by drag exists."
+  },
+  "3.1.2": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Switched the UI to Simplified Chinese and Arabic via the Language dialog: <html lang> updates to zh-CN/ar and dir to rtl for Arabic; the document title and all UI strings translate. Text-node scan of the classrooms, assignments, roster, and settings pages found no untranslated UI strings, only the product name 'Classroom 50' and the classroom's proper name, which are exempt as names. No mixed-language passages needing a lang attribute."
+  },
+  "3.2.1": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Keyboard pass in Chromium tabbing through every focusable element on the organizations (14), classrooms (43), assignments (25), roster, submissions, and settings pages: focusing a control never navigated, submitted, opened a dialog, or moved focus. Card and row 'More actions' menus become visible when their trigger receives focus (CSS focus-within) while focus stays on the trigger; per WCAG this is not a change of context. (That trigger lacks aria-expanded, tracked under 4.1.2.)"
+  },
+  "3.2.2": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Changed every visible <select> on the classrooms, assignments, roster, and members pages (term, sort, type, due-date, status, section, group-by, classroom filters) and the Active/Archived/All and grid/list toggles: the list updates in place, the URL does not change, and focus stays on the control. The Language dialog's select applies the language immediately, which changes content but not context. No auto-submit on input."
   },
   "3.2.3": {
     "status": "supports",
@@ -94,6 +178,24 @@
     "evidence": "manual",
     "assessed": "2026-08-05",
     "remark": "guided review of repeated actions across flows: same-function components are identified consistently — 'Settings'/'Sign out' are worded identically everywhere, overflow menus follow 'More actions for {name}', row actions follow '{verb} {item}' ('Delete/Lock {assignment}'), and the card links use 'Open {org}' / 'View assignments for {classroom}'. No same-function control is labeled inconsistently."
+  },
+  "3.2.6": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Help mechanisms are the Docs link, About entry, and Accessibility link in the sidebar footer, plus 'Ask a question' and 'Report an issue' in the account menu. Checked 14 routes: they appear in the same relative order on every route that shows the sidebar, including the student accept page."
+  },
+  "3.3.3": {
+    "status": "partially",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Submitted the new-classroom, new-assignment, and add-member forms with missing or invalid input in Chromium. Required-field errors are clear and inline ('Classroom name is required.', 'Assignment name is required.'). The add-member form with an unknown GitHub username shows 'Couldn't add <name>: Not Found', which passes through GitHub's raw error and offers no suggestion (check the spelling, or invite by email instead), and it is not in a live region. Partially until that message suggests a fix."
+  },
+  "3.3.4": {
+    "status": "supports",
+    "evidence": "manual",
+    "assessed": "2026-09-05",
+    "remark": "Walked the destructive actions in the browser and cancelled each: Unenroll student opens a confirmation stating exactly what happens ('This will remove student X from the classroom... repositories will not be deleted') with Keep student / Unenroll student choices; Archive classroom opens 'Archive classroom?' with Cancel / Archive. Assignment deletion and other irreversible actions use the shared ConfirmModal, which requires typing the item name for the highest-impact ones. Roster and assignment forms can be reviewed and edited before submit. Every deletion or data change is confirmed before commit."
   },
   "3.3.7": {
     "status": "supports",

--- a/web/accessibility/vpatVerdicts.json
+++ b/web/accessibility/vpatVerdicts.json
@@ -39,7 +39,7 @@
     "status": "supports",
     "evidence": "manual",
     "assessed": "2026-09-05",
-    "remark": "Reviewed the organizations, classrooms, assignments, roster, members, submissions, and activity pages in grayscale (CSS filter) and via the DOM: every status/role/grade badge carries text ('Enrolled', 'Pending invite', 'Teacher', '10/10'); the active sidebar item has a left bar plus background, not color alone, and is exposed with aria-current=page; form errors are text. Prose links in the org-details panel are green with no underline at rest but gain an underline on hover/focus and sit at about 3.1:1 against body text (G183). No information conveyed by color alone found."
+    "remark": "Reviewed the organizations, classrooms, assignments, roster, members, submissions, and activity pages in grayscale (CSS filter) and via the DOM: every status/role/grade badge carries text ('Enrolled', 'Pending invite', 'Teacher', '10/10'); the active sidebar item has a left bar plus background, not color alone, and is exposed with aria-current=page; form errors are text. Prose links in the org-details panel are green with no underline at rest but gain an underline on hover/focus and measure 3.11:1 against the surrounding body text (rgb(26,127,55) on rgb(31,35,40)), meeting G183's 3:1 floor. No information conveyed by color alone found."
   },
   "1.4.13": {
     "status": "partially",
@@ -75,7 +75,7 @@
     "status": "supports",
     "evidence": "manual",
     "assessed": "2026-09-05",
-    "remark": "The only moving content is loading spinners and the skeleton shimmer (progress indicators, exempt as essential) plus sub-second transitions; the activity timeline auto-refreshes only while an operation is in flight (progress of a process the user started) and stops when idle. Verified in Chromium that the shimmer is disabled under prefers-reduced-motion. Note: the in-app 'Interface motion: Off' toggle (data-reduce-motion) does not yet stop the shimmer, only the OS setting does; a follow-up."
+    "remark": "The only moving content is loading spinners and the skeleton shimmer (progress indicators, exempt as essential) plus sub-second transitions; the activity timeline auto-refreshes only while an operation is in flight (progress of a process the user started) and stops when idle. Verified in Chromium that the shimmer is disabled under prefers-reduced-motion. The in-app 'Interface motion: Off' setting (data-reduce-motion) likewise collapses every animation to a single 0.01 ms iteration, verified in the stylesheet."
   },
   "2.4.1": {
     "status": "partially",

--- a/web/scripts/a11y/genVpatReport.ts
+++ b/web/scripts/a11y/genVpatReport.ts
@@ -21,12 +21,10 @@ const here = path.dirname(fileURLToPath(import.meta.url))
 // scripts/a11y/ -> web/ (two levels up): outputs land at the web root.
 const dir = path.resolve(here, "..", "..")
 
-// Same precedence as vite.config.ts's release info: a `web-v*` release tag in
-// CI, else package.json (npm exposes it to scripts it runs).
+// Tag-derived only, matching vite.config.ts: package.json's version is the last
+// release, not necessarily what this working tree contains.
 const version =
-  (process.env.VITE_APP_VERSION || "").replace(/^web-v/, "") ||
-  process.env.npm_package_version ||
-  undefined
+  (process.env.VITE_APP_VERSION || "").replace(/^web-v/, "") || undefined
 const options = { version }
 
 const outputs: [string, string][] = [

--- a/web/scripts/a11y/genVpatReport.ts
+++ b/web/scripts/a11y/genVpatReport.ts
@@ -21,10 +21,18 @@ const here = path.dirname(fileURLToPath(import.meta.url))
 // scripts/a11y/ -> web/ (two levels up): outputs land at the web root.
 const dir = path.resolve(here, "..", "..")
 
+// Same precedence as vite.config.ts's release info: a `web-v*` release tag in
+// CI, else package.json (npm exposes it to scripts it runs).
+const version =
+  (process.env.VITE_APP_VERSION || "").replace(/^web-v/, "") ||
+  process.env.npm_package_version ||
+  undefined
+const options = { version }
+
 const outputs: [string, string][] = [
-  ["vpat-report.json", renderVpatJson()],
-  ["VPAT.md", renderVpatReport()],
-  ["ACCESSIBILITY-REPORT.md", renderCombinedReport()],
+  ["vpat-report.json", renderVpatJson(undefined, options)],
+  ["VPAT.md", renderVpatReport(undefined, options)],
+  ["ACCESSIBILITY-REPORT.md", renderCombinedReport(undefined, options)],
 ]
 for (const [name, body] of outputs) {
   const outPath = path.join(dir, name)

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -35,6 +35,7 @@
     "print": {
       "reportTitle": "{{vendor}} Accessibility Conformance Report",
       "reportProduct": "WCAG Edition (based on VPAT 2.5Rev). Name of product/version: {{product}}.",
+      "productWithVersion": "{{product}}, version {{version}}",
       "reportMeta": "Standard: {{standard}}, target Level {{target}}. Applicable standards: WCAG {{versions}}, Level A and AA. Report date: {{date}}.",
       "vpatSummary": "Summary ({{total}} criteria): {{supports}} Supports, {{partially}} Partially Supports, {{doesNotSupport}} Does Not Support, {{notApplicable}} Not Applicable, {{notEvaluated}} Not Evaluated.",
       "contrastTitle": "Color contrast audit",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -98,6 +98,7 @@
       "loadError": "Couldn't load the conformance report.",
       "generated": "Report date {{generated}}",
       "principleTabsAria": "WCAG principle",
+      "tabAll": "All",
       "searchPlaceholder": "Search criteria",
       "searchAria": "Search conformance criteria",
       "filterAll": "All statuses",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -33,7 +33,8 @@
       "fullDesc": "The VPAT and the color contrast audit in one document."
     },
     "print": {
-      "reportTitle": "Accessibility Conformance Report: {{product}}",
+      "reportTitle": "{{vendor}} Accessibility Conformance Report",
+      "reportProduct": "WCAG Edition (based on VPAT 2.5Rev). Name of product/version: {{product}}.",
       "reportMeta": "Standard: {{standard}}, target Level {{target}}. Applicable standards: WCAG {{versions}}, Level A and AA. Report date: {{date}}.",
       "vpatSummary": "Summary ({{total}} criteria): {{supports}} Supports, {{partially}} Partially Supports, {{doesNotSupport}} Does Not Support, {{notApplicable}} Not Applicable, {{notEvaluated}} Not Evaluated.",
       "contrastTitle": "Color contrast audit",
@@ -120,6 +121,10 @@
         "doesNotSupport": "Does Not Support",
         "notApplicable": "Not Applicable",
         "notEvaluated": "Not Evaluated"
+      },
+      "since": {
+        "2.1": "WCAG 2.1 and 2.2",
+        "2.2": "WCAG 2.2 only"
       }
     }
   },

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2,7 +2,7 @@
   "accessibility": {
     "title": "Color contrast audit",
     "pageTitle": "Accessibility",
-    "pageSubtitle": "How the Classroom 50 web app conforms to WCAG 2.2 Level AA, checked automatically on every build.",
+    "pageSubtitle": "How the Classroom 50 web app conforms to WCAG 2.0, 2.1, and 2.2 at Level A and AA, with color contrast checked on every build.",
     "nav": {
       "contrast": "Color contrast",
       "vpat": "Conformance",
@@ -13,7 +13,7 @@
       "heading": "Accessibility statement",
       "intro": "We want everyone to be able to use Classroom 50, including people who use a keyboard, a screen reader, or other assistive technology.",
       "targetHeading": "How we measure up",
-      "target": "We aim to meet WCAG 2.2 Level AA. Color contrast is checked on every build; the rest is checked by hand with a keyboard and a screen reader. The conformance report lists where we stand on each criterion.",
+      "target": "We aim to meet WCAG 2.2 Level AA, which also covers the Level A and AA criteria of WCAG 2.0 and 2.1. Color contrast is checked on every build; the rest is checked by hand with a keyboard and a screen reader. The conformance report lists every Level A and AA criterion, including the ones that don't apply to this app and why.",
       "limitationsHeading": "Known limitations",
       "limitations": "A few criteria are marked \"Partially Supports\" in the conformance report, each with a note on what's left to do. We fix these as work lands.",
       "feedbackHeading": "Give us feedback",
@@ -26,7 +26,7 @@
       "markdownAction": "Markdown",
       "pdfAction": "PDF",
       "vpatWcagTitle": "VPAT: WCAG edition",
-      "vpatWcagDesc": "Accessibility Conformance Report against WCAG 2.2 (VPAT 2.5Rev).",
+      "vpatWcagDesc": "Accessibility Conformance Report against WCAG 2.0, 2.1, and 2.2, Level A and AA (VPAT 2.5Rev).",
       "contrastTitle": "Color contrast audit",
       "contrastDesc": "Per-pair contrast ratios for every audited color, both themes.",
       "fullTitle": "Full report",
@@ -34,8 +34,8 @@
     },
     "print": {
       "reportTitle": "Accessibility Conformance Report: {{product}}",
-      "reportMeta": "Standard: WCAG {{standard}}, target Level {{target}}. Report date: {{date}}.",
-      "vpatSummary": "Summary ({{total}} applicable criteria): {{supports}} Supports, {{partially}} Partially Supports, {{doesNotSupport}} Does Not Support, {{notApplicable}} Not Applicable, {{notEvaluated}} Not Evaluated.",
+      "reportMeta": "Standard: {{standard}}, target Level {{target}}. Applicable standards: WCAG {{versions}}, Level A and AA. Report date: {{date}}.",
+      "vpatSummary": "Summary ({{total}} criteria): {{supports}} Supports, {{partially}} Partially Supports, {{doesNotSupport}} Does Not Support, {{notApplicable}} Not Applicable, {{notEvaluated}} Not Evaluated.",
       "contrastTitle": "Color contrast audit",
       "contrastMeta": "Per-pair WCAG contrast ratios for every audited color, both themes. Generated {{date}}.",
       "colColors": "Colors (fg / bg)",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -126,6 +126,12 @@
       "since": {
         "2.1": "WCAG 2.1 and 2.2",
         "2.2": "WCAG 2.2 only"
+      },
+      "principle": {
+        "Perceivable": "Perceivable",
+        "Operable": "Operable",
+        "Understandable": "Understandable",
+        "Robust": "Robust"
       }
     }
   },

--- a/web/src/pages/AssessmentPage.tsx
+++ b/web/src/pages/AssessmentPage.tsx
@@ -47,7 +47,7 @@ const EVIDENCE_LABEL: Record<EvidenceKind, string> = {
   contrast: "Automated (contrast)",
   automated: "Automated",
   manual: "Manual",
-  architectural: "Architectural (N/A)",
+  architectural: "Architectural (from the design)",
 }
 
 // A criterion is manually-owned when it is still notEvaluated with no evidence,

--- a/web/src/pages/AssessmentPage.tsx
+++ b/web/src/pages/AssessmentPage.tsx
@@ -17,6 +17,7 @@ import {
   CONFORMANCE_TONE,
   type Criterion,
   type EvidenceKind,
+  isManuallyOwned,
   type ManualVerdict,
 } from "@/util/a11y/vpatModel"
 import type { Guidance } from "@/util/a11y/assessmentGuidance"
@@ -50,11 +51,7 @@ const EVIDENCE_LABEL: Record<EvidenceKind, string> = {
   architectural: "Architectural (from the design)",
 }
 
-// A criterion is manually-owned when it is still notEvaluated with no evidence,
-// or already carries a recorded manual verdict.
-const isManual = (c: Criterion, verdicts: Record<string, ManualVerdict>) =>
-  (c.status === "notEvaluated" && c.evidence === undefined) ||
-  verdicts[c.id] !== undefined
+const isManual = isManuallyOwned
 
 export default function AssessmentPage() {
   useDocumentTitle("Assessment mode — WCAG 2.2 AA")

--- a/web/src/pages/accessibility/VpatSection.tsx
+++ b/web/src/pages/accessibility/VpatSection.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useId, useMemo, useState } from "react"
+import { useId, useMemo, useState } from "react"
 import { SkeletonRegion } from "@/components/list"
 import { useTranslation } from "react-i18next"
 import {
@@ -72,7 +72,15 @@ function VpatConformanceTable({
     activeTab === "all"
       ? criteria
       : criteria.filter((c) => c.principle === activeTab)
-  const showGroups = activeTab === "all" && groupByPrinciple
+  // One <tbody> per principle in the All view so each heading row is a proper
+  // row-group header (scope="rowgroup"); a single unlabeled group otherwise.
+  const groups: { principle: WcagPrinciple | null; rows: Criterion[] }[] =
+    activeTab === "all" && groupByPrinciple
+      ? PRINCIPLE_ORDER.map((p) => ({
+          principle: p,
+          rows: rows.filter((c) => c.principle === p),
+        })).filter((g) => g.rows.length > 0)
+      : [{ principle: null, rows }]
 
   return (
     <Card shadow={false}>
@@ -94,7 +102,9 @@ function VpatConformanceTable({
               onClick={() => setActiveTab(tab)}
               {...tabProps(index)}
             >
-              {tab === "all" ? t("accessibility.vpat.tabAll") : tab}
+              {tab === "all"
+                ? t("accessibility.vpat.tabAll")
+                : t(`accessibility.vpat.principle.${tab}`)}
               <span
                 className={cx(
                   "text-xs tabular-nums",
@@ -144,22 +154,21 @@ function VpatConformanceTable({
                     </th>
                   </tr>
                 </thead>
-                <tbody>
-                  {rows.map((c, i) => (
-                    <Fragment key={c.id}>
-                      {showGroups &&
-                        (i === 0 || rows[i - 1].principle !== c.principle) && (
-                          <tr className="bg-base-200/50">
-                            <th
-                              scope="colgroup"
-                              colSpan={5}
-                              className="text-xs font-semibold tracking-wide text-base-content/70 uppercase"
-                            >
-                              {c.principle}
-                            </th>
-                          </tr>
-                        )}
-                      <tr>
+                {groups.map((group) => (
+                  <tbody key={group.principle ?? "all"}>
+                    {group.principle && (
+                      <tr className="bg-base-200/50">
+                        <th
+                          scope="rowgroup"
+                          colSpan={5}
+                          className="text-xs font-semibold tracking-wide text-base-content/70 uppercase"
+                        >
+                          {t(`accessibility.vpat.principle.${group.principle}`)}
+                        </th>
+                      </tr>
+                    )}
+                    {group.rows.map((c) => (
+                      <tr key={c.id}>
                         <td className="align-top">
                           <span className="font-mono text-xs text-base-content/60">
                             {c.id}
@@ -190,9 +199,9 @@ function VpatConformanceTable({
                           )}
                         </td>
                       </tr>
-                    </Fragment>
-                  ))}
-                </tbody>
+                    ))}
+                  </tbody>
+                ))}
               </table>
             </div>
           )}

--- a/web/src/pages/accessibility/VpatSection.tsx
+++ b/web/src/pages/accessibility/VpatSection.tsx
@@ -141,6 +141,11 @@ function VpatConformanceTable({
                           {c.id}
                         </span>{" "}
                         {c.name}
+                        {c.since && (
+                          <span className="ms-1 text-xs text-base-content/60">
+                            ({t(`accessibility.vpat.since.${c.since}`)})
+                          </span>
+                        )}
                       </td>
                       <td className="align-top font-mono text-xs">{c.level}</td>
                       <td className="align-top">

--- a/web/src/pages/accessibility/VpatSection.tsx
+++ b/web/src/pages/accessibility/VpatSection.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useState } from "react"
+import { Fragment, useId, useMemo, useState } from "react"
 import { SkeletonRegion } from "@/components/list"
 import { useTranslation } from "react-i18next"
 import {
@@ -27,6 +27,11 @@ import {
 
 type VpatFilter = ConformanceLevel | "all"
 type VpatSort = "criterion" | "status"
+type VpatTab = WcagPrinciple | "all"
+
+// "All" first so the full list is the default view; the per-principle tabs
+// narrow it.
+const TAB_ORDER: VpatTab[] = ["all", ...PRINCIPLE_ORDER]
 
 const STATUS_SORT_WEIGHT: Record<ConformanceLevel, number> = {
   supports: 0,
@@ -39,29 +44,35 @@ const STATUS_SORT_WEIGHT: Record<ConformanceLevel, number> = {
 function VpatConformanceTable({
   criteria,
   generated,
+  groupByPrinciple,
 }: {
   criteria: Criterion[]
   generated: string
+  /** Show principle heading rows in the All view (off when sorted by status). */
+  groupByPrinciple: boolean
 }) {
   const { t } = useTranslation()
-  const [activePrinciple, setActivePrinciple] =
-    useState<WcagPrinciple>("Perceivable")
+  const [activeTab, setActiveTab] = useState<VpatTab>("all")
   const tabsId = useId()
   const tabProps = useRovingTabList(
-    PRINCIPLE_ORDER.length,
-    PRINCIPLE_ORDER.indexOf(activePrinciple),
+    TAB_ORDER.length,
+    TAB_ORDER.indexOf(activeTab),
   )
 
-  // Counts per principle reflect the current search/filter so a tab shows how
-  // many rows it holds (and an emptied tab reads 0 rather than looking broken).
-  const countByPrinciple = useMemo(() => {
-    const counts = {} as Record<WcagPrinciple, number>
+  // Counts per tab reflect the current search/filter so a tab shows how many
+  // rows it holds (and an emptied tab reads 0 rather than looking broken).
+  const countByTab = useMemo(() => {
+    const counts = { all: criteria.length } as Record<VpatTab, number>
     for (const p of PRINCIPLE_ORDER)
       counts[p] = criteria.filter((c) => c.principle === p).length
     return counts
   }, [criteria])
 
-  const rows = criteria.filter((c) => c.principle === activePrinciple)
+  const rows =
+    activeTab === "all"
+      ? criteria
+      : criteria.filter((c) => c.principle === activeTab)
+  const showGroups = activeTab === "all" && groupByPrinciple
 
   return (
     <Card shadow={false}>
@@ -71,28 +82,28 @@ function VpatConformanceTable({
           aria-label={t("accessibility.vpat.principleTabsAria")}
           className="tabs-boxed tabs w-fit"
         >
-          {PRINCIPLE_ORDER.map((principle, index) => (
+          {TAB_ORDER.map((tab, index) => (
             <button
-              key={principle}
+              key={tab}
               type="button"
               role="tab"
-              id={`${tabsId}-tab-${principle}`}
-              aria-selected={principle === activePrinciple}
+              id={`${tabsId}-tab-${tab}`}
+              aria-selected={tab === activeTab}
               aria-controls={`${tabsId}-panel`}
-              className={tabClass(principle === activePrinciple)}
-              onClick={() => setActivePrinciple(principle)}
+              className={tabClass(tab === activeTab)}
+              onClick={() => setActiveTab(tab)}
               {...tabProps(index)}
             >
-              {principle}
+              {tab === "all" ? t("accessibility.vpat.tabAll") : tab}
               <span
                 className={cx(
                   "text-xs tabular-nums",
-                  principle === activePrinciple
+                  tab === activeTab
                     ? "text-primary-content/70"
                     : "text-base-content/50",
                 )}
               >
-                {countByPrinciple[principle]}
+                {countByTab[tab]}
               </span>
             </button>
           ))}
@@ -101,7 +112,7 @@ function VpatConformanceTable({
         <div
           role="tabpanel"
           id={`${tabsId}-panel`}
-          aria-labelledby={`${tabsId}-tab-${activePrinciple}`}
+          aria-labelledby={`${tabsId}-tab-${activeTab}`}
         >
           {rows.length === 0 ? (
             <div className="flex flex-col items-center gap-2 p-8 text-center text-sm text-base-content/60">
@@ -134,36 +145,52 @@ function VpatConformanceTable({
                   </tr>
                 </thead>
                 <tbody>
-                  {rows.map((c) => (
-                    <tr key={c.id}>
-                      <td className="align-top">
-                        <span className="font-mono text-xs text-base-content/60">
-                          {c.id}
-                        </span>{" "}
-                        {c.name}
-                        {c.since && (
-                          <span className="ms-1 text-xs text-base-content/60">
-                            ({t(`accessibility.vpat.since.${c.since}`)})
-                          </span>
+                  {rows.map((c, i) => (
+                    <Fragment key={c.id}>
+                      {showGroups &&
+                        (i === 0 || rows[i - 1].principle !== c.principle) && (
+                          <tr className="bg-base-200/50">
+                            <th
+                              scope="colgroup"
+                              colSpan={5}
+                              className="text-xs font-semibold tracking-wide text-base-content/70 uppercase"
+                            >
+                              {c.principle}
+                            </th>
+                          </tr>
                         )}
-                      </td>
-                      <td className="align-top font-mono text-xs">{c.level}</td>
-                      <td className="align-top">
-                        <Badge tone={CONFORMANCE_TONE[c.status]}>
-                          {t(`accessibility.vpat.status.${c.status}`)}
-                        </Badge>
-                      </td>
-                      <td className="align-top font-mono text-xs whitespace-nowrap text-base-content/60">
-                        {c.assessed ?? generated}
-                      </td>
-                      <td className="align-top text-sm text-base-content/70">
-                        {hasGenericRemark(c) ? (
-                          <span className="text-base-content/40">—</span>
-                        ) : (
-                          c.remark
-                        )}
-                      </td>
-                    </tr>
+                      <tr>
+                        <td className="align-top">
+                          <span className="font-mono text-xs text-base-content/60">
+                            {c.id}
+                          </span>{" "}
+                          {c.name}
+                          {c.since && (
+                            <span className="ms-1 text-xs text-base-content/60">
+                              ({t(`accessibility.vpat.since.${c.since}`)})
+                            </span>
+                          )}
+                        </td>
+                        <td className="align-top font-mono text-xs">
+                          {c.level}
+                        </td>
+                        <td className="align-top">
+                          <Badge tone={CONFORMANCE_TONE[c.status]}>
+                            {t(`accessibility.vpat.status.${c.status}`)}
+                          </Badge>
+                        </td>
+                        <td className="align-top font-mono text-xs whitespace-nowrap text-base-content/60">
+                          {c.assessed ?? generated}
+                        </td>
+                        <td className="align-top text-sm text-base-content/70">
+                          {hasGenericRemark(c) ? (
+                            <span className="text-base-content/40">—</span>
+                          ) : (
+                            c.remark
+                          )}
+                        </td>
+                      </tr>
+                    </Fragment>
                   ))}
                 </tbody>
               </table>
@@ -336,6 +363,7 @@ export function VpatSection() {
           <VpatConformanceTable
             criteria={visibleCriteria}
             generated={vpat.generated}
+            groupByPrinciple={sort === "criterion"}
           />
 
           <p className="text-xs text-base-content/60">

--- a/web/src/pages/accessibility/data.ts
+++ b/web/src/pages/accessibility/data.ts
@@ -40,11 +40,14 @@ export type Vpat = Pick<
   | "summary"
   | "criteria"
   | "standard"
-  | "wcagVersions"
   | "target"
   | "vendor"
   | "version"
->
+> & {
+  // Optional on the read side only: the JSON is an unhashed asset, so a cached
+  // copy from an older deploy may predate the field.
+  wcagVersions?: VpatReportJson["wcagVersions"]
+}
 
 // One shared fetch of the build-emitted vpat-report.json, so the conformance
 // table and the statement's "last reviewed" date read from a single request

--- a/web/src/pages/accessibility/data.ts
+++ b/web/src/pages/accessibility/data.ts
@@ -41,11 +41,11 @@ export type Vpat = Pick<
   | "criteria"
   | "standard"
   | "target"
-  | "vendor"
   | "version"
 > & {
   // Optional on the read side only: the JSON is an unhashed asset, so a cached
-  // copy from an older deploy may predate the field.
+  // copy from an older deploy may predate these fields.
+  vendor?: VpatReportJson["vendor"]
   wcagVersions?: VpatReportJson["wcagVersions"]
 }
 

--- a/web/src/pages/accessibility/data.ts
+++ b/web/src/pages/accessibility/data.ts
@@ -42,6 +42,8 @@ export type Vpat = Pick<
   | "standard"
   | "wcagVersions"
   | "target"
+  | "vendor"
+  | "version"
 >
 
 // One shared fetch of the build-emitted vpat-report.json, so the conformance

--- a/web/src/pages/accessibility/data.ts
+++ b/web/src/pages/accessibility/data.ts
@@ -40,6 +40,7 @@ export type Vpat = Pick<
   | "summary"
   | "criteria"
   | "standard"
+  | "wcagVersions"
   | "target"
 >
 

--- a/web/src/pages/accessibility/reports/PrintableReport.tsx
+++ b/web/src/pages/accessibility/reports/PrintableReport.tsx
@@ -126,6 +126,7 @@ function PrintableVpat({ vpat }: { vpat: Vpat }) {
         {t("accessibility.print.reportMeta", {
           standard: vpat.standard,
           target: vpat.target,
+          versions: vpat.wcagVersions.join(", "),
           date: vpat.generated,
         })}
       </p>

--- a/web/src/pages/accessibility/reports/PrintableReport.tsx
+++ b/web/src/pages/accessibility/reports/PrintableReport.tsx
@@ -121,11 +121,18 @@ function PrintableVpat({ vpat }: { vpat: Vpat }) {
 
   return (
     <section className="report-doc">
-      <h1>{t("accessibility.print.reportTitle", { vendor: vpat.vendor })}</h1>
+      <h1>
+        {t("accessibility.print.reportTitle", {
+          vendor: vpat.vendor ?? vpat.product,
+        })}
+      </h1>
       <p className="report-meta">
         {t("accessibility.print.reportProduct", {
           product: vpat.version
-            ? `${vpat.product}, ${vpat.version}`
+            ? t("accessibility.print.productWithVersion", {
+                product: vpat.product,
+                version: vpat.version,
+              })
             : vpat.product,
         })}
       </p>

--- a/web/src/pages/accessibility/reports/PrintableReport.tsx
+++ b/web/src/pages/accessibility/reports/PrintableReport.tsx
@@ -133,7 +133,7 @@ function PrintableVpat({ vpat }: { vpat: Vpat }) {
         {t("accessibility.print.reportMeta", {
           standard: vpat.standard,
           target: vpat.target,
-          versions: vpat.wcagVersions.join(", "),
+          versions: (vpat.wcagVersions ?? []).join(", "),
           date: vpat.generated,
         })}
       </p>
@@ -150,7 +150,7 @@ function PrintableVpat({ vpat }: { vpat: Vpat }) {
       {PRINCIPLE_ORDER.filter((p) => criteriaByPrinciple[p].length > 0).map(
         (principle) => (
           <div key={principle}>
-            <h2>{principle}</h2>
+            <h2>{t(`accessibility.vpat.principle.${principle}`)}</h2>
             <table>
               <thead>
                 <tr>

--- a/web/src/pages/accessibility/reports/PrintableReport.tsx
+++ b/web/src/pages/accessibility/reports/PrintableReport.tsx
@@ -121,7 +121,14 @@ function PrintableVpat({ vpat }: { vpat: Vpat }) {
 
   return (
     <section className="report-doc">
-      <h1>{t("accessibility.print.reportTitle", { product: vpat.product })}</h1>
+      <h1>{t("accessibility.print.reportTitle", { vendor: vpat.vendor })}</h1>
+      <p className="report-meta">
+        {t("accessibility.print.reportProduct", {
+          product: vpat.version
+            ? `${vpat.product}, ${vpat.version}`
+            : vpat.product,
+        })}
+      </p>
       <p className="report-meta">
         {t("accessibility.print.reportMeta", {
           standard: vpat.standard,
@@ -159,6 +166,12 @@ function PrintableVpat({ vpat }: { vpat: Vpat }) {
                   <tr key={c.id}>
                     <td>
                       <span className="mono report-sub">{c.id}</span> {c.name}
+                      {c.since && (
+                        <span className="report-sub">
+                          {" "}
+                          ({t(`accessibility.vpat.since.${c.since}`)})
+                        </span>
+                      )}
                     </td>
                     <td className="mono">{c.level}</td>
                     <td>{CONFORMANCE_LABEL[c.status]}</td>

--- a/web/src/util/a11y/assessmentGuidance.test.ts
+++ b/web/src/util/a11y/assessmentGuidance.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { ASSESSMENT_GUIDANCE } from "./assessmentGuidance"
+import { CRITERIA } from "./vpatModel"
+
+// Every criterion still awaiting a manual verdict must have assessor guidance,
+// otherwise the /assess tool shows it with no instructions and it silently
+// stays Not Evaluated.
+describe("assessmentGuidance", () => {
+  const guided = new Set(ASSESSMENT_GUIDANCE.map((g) => g.id))
+
+  it("covers every criterion the manual assessment still owns", () => {
+    const outstanding = CRITERIA.filter(
+      (c) => c.status === "notEvaluated" && c.evidence === undefined,
+    ).map((c) => c.id)
+    const missing = outstanding.filter((id) => !guided.has(id))
+    expect(missing).toEqual([])
+  })
+
+  it("only targets criteria that exist in the model", () => {
+    const known = new Set(CRITERIA.map((c) => c.id))
+    expect([...guided].filter((id) => !known.has(id))).toEqual([])
+  })
+
+  it("has a lead-in bullet and no duplicate ids", () => {
+    expect(guided.size).toBe(ASSESSMENT_GUIDANCE.length)
+    for (const g of ASSESSMENT_GUIDANCE) {
+      expect(g.bullets.length, g.id).toBeGreaterThanOrEqual(2)
+      expect(g.bullets[0].label, g.id).toBe("Supports means")
+    }
+  })
+})

--- a/web/src/util/a11y/assessmentGuidance.test.ts
+++ b/web/src/util/a11y/assessmentGuidance.test.ts
@@ -1,20 +1,22 @@
 import { describe, expect, it } from "vitest"
 
 import { ASSESSMENT_GUIDANCE } from "./assessmentGuidance"
-import { CRITERIA } from "./vpatModel"
+import verdicts from "../../../accessibility/vpatVerdicts.json" with { type: "json" }
+import { CRITERIA, isManuallyOwned, type VerdictOverlay } from "./vpatModel"
 
-// Every criterion still awaiting a manual verdict must have assessor guidance,
-// otherwise the /assess tool shows it with no instructions and it silently
-// stays Not Evaluated.
+// Every criterion the manual assessment owns (awaiting a verdict or already
+// carrying one) must have assessor guidance, otherwise the /assess tool shows
+// it with no instructions and a re-assessment has nothing to follow.
 describe("assessmentGuidance", () => {
   const guided = new Set(ASSESSMENT_GUIDANCE.map((g) => g.id))
+  const overlay = verdicts as VerdictOverlay
 
-  it("covers every criterion the manual assessment still owns", () => {
-    const outstanding = CRITERIA.filter(
-      (c) => c.status === "notEvaluated" && c.evidence === undefined,
-    ).map((c) => c.id)
-    const missing = outstanding.filter((id) => !guided.has(id))
-    expect(missing).toEqual([])
+  it("covers every manually-owned criterion", () => {
+    const owned = CRITERIA.filter((c) => isManuallyOwned(c, overlay)).map(
+      (c) => c.id,
+    )
+    expect(owned.length).toBeGreaterThan(0)
+    expect(owned.filter((id) => !guided.has(id))).toEqual([])
   })
 
   it("only targets criteria that exist in the model", () => {

--- a/web/src/util/a11y/assessmentGuidance.ts
+++ b/web/src/util/a11y/assessmentGuidance.ts
@@ -63,6 +63,32 @@ export const ASSESSMENT_GUIDANCE: Guidance[] = [
     ],
   },
   {
+    id: "1.3.3",
+    bullets: [
+      {
+        label: "Supports means",
+        text: 'no instruction relies only on shape, size, position, or sound (e.g. "the button on the right", "the green one").',
+      },
+      {
+        label: "Visual",
+        text: "read every instruction, empty state, and help text on the primary flows; each identifies its target by name, not by where it is or what it looks like.",
+      },
+    ],
+  },
+  {
+    id: "1.3.4",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "content works in both portrait and landscape; nothing locks the orientation.",
+      },
+      {
+        label: "Visual",
+        text: "in devtools, emulate a tablet in portrait and landscape on the organizations, assignments, and student accept pages; layout adapts and nothing is unreachable. Confirm no orientation lock in CSS or a manifest.",
+      },
+    ],
+  },
+  {
     id: "1.3.5",
     bullets: [
       {
@@ -73,6 +99,32 @@ export const ASSESSMENT_GUIDANCE: Guidance[] = [
       {
         label: "Screen reader / inspect",
         text: "check login/profile inputs expose the correct input purpose (autocomplete).",
+      },
+    ],
+  },
+  {
+    id: "1.4.1",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "color is never the only way information is conveyed (status, errors, links, selection).",
+      },
+      {
+        label: "Visual",
+        text: "review status badges, submission/grade states, form errors, and the active sidebar item in grayscale (devtools rendering emulation: achromatopsia); each still has a text label, icon, or underline that carries the meaning.",
+      },
+    ],
+  },
+  {
+    id: "1.4.5",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "text is real text, not an image of text (logos are exempt).",
+      },
+      {
+        label: "Visual / inspect",
+        text: "check every <img> and background image on the primary flows; none renders words that could be real text. Org and user avatars and the logo are exempt.",
       },
     ],
   },
@@ -121,6 +173,32 @@ export const ASSESSMENT_GUIDANCE: Guidance[] = [
     ],
   },
   {
+    id: "2.2.1",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "any time limit can be turned off, adjusted, or extended, unless it is essential or over 20 hours.",
+      },
+      {
+        label: "Keyboard + screen reader",
+        text: "trigger a non-error toast (they auto-dismiss; errors persist): confirm the information is not lost when it disappears, or is available elsewhere on the page. Confirm the GitHub device-code expiry shows a way to request a new code. No other timeouts exist (the session is GitHub's, with no app-side idle logout).",
+      },
+    ],
+  },
+  {
+    id: "2.2.2",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "moving or auto-updating content that starts automatically and lasts over 5 seconds can be paused, stopped, or hidden, unless essential.",
+      },
+      {
+        label: "Visual",
+        text: "the only motion is loading spinners and the skeleton shimmer (progress indicators, which are exempt as essential) and short transitions. Confirm nothing else moves or auto-updates in parallel with content, and that prefers-reduced-motion and the in-app reduce-motion toggle stop the shimmer.",
+      },
+    ],
+  },
+  {
     id: "2.4.1",
     bullets: [
       {
@@ -134,6 +212,19 @@ export const ASSESSMENT_GUIDANCE: Guidance[] = [
       {
         label: "Screen reader",
         text: "confirm landmark navigation (main/nav) works via the rotor.",
+      },
+    ],
+  },
+  {
+    id: "2.4.2",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "every page has a title that describes its topic or purpose (routes call useDocumentTitle).",
+      },
+      {
+        label: "Screen reader",
+        text: "navigate to each primary route (organizations, classroom, assignments, roster, submissions, student accept, settings, accessibility); the announced document title names the page and, where relevant, the org/classroom/assignment, and it changes on navigation.",
       },
     ],
   },
@@ -160,6 +251,19 @@ export const ASSESSMENT_GUIDANCE: Guidance[] = [
       {
         label: "Screen reader",
         text: 'list links via the rotor; each is distinguishable and purposeful (no bare "click here"/"link").',
+      },
+    ],
+  },
+  {
+    id: "2.4.5",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "more than one way exists to reach any page, unless it is a step in a process.",
+      },
+      {
+        label: "Keyboard/visual",
+        text: "for each teacher page, confirm at least two routes to it (sidebar nav plus breadcrumbs, cards, or in-page links). Student accept/submit pages are steps in a process (reached by invite link) and are exempt.",
       },
     ],
   },
@@ -203,6 +307,32 @@ export const ASSESSMENT_GUIDANCE: Guidance[] = [
     ],
   },
   {
+    id: "2.5.1",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "no function needs a multipoint or path-based gesture (pinch, swipe, draw) without a single-pointer alternative.",
+      },
+      {
+        label: "Pointer",
+        text: "on a touch device or devtools touch emulation, walk the primary flows; every action works with single taps. The roster/file dropzones accept a drag but also open a file picker on click.",
+      },
+    ],
+  },
+  {
+    id: "2.5.2",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "actions fire on pointer up (not down) and can be aborted by moving off the target before release.",
+      },
+      {
+        label: "Pointer",
+        text: "on buttons, menu items, table row actions, and the dropzones: press, drag off, release; nothing fires. Confirm no onMouseDown/onPointerDown handlers trigger actions.",
+      },
+    ],
+  },
+  {
     id: "2.5.3",
     bullets: [
       {
@@ -212,6 +342,58 @@ export const ASSESSMENT_GUIDANCE: Guidance[] = [
       {
         label: "Screen reader",
         text: "for controls with visible text, confirm the announced name includes that text (matters for voice-control users).",
+      },
+    ],
+  },
+  {
+    id: "2.5.7",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "anything operable by dragging also works with a single pointer without dragging.",
+      },
+      {
+        label: "Pointer + keyboard",
+        text: "the only drag interactions are the file dropzones (roster upload, FileDropzone). Confirm each also opens a native file picker on click and on Enter/Space, and that no list reorders or resizes by drag alone.",
+      },
+    ],
+  },
+  {
+    id: "3.1.2",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "any passage in a language other than the page language carries its own lang attribute (proper names and code are exempt).",
+      },
+      {
+        label: "Inspect",
+        text: 'switch the UI language and check for untranslated fixed strings (GitHub-owned terms like repository names and usernames are exempt). If an English fragment remains in a translated UI, it needs lang="en".',
+      },
+    ],
+  },
+  {
+    id: "3.2.1",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "merely focusing a control never triggers a change of context (navigation, new window, focus jump, form submit).",
+      },
+      {
+        label: "Keyboard",
+        text: "Tab through every control on the primary flows, including selects, comboboxes, and menu triggers; nothing opens, navigates, or submits until you activate it.",
+      },
+    ],
+  },
+  {
+    id: "3.2.2",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "changing a control's value never causes an unannounced change of context; if it does, the user is told beforehand.",
+      },
+      {
+        label: "Keyboard",
+        text: "change the sort/view/filter selects, the language and theme controls, and every form select or checkbox; the page updates in place without navigating away or moving focus unexpectedly. Auto-submit on change is a fail unless announced.",
       },
     ],
   },
@@ -238,6 +420,45 @@ export const ASSESSMENT_GUIDANCE: Guidance[] = [
       {
         label: "Screen reader",
         text: 'the same action (e.g. "Sign out", icon buttons) has a consistent accessible name across the app.',
+      },
+    ],
+  },
+  {
+    id: "3.2.6",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "if a help mechanism (docs link, contact, feedback) repeats across pages, it appears in the same relative place on each.",
+      },
+      {
+        label: "Visual",
+        text: "the Docs link and About entry live in the sidebar footer; confirm their position is the same on every route that shows the sidebar, and that the student accept/submit pages either offer help in one consistent spot or none.",
+      },
+    ],
+  },
+  {
+    id: "3.3.3",
+    bullets: [
+      {
+        label: "Supports means",
+        text: 'when an input error is detected and a fix is known, the message suggests it (e.g. the expected format), not just "invalid".',
+      },
+      {
+        label: "Keyboard + screen reader",
+        text: "submit each form with bad input (empty required field, malformed username/email, bad slug, roster file of the wrong shape); every error says what is wrong and how to fix it, and is announced.",
+      },
+    ],
+  },
+  {
+    id: "3.3.4",
+    bullets: [
+      {
+        label: "Supports means",
+        text: "actions that delete or change user-controllable data are reversible, checked, or confirmed before commit.",
+      },
+      {
+        label: "Keyboard",
+        text: "walk each destructive action (unenroll students, delete/lock an assignment, remove a member, revoke a token, delete a group): a confirmation step names what will happen and requires an explicit confirm. Note which are reversible.",
       },
     ],
   },

--- a/web/src/util/a11y/contrastReport.ts
+++ b/web/src/util/a11y/contrastReport.ts
@@ -152,7 +152,7 @@ export function renderContrastReport(now = new Date()): string {
   const { thresholds: t, margins: m, enhancedThresholds: e, summary } = audit
 
   const out: string[] = []
-  out.push("# WCAG 2.2 Contrast Audit — Classroom50 web app")
+  out.push("# WCAG 2.2 Contrast Audit — Classroom 50 web app")
   out.push("")
   out.push(
     "Derived from `contrast-audit.json` (built from `src/util/a11y/contrastModel.ts`). " +

--- a/web/src/util/a11y/vpatArchitectural.test.ts
+++ b/web/src/util/a11y/vpatArchitectural.test.ts
@@ -1,0 +1,80 @@
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import { CRITERIA } from "./vpatModel"
+
+// The architectural verdicts (Not Applicable for media, motion, and shortcut
+// criteria; Supports for flashing) rest on "the source contains no X". Those
+// rows carry the build date in the report, so something must actually re-check
+// the claim on every build; this is that check. A hit here means the verdict
+// needs re-assessing, not that the test is wrong.
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const srcRoot = path.resolve(here, "..", "..")
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = path.join(dir, name)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (/\.(tsx?|css|html)$/.test(name) && !/\.test\./.test(name))
+      out.push(full)
+  }
+  return out
+}
+
+// The a11y model itself and the /assess guidance name these tokens in prose.
+const files = walk(srcRoot).filter(
+  (f) => !f.includes(`${path.sep}a11y${path.sep}`),
+)
+const sources = files.map((f) => ({
+  file: path.relative(srcRoot, f),
+  text: readFileSync(f, "utf8"),
+}))
+
+const hits = (re: RegExp) =>
+  sources.filter((s) => re.test(s.text)).map((s) => s.file)
+
+const architectural = (id: string) => CRITERIA.find((c) => c.id === id)
+
+describe("architectural verdicts hold against the current source", () => {
+  it("1.2.x / 1.4.2: no audio, video, or embedded media", () => {
+    for (const id of ["1.2.1", "1.2.2", "1.2.3", "1.2.4", "1.2.5", "1.4.2"]) {
+      expect(architectural(id)?.evidence, id).toBe("architectural")
+    }
+    expect(hits(/<(video|audio|iframe|embed|object)\b/)).toEqual([])
+    expect(hits(/new Audio\(|\.play\(\)/)).toEqual([])
+  })
+
+  it("2.5.4: nothing listens to device motion or orientation", () => {
+    expect(architectural("2.5.4")?.evidence).toBe("architectural")
+    expect(hits(/devicemotion|deviceorientation|DeviceMotionEvent/)).toEqual([])
+  })
+
+  it("2.1.4: no single-character key shortcuts", () => {
+    expect(architectural("2.1.4")?.evidence).toBe("architectural")
+    // A handler comparing key to a single printable character (letters, digits,
+    // punctuation) outside a focused widget. Arrow/Enter/Escape/Tab are exempt.
+    expect(
+      hits(/\.key\s*===\s*["'][A-Za-z0-9?/.,;'`~!@#$%^&*()\-=+[\]{}\\|]["']/),
+    ).toEqual([])
+    expect(hits(/useHotkeys|hotkeys-js|mousetrap/i)).toEqual([])
+  })
+
+  it("2.3.1: no flashing content sources", () => {
+    expect(architectural("2.3.1")?.evidence).toBe("architectural")
+    expect(hits(/<canvas\b|<marquee\b|<blink\b/)).toEqual([])
+    // Any infinite CSS animation must be one of the known slow indicators.
+    const infinite = sources
+      .filter((s) => s.file.endsWith(".css"))
+      .flatMap((s) =>
+        [...s.text.matchAll(/animation:\s*([^;]*infinite[^;]*);/g)].map(
+          (m) => m[1],
+        ),
+      )
+    for (const decl of infinite)
+      expect(decl, "infinite animation").toMatch(/shimmer|spin|pulse/)
+  })
+})

--- a/web/src/util/a11y/vpatGuard.test.ts
+++ b/web/src/util/a11y/vpatGuard.test.ts
@@ -16,10 +16,19 @@ import { buildVpatReport } from "./vpatReport"
 const report = buildVpatReport()
 
 describe("VPAT integrity guard", () => {
-  it("has a non-empty criteria set covering both Level A and AA", () => {
-    expect(report.criteria.length).toBeGreaterThanOrEqual(25)
-    expect(report.criteria.some((c) => c.level === "A")).toBe(true)
-    expect(report.criteria.some((c) => c.level === "AA")).toBe(true)
+  it("lists every WCAG 2.2 Level A/AA criterion (55), so nothing is silently omitted", () => {
+    // 4.1.1 is a 2.0/2.1-only row kept for those reviewers; it is not one of
+    // the 55 WCAG 2.2 A/AA criteria.
+    const aa = report.criteria.filter(
+      (c) => c.level !== "AAA" && c.id !== "4.1.1",
+    )
+    expect(aa).toHaveLength(55)
+    expect(aa.filter((c) => c.level === "A")).toHaveLength(31)
+    expect(aa.filter((c) => c.level === "AA")).toHaveLength(24)
+  })
+
+  it("declares the WCAG versions the report can be filed against", () => {
+    expect(report.wcagVersions).toEqual(["2.0", "2.1", "2.2"])
   })
 
   it.each(report.criteria)(
@@ -30,6 +39,20 @@ describe("VPAT integrity guard", () => {
           c.evidence,
           `${c.id} claims Supports with no evidence tag`,
         ).toBeDefined()
+      }
+    },
+  )
+
+  it.each(report.criteria)(
+    "$id never claims Not Applicable without an architectural reason",
+    (c) => {
+      if (c.status === "notApplicable") {
+        expect(c.evidence, `${c.id} N/A with no evidence tag`).toBe(
+          "architectural",
+        )
+        expect(c.remark, `${c.id} N/A with no reason`).toMatch(
+          /^Not applicable: /,
+        )
       }
     },
   )

--- a/web/src/util/a11y/vpatModel.test.ts
+++ b/web/src/util/a11y/vpatModel.test.ts
@@ -132,10 +132,39 @@ describe("vpatModel — criteria integrity", () => {
     }
   })
 
-  it("marks 4.1.1 Parsing as Not Applicable (removed in WCAG 2.2)", () => {
+  it("marks 4.1.1 Parsing as Supports for WCAG 2.0/2.1, as the VPAT template instructs", () => {
     const c = CRITERIA.find((x) => x.id === "4.1.1")
-    expect(c?.status).toBe("notApplicable")
+    expect(c?.status).toBe("supports")
+    expect(c?.evidence).toBe("architectural")
     expect(c?.remark).toContain("WCAG 2.2 removed 4.1.1")
+  })
+
+  // The VPAT WCAG edition flags criteria added after 2.0 as "2.1 and 2.2" or
+  // "2.2 only" so a reviewer on an older version knows which rows to skip.
+  it("tags exactly the WCAG 2.1 and 2.2 additions with `since`", () => {
+    const since = (v: "2.1" | "2.2") =>
+      CRITERIA.filter((c) => c.since === v)
+        .map((c) => c.id)
+        .sort()
+    expect(since("2.1")).toEqual(
+      [
+        "1.3.4",
+        "1.3.5",
+        "1.4.10",
+        "1.4.11",
+        "1.4.12",
+        "1.4.13",
+        "2.1.4",
+        "2.5.1",
+        "2.5.2",
+        "2.5.3",
+        "2.5.4",
+        "4.1.3",
+      ].sort(),
+    )
+    expect(since("2.2")).toEqual(
+      ["2.4.11", "2.5.7", "2.5.8", "3.2.6", "3.3.7", "3.3.8"].sort(),
+    )
   })
 
   it("covers exactly the applicable success-criteria set", () => {

--- a/web/src/util/a11y/vpatModel.test.ts
+++ b/web/src/util/a11y/vpatModel.test.ts
@@ -30,42 +30,74 @@ const VALID_EVIDENCE = new Set<EvidenceKind>([
 ])
 const VALID_PRINCIPLE = new Set<WcagPrinciple>(PRINCIPLE_ORDER)
 
-// The applicable SC set the model must cover (from the plan's criteria list).
-// A dropped criterion — or a stray extra one — fails here loudly.
-const EXPECTED_IDS = [
+// Every WCAG 2.2 Level A/AA success criterion (55), plus 1.4.6 (AAA contrast,
+// reported for transparency) and 4.1.1 (removed in 2.2, kept for 2.0/2.1
+// reviewers). A dropped criterion, or a stray extra one, fails here loudly.
+const WCAG_22_A_AA_IDS = [
   "1.1.1",
+  "1.2.1",
+  "1.2.2",
+  "1.2.3",
+  "1.2.4",
+  "1.2.5",
   "1.3.1",
   "1.3.2",
+  "1.3.3",
+  "1.3.4",
   "1.3.5",
+  "1.4.1",
+  "1.4.2",
   "1.4.3",
-  "1.4.6",
-  "1.4.11",
   "1.4.4",
+  "1.4.5",
   "1.4.10",
+  "1.4.11",
   "1.4.12",
   "1.4.13",
   "2.1.1",
   "2.1.2",
+  "2.1.4",
+  "2.2.1",
+  "2.2.2",
+  "2.3.1",
   "2.4.1",
+  "2.4.2",
   "2.4.3",
   "2.4.4",
+  "2.4.5",
   "2.4.6",
   "2.4.7",
   "2.4.11",
+  "2.5.1",
+  "2.5.2",
   "2.5.3",
+  "2.5.4",
+  "2.5.7",
   "2.5.8",
   "3.1.1",
+  "3.1.2",
+  "3.2.1",
+  "3.2.2",
   "3.2.3",
   "3.2.4",
+  "3.2.6",
   "3.3.1",
   "3.3.2",
+  "3.3.3",
+  "3.3.4",
   "3.3.7",
   "3.3.8",
   "4.1.2",
   "4.1.3",
 ]
+const EXPECTED_IDS = [...WCAG_22_A_AA_IDS, "1.4.6", "4.1.1"]
 
 describe("vpatModel — criteria integrity", () => {
+  it("lists all 55 WCAG 2.2 Level A/AA criteria", () => {
+    expect(WCAG_22_A_AA_IDS).toHaveLength(55)
+    const aa = CRITERIA.filter((c) => c.level !== "AAA" && c.id !== "4.1.1")
+    expect(aa.map((c) => c.id).sort()).toEqual([...WCAG_22_A_AA_IDS].sort())
+  })
   it("has a unique id, valid enums, and a non-empty name/remark per criterion", () => {
     const seen = new Set<string>()
     for (const c of CRITERIA) {
@@ -93,11 +125,17 @@ describe("vpatModel — criteria integrity", () => {
     }
   })
 
-  it("tags every notApplicable criterion architecturally with a remark", () => {
+  it("tags every notApplicable criterion architecturally with a specific remark", () => {
     for (const c of CRITERIA.filter((x) => x.status === "notApplicable")) {
       expect(c.evidence, `${c.id} N/A evidence`).toBe("architectural")
-      expect(c.remark.length, `${c.id} N/A remark`).toBeGreaterThan(0)
+      expect(c.remark, `${c.id} N/A remark`).toMatch(/^Not applicable: /)
     }
+  })
+
+  it("marks 4.1.1 Parsing as Not Applicable (removed in WCAG 2.2)", () => {
+    const c = CRITERIA.find((x) => x.id === "4.1.1")
+    expect(c?.status).toBe("notApplicable")
+    expect(c?.remark).toContain("WCAG 2.2 removed 4.1.1")
   })
 
   it("covers exactly the applicable success-criteria set", () => {

--- a/web/src/util/a11y/vpatModel.ts
+++ b/web/src/util/a11y/vpatModel.ts
@@ -65,6 +65,12 @@ export type Criterion = {
   name: string
   level: WcagLevel
   principle: WcagPrinciple
+  /**
+   * The WCAG version that introduced the criterion, when later than 2.0. The
+   * VPAT WCAG edition marks these rows ("2.1 and 2.2" / "2.2 only") so a
+   * reviewer filing against 2.0 or 2.1 knows which rows to disregard.
+   */
+  since?: "2.1" | "2.2"
   status: ConformanceLevel
   /** Required whenever status is `supports` (the overclaim guard enforces this). */
   evidence?: EvidenceKind
@@ -202,6 +208,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Orientation",
     level: "AA",
     principle: "Perceivable",
+    since: "2.1",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
   },
@@ -210,6 +217,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Identify Input Purpose",
     level: "AA",
     principle: "Perceivable",
+    since: "2.1",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
   },
@@ -256,6 +264,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Non-text Contrast",
     level: "AA",
     principle: "Perceivable",
+    since: "2.1",
     status: "supports",
     evidence: "contrast",
     remark: "Resolved from the automated contrast audit.",
@@ -287,6 +296,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Reflow",
     level: "AA",
     principle: "Perceivable",
+    since: "2.1",
     status: "supports",
     evidence: "automated",
     remark:
@@ -300,6 +310,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Text Spacing",
     level: "AA",
     principle: "Perceivable",
+    since: "2.1",
     status: "supports",
     evidence: "automated",
     remark:
@@ -314,6 +325,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Content on Hover or Focus",
     level: "AA",
     principle: "Perceivable",
+    since: "2.1",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
   },
@@ -339,6 +351,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Character Key Shortcuts",
     level: "A",
     principle: "Operable",
+    since: "2.1",
     status: "notApplicable",
     evidence: "architectural",
     remark:
@@ -436,6 +449,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Focus Not Obscured (Minimum)",
     level: "AA",
     principle: "Operable",
+    since: "2.2",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
   },
@@ -444,6 +458,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Pointer Gestures",
     level: "A",
     principle: "Operable",
+    since: "2.1",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
   },
@@ -452,6 +467,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Pointer Cancellation",
     level: "A",
     principle: "Operable",
+    since: "2.1",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
   },
@@ -460,6 +476,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Label in Name",
     level: "A",
     principle: "Operable",
+    since: "2.1",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
   },
@@ -468,6 +485,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Motion Actuation",
     level: "A",
     principle: "Operable",
+    since: "2.1",
     status: "notApplicable",
     evidence: "architectural",
     remark:
@@ -480,6 +498,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Dragging Movements",
     level: "AA",
     principle: "Operable",
+    since: "2.2",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
   },
@@ -488,6 +507,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Target Size (Minimum)",
     level: "AA",
     principle: "Operable",
+    since: "2.2",
     status: "supports",
     evidence: "automated",
     remark:
@@ -555,6 +575,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Consistent Help",
     level: "A",
     principle: "Understandable",
+    since: "2.2",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
   },
@@ -606,6 +627,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Redundant Entry",
     level: "A",
     principle: "Understandable",
+    since: "2.2",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
   },
@@ -614,6 +636,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Accessible Authentication (Minimum)",
     level: "AA",
     principle: "Understandable",
+    since: "2.2",
     status: "notEvaluated",
     remark:
       "Authentication is delegated entirely to GitHub's OAuth / device-code " +
@@ -623,19 +646,20 @@ const BASE_CRITERIA: Criterion[] = [
   },
   // ── Robust ─────────────────────────────────────────────────────────────────
   {
-    // Not a WCAG 2.2 criterion, but reviewers evaluating against 2.0/2.1 expect
-    // a row for it, so the report says why it carries no verdict.
+    // Removed in WCAG 2.2, but the VPAT WCAG edition keeps the row and
+    // instructs authors to answer Supports for 2.0/2.1 (the 2023 errata make it
+    // always satisfied), so reviewers on those versions see a verdict.
     id: "4.1.1",
     name: "Parsing",
     level: "A",
     principle: "Robust",
-    status: "notApplicable",
+    status: "supports",
     evidence: "architectural",
     remark:
-      "Not applicable: WCAG 2.2 removed 4.1.1 Parsing, and the W3C's 2023 " +
-      "errata treat it as always satisfied under WCAG 2.0 and 2.1 for content " +
-      "using HTML. The markup issues it once caught are reported under 1.3.1 " +
-      "and 4.1.2 instead.",
+      "For WCAG 2.0 and 2.1, the September 2023 errata state this criterion " +
+      "is always satisfied for HTML content, so it is answered Supports as the " +
+      "VPAT template instructs. WCAG 2.2 removed 4.1.1; the markup issues it " +
+      "once caught are reported under 1.3.1 and 4.1.2.",
   },
   {
     id: "4.1.2",
@@ -650,6 +674,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Status Messages",
     level: "AA",
     principle: "Robust",
+    since: "2.1",
     status: "supports",
     evidence: "automated",
     remark:

--- a/web/src/util/a11y/vpatModel.ts
+++ b/web/src/util/a11y/vpatModel.ts
@@ -71,6 +71,11 @@ export type Criterion = {
    * reviewer filing against 2.0 or 2.1 knows which rows to disregard.
    */
   since?: "2.1" | "2.2"
+  /**
+   * The last WCAG version that still contains the criterion, when it was later
+   * removed (4.1.1 Parsing, dropped in 2.2). Rendered as "(2.0 and 2.1 only)".
+   */
+  until?: "2.1"
   status: ConformanceLevel
   /** Required whenever status is `supports` (the overclaim guard enforces this). */
   evidence?: EvidenceKind
@@ -653,6 +658,7 @@ const BASE_CRITERIA: Criterion[] = [
     name: "Parsing",
     level: "A",
     principle: "Robust",
+    until: "2.1",
     status: "supports",
     evidence: "architectural",
     remark:
@@ -708,6 +714,21 @@ export type ManualVerdict = {
 }
 
 export type VerdictOverlay = Record<string, ManualVerdict>
+
+/**
+ * Whether a criterion belongs to the manual assessment: still awaiting a verdict
+ * (notEvaluated with no evidence) or already carrying a recorded one. Shared by
+ * the dev-only /assess tool and the guidance-coverage test so they can't drift.
+ */
+export function isManuallyOwned(
+  c: Pick<Criterion, "id" | "status" | "evidence">,
+  overlay: VerdictOverlay,
+): boolean {
+  return (
+    (c.status === "notEvaluated" && c.evidence === undefined) ||
+    overlay[c.id] !== undefined
+  )
+}
 
 // True for a real calendar date in ISO YYYY-MM-DD form. A bare regex would
 // admit impossible dates (2026-13-40, 0000-00-00), so round-trip through Date:

--- a/web/src/util/a11y/vpatModel.ts
+++ b/web/src/util/a11y/vpatModel.ts
@@ -1,9 +1,12 @@
 // The WCAG 2.2 conformance model the VPAT report renders from.
 //
 // A pure leaf (data + types only, no app imports, no fs) mirroring
-// contrastModel.ts. Each entry is one applicable WCAG 2.2 success criterion with
+// contrastModel.ts. Each entry is one WCAG 2.2 Level A/AA success criterion with
 // its conformance status, the KIND of evidence backing that status, and a
-// remark. The report renderer (vpatReport.ts) and the integrity guard
+// remark. Every A/AA criterion is listed, including the ones the product's
+// design rules out, so a reader can tell "Not Applicable" from "not yet
+// evaluated" (a university reviewer asked exactly that in discussion #493).
+// The report renderer (vpatReport.ts) and the integrity guard
 // (vpatGuard.test.ts) both consume this, so a single edit here flows to every
 // rendering.
 //
@@ -50,8 +53,9 @@ export const CONFORMANCE_TONE: Record<ConformanceLevel, BadgeTone> = {
 /**
  * What backs a status. `contrast` is computed from the contrast audit;
  * `automated` is a zero-violation tooling category; `manual` is a human
- * keyboard/screen-reader attestation; `architectural` justifies a `notApplicable`
- * from the 100%-client-side design (no server auth, sessions, or stored data).
+ * keyboard/screen-reader attestation; `architectural` is a verdict that follows
+ * from what the product is (no media, no server-side state, no single-key
+ * shortcuts), verifiable from the source rather than by testing a screen.
  */
 export type EvidenceKind = "contrast" | "automated" | "manual" | "architectural"
 
@@ -100,12 +104,20 @@ const NOT_EVALUATED_REMARK =
   "keyboard and screen-reader pass on the primary flows will set the final " +
   "conformance level."
 
-// The applicable WCAG 2.2 Level A/AA criteria for the app, plus 1.4.6 (AAA
-// contrast) reported for transparency beyond the AA target. Grouped by
-// principle. Contrast rows carry a placeholder status/evidence that
-// vpatReport.ts replaces from the live audit; client-side-only rows are
-// notApplicable with an architectural remark; the rest start notEvaluated until
-// the manual assessment sets them.
+// A time-based-media criterion the product can never trigger: the app renders
+// no <video>, <audio>, or embedded player anywhere. One remark, shared by all
+// five 1.2.x rows and 1.4.2, so the reason is stated once.
+const NO_MEDIA_REMARK =
+  "Not applicable: the app contains no audio or video content (no <video>, " +
+  "<audio>, or embedded media players). Verified against the source."
+
+// Every WCAG 2.2 Level A/AA criterion, plus 1.4.6 (AAA contrast) reported for
+// transparency beyond the AA target, plus 4.1.1 Parsing so the report also
+// answers WCAG 2.0/2.1 reviewers. Grouped by principle. Contrast rows carry a
+// placeholder status/evidence that vpatReport.ts replaces from the live audit;
+// criteria the product's design rules out are notApplicable with an
+// architectural remark; the rest start notEvaluated until the manual
+// assessment sets them.
 const BASE_CRITERIA: Criterion[] = [
   // ── Perceivable ────────────────────────────────────────────────────────────
   {
@@ -115,6 +127,51 @@ const BASE_CRITERIA: Criterion[] = [
     principle: "Perceivable",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "1.2.1",
+    name: "Audio-only and Video-only (Prerecorded)",
+    level: "A",
+    principle: "Perceivable",
+    status: "notApplicable",
+    evidence: "architectural",
+    remark: NO_MEDIA_REMARK,
+  },
+  {
+    id: "1.2.2",
+    name: "Captions (Prerecorded)",
+    level: "A",
+    principle: "Perceivable",
+    status: "notApplicable",
+    evidence: "architectural",
+    remark: NO_MEDIA_REMARK,
+  },
+  {
+    id: "1.2.3",
+    name: "Audio Description or Media Alternative (Prerecorded)",
+    level: "A",
+    principle: "Perceivable",
+    status: "notApplicable",
+    evidence: "architectural",
+    remark: NO_MEDIA_REMARK,
+  },
+  {
+    id: "1.2.4",
+    name: "Captions (Live)",
+    level: "AA",
+    principle: "Perceivable",
+    status: "notApplicable",
+    evidence: "architectural",
+    remark: NO_MEDIA_REMARK,
+  },
+  {
+    id: "1.2.5",
+    name: "Audio Description (Prerecorded)",
+    level: "AA",
+    principle: "Perceivable",
+    status: "notApplicable",
+    evidence: "architectural",
+    remark: NO_MEDIA_REMARK,
   },
   {
     id: "1.3.1",
@@ -133,12 +190,45 @@ const BASE_CRITERIA: Criterion[] = [
     remark: NOT_EVALUATED_REMARK,
   },
   {
+    id: "1.3.3",
+    name: "Sensory Characteristics",
+    level: "A",
+    principle: "Perceivable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "1.3.4",
+    name: "Orientation",
+    level: "AA",
+    principle: "Perceivable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
     id: "1.3.5",
     name: "Identify Input Purpose",
     level: "AA",
     principle: "Perceivable",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "1.4.1",
+    name: "Use of Color",
+    level: "A",
+    principle: "Perceivable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "1.4.2",
+    name: "Audio Control",
+    level: "A",
+    principle: "Perceivable",
+    status: "notApplicable",
+    evidence: "architectural",
+    remark: NO_MEDIA_REMARK,
   },
   {
     id: "1.4.3",
@@ -183,6 +273,14 @@ const BASE_CRITERIA: Criterion[] = [
       "units) and the layout still fits without clipping or horizontal overflow. " +
       "Verified automatically on the shared primitives; a per-route zoom sweep is " +
       "a manual follow-up.",
+  },
+  {
+    id: "1.4.5",
+    name: "Images of Text",
+    level: "AA",
+    principle: "Perceivable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
   },
   {
     id: "1.4.10",
@@ -237,8 +335,57 @@ const BASE_CRITERIA: Criterion[] = [
     remark: NOT_EVALUATED_REMARK,
   },
   {
+    id: "2.1.4",
+    name: "Character Key Shortcuts",
+    level: "A",
+    principle: "Operable",
+    status: "notApplicable",
+    evidence: "architectural",
+    remark:
+      "Not applicable: the app defines no single-character keyboard shortcuts. " +
+      "Its only key handling is Tab, Enter, Escape, and arrow keys inside the " +
+      "focused widget (menus, comboboxes, roving tab lists), which the " +
+      "criterion exempts. Verified against the source.",
+  },
+  {
+    id: "2.2.1",
+    name: "Timing Adjustable",
+    level: "A",
+    principle: "Operable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "2.2.2",
+    name: "Pause, Stop, Hide",
+    level: "A",
+    principle: "Operable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "2.3.1",
+    name: "Three Flashes or Below Threshold",
+    level: "A",
+    principle: "Operable",
+    status: "supports",
+    evidence: "architectural",
+    remark:
+      "Nothing in the app flashes: there is no video, canvas, or embedded " +
+      "content, and the only motion is CSS transitions, spinners, and a 1.5 s " +
+      "loading shimmer, none of which flash. Verified against the source.",
+  },
+  {
     id: "2.4.1",
     name: "Bypass Blocks",
+    level: "A",
+    principle: "Operable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "2.4.2",
+    name: "Page Titled",
     level: "A",
     principle: "Operable",
     status: "notEvaluated",
@@ -256,6 +403,14 @@ const BASE_CRITERIA: Criterion[] = [
     id: "2.4.4",
     name: "Link Purpose (In Context)",
     level: "A",
+    principle: "Operable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "2.4.5",
+    name: "Multiple Ways",
+    level: "AA",
     principle: "Operable",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
@@ -285,9 +440,45 @@ const BASE_CRITERIA: Criterion[] = [
     remark: NOT_EVALUATED_REMARK,
   },
   {
+    id: "2.5.1",
+    name: "Pointer Gestures",
+    level: "A",
+    principle: "Operable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "2.5.2",
+    name: "Pointer Cancellation",
+    level: "A",
+    principle: "Operable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
     id: "2.5.3",
     name: "Label in Name",
     level: "A",
+    principle: "Operable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "2.5.4",
+    name: "Motion Actuation",
+    level: "A",
+    principle: "Operable",
+    status: "notApplicable",
+    evidence: "architectural",
+    remark:
+      "Not applicable: no function is operated by device motion or user " +
+      "motion. The app never listens to devicemotion or deviceorientation " +
+      "events. Verified against the source.",
+  },
+  {
+    id: "2.5.7",
+    name: "Dragging Movements",
+    level: "AA",
     principle: "Operable",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
@@ -320,6 +511,30 @@ const BASE_CRITERIA: Criterion[] = [
       "document.documentElement.lang in sync).",
   },
   {
+    id: "3.1.2",
+    name: "Language of Parts",
+    level: "AA",
+    principle: "Understandable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "3.2.1",
+    name: "On Focus",
+    level: "A",
+    principle: "Understandable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "3.2.2",
+    name: "On Input",
+    level: "A",
+    principle: "Understandable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
     id: "3.2.3",
     name: "Consistent Navigation",
     level: "AA",
@@ -331,6 +546,14 @@ const BASE_CRITERIA: Criterion[] = [
     id: "3.2.4",
     name: "Consistent Identification",
     level: "AA",
+    principle: "Understandable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "3.2.6",
+    name: "Consistent Help",
+    level: "A",
     principle: "Understandable",
     status: "notEvaluated",
     remark: NOT_EVALUATED_REMARK,
@@ -363,6 +586,22 @@ const BASE_CRITERIA: Criterion[] = [
       "is a manual content check.",
   },
   {
+    id: "3.3.3",
+    name: "Error Suggestion",
+    level: "AA",
+    principle: "Understandable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
+    id: "3.3.4",
+    name: "Error Prevention (Legal, Financial, Data)",
+    level: "AA",
+    principle: "Understandable",
+    status: "notEvaluated",
+    remark: NOT_EVALUATED_REMARK,
+  },
+  {
     id: "3.3.7",
     name: "Redundant Entry",
     level: "A",
@@ -383,6 +622,21 @@ const BASE_CRITERIA: Criterion[] = [
       "accessibly.",
   },
   // ── Robust ─────────────────────────────────────────────────────────────────
+  {
+    // Not a WCAG 2.2 criterion, but reviewers evaluating against 2.0/2.1 expect
+    // a row for it, so the report says why it carries no verdict.
+    id: "4.1.1",
+    name: "Parsing",
+    level: "A",
+    principle: "Robust",
+    status: "notApplicable",
+    evidence: "architectural",
+    remark:
+      "Not applicable: WCAG 2.2 removed 4.1.1 Parsing, and the W3C's 2023 " +
+      "errata treat it as always satisfied under WCAG 2.0 and 2.1 for content " +
+      "using HTML. The markup issues it once caught are reported under 1.3.1 " +
+      "and 4.1.2 instead.",
+  },
   {
     id: "4.1.2",
     name: "Name, Role, Value",

--- a/web/src/util/a11y/vpatReport.test.ts
+++ b/web/src/util/a11y/vpatReport.test.ts
@@ -4,6 +4,7 @@ import { CONTRAST_CRITERION_IDS, ENHANCED_CRITERION_ID } from "./vpatModel"
 import {
   buildVpatReport,
   criterionLabel,
+  deviationNote,
   renderCombinedReport,
   renderVpatJson,
   renderVpatReport,
@@ -116,7 +117,7 @@ describe("renderVpatReport (WCAG edition)", () => {
     expect(md).toContain("# Classroom 50 Accessibility Conformance Report")
     expect(md).toContain("**WCAG Edition** (Based on VPAT® Version 2.5Rev)")
     expect(md).toContain(
-      "**Name of Product/Version:** Classroom50 web app, version 1.45.0",
+      "**Name of Product/Version:** Classroom 50 web app, version 1.45.0",
     )
     expect(md).toContain("**Report Date:** 2026-08-04")
     expect(md).toContain("**Product Description:**")
@@ -129,7 +130,7 @@ describe("renderVpatReport (WCAG edition)", () => {
 
   it("omits the version clause when the build has none", () => {
     expect(renderVpatReport(FIXED)).toContain(
-      "**Name of Product/Version:** Classroom50 web app\n",
+      "**Name of Product/Version:** Classroom 50 web app\n",
     )
   })
 
@@ -150,31 +151,73 @@ describe("renderVpatReport (WCAG edition)", () => {
     )
   })
 
-  it("declares the Not Evaluated deviation in Notes while A/AA rows await assessment", () => {
-    const pending = buildVpatReport(FIXED).criteria.filter(
-      (c) => c.level !== "AAA" && c.status === "notEvaluated",
+  it("declares the Not Evaluated deviation in Notes only while A/AA rows are pending", () => {
+    const row = (
+      id: string,
+      level: "A" | "AAA",
+      status: "supports" | "notEvaluated",
+    ) =>
+      ({
+        id,
+        name: "x",
+        level,
+        principle: "Robust",
+        status,
+        remark: "r",
+      }) as const
+    expect(deviationNote([row("1.1.1", "A", "supports")])).toBeNull()
+    // AAA rows may legitimately be Not Evaluated; only A/AA trigger the note.
+    expect(deviationNote([row("1.4.6", "AAA", "notEvaluated")])).toBeNull()
+    const note = deviationNote([
+      row("2.2.1", "A", "notEvaluated"),
+      row("3.3.4", "A", "notEvaluated"),
+    ])
+    expect(note).toContain(
+      "Deviation from the ITI terms: 2 Level A/AA criteria (2.2.1, 3.3.4)",
     )
-    if (pending.length === 0) {
-      expect(md).not.toContain("Deviation from the ITI terms")
-      return
-    }
-    expect(md).toContain(
-      `Deviation from the ITI terms: ${pending.length} Level A/AA criteria`,
+    // The shipped report reflects the live verdicts: the term definition points
+    // at Notes only when the bullet is actually present.
+    const live = deviationNote(buildVpatReport(FIXED).criteria)
+    expect(md.includes("Deviation from the ITI terms")).toBe(live !== null)
+    expect(md.includes("See Notes for this report's use of it")).toBe(
+      live !== null,
     )
-    for (const c of pending) expect(md).toContain(c.id)
   })
 
-  it("marks criteria newer than WCAG 2.0 the way the template does", () => {
+  it("uses the ITI Not Evaluated definition verbatim", () => {
+    expect(md).toContain(
+      "**Not Evaluated:** The product has not been evaluated against the criterion. This can only be used in WCAG Level AAA criteria.",
+    )
+  })
+
+  it("marks criteria newer than WCAG 2.0, and 4.1.1, the way the template does", () => {
     expect(md).toContain("| 2.1.4 Character Key Shortcuts (2.1 and 2.2) | A |")
     expect(md).toContain("| 2.5.8 Target Size (Minimum) (2.2 only) | AA |")
+    expect(md).toContain("| 4.1.1 Parsing (2.0 and 2.1 only) | A | Supports |")
     expect(md).toContain("| 1.1.1 Non-text Content | A |")
+  })
+
+  it("escapes angle brackets in remarks so Markdown does not swallow them as HTML", () => {
+    expect(md).toContain(
+      "no &lt;video&gt;, &lt;audio&gt;, or embedded media players",
+    )
+    expect(md).not.toMatch(/\| [^|\n]*<video>/)
+  })
+
+  it("lists criteria in numeric WCAG order within each principle", () => {
+    const ids = buildVpatReport(FIXED).criteria.map((c) => c.id)
+    const i = (id: string) => ids.indexOf(id)
+    expect(i("1.4.4")).toBeLessThan(i("1.4.5"))
+    expect(i("1.4.5")).toBeLessThan(i("1.4.6"))
+    expect(i("1.4.6")).toBeLessThan(i("1.4.10"))
+    expect(i("1.4.10")).toBeLessThan(i("1.4.11"))
+    expect(md.indexOf("| 1.4.4 ")).toBeLessThan(md.indexOf("| 1.4.10 "))
   })
 
   it("renders Not Applicable rows with their reason instead of omitting them", () => {
     expect(md).toContain(
       "| 1.2.2 Captions (Prerecorded) | A | Not Applicable |",
     )
-    expect(md).toContain("| 4.1.1 Parsing | A | Supports |")
   })
 
   it("has one table per WCAG principle under the WCAG 2.x Report heading", () => {
@@ -221,7 +264,7 @@ describe("renderCombinedReport", () => {
 
   it("bundles the VPAT and the contrast audit", () => {
     expect(md).toContain("(Based on VPAT® Version 2.5Rev)")
-    expect(md).toContain("# WCAG 2.2 Contrast Audit — Classroom50 web app")
+    expect(md).toContain("# WCAG 2.2 Contrast Audit — Classroom 50 web app")
   })
 
   it("does not include the dropped INT / 508 edition", () => {

--- a/web/src/util/a11y/vpatReport.test.ts
+++ b/web/src/util/a11y/vpatReport.test.ts
@@ -113,7 +113,7 @@ describe("renderVpatReport (WCAG edition)", () => {
   const md = renderVpatReport(FIXED, { version: "1.45.0" })
 
   it("carries every field the VPAT 2.5Rev essential requirements list", () => {
-    expect(md).toContain("# Fifty Foundation Accessibility Conformance Report")
+    expect(md).toContain("# Classroom 50 Accessibility Conformance Report")
     expect(md).toContain("**WCAG Edition** (Based on VPAT® Version 2.5Rev)")
     expect(md).toContain(
       "**Name of Product/Version:** Classroom50 web app, version 1.45.0",
@@ -206,7 +206,7 @@ describe("renderVpatJson", () => {
     const parsed = JSON.parse(renderVpatJson(FIXED))
     expect(parsed.summary).toEqual(buildVpatReport(FIXED).summary)
     expect(parsed.generated).toBe("2026-08-04")
-    expect(parsed.vendor).toBe("Fifty Foundation")
+    expect(parsed.vendor).toBe("Classroom 50")
     expect(parsed.version).toBeUndefined()
   })
 

--- a/web/src/util/a11y/vpatReport.test.ts
+++ b/web/src/util/a11y/vpatReport.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import { CONTRAST_CRITERION_IDS, ENHANCED_CRITERION_ID } from "./vpatModel"
 import {
   buildVpatReport,
+  criterionLabel,
   renderCombinedReport,
   renderVpatJson,
   renderVpatReport,
@@ -109,35 +110,79 @@ describe("buildVpatReport (JSON source of truth)", () => {
 })
 
 describe("renderVpatReport (WCAG edition)", () => {
-  const md = renderVpatReport(FIXED)
+  const md = renderVpatReport(FIXED, { version: "1.45.0" })
 
-  it("states the format, standard, and date", () => {
-    expect(md).toContain("VPAT® 2.5Rev — WCAG Edition")
-    expect(md).toContain("WCAG 2.2, target Level AA")
-    expect(md).toContain("Report date:** 2026-08-04")
+  it("carries every field the VPAT 2.5Rev essential requirements list", () => {
+    expect(md).toContain("# Fifty Foundation Accessibility Conformance Report")
+    expect(md).toContain("**WCAG Edition** (Based on VPAT® Version 2.5Rev)")
+    expect(md).toContain(
+      "**Name of Product/Version:** Classroom50 web app, version 1.45.0",
+    )
+    expect(md).toContain("**Report Date:** 2026-08-04")
+    expect(md).toContain("**Product Description:**")
+    expect(md).toContain("**Contact Information:**")
+    expect(md).toContain("**Notes:**")
+    expect(md).toContain("**Evaluation Methods Used:**")
+    expect(md).toContain("## Applicable Standards/Guidelines")
+    expect(md).toContain("## Terms")
   })
 
-  it("declares WCAG 2.0, 2.1, and 2.2 at Level A and AA as the applicable standards", () => {
+  it("omits the version clause when the build has none", () => {
+    expect(renderVpatReport(FIXED)).toContain(
+      "**Name of Product/Version:** Classroom50 web app\n",
+    )
+  })
+
+  it("lists WCAG 2.0, 2.1, and 2.2 at Level A and AA in the standards table", () => {
+    for (const v of ["2.0", "2.1", "2.2"]) {
+      expect(md).toContain(
+        `| Web Content Accessibility Guidelines ${v} | Level A (Yes), Level AA (Yes), Level AAA (No) |`,
+      )
+    }
+  })
+
+  it("uses the ITI term definitions verbatim", () => {
     expect(md).toContain(
-      "**Applicable standards/guidelines:** WCAG 2.0, WCAG 2.1, and WCAG 2.2, Level A and Level AA.",
+      "**Supports:** The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.",
     )
     expect(md).toContain(
-      "4.1.1 Parsing, which WCAG 2.2 removed, has its own row",
+      "**Not Applicable:** The criterion is not relevant to the product.",
     )
+  })
+
+  it("declares the Not Evaluated deviation in Notes while A/AA rows await assessment", () => {
+    const pending = buildVpatReport(FIXED).criteria.filter(
+      (c) => c.level !== "AAA" && c.status === "notEvaluated",
+    )
+    if (pending.length === 0) {
+      expect(md).not.toContain("Deviation from the ITI terms")
+      return
+    }
+    expect(md).toContain(
+      `Deviation from the ITI terms: ${pending.length} Level A/AA criteria`,
+    )
+    for (const c of pending) expect(md).toContain(c.id)
+  })
+
+  it("marks criteria newer than WCAG 2.0 the way the template does", () => {
+    expect(md).toContain("| 2.1.4 Character Key Shortcuts (2.1 and 2.2) | A |")
+    expect(md).toContain("| 2.5.8 Target Size (Minimum) (2.2 only) | AA |")
+    expect(md).toContain("| 1.1.1 Non-text Content | A |")
   })
 
   it("renders Not Applicable rows with their reason instead of omitting them", () => {
     expect(md).toContain(
       "| 1.2.2 Captions (Prerecorded) | A | Not Applicable |",
     )
-    expect(md).toContain("| 4.1.1 Parsing | A | Not Applicable |")
+    expect(md).toContain("| 4.1.1 Parsing | A | Supports |")
   })
 
-  it("has one table per WCAG principle", () => {
-    expect(md).toContain("## Perceivable")
-    expect(md).toContain("## Operable")
-    expect(md).toContain("## Understandable")
-    expect(md).toContain("## Robust")
+  it("has one table per WCAG principle under the WCAG 2.x Report heading", () => {
+    expect(md).toContain("## WCAG 2.x Report")
+    expect(md).toContain("### Perceivable")
+    expect(md).toContain("### Operable")
+    expect(md).toContain("### Understandable")
+    expect(md).toContain("### Robust")
   })
 
   it("resolves the contrast criterion 1.4.3 to Supports from its single verdict", () => {
@@ -147,12 +192,12 @@ describe("renderVpatReport (WCAG edition)", () => {
   it("renders a row for every criterion in the report", () => {
     const report = buildVpatReport(FIXED)
     for (const c of report.criteria) {
-      expect(md, `row for ${c.id}`).toContain(`| ${c.id} ${c.name} |`)
+      expect(md, `row for ${c.id}`).toContain(`| ${criterionLabel(c)} |`)
     }
   })
 
   it("is deterministic for a fixed date", () => {
-    expect(renderVpatReport(FIXED)).toBe(md)
+    expect(renderVpatReport(FIXED, { version: "1.45.0" })).toBe(md)
   })
 })
 
@@ -161,6 +206,13 @@ describe("renderVpatJson", () => {
     const parsed = JSON.parse(renderVpatJson(FIXED))
     expect(parsed.summary).toEqual(buildVpatReport(FIXED).summary)
     expect(parsed.generated).toBe("2026-08-04")
+    expect(parsed.vendor).toBe("Fifty Foundation")
+    expect(parsed.version).toBeUndefined()
+  })
+
+  it("carries the release version when the build supplies one", () => {
+    const parsed = JSON.parse(renderVpatJson(FIXED, { version: "1.45.0" }))
+    expect(parsed.version).toBe("1.45.0")
   })
 })
 
@@ -168,7 +220,7 @@ describe("renderCombinedReport", () => {
   const md = renderCombinedReport(FIXED)
 
   it("bundles the VPAT and the contrast audit", () => {
-    expect(md).toContain("VPAT® 2.5Rev — WCAG Edition")
+    expect(md).toContain("(Based on VPAT® Version 2.5Rev)")
     expect(md).toContain("# WCAG 2.2 Contrast Audit — Classroom50 web app")
   })
 

--- a/web/src/util/a11y/vpatReport.test.ts
+++ b/web/src/util/a11y/vpatReport.test.ts
@@ -16,6 +16,7 @@ describe("buildVpatReport (JSON source of truth)", () => {
   it("carries schema, standard, editions, target, product, and date", () => {
     expect(report.schema).toBe("vpat-report/v1")
     expect(report.standard).toBe("WCAG 2.2")
+    expect(report.wcagVersions).toEqual(["2.0", "2.1", "2.2"])
     expect(report.editions).toEqual(["2.5Rev-wcag"])
     expect(report.target).toBe("AA")
     expect(report.product.length).toBeGreaterThan(0)
@@ -114,6 +115,22 @@ describe("renderVpatReport (WCAG edition)", () => {
     expect(md).toContain("VPAT® 2.5Rev — WCAG Edition")
     expect(md).toContain("WCAG 2.2, target Level AA")
     expect(md).toContain("Report date:** 2026-08-04")
+  })
+
+  it("declares WCAG 2.0, 2.1, and 2.2 at Level A and AA as the applicable standards", () => {
+    expect(md).toContain(
+      "**Applicable standards/guidelines:** WCAG 2.0, WCAG 2.1, and WCAG 2.2, Level A and Level AA.",
+    )
+    expect(md).toContain(
+      "4.1.1 Parsing, which WCAG 2.2 removed, has its own row",
+    )
+  })
+
+  it("renders Not Applicable rows with their reason instead of omitting them", () => {
+    expect(md).toContain(
+      "| 1.2.2 Captions (Prerecorded) | A | Not Applicable |",
+    )
+    expect(md).toContain("| 4.1.1 Parsing | A | Not Applicable |")
   })
 
   it("has one table per WCAG principle", () => {

--- a/web/src/util/a11y/vpatReport.ts
+++ b/web/src/util/a11y/vpatReport.ts
@@ -48,7 +48,7 @@ export type VpatReportJson = {
 // The VPAT title format is "[Company Name] Accessibility Conformance Report";
 // the product name stands in for the company, as is usual for open source.
 const VENDOR = "Classroom 50"
-const PRODUCT = "Classroom50 web app"
+const PRODUCT = "Classroom 50 web app"
 const PRODUCT_DESCRIPTION =
   "Classroom 50 is a free, open-source web app for creating and grading " +
   "programming assignments on GitHub: teachers manage classrooms, rosters, " +
@@ -158,11 +158,11 @@ export function buildVpatReport(
   )
   const contrastIds = new Set<string>(CONTRAST_CRITERION_IDS)
 
-  const criteria: Criterion[] = CRITERIA.map((c) => {
+  const criteria: Criterion[] = CRITERIA.map((c): Criterion => {
     if (!contrastIds.has(c.id)) return { ...c }
     const d = c.id === ENHANCED_CRITERION_ID ? derivedEnhanced : derived
     return { ...c, status: d.status, evidence: "contrast", remark: d.remark }
-  })
+  }).sort(compareCriterionIds)
 
   const byStatus = criteria.reduce(
     (acc, c) => {
@@ -212,33 +212,64 @@ function criteriaFor(
 
 /**
  * The criterion cell as the VPAT WCAG template writes it: id, short title, and
- * for criteria newer than WCAG 2.0 the versions they belong to, so a reviewer
- * filing against 2.0 or 2.1 can see which rows to disregard.
+ * for criteria that exist only in some WCAG versions the versions they belong
+ * to, so a reviewer filing against one version can see which rows to disregard.
  */
-export function criterionLabel(c: Pick<Criterion, "id" | "name" | "since">) {
-  const since =
-    c.since === "2.1"
-      ? " (2.1 and 2.2)"
-      : c.since === "2.2"
-        ? " (2.2 only)"
-        : ""
-  return `${c.id} ${c.name}${since}`
+export function criterionLabel(
+  c: Pick<Criterion, "id" | "name" | "since" | "until">,
+) {
+  const versions =
+    c.until === "2.1"
+      ? " (2.0 and 2.1 only)"
+      : c.since === "2.1"
+        ? " (2.1 and 2.2)"
+        : c.since === "2.2"
+          ? " (2.2 only)"
+          : ""
+  return `${c.id} ${c.name}${versions}`
+}
+
+// WCAG ids sort numerically by segment (1.4.4 before 1.4.10), not as strings.
+export function compareCriterionIds(a: { id: string }, b: { id: string }) {
+  const pa = a.id.split(".").map(Number)
+  const pb = b.id.split(".").map(Number)
+  for (let i = 0; i < 3; i++) if (pa[i] !== pb[i]) return pa[i] - pb[i]
+  return 0
+}
+
+// Remarks are cell content in a Markdown table: a pipe would split the cell and
+// a raw tag like <video> would be swallowed as inline HTML by most renderers.
+function escapeCell(text: string): string {
+  return text.replace(/\|/g, "\\|").replace(/</g, "&lt;").replace(/>/g, "&gt;")
 }
 
 function criterionRow(c: Criterion, fallbackDate: string): string {
-  const remark = c.remark.replace(/\|/g, "\\|")
-  // Manual rows carry their own assessed date; the contrast rows are re-derived
-  // every build, so they take the report's generation date.
+  // Manual rows carry their own assessed date. Contrast and architectural rows
+  // are re-derived or re-guarded on every build (the contrast audit and
+  // vpatArchitectural.test.ts), so they take the report's generation date.
   const date = c.assessed ?? fallbackDate
-  return `| ${criterionLabel(c)} | ${c.level} | ${CONFORMANCE_LABEL[c.status]} | ${date} | ${remark} |`
+  return `| ${criterionLabel(c)} | ${c.level} | ${CONFORMANCE_LABEL[c.status]} | ${date} | ${escapeCell(c.remark)} |`
 }
 
 // Level A/AA rows still Not Evaluated. The ITI terms reserve Not Evaluated for
 // Level AAA, so using it on an A/AA row is a deviation the Notes section must
 // declare (the template requires that) until the manual assessment lands.
-function pendingAaRows(report: VpatReportJson): Criterion[] {
-  return report.criteria.filter(
+export function pendingAaRows(criteria: Criterion[]): Criterion[] {
+  return criteria.filter(
     (c) => c.level !== "AAA" && c.status === "notEvaluated",
+  )
+}
+
+/** The Notes bullet declaring the deviation, or null once nothing is pending. */
+export function deviationNote(criteria: Criterion[]): string | null {
+  const pending = pendingAaRows(criteria)
+  if (pending.length === 0) return null
+  return (
+    `- Deviation from the ITI terms: ${pending.length} Level A/AA criteria ` +
+    `(${pending.map((c) => c.id).join(", ")}) are marked Not Evaluated ` +
+    "because their manual keyboard and screen-reader assessment is still in " +
+    "progress. ITI reserves Not Evaluated for Level AAA. Those rows carry no " +
+    "conformance claim; they will be updated as the assessment completes."
   )
 }
 
@@ -248,7 +279,7 @@ function pendingAaRows(report: VpatReportJson): Criterion[] {
 // description, contact, notes, evaluation methods, applicable standards, and
 // the ITI term definitions.
 function preamble(report: VpatReportJson): string[] {
-  const pending = pendingAaRows(report)
+  const deviation = deviationNote(report.criteria)
   const productLine = report.version
     ? `${report.product}, version ${report.version}`
     : report.product
@@ -280,16 +311,7 @@ function preamble(report: VpatReportJson): string[] {
       "is no media) are marked Not Applicable with the reason. Per the ITI " +
       "note on WCAG conformance, such criteria may equally be read as " +
       "satisfied.",
-    ...(pending.length > 0
-      ? [
-          `- Deviation from the ITI terms: ${pending.length} Level A/AA ` +
-            `criteria (${pending.map((c) => c.id).join(", ")}) are marked Not ` +
-            "Evaluated because their manual keyboard and screen-reader " +
-            "assessment is still in progress. ITI reserves Not Evaluated for " +
-            "Level AAA. Those rows carry no conformance claim; they will be " +
-            "updated as the assessment completes.",
-        ]
-      : []),
+    ...(deviation ? [deviation] : []),
     "",
     "**Evaluation Methods Used:** Testing is performed by the product's " +
       "maintainers, who know its teacher and student flows. Automated checks " +
@@ -333,8 +355,8 @@ function preamble(report: VpatReportJson): string[] {
       "meet the criterion.",
     "- **Not Applicable:** The criterion is not relevant to the product.",
     "- **Not Evaluated:** The product has not been evaluated against the " +
-      "criterion. ITI limits this to Level AAA criteria; see Notes for this " +
-      "report's use of it.",
+      "criterion. This can only be used in WCAG Level AAA criteria." +
+      (deviation ? " See Notes for this report's use of it." : ""),
     "",
   ]
 }

--- a/web/src/util/a11y/vpatReport.ts
+++ b/web/src/util/a11y/vpatReport.ts
@@ -25,6 +25,12 @@ export type VpatReportJson = {
   /** Bump when the JSON shape changes so consumers can guard. */
   schema: "vpat-report/v1"
   standard: "WCAG 2.2"
+  /**
+   * The WCAG versions a reviewer can file this report against. WCAG 2.2 A/AA is
+   * a superset of the 2.0 and 2.1 A/AA criteria (4.1.1 Parsing, dropped in 2.2,
+   * gets its own row), so one assessment answers all three.
+   */
+  wcagVersions: typeof WCAG_VERSIONS
   editions: ["2.5Rev-wcag"]
   target: "AA"
   product: string
@@ -37,6 +43,7 @@ export type VpatReportJson = {
 }
 
 const PRODUCT = "Classroom50 web app"
+export const WCAG_VERSIONS = ["2.0", "2.1", "2.2"] as const
 
 /**
  * Derive the contrast criteria's conformance from the live contrast audit.
@@ -152,6 +159,7 @@ export function buildVpatReport(
   return {
     schema: "vpat-report/v1",
     standard: "WCAG 2.2",
+    wcagVersions: WCAG_VERSIONS,
     editions: ["2.5Rev-wcag"],
     target: "AA",
     product: PRODUCT,
@@ -181,9 +189,11 @@ function criterionRow(c: Criterion, fallbackDate: string): string {
   return `| ${c.id} ${c.name} | ${c.level} | ${CONFORMANCE_LABEL[c.status]} | ${date} | ${remark} |`
 }
 
-// Preamble: product, date, evaluation methods, and the honest automated-vs-
-// manual boundary a reviewer needs to weight the claims.
+// Preamble: product, date, the standards covered, evaluation methods, and the
+// honest automated-vs-manual boundary a reviewer needs to weight the claims.
 function preamble(report: VpatReportJson): string[] {
+  const versions = report.wcagVersions.map((v) => `WCAG ${v}`)
+  const versionList = `${versions.slice(0, -1).join(", ")}, and ${versions[versions.length - 1]}`
   return [
     `# Accessibility Conformance Report — ${report.product}`,
     "",
@@ -191,6 +201,18 @@ function preamble(report: VpatReportJson): string[] {
     `**Standard:** WCAG ${report.standard.replace("WCAG ", "")}, target Level ${report.target}`,
     `**Product:** ${report.product}`,
     `**Report date:** ${report.generated}`,
+    "",
+    `**Applicable standards/guidelines:** ${versionList}, Level A and Level ` +
+      "AA. Level AAA is not a conformance target; 1.4.6 Contrast (Enhanced) is " +
+      "reported for transparency only. The WCAG 2.2 Level A and AA criteria are " +
+      "a superset of the WCAG 2.0 and 2.1 Level A and AA criteria, so one " +
+      "assessment covers all three versions. 4.1.1 Parsing, which WCAG 2.2 " +
+      "removed, has its own row for reviewers working from WCAG 2.0 or 2.1.",
+    "",
+    "**Scope:** Every Level A and AA success criterion is listed with an " +
+      "explicit conformance level. A criterion the product cannot trigger " +
+      "(for example, captions when there is no media) is marked *Not " +
+      "Applicable* with the reason; nothing is omitted.",
     "",
     "**Evaluation methods:** Automated checks (color-contrast audit computed " +
       "per rendered pixel and guarded in CI; static and axe-based rule scans) " +
@@ -210,7 +232,7 @@ function preamble(report: VpatReportJson): string[] {
 function summaryLine(report: VpatReportJson): string {
   const s = report.summary.byStatus
   return (
-    `**Summary (${report.summary.total} applicable criteria):** ` +
+    `**Summary (${report.summary.total} criteria):** ` +
     `${s.supports} Supports, ${s.partially} Partially, ` +
     `${s.doesNotSupport} Does Not Support, ${s.notApplicable} Not Applicable, ` +
     `${s.notEvaluated} Not Evaluated.`

--- a/web/src/util/a11y/vpatReport.ts
+++ b/web/src/util/a11y/vpatReport.ts
@@ -28,12 +28,15 @@ export type VpatReportJson = {
   /**
    * The WCAG versions a reviewer can file this report against. WCAG 2.2 A/AA is
    * a superset of the 2.0 and 2.1 A/AA criteria (4.1.1 Parsing, dropped in 2.2,
-   * gets its own row), so one assessment answers all three.
+   * keeps its row), so one assessment answers all three.
    */
   wcagVersions: typeof WCAG_VERSIONS
   editions: ["2.5Rev-wcag"]
   target: "AA"
+  vendor: string
   product: string
+  /** Release the report describes (semver or tag); absent for an untagged build. */
+  version?: string
   generated: string
   summary: {
     total: number
@@ -42,8 +45,26 @@ export type VpatReportJson = {
   criteria: Criterion[]
 }
 
+// The VPAT title format is "[Company Name] Accessibility Conformance Report";
+// Classroom 50 is published by the Fifty Foundation (see the repo README).
+const VENDOR = "Fifty Foundation"
 const PRODUCT = "Classroom50 web app"
+const PRODUCT_DESCRIPTION =
+  "Classroom 50 is a free, open-source web app for creating and grading " +
+  "programming assignments on GitHub: teachers manage classrooms, rosters, " +
+  "assignments, and autograded submissions; students accept and submit " +
+  "assignments. It runs entirely in the browser against the GitHub API, with " +
+  "no server of its own. This report covers the web app at classroom50.org; " +
+  "the companion command-line tools are out of scope."
+const CONTACT_URL =
+  "https://github.com/foundation50/classroom50/issues/new?template=2_accessibility_report.yml"
 export const WCAG_VERSIONS = ["2.0", "2.1", "2.2"] as const
+
+/** Report metadata the caller knows and the pure renderer cannot read itself. */
+export type VpatReportOptions = {
+  /** App release the report describes; the Vite build and CI generator pass it. */
+  version?: string
+}
 
 /**
  * Derive the contrast criteria's conformance from the live contrast audit.
@@ -126,6 +147,7 @@ export function buildVpatReport(
       enhancedMisses: s.enhancedMisses,
     }
   })(),
+  options: VpatReportOptions = {},
 ): VpatReportJson {
   const derived = contrastStatus(contrast.allPass, contrast.failures)
   // 1.4.6 is the AAA tier: same audit, stricter floors, so it gets its own
@@ -162,7 +184,9 @@ export function buildVpatReport(
     wcagVersions: WCAG_VERSIONS,
     editions: ["2.5Rev-wcag"],
     target: "AA",
+    vendor: VENDOR,
     product: PRODUCT,
+    ...(options.version ? { version: options.version } : {}),
     generated: now.toISOString().slice(0, 10),
     summary: { total: criteria.length, byStatus },
     criteria,
@@ -170,8 +194,13 @@ export function buildVpatReport(
 }
 
 /** Serialize the canonical VPAT as pretty JSON (the emitted artifact). */
-export function renderVpatJson(now = new Date()): string {
-  return JSON.stringify(buildVpatReport(now), null, 2) + "\n"
+export function renderVpatJson(
+  now = new Date(),
+  options: VpatReportOptions = {},
+): string {
+  return (
+    JSON.stringify(buildVpatReport(now, undefined, options), null, 2) + "\n"
+  )
 }
 
 function criteriaFor(
@@ -181,50 +210,131 @@ function criteriaFor(
   return report.criteria.filter((c) => c.principle === principle)
 }
 
+/**
+ * The criterion cell as the VPAT WCAG template writes it: id, short title, and
+ * for criteria newer than WCAG 2.0 the versions they belong to, so a reviewer
+ * filing against 2.0 or 2.1 can see which rows to disregard.
+ */
+export function criterionLabel(c: Pick<Criterion, "id" | "name" | "since">) {
+  const since =
+    c.since === "2.1"
+      ? " (2.1 and 2.2)"
+      : c.since === "2.2"
+        ? " (2.2 only)"
+        : ""
+  return `${c.id} ${c.name}${since}`
+}
+
 function criterionRow(c: Criterion, fallbackDate: string): string {
   const remark = c.remark.replace(/\|/g, "\\|")
   // Manual rows carry their own assessed date; the contrast rows are re-derived
   // every build, so they take the report's generation date.
   const date = c.assessed ?? fallbackDate
-  return `| ${c.id} ${c.name} | ${c.level} | ${CONFORMANCE_LABEL[c.status]} | ${date} | ${remark} |`
+  return `| ${criterionLabel(c)} | ${c.level} | ${CONFORMANCE_LABEL[c.status]} | ${date} | ${remark} |`
 }
 
-// Preamble: product, date, the standards covered, evaluation methods, and the
-// honest automated-vs-manual boundary a reviewer needs to weight the claims.
+// Level A/AA rows still Not Evaluated. The ITI terms reserve Not Evaluated for
+// Level AAA, so using it on an A/AA row is a deviation the Notes section must
+// declare (the template requires that) until the manual assessment lands.
+function pendingAaRows(report: VpatReportJson): Criterion[] {
+  return report.criteria.filter(
+    (c) => c.level !== "AAA" && c.status === "notEvaluated",
+  )
+}
+
+// The report header, with every field the VPAT 2.5Rev "Essential Requirements
+// for Authors" list as mandatory: title in the "[Company] Accessibility
+// Conformance Report" form, template version, product/version, date, product
+// description, contact, notes, evaluation methods, applicable standards, and
+// the ITI term definitions.
 function preamble(report: VpatReportJson): string[] {
-  const versions = report.wcagVersions.map((v) => `WCAG ${v}`)
-  const versionList = `${versions.slice(0, -1).join(", ")}, and ${versions[versions.length - 1]}`
+  const pending = pendingAaRows(report)
+  const productLine = report.version
+    ? `${report.product}, version ${report.version}`
+    : report.product
   return [
-    `# Accessibility Conformance Report — ${report.product}`,
+    `# ${report.vendor} Accessibility Conformance Report`,
     "",
-    `**Format:** VPAT® 2.5Rev — WCAG Edition`,
-    `**Standard:** WCAG ${report.standard.replace("WCAG ", "")}, target Level ${report.target}`,
-    `**Product:** ${report.product}`,
-    `**Report date:** ${report.generated}`,
+    "**WCAG Edition** (Based on VPAT® Version 2.5Rev)",
     "",
-    `**Applicable standards/guidelines:** ${versionList}, Level A and Level ` +
-      "AA. Level AAA is not a conformance target; 1.4.6 Contrast (Enhanced) is " +
-      "reported for transparency only. The WCAG 2.2 Level A and AA criteria are " +
-      "a superset of the WCAG 2.0 and 2.1 Level A and AA criteria, so one " +
-      "assessment covers all three versions. 4.1.1 Parsing, which WCAG 2.2 " +
-      "removed, has its own row for reviewers working from WCAG 2.0 or 2.1.",
+    `**Name of Product/Version:** ${productLine}`,
     "",
-    "**Scope:** Every Level A and AA success criterion is listed with an " +
-      "explicit conformance level. A criterion the product cannot trigger " +
-      "(for example, captions when there is no media) is marked *Not " +
-      "Applicable* with the reason; nothing is omitted.",
+    `**Report Date:** ${report.generated}`,
     "",
-    "**Evaluation methods:** Automated checks (color-contrast audit computed " +
-      "per rendered pixel and guarded in CI; static and axe-based rule scans) " +
-      "establish a floor; criteria backed only by automation are marked " +
-      "provisionally and a manual keyboard + screen-reader pass sets the final " +
-      "conformance level. Criteria still awaiting that pass are shown as *Not " +
-      "Evaluated* rather than claimed.",
+    `**Product Description:** ${PRODUCT_DESCRIPTION}`,
     "",
-    "**Conformance terms:** *Supports* — meets the criterion. *Partially " +
-      "Supports* — meets it with exceptions. *Does Not Support* — does not meet " +
-      "it. *Not Applicable* — the criterion does not apply. *Not Evaluated* — " +
-      "not yet assessed.",
+    `**Contact Information:** Open an accessibility report at ${CONTACT_URL} ` +
+      "(the maintainers answer there in public), or use the same link from " +
+      "the Accessibility page in the app.",
+    "",
+    "**Notes:**",
+    "",
+    "- This report is generated from the app's source on every build, so the " +
+      "Report Date is the build date and the version is the release it " +
+      "describes. Earlier reports are superseded; the Assessed column records " +
+      "when each manual verdict was taken.",
+    "- The conformance target is WCAG 2.2 Level AA. Level AAA is not " +
+      "evaluated except 1.4.6 Contrast (Enhanced), reported for transparency " +
+      "only.",
+    "- Criteria the product cannot trigger (for example, captions when there " +
+      "is no media) are marked Not Applicable with the reason. Per the ITI " +
+      "note on WCAG conformance, such criteria may equally be read as " +
+      "satisfied.",
+    ...(pending.length > 0
+      ? [
+          `- Deviation from the ITI terms: ${pending.length} Level A/AA ` +
+            `criteria (${pending.map((c) => c.id).join(", ")}) are marked Not ` +
+            "Evaluated because their manual keyboard and screen-reader " +
+            "assessment is still in progress. ITI reserves Not Evaluated for " +
+            "Level AAA. Those rows carry no conformance claim; they will be " +
+            "updated as the assessment completes.",
+        ]
+      : []),
+    "",
+    "**Evaluation Methods Used:** Testing is performed by the product's " +
+      "maintainers, who know its teacher and student flows. Automated checks " +
+      "run on every build and are enforced in CI: a color-contrast audit " +
+      "computed per rendered pixel for both themes, axe-core rule scans, and " +
+      "real-browser checks of reflow, text resize, text spacing, target size, " +
+      "and form-field semantics on the shared UI primitives. Manual testing is " +
+      "a keyboard-only pass plus accessibility-tree inspection in Chromium " +
+      "(and a screen-reader listen where noted) on the primary flows; each " +
+      "manual remark names the flow and method used. Criteria backed only by " +
+      "automation say so in their remark.",
+    "",
+    "## Applicable Standards/Guidelines",
+    "",
+    "This report covers the degree of conformance for the following " +
+      "accessibility standard/guidelines:",
+    "",
+    "| Standard/Guideline | Included In Report |",
+    "| --- | --- |",
+    ...report.wcagVersions.map(
+      (v) =>
+        `| Web Content Accessibility Guidelines ${v} | Level A (Yes), ` +
+        "Level AA (Yes), Level AAA (No) |",
+    ),
+    "",
+    "WCAG 2.2 Level A and AA are a superset of WCAG 2.0 and 2.1 Level A and " +
+      "AA, so one assessment answers all three versions. Rows marked " +
+      '"(2.1 and 2.2)" or "(2.2 only)" do not apply to earlier versions; ' +
+      "4.1.1 Parsing applies only to WCAG 2.0 and 2.1.",
+    "",
+    "## Terms",
+    "",
+    "The terms used in the Conformance Level information are defined as follows:",
+    "",
+    "- **Supports:** The functionality of the product has at least one method " +
+      "that meets the criterion without known defects or meets with " +
+      "equivalent facilitation.",
+    "- **Partially Supports:** Some functionality of the product does not " +
+      "meet the criterion.",
+    "- **Does Not Support:** The majority of product functionality does not " +
+      "meet the criterion.",
+    "- **Not Applicable:** The criterion is not relevant to the product.",
+    "- **Not Evaluated:** The product has not been evaluated against the " +
+      "criterion. ITI limits this to Level AAA criteria; see Notes for this " +
+      "report's use of it.",
     "",
   ]
 }
@@ -233,22 +343,33 @@ function summaryLine(report: VpatReportJson): string {
   const s = report.summary.byStatus
   return (
     `**Summary (${report.summary.total} criteria):** ` +
-    `${s.supports} Supports, ${s.partially} Partially, ` +
+    `${s.supports} Supports, ${s.partially} Partially Supports, ` +
     `${s.doesNotSupport} Does Not Support, ${s.notApplicable} Not Applicable, ` +
     `${s.notEvaluated} Not Evaluated.`
   )
 }
 
-// The per-principle WCAG 2.2 conformance tables.
+// The conformance tables. The ITI template splits by level (A, AA, AAA) and
+// allows combining into one table in numerical order; we group by WCAG
+// principle, which keeps the same numerical order within each guideline and
+// matches the interactive /accessibility view.
 function principleTables(report: VpatReportJson): string[] {
-  const out: string[] = []
+  const out: string[] = [
+    "## WCAG 2.x Report",
+    "",
+    "Note: When reporting on conformance with the WCAG 2.x Success Criteria, " +
+      "they are scoped for full pages, complete processes, and " +
+      "accessibility-supported ways of using technology as documented in the " +
+      "WCAG 2.0 Conformance Requirements.",
+    "",
+  ]
   for (const principle of PRINCIPLE_ORDER) {
     const rows = criteriaFor(report, principle)
     if (rows.length === 0) continue
-    out.push(`## ${principle}`)
+    out.push(`### ${principle}`)
     out.push("")
     out.push(
-      "| Criterion | Level | Conformance Level | Assessed | Remarks and Explanations |",
+      "| Criteria | Level | Conformance Level | Assessed | Remarks and Explanations |",
     )
     out.push("| --- | --- | --- | --- | --- |")
     for (const c of rows) out.push(criterionRow(c, report.generated))
@@ -258,8 +379,11 @@ function principleTables(report: VpatReportJson): string[] {
 }
 
 /** Render the Markdown ACR (VPAT 2.5Rev WCAG edition) — derived from one model. */
-export function renderVpatReport(now = new Date()): string {
-  const report = buildVpatReport(now)
+export function renderVpatReport(
+  now = new Date(),
+  options: VpatReportOptions = {},
+): string {
+  const report = buildVpatReport(now, undefined, options)
   return (
     [
       ...preamble(report),
@@ -275,8 +399,11 @@ export function renderVpatReport(now = new Date()): string {
 // contrast evidence the contrast criteria derive from). A rendering over the
 // same single sources as the individual downloads — never a separate assessment
 // — so it can't disagree with them.
-export function renderCombinedReport(now = new Date()): string {
-  const sections = [renderVpatReport(now), renderContrastReport(now)]
+export function renderCombinedReport(
+  now = new Date(),
+  options: VpatReportOptions = {},
+): string {
+  const sections = [renderVpatReport(now, options), renderContrastReport(now)]
   // A horizontal rule between the two documents so their headings don't read
   // as one continuous report when concatenated.
   return sections.join("\n---\n\n")

--- a/web/src/util/a11y/vpatReport.ts
+++ b/web/src/util/a11y/vpatReport.ts
@@ -46,8 +46,8 @@ export type VpatReportJson = {
 }
 
 // The VPAT title format is "[Company Name] Accessibility Conformance Report";
-// Classroom 50 is published by the Fifty Foundation (see the repo README).
-const VENDOR = "Fifty Foundation"
+// the product name stands in for the company, as is usual for open source.
+const VENDOR = "Classroom 50"
 const PRODUCT = "Classroom50 web app"
 const PRODUCT_DESCRIPTION =
   "Classroom 50 is a free, open-source web app for creating and grading " +

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -60,7 +60,9 @@ function resolveReleaseInfo() {
     process.env.VITE_APP_COMMIT || git("rev-parse --short=12 HEAD") || "unknown"
   const buildDate = process.env.VITE_APP_BUILD_DATE || new Date().toISOString()
 
-  return { version, commit, buildDate }
+  // Only a release tag names a published version; an untagged (main push /
+  // local) build carries none, so the ACR can't claim a release it isn't.
+  return { version, commit, buildDate, tagVersion: tagVersion || undefined }
 }
 
 const release = resolveReleaseInfo()
@@ -134,7 +136,9 @@ function contrastAuditPlugin(): Plugin {
 function vpatReportPlugin(): Plugin {
   // The ACR names the release it describes (a VPAT "Name of Product/Version"
   // requirement); the pure renderer can't read the build's version itself.
-  const options = { version: release.version }
+  // Tag-derived only: an untagged build would otherwise be labelled with the
+  // last released version while containing unreleased changes.
+  const options = { version: release.tagVersion }
   const assets: { fileName: string; source: string; type: string }[] = [
     {
       fileName: "vpat-report.json",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -132,20 +132,23 @@ function contrastAuditPlugin(): Plugin {
 // vpatGuard.test.ts is the enforcement. Same dev + build wiring as the contrast
 // audit above.
 function vpatReportPlugin(): Plugin {
+  // The ACR names the release it describes (a VPAT "Name of Product/Version"
+  // requirement); the pure renderer can't read the build's version itself.
+  const options = { version: release.version }
   const assets: { fileName: string; source: string; type: string }[] = [
     {
       fileName: "vpat-report.json",
-      source: renderVpatJson(),
+      source: renderVpatJson(undefined, options),
       type: "application/json",
     },
     {
       fileName: "VPAT.md",
-      source: renderVpatReport(),
+      source: renderVpatReport(undefined, options),
       type: "text/markdown; charset=utf-8",
     },
     {
       fileName: "ACCESSIBILITY-REPORT.md",
-      source: renderCombinedReport(),
+      source: renderCombinedReport(undefined, options),
       type: "text/markdown; charset=utf-8",
     },
   ]


### PR DESCRIPTION
## What changed

**Full criteria list.** `vpatModel.ts` now carries every WCAG 2.2 A/AA criterion (55), plus 1.4.6 (AAA, for transparency) and 4.1.1 Parsing (answered Supports for WCAG 2.0/2.1 as the ITI template instructs). Criteria the product cannot trigger are Not Applicable with a reason: no media (1.2.x, 1.4.2), no single-key shortcuts (2.1.4), no motion actuation (2.5.4). Criteria added in WCAG 2.1 or 2.2 are marked "(2.1 and 2.2)" / "(2.2 only)" like the template.

**Template-conformant header.** Cross-checked against the [VPAT 2.5Rev WCAG edition](https://www.itic.org/policy/accessibility/vpat): the report now has the "[Company] Accessibility Conformance Report" title, template version, Name of Product/Version (from the release tag), Report Date, Product Description, Contact Information, Notes, Evaluation Methods Used, the Applicable Standards/Guidelines table (WCAG 2.0, 2.1, 2.2 at A and AA), and the ITI term definitions verbatim. While any A/AA row is Not Evaluated, Notes declares that as a deviation from the ITI terms; the note removes itself once none remain.

**Manual assessment completed.** The 17 previously unevaluated criteria were assessed in Chromium against a test org (keyboard, pointer, orientation, language, grayscale, and form-error passes) and recorded through the `/assess` tool. Three land as Partially Supports, each with a concrete fix in its remark:

- 2.2.1 Timing Adjustable: non-error toasts auto-dismiss after 6 s with no pause or extend.
- 2.5.2 Pointer Cancellation: the shared `Combobox` commits the option on `pointerdown`.
- 3.3.3 Error Suggestion: an unknown GitHub username surfaces the raw "Not Found" with no suggestion, outside a live region.

Final summary: 40 Supports, 9 Partially Supports, 0 Does Not Support, 8 Not Applicable, 0 Not Evaluated.

**Accessibility page.** The conformance table opens on an All tab (full list, one `<tbody>` per principle with a row-group heading) with the four principle tabs after it; principle names, version markers, and the print header go through `t()`.

**Guards.** `vpatGuard.test.ts` pins the 55-row set so it can't silently shrink; `assessmentGuidance.test.ts` fails if a manually-owned criterion has no assessor guidance; `vpatArchitectural.test.ts` re-checks the "no media / no motion / no shortcuts / no flashing" claims against `src/` on every build so the build date on those rows is honest.

## Verification

`npm run check` green (tsc, eslint, prettier, arch:validate, vitest incl. browser mode). Rendered `VPAT.md` diffed row-for-row against the ITI template's Level A and AA tables: 56/56 match.

## Follow-ups (separate PRs)

- Fix the three Partially Supports items above.
- `npm run audit:vpat` writes its files but the `vite-node` process never exits (pre-existing on `main`).
- Card/row "More actions" triggers open on focus via CSS `:focus-within` and lack `aria-expanded` (already tracked under 4.1.2).

Related: #493
