### PR TITLE
fix(web): unblock locale translation and stabilize a flaky invite test

### DIFF
--- a/web/src/domain/students.test.ts
+++ b/web/src/domain/students.test.ts
@@ -32,6 +32,7 @@ import {
 import { removeEmailInviteRow } from "./students/rosterPrimitives"
 import { inviteTeamName, marshalInviteDescription } from "@/util/inviteTeam"
 import { GitHubAPIError } from "@/github-core/errors"
+import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
 import type { GitHubClient } from "@/github-core/client"
 
 // An already-org-member must land `enrolled` (not stuck "awaiting"), the per-row
@@ -600,11 +601,22 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
     // 500 every per-invite metadata team create — the invite must then be
     // reported as failed rather than sent without email retention.
     failInviteTeams?: boolean
+    // Park every successful POST /invitations until a macrotask after the
+    // first rateLimitEmails 429 was issued. By then the throttled rejection has
+    // fully unwound (flag flipped, idle worker drained the queue as deferred),
+    // so the peers in flight when it hit are exactly the ones that get sent.
+    // Without it the count depends on how the libuv threadpool orders each
+    // target's inviteTeamName digest, which drifts with machine load.
+    holdInvitesUntilThrottled?: boolean
   }) => {
     const memberEmails = new Set(opts?.memberEmails ?? [])
     const rateLimitEmails = new Set(opts?.rateLimitEmails ?? [])
     const failEmails = new Set(opts?.failEmails ?? [])
     let inviteAttempts = 0
+    let releaseHeldInvites = () => {}
+    const heldInvites = new Promise<void>((resolve) => {
+      releaseHeldInvites = resolve
+    })
     const state = {
       // roster.csv content committed by the batch pending-row write (null =
       // no roster write happened).
@@ -738,10 +750,17 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
               return Promise.reject(apiError(422, "already a member"))
             }
             if (rateLimitEmails.has(body.email)) {
+              setTimeout(releaseHeldInvites, 0)
               return Promise.reject(apiError(429, "rate limited"))
             }
             if (failEmails.has(body.email)) {
               return Promise.reject(apiError(500, "server error"))
+            }
+            if (opts?.holdInvitesUntilThrottled) {
+              return heldInvites.then(() => {
+                state.inviteBodies.push(body)
+                return {}
+              })
             }
             state.inviteBodies.push(body)
             return Promise.resolve({})
@@ -907,15 +926,19 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
   })
 
   it("defers the rest once a mid-batch rate limit hits, sending no new invites", async () => {
-    // More targets than REPO_READ_CONCURRENCY (=8): once the throttled invite
-    // sets the rateLimited flag, every not-yet-started target short-circuits to
+    // More targets than REPO_READ_CONCURRENCY: once the throttled invite sets
+    // the rateLimited flag, every not-yet-started target short-circuits to
     // `deferred` (never `failed`), and no invite body is recorded for them.
     const total = 20
     const targets = Array.from({ length: total }, (_, i) => ({
       email: `u${i}@x.edu`,
     }))
-    // Throttle the very first target so the flag flips as early as possible.
-    const { client, state } = makeClient({ rateLimitEmails: ["u0@x.edu"] })
+    // Throttle the very first target so the flag flips as early as possible;
+    // hold the peers so the flip lands before any worker can pick up more.
+    const { client, state } = makeClient({
+      rateLimitEmails: ["u0@x.edu"],
+      holdInvitesUntilThrottled: true,
+    })
 
     const result = await bulkInviteByEmail(client, {
       org: "acme",
@@ -928,17 +951,12 @@ describe("bulkInviteByEmail — bulk org invites by email, one batch row write",
     // The throttled email is deferred; nothing is misrouted to `failed`.
     expect(result.deferred).toContain("u0@x.edu")
     expect(result.failed).toEqual([])
-    // Every target is accounted for exactly once across the buckets.
-    expect(
-      result.invited.length +
-        result.skipped.length +
-        result.failed.length +
-        result.deferred.length,
-    ).toBe(total)
-    // The short-circuit actually fired: with the flag set early, most targets
-    // are deferred rather than sent (bounded by the concurrency window that was
-    // already in flight when the flag flipped).
-    expect(result.deferred.length).toBeGreaterThan(total / 2)
+    expect(result.skipped).toEqual([])
+    // Only the peers already past the flag check when u0 was throttled (the
+    // rest of the concurrency window) were sent; every later target deferred.
+    const peersInFlight = REPO_READ_CONCURRENCY - 1
+    expect(result.invited).toHaveLength(peersInFlight)
+    expect(result.deferred).toHaveLength(total - peersInFlight)
     // No invite was sent for a deferred email.
     const sentEmails = new Set(state.inviteBodies.map((b) => b.email))
     for (const email of result.deferred) {

--- a/web/src/i18n/keyAudit.test.ts
+++ b/web/src/i18n/keyAudit.test.ts
@@ -50,6 +50,30 @@ function walk(dir: string): string[] {
 const T_CALL = /\bt\(\s*(["'`])((?:(?!\1)[^\\$]|\\.)*)\1/g
 
 describe("i18n key audit", () => {
+  it("no key segment in en.json contains a dot", () => {
+    // Every flattener in the pipeline (flattenBundle, verify_locale.py,
+    // audit_i18n.py, translate_locales.py) joins segments with "." and splits
+    // them back the same way, so a leaf named "2.1" flattens to a path that no
+    // longer resolves. i18next happens to tolerate it, which is why only the
+    // translation workflow noticed.
+    const dotted: string[] = []
+    const walkKeys = (node: unknown, path: string[]) => {
+      if (!node || typeof node !== "object") return
+      for (const [segment, value] of Object.entries(node)) {
+        const here = [...path, segment]
+        if (segment.includes(".")) dotted.push(here.join("/"))
+        walkKeys(value, here)
+      }
+    }
+    walkKeys(en, [])
+    expect(
+      dotted,
+      `en.json key segments must not contain "." (shown as nested paths):\n${dotted
+        .map((k) => `  ${k}`)
+        .join("\n")}`,
+    ).toEqual([])
+  })
+
   it('every static t("…") key exists in en.json', () => {
     const missing: { file: string; key: string }[] = []
     for (const file of walk(SRC_DIR)) {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -125,8 +125,8 @@
         "notEvaluated": "Not Evaluated"
       },
       "since": {
-        "2.1": "WCAG 2.1 and 2.2",
-        "2.2": "WCAG 2.2 only"
+        "wcag21": "WCAG 2.1 and 2.2",
+        "wcag22": "WCAG 2.2 only"
       },
       "principle": {
         "Perceivable": "Perceivable",

--- a/web/src/pages/accessibility/VpatSection.tsx
+++ b/web/src/pages/accessibility/VpatSection.tsx
@@ -20,6 +20,7 @@ import {
 
 import {
   TONE_DOT_CLASS,
+  VPAT_SINCE_KEY,
   VPAT_STATUS_ORDER,
   tabClass,
   useVpatReport,
@@ -176,7 +177,7 @@ function VpatConformanceTable({
                           {c.name}
                           {c.since && (
                             <span className="ms-1 text-xs text-base-content/60">
-                              ({t(`accessibility.vpat.since.${c.since}`)})
+                              ({t(VPAT_SINCE_KEY[c.since])})
                             </span>
                           )}
                         </td>

--- a/web/src/pages/accessibility/data.ts
+++ b/web/src/pages/accessibility/data.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query"
 
 import type { BadgeTone } from "@/types/badgeTone"
 import { cx } from "@/components/ui"
-import { type ConformanceLevel } from "@/util/a11y/vpatModel"
+import { type ConformanceLevel, type Criterion } from "@/util/a11y/vpatModel"
 import type {
   ContrastAuditJson,
   ContrastStatus,
@@ -89,6 +89,13 @@ export const TONE_DOT_CLASS: Record<BadgeTone, string> = {
   info: "bg-info",
   primary: "bg-primary",
   secondary: "bg-secondary",
+}
+
+// The WCAG version number can't be the key segment itself: every flattener in
+// the i18n pipeline splits keys on ".", so "since.2.1" is unresolvable.
+export const VPAT_SINCE_KEY: Record<NonNullable<Criterion["since"]>, string> = {
+  "2.1": "accessibility.vpat.since.wcag21",
+  "2.2": "accessibility.vpat.since.wcag22",
 }
 
 // The order the VPAT summary chips + status filter render in: best-first, then

--- a/web/src/pages/accessibility/reports/PrintableReport.tsx
+++ b/web/src/pages/accessibility/reports/PrintableReport.tsx
@@ -12,7 +12,13 @@ import {
 } from "@/util/a11y/vpatModel"
 import { DownloadIcon, FileIcon } from "@/components/ui/icons"
 
-import { useContrastAudit, useVpatReport, type Audit, type Vpat } from "../data"
+import {
+  VPAT_SINCE_KEY,
+  useContrastAudit,
+  useVpatReport,
+  type Audit,
+  type Vpat,
+} from "../data"
 
 // Which report the browser print / Save-as-PDF should render. The full report
 // prints every document; the others print just their own.
@@ -176,7 +182,7 @@ function PrintableVpat({ vpat }: { vpat: Vpat }) {
                       {c.since && (
                         <span className="report-sub">
                           {" "}
-                          ({t(`accessibility.vpat.since.${c.since}`)})
+                          ({t(VPAT_SINCE_KEY[c.since])})
                         </span>
                       )}
                     </td>


### PR DESCRIPTION
## Summary

Language packs translate again, and the web build gate no longer fails at random on the bulk-invite rate-limit test. Both post-merge workflows have been red since the last two merges: `translate-locales` on every push since #888, and `web-deploy-preview` on #891.

## Locale translation

#888 added `en.json` leaves named `"2.1"` and `"2.2"` under `accessibility.vpat.since`. Every reader in the i18n pipeline joins key segments with `.` and splits them back the same way, so `translate_locales.py` produced `accessibility.vpat.since.2.1`, could not resolve it, and died before contacting the model. The `--full` self-heal hits the same line, which is why all 19 languages failed. i18next tolerates dotted keys at runtime, so the app, `keyAudit`, and `audit_i18n.py --strict` all stayed green.

The segments are now `wcag21` / `wcag22`, looked up through one `VPAT_SINCE_KEY` map instead of a dynamic template. A new `keyAudit` test walks the nested `en.json` and rejects any segment containing `.`, so this is caught in `npm run check` rather than in the post-merge translate job. Against the pre-fix file it flags exactly the two offending keys.

## Flaky invite test

`students.test.ts` asserted `deferred.length > total / 2`, which depends on how many workers slip past the `rateLimited` flag before the throttled rejection lands. `inviteOne` awaits `crypto.subtle.digest`, which Node runs on the libuv threadpool, so that count follows thread scheduling and runner load. Under CPU load the old test produced 13, 12, and 6 deferred out of 20; CI hit exactly 10.

The mock now parks successful invitation POSTs until a macrotask after the 429 is issued, so the flag flip has fully unwound before any peer can pick up another target. The test asserts exact counts (`REPO_READ_CONCURRENCY - 1` invited, the rest deferred) and passed 12/12 under the same load that broke the original, and under Node 24.20.0 as in CI.

## Validation

- `npm run check` green: tsc, eslint, prettier, `arch:validate`, 5196 tests across 393 files.
- `audit_i18n.py --strict` PASS; `test_verify_locale.py` and `test_audit_i18n.py` 92 passed.
- `translate_locales.py`'s `chunk_keys` round-trips all 3255 `en.json` keys. The end-to-end translate job needs the Bedrock secret, so it will only be exercised by the workflow run on merge.

Failing runs: [translate-locales](https://github.com/foundation50/classroom50/actions/runs/33984639404), [web-deploy-preview](https://github.com/foundation50/classroom50/actions/runs/33984639401).
