### PR TITLE
fix(web): announce spinners through one persistent live region

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -108,8 +108,8 @@ export default defineConfig([
       "jsx-a11y/role-supports-aria-props": "warn",
       "jsx-a11y/scope": "warn",
       "jsx-a11y/tabindex-no-positive": "warn",
-      // Nudge new loading UI toward the accessible <Spinner> (role=status +
-      // sr-only label) instead of a bare, silent daisyUI spinner span. In-button
+      // Nudge new loading UI toward the accessible <Spinner> (announced via the
+      // persistent live region) instead of a bare, silent daisyUI spinner span. In-button
       // spinners may stay inline when the button already carries an aria-label;
       // this only flags the literal utility class in JSX className literals.
       "no-restricted-syntax": [
@@ -118,7 +118,7 @@ export default defineConfig([
           selector:
             "JSXAttribute[name.name='className'] > Literal[value=/\\bloading-spinner\\b/]",
           message:
-            'Prefer the accessible <Spinner> component over a bare `loading loading-spinner` span (it adds role="status" + an sr-only label). In-button spinners may stay inline if the button already has an accessible name.',
+            "Prefer the accessible <Spinner> component over a bare `loading loading-spinner` span (it announces its label through the persistent live region). In-button spinners may stay inline if the button already has an accessible name.",
         },
         {
           // Warn when a <Button> sits in a form without an explicit `type`: a

--- a/web/src/components/Spinner.tsx
+++ b/web/src/components/Spinner.tsx
@@ -1,19 +1,23 @@
 import type { ComponentPropsWithoutRef } from "react"
 import { useTranslation } from "react-i18next"
 
+import { useAnnounce } from "@/hooks/useAnnounce"
+
 type SpinnerSize = "xs" | "sm" | "md" | "lg" | "xl"
 
 /**
- * Accessible loading spinner: daisyUI `loading-spinner` in a `role="status"`
- * region with a visually-hidden `label` so screen readers announce the busy
- * state. Use when the spinner is the ONLY loading indicator; when the busy
- * state is already announced (adjacent text, an in-button spinner on a labeled
- * disabled button), keep a bare `aria-hidden` span — the resolution the
- * `no-restricted-syntax` lint nudge expects.
+ * Accessible loading spinner: daisyUI `loading-spinner` whose `label` is
+ * announced through the app's persistent live region (`LiveAnnouncer`), so
+ * the announcement does not depend on a `role="status"` appearing in the same
+ * DOM mutation as its text. Several spinners on one page announce once. Use
+ * when the spinner is the ONLY loading indicator; when the busy state is
+ * already announced (adjacent text, an in-button spinner on a labeled disabled
+ * button), use `InlineSpinner` — the resolution the `no-restricted-syntax`
+ * lint nudge expects.
  *
  * The visual is anti-flash guarded (`indicator-appear`): it stays invisible
  * for the first ~250ms so sub-second loads never flash an indicator (Primer
- * loading guidance). The sr-only label is not delayed.
+ * loading guidance). The announcement is not delayed.
  */
 export function Spinner({
   size = "md",
@@ -25,18 +29,16 @@ export function Spinner({
   label?: string
 } & Omit<ComponentPropsWithoutRef<"span">, "children">) {
   const { t } = useTranslation()
-  const resolvedLabel = label ?? t("common.loading")
+  useAnnounce(label ?? t("common.loading"))
   return (
     <span
-      role="status"
       className={`inline-flex items-center justify-center${className ? ` ${className}` : ""}`}
+      aria-hidden="true"
       {...props}
     >
       <span
         className={`loading loading-spinner loading-${size} indicator-appear`}
-        aria-hidden="true"
       />
-      <span className="sr-only">{resolvedLabel}</span>
     </span>
   )
 }

--- a/web/src/components/status/BackgroundPassTag.test.tsx
+++ b/web/src/components/status/BackgroundPassTag.test.tsx
@@ -48,6 +48,11 @@ vi.mock("motion/react", () => ({
 }))
 
 import { BackgroundPassTag } from "./BackgroundPassTag"
+import { LiveAnnouncer } from "./LiveAnnouncer"
+import {
+  ANNOUNCE_LINGER_MS,
+  __resetLiveAnnouncerForTest,
+} from "@/lib/liveAnnouncer"
 
 const BG = { keepTabOpen: true, backgroundPass: true }
 const live = () => screen.getByRole("status")
@@ -55,20 +60,28 @@ const pill = () => document.querySelector(".bg-warning")
 
 let rerender: (ui: ReactNode) => void = () => {}
 
+// The tag announces through the app-wide LiveAnnouncer, so tests mount both.
+const tree = () => (
+  <>
+    <LiveAnnouncer />
+    <BackgroundPassTag />
+  </>
+)
 const mount = () => {
-  rerender = render(<BackgroundPassTag />).rerender
+  rerender = render(tree()).rerender
 }
 
 const setCache = (next: Fake[]) => {
   act(() => {
     cache = next
-    rerender(<BackgroundPassTag />)
+    rerender(tree())
   })
 }
 
 beforeEach(() => {
   vi.useFakeTimers()
   cache = []
+  __resetLiveAnnouncerForTest()
 })
 
 afterEach(() => {
@@ -78,7 +91,7 @@ afterEach(() => {
 })
 
 describe("BackgroundPassTag", () => {
-  it("always renders the live region, empty while idle", () => {
+  it("renders nothing into the live region while idle", () => {
     mount()
     expect(live().textContent).toBe("")
     expect(pill()).toBeNull()
@@ -104,7 +117,10 @@ describe("BackgroundPassTag", () => {
     act(() => vi.advanceTimersByTime(200))
     expect(pill()).toBeNull()
 
+    // The tag withdraws its text after its own linger; the announcer then
+    // clears the region after its own.
     act(() => vi.advanceTimersByTime(5000))
+    act(() => vi.advanceTimersByTime(ANNOUNCE_LINGER_MS))
     expect(live().textContent).toBe("")
   })
 
@@ -183,7 +199,10 @@ describe("BackgroundPassTag", () => {
       { mutationId: 2, meta: BG, status: "error" },
     ])
     expect(live().textContent).toBe("backgroundPass.failed")
+    // The tag withdraws its text after its own linger; the announcer then
+    // clears the region after its own.
     act(() => vi.advanceTimersByTime(5000))
+    act(() => vi.advanceTimersByTime(ANNOUNCE_LINGER_MS))
     expect(live().textContent).toBe("")
   })
 

--- a/web/src/components/status/BackgroundPassTag.tsx
+++ b/web/src/components/status/BackgroundPassTag.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next"
 import { AnimatePresence, motion } from "motion/react"
 
 import { InlineSpinner } from "@/components/ui"
+import { useAnnounce } from "@/hooks/useAnnounce"
 import { topBarClass, useRevealCycle } from "./TopProgressBar"
 
 export const isBackgroundPass = (mutation: Mutation) =>
@@ -20,10 +21,10 @@ type Announcement = "idle" | "syncing" | "synced" | "failed"
 // Spinner + label for a `backgroundPass` mutation the app started itself: the
 // only in-page cause for the leave prompt those passes raise. Indeterminate
 // because a reconcile's length is unknown; warning-toned to read as "writing on
-// your behalf" beside the green read bar. The live region is always mounted
-// (one inserted on demand is often not announced) and the visible pill is
-// decorative. These passes swallow their own errors, so completion says
-// "failed" when one did rather than claiming a sync.
+// your behalf" beside the green read bar. Announcements go through the app's
+// persistent live region and the visible pill is decorative. These passes
+// swallow their own errors, so completion says "failed" when one did rather
+// than claiming a sync.
 export function BackgroundPassTag() {
   const { t } = useTranslation()
   const passes = useMutationState({
@@ -87,30 +88,26 @@ export function BackgroundPassTag() {
     synced: t("backgroundPass.synced"),
     failed: t("backgroundPass.failed"),
   }
+  useAnnounce(liveText[announcement])
   return (
-    <>
-      <span role="status" className="sr-only">
-        {liveText[announcement]}
-      </span>
-      <AnimatePresence>
-        {visible && (
-          <motion.div
-            className={topBarClass(
-              "z-[59] flex justify-center pointer-events-none",
-            )}
-            initial={{ opacity: 0, y: -8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -8, transition: { duration: 0.15 } }}
-            aria-hidden="true"
-          >
-            <span className="inline-flex items-center gap-1.5 rounded-b-box bg-warning px-2.5 py-1 text-xs font-medium text-warning-content shadow-sm">
-              {/* The tag's reveal already served the anti-flash delay. */}
-              <InlineSpinner immediate />
-              {t("backgroundPass.syncing")}
-            </span>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </>
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          className={topBarClass(
+            "z-[59] flex justify-center pointer-events-none",
+          )}
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -8, transition: { duration: 0.15 } }}
+          aria-hidden="true"
+        >
+          <span className="inline-flex items-center gap-1.5 rounded-b-box bg-warning px-2.5 py-1 text-xs font-medium text-warning-content shadow-sm">
+            {/* The tag's reveal already served the anti-flash delay. */}
+            <InlineSpinner immediate />
+            {t("backgroundPass.syncing")}
+          </span>
+        </motion.div>
+      )}
+    </AnimatePresence>
   )
 }

--- a/web/src/components/status/LiveAnnouncer.test.tsx
+++ b/web/src/components/status/LiveAnnouncer.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, cleanup, render, screen } from "@testing-library/react"
+
+import { Spinner } from "@/components/Spinner"
+import { useAnnounce } from "@/hooks/useAnnounce"
+import {
+  ANNOUNCE_LINGER_MS,
+  __resetLiveAnnouncerForTest,
+} from "@/lib/liveAnnouncer"
+import { LiveAnnouncer } from "./LiveAnnouncer"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const Announce = ({ text }: { text: string | null }) => {
+  useAnnounce(text)
+  return null
+}
+
+const live = () => screen.getByRole("status")
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  __resetLiveAnnouncerForTest()
+})
+
+afterEach(() => {
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+  cleanup()
+})
+
+describe("LiveAnnouncer", () => {
+  it("is present and empty before anything announces", () => {
+    render(<LiveAnnouncer />)
+    expect(live().getAttribute("aria-live")).toBe("polite")
+    expect(live().textContent).toBe("")
+  })
+
+  it("announces a mounted Spinner and clears after the last one leaves", () => {
+    const { rerender } = render(
+      <>
+        <LiveAnnouncer />
+        <Spinner />
+      </>,
+    )
+    expect(live().textContent).toBe("common.loading")
+    // The spinner itself is decorative; the region owns the text.
+    expect(document.querySelectorAll("[role='status']")).toHaveLength(1)
+
+    rerender(<LiveAnnouncer />)
+    expect(live().textContent).toBe("common.loading")
+    act(() => vi.advanceTimersByTime(ANNOUNCE_LINGER_MS))
+    expect(live().textContent).toBe("")
+  })
+
+  it("announces once for several spinners with the same label", () => {
+    const { rerender } = render(
+      <>
+        <LiveAnnouncer />
+        <Spinner />
+        <Spinner />
+        <Spinner label="Loading rows" />
+      </>,
+    )
+    expect(live().textContent).toBe("Loading rows")
+
+    rerender(
+      <>
+        <LiveAnnouncer />
+        <Spinner />
+      </>,
+    )
+    // One of the same-label spinners remains: the text falls back to it.
+    expect(live().textContent).toBe("common.loading")
+  })
+
+  it("does not re-announce a same-text remount inside the linger", () => {
+    const { rerender } = render(
+      <>
+        <LiveAnnouncer />
+        <Spinner />
+      </>,
+    )
+    const region = live()
+    let changes = 0
+    const observer = new MutationObserver(() => {
+      changes += 1
+    })
+    observer.observe(region, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    })
+
+    rerender(<LiveAnnouncer />)
+    act(() => vi.advanceTimersByTime(ANNOUNCE_LINGER_MS / 2))
+    rerender(
+      <>
+        <LiveAnnouncer />
+        <Spinner />
+      </>,
+    )
+    act(() => vi.advanceTimersByTime(ANNOUNCE_LINGER_MS))
+    expect(live().textContent).toBe("common.loading")
+    expect(changes).toBe(0)
+    observer.disconnect()
+  })
+
+  it("follows a caller's text as it changes and withdraws on empty", () => {
+    const { rerender } = render(
+      <>
+        <LiveAnnouncer />
+        <Announce text="Syncing" />
+      </>,
+    )
+    expect(live().textContent).toBe("Syncing")
+    rerender(
+      <>
+        <LiveAnnouncer />
+        <Announce text="Synced" />
+      </>,
+    )
+    expect(live().textContent).toBe("Synced")
+    rerender(
+      <>
+        <LiveAnnouncer />
+        <Announce text={null} />
+      </>,
+    )
+    act(() => vi.advanceTimersByTime(ANNOUNCE_LINGER_MS))
+    expect(live().textContent).toBe("")
+  })
+})

--- a/web/src/components/status/LiveAnnouncer.tsx
+++ b/web/src/components/status/LiveAnnouncer.tsx
@@ -1,0 +1,22 @@
+import { useSyncExternalStore } from "react"
+
+import {
+  getLiveAnnouncement,
+  subscribeLiveAnnouncer,
+} from "@/lib/liveAnnouncer"
+
+// The one polite live region for presence-shaped status (spinners, background
+// passes). Mounted once in main.tsx from first paint, empty while idle, so the
+// text change is what assistive tech hears rather than the region appearing.
+export function LiveAnnouncer() {
+  const text = useSyncExternalStore(
+    subscribeLiveAnnouncer,
+    getLiveAnnouncement,
+    getLiveAnnouncement,
+  )
+  return (
+    <div role="status" aria-live="polite" className="sr-only">
+      {text}
+    </div>
+  )
+}

--- a/web/src/hooks/useAnnounce.ts
+++ b/web/src/hooks/useAnnounce.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react"
+
+import {
+  addAnnouncement,
+  removeAnnouncement,
+  updateAnnouncement,
+} from "@/lib/liveAnnouncer"
+
+// Announce `text` through the app's persistent live region for as long as the
+// caller is mounted with a non-empty value. Pass an empty string or null to
+// withdraw without unmounting.
+export function useAnnounce(text: string | null | undefined): void {
+  const id = useRef<number | null>(null)
+  useEffect(() => {
+    if (!text) {
+      if (id.current !== null) {
+        removeAnnouncement(id.current)
+        id.current = null
+      }
+      return
+    }
+    if (id.current === null) id.current = addAnnouncement(text)
+    else updateAnnouncement(id.current, text)
+  }, [text])
+  useEffect(
+    () => () => {
+      if (id.current !== null) removeAnnouncement(id.current)
+    },
+    [],
+  )
+}
+
+export default useAnnounce

--- a/web/src/lib/liveAnnouncer.ts
+++ b/web/src/lib/liveAnnouncer.ts
@@ -1,0 +1,90 @@
+// Backing store for the app's one persistent polite live region. A live region
+// only announces changes inside an element assistive tech is already watching,
+// so a `role="status"` mounted together with its text (the old `<Spinner>`
+// shape) is announced by some browser/AT pairs and not others. Callers register
+// presence-shaped text (a spinner is mounted, a pass is syncing) and the region
+// shows the most recently registered or changed one, so several spinners
+// announce once.
+
+const listeners = new Set<() => void>()
+const entries = new Map<number, { text: string; seq: number }>()
+let nextId = 1
+let nextSeq = 1
+let snapshot = ""
+let clearTimer: ReturnType<typeof setTimeout> | null = null
+
+// When the last registration leaves, the text stays this long so a remount
+// with the same text (a route change swapping one spinner for another) is not
+// re-announced.
+export const ANNOUNCE_LINGER_MS = 500
+
+function emit() {
+  for (const listener of listeners) listener()
+}
+
+function publish(text: string) {
+  if (text === snapshot) return
+  snapshot = text
+  emit()
+}
+
+function latestText(): string {
+  let latest: { text: string; seq: number } | undefined
+  for (const entry of entries.values()) {
+    if (!latest || entry.seq > latest.seq) latest = entry
+  }
+  return latest?.text ?? ""
+}
+
+function reconcile() {
+  const text = latestText()
+  if (text) {
+    if (clearTimer) {
+      clearTimeout(clearTimer)
+      clearTimer = null
+    }
+    publish(text)
+    return
+  }
+  if (clearTimer || snapshot === "") return
+  clearTimer = setTimeout(() => {
+    clearTimer = null
+    publish("")
+  }, ANNOUNCE_LINGER_MS)
+}
+
+export function addAnnouncement(text: string): number {
+  const id = nextId++
+  entries.set(id, { text, seq: nextSeq++ })
+  reconcile()
+  return id
+}
+
+export function updateAnnouncement(id: number, text: string): void {
+  const entry = entries.get(id)
+  if (!entry || entry.text === text) return
+  entries.set(id, { text, seq: nextSeq++ })
+  reconcile()
+}
+
+export function removeAnnouncement(id: number): void {
+  if (!entries.delete(id)) return
+  reconcile()
+}
+
+export function subscribeLiveAnnouncer(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function getLiveAnnouncement(): string {
+  return snapshot
+}
+
+export function __resetLiveAnnouncerForTest(): void {
+  entries.clear()
+  if (clearTimer) clearTimeout(clearTimer)
+  clearTimer = null
+  snapshot = ""
+  listeners.clear()
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -19,6 +19,7 @@ import { ActionActivityProvider } from "./context/actions/ActionActivityProvider
 import { ActionsBanner } from "./components/status/ActionsBanner"
 import { BackgroundPassTag } from "./components/status/BackgroundPassTag"
 import { KeepTabOpenGuard } from "./components/status/KeepTabOpenGuard"
+import { LiveAnnouncer } from "./components/status/LiveAnnouncer"
 import { RouteProgressBar } from "./components/status/RouteProgressBar"
 import { LanguagePackUpdateToaster } from "./components/settings/LanguagePackUpdateToaster"
 import App from "./App"
@@ -106,6 +107,7 @@ createRoot(document.getElementById("root")!).render(
               <NotificationProvider>
                 <HiddenOrgsProvider>
                   <RouteProgressBar />
+                  <LiveAnnouncer />
                   <BackgroundPassTag />
                   <KeepTabOpenGuard />
                   <App />

--- a/web/src/pages/OrgSetupPage.test.tsx
+++ b/web/src/pages/OrgSetupPage.test.tsx
@@ -84,6 +84,8 @@ vi.mock("@/components/skeletonOverwrite/skeletonOverwriteUi", () => ({
 }))
 
 import OrgSetupPage from "./OrgSetupPage"
+import { LiveAnnouncer } from "@/components/status/LiveAnnouncer"
+import { __resetLiveAnnouncerForTest } from "@/lib/liveAnnouncer"
 
 const retry = vi.fn()
 const owner = (over: Record<string, unknown>) =>
@@ -117,8 +119,11 @@ const renderPage = () => {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   })
+  // The page's Spinner announces through the app-wide live region, so the
+  // "loading" assertions need it mounted beside the page.
   return render(
     <QueryClientProvider client={client}>
+      <LiveAnnouncer />
       <OrgSetupPage />
     </QueryClientProvider>,
   )
@@ -126,6 +131,7 @@ const renderPage = () => {
 
 afterEach(() => {
   cleanup()
+  __resetLiveAnnouncerForTest()
   ownerMock.mockReset()
   repoStatusMock.mockReset()
   tokenStatusMock.mockReset()
@@ -282,6 +288,7 @@ describe("OrgSetupPage wizard navigation", () => {
           new QueryClient({ defaultOptions: { queries: { retry: false } } })
         }
       >
+        <LiveAnnouncer />
         <OrgSetupPage />
       </QueryClientProvider>,
     )


### PR DESCRIPTION
## Why

`Spinner` rendered its `role="status"` region and sr-only label together, and every call site mounts it conditionally. A live region only announces changes inside an element assistive tech is already watching, so when the region and its text arrive in one DOM mutation there is nothing to observe: some browser/AT pairs read "Loading", some race, some stay silent. Primer's loading guidance says the `role="status"` element must always be rendered, not just when a message should be announced. `BackgroundPassTag` had the same shape and got a private always-mounted region in #891; `Spinner` has 26 call sites, so it needs a shared mechanism.

Fixes #890

## What

- **One persistent polite live region**, `LiveAnnouncer`, mounted once in `main.tsx` beside `RouteProgressBar`. Present from first paint, empty while idle.
- **`useAnnounce(text)`** writes presence-shaped text into it for as long as the caller is mounted with a non-empty value. The store (`lib/liveAnnouncer.ts`) shows the most recently registered or changed text, so several spinners on one page announce once. When the last registration leaves, the text lingers 500ms so a route change that swaps one spinner for another with the same label is not re-announced.
- **`Spinner`** calls the hook with its label and is now `aria-hidden` (Primer's `srText={null}` shape). No call site changes.
- **`BackgroundPassTag`** drops its private region and announces through the same hook; the state machine from #891 is unchanged.
- `InlineSpinner` is untouched: it was already `aria-hidden` by contract.

## Testing

`npm run check` passes: `tsc -b`, eslint (26 warnings, identical to `main`), prettier, `arch:validate`, 5182 vitest tests. New `LiveAnnouncer.test.tsx` covers: region present and empty before any spinner mounts; text changes on mount and clears after the linger when the last one leaves; several spinners announce once; a same-text remount inside the linger produces no DOM mutation in the region (asserted with a `MutationObserver`); a caller's changing text is followed and withdrawn on empty. `BackgroundPassTag.test.tsx` and `OrgSetupPage.test.tsx` now mount `LiveAnnouncer` beside the component, since the text they assert lives there.

Not verified here: an actual screen reader pass (VoiceOver + Safari, NVDA + Firefox) confirming a conditionally mounted `<Spinner>` is now read. Worth a quick check before release.
