### PR TITLE
docs: tighten 1.46.0 comments and document the sync tag and VPAT

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -108,8 +108,8 @@ export default defineConfig([
       "jsx-a11y/role-supports-aria-props": "warn",
       "jsx-a11y/scope": "warn",
       "jsx-a11y/tabindex-no-positive": "warn",
-      // Nudge new loading UI toward the accessible <Spinner> (announced via the
-      // persistent live region) instead of a bare, silent daisyUI spinner span. In-button
+      // Nudge new loading UI toward <Spinner> (announced through the persistent
+      // live region) instead of a bare, silent daisyUI spinner span. In-button
       // spinners may stay inline when the button already carries an aria-label;
       // this only flags the literal utility class in JSX className literals.
       "no-restricted-syntax": [

--- a/web/src/components/Spinner.tsx
+++ b/web/src/components/Spinner.tsx
@@ -6,18 +6,15 @@ import { useAnnounce } from "@/hooks/useAnnounce"
 type SpinnerSize = "xs" | "sm" | "md" | "lg" | "xl"
 
 /**
- * Accessible loading spinner: daisyUI `loading-spinner` whose `label` is
- * announced through the app's persistent live region (`LiveAnnouncer`), so
- * the announcement does not depend on a `role="status"` appearing in the same
- * DOM mutation as its text. Several spinners on one page announce once. Use
- * when the spinner is the ONLY loading indicator; when the busy state is
- * already announced (adjacent text, an in-button spinner on a labeled disabled
- * button), use `InlineSpinner` — the resolution the `no-restricted-syntax`
- * lint nudge expects.
+ * Loading spinner whose `label` is announced through the app's persistent live
+ * region (`useAnnounce`), so several spinners on one page announce once. Use it
+ * when the spinner is the only loading indicator; when the busy state is
+ * already announced (adjacent text, a labeled disabled button), use
+ * `InlineSpinner`, which is what the `no-restricted-syntax` lint nudge expects.
  *
- * The visual is anti-flash guarded (`indicator-appear`): it stays invisible
- * for the first ~250ms so sub-second loads never flash an indicator (Primer
- * loading guidance). The announcement is not delayed.
+ * The visual is anti-flash guarded (`indicator-appear`): invisible for the
+ * first ~250ms so sub-second loads never flash (Primer loading guidance). The
+ * announcement is not delayed.
  */
 export function Spinner({
   size = "md",

--- a/web/src/hooks/useBeforeUnloadGuard.ts
+++ b/web/src/hooks/useBeforeUnloadGuard.ts
@@ -3,8 +3,8 @@ import { useEffect } from "react"
 // Ask the browser to confirm before the tab closes while `active`. The prompt
 // text is the browser's own, so in-page copy must say why the tab should stay
 // open; and browsers only show it once the user has interacted with the page.
-// Multi-write mutation hooks hold the tab via `meta: { keepTabOpen: true }`
-// instead (see hooks/mutations/README.md); this is for component-run fan-outs.
+// Mutation hooks hold the tab via `meta: { keepTabOpen: true }` instead (see
+// hooks/mutations/README.md); this is for component-run fan-outs.
 export function useBeforeUnloadGuard(active: boolean) {
   useEffect(() => {
     if (!active) return

--- a/web/src/types/reactQuery.ts
+++ b/web/src/types/reactQuery.ts
@@ -2,8 +2,9 @@
 // list of what is (and isn't) flagged: hooks/mutations/README.md.
 export type MutationMeta =
   | {
-      // The mutationFn chains several GitHub writes, so closing the tab
-      // mid-run strands partial state. KeepTabOpenGuard holds the tab.
+      // Losing the tab mid-run costs the user something: a chain of GitHub
+      // writes strands partial state, or a long read (an archive download)
+      // has to start over. KeepTabOpenGuard holds the tab.
       keepTabOpen?: boolean
       backgroundPass?: never
     }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -60,8 +60,8 @@ function resolveReleaseInfo() {
     process.env.VITE_APP_COMMIT || git("rev-parse --short=12 HEAD") || "unknown"
   const buildDate = process.env.VITE_APP_BUILD_DATE || new Date().toISOString()
 
-  // Only a release tag names a published version; an untagged (main push /
-  // local) build carries none, so the ACR can't claim a release it isn't.
+  // `tagVersion` is set only for a tagged release build; a main push or local
+  // build has none.
   return { version, commit, buildDate, tagVersion: tagVersion || undefined }
 }
 
@@ -134,10 +134,9 @@ function contrastAuditPlugin(): Plugin {
 // vpatGuard.test.ts is the enforcement. Same dev + build wiring as the contrast
 // audit above.
 function vpatReportPlugin(): Plugin {
-  // The ACR names the release it describes (a VPAT "Name of Product/Version"
-  // requirement); the pure renderer can't read the build's version itself.
-  // Tag-derived only: an untagged build would otherwise be labelled with the
-  // last released version while containing unreleased changes.
+  // The ACR's "Name of Product/Version" field. Passed in because the pure
+  // renderer can't read the build, and tag-derived so an untagged build isn't
+  // labelled with the last release while carrying unreleased changes.
   const options = { version: release.tagVersion }
   const assets: { fileName: string; source: string; type: string }[] = [
     {

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -431,6 +431,20 @@ with GitHub and on how much identifying data you put on GitHub. For the full
 picture, including practices that keep student data off GitHub, see
 [Privacy and FERPA](GitHub-Integration#privacy-and-ferpa).
 
+### Is Classroom 50 accessible? Is there a VPAT?
+
+Yes. The web app targets WCAG 2.2 Level A and AA and publishes an Accessibility
+Conformance Report (VPAT 2.5Rev, WCAG edition) at
+[classroom50.org/accessibility](https://classroom50.org/accessibility), no
+sign-in needed. The report lists every WCAG 2.0, 2.1, and 2.2 Level A and AA
+criterion with a verdict, the date it was assessed, and a remark, so a
+criterion that can't apply (the app has no audio or video) reads as **Not
+Applicable** with the reason rather than as unevaluated. The same page carries
+the accessibility statement, a color contrast audit of both themes that runs on
+every build, and each report as a Markdown download or a print-to-PDF view for
+procurement reviews. The reports are generated from the shipped build, so they
+describe the version you're using.
+
 ## Roadmap
 
 Some capabilities from GitHub Classroom aren't available today, including

--- a/wiki/How-Classroom-50-Works.md
+++ b/wiki/How-Classroom-50-Works.md
@@ -95,6 +95,12 @@ about why a change did or did not take effect:
 1. **Interactive actions** run as you, with your signed-in GitHub token, at the
    time you take them (create a classroom, add a student, accept an assignment).
    They are limited by your GitHub permissions and require you to be present.
+   When one makes several GitHub writes in a row (accepting an assignment,
+   importing a roster, a bulk action) or a long download, the web app asks the
+   browser to confirm before you close the tab, so the run isn't cut off with
+   the work half done. Syncs the app starts on its own show a
+   **Syncing with GitHub…** tag at the top of the page when they take more
+   than a moment.
 2. **Asynchronous actions** run in **GitHub Actions workflows** in your
    `classroom50` repository (publishing to Pages, collecting scores,
    regrading). They run in the background, can take a minute or more, and

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -729,8 +729,11 @@ skipped and reported rather than overwritten.
 anything new (members who joined or left, accepted invitations, role changes)
 and updates the roster to match; the same check runs when you open the page.
 It runs in the background (the roster stays fully usable) with the button
-reading **Refreshing roster…** while it works. The caption beside the button
-shows when the roster last changed and what the last refresh found.
+reading **Refreshing roster…** while it works, and a **Syncing with GitHub…**
+tag at the top of the page if it takes more than a moment. The browser asks
+before you close the tab mid-sync; if you close anyway, nothing is lost, and
+the sync runs again the next time you open the classroom. The caption beside
+the button shows when the roster last changed and what the last refresh found.
 
 ## Manage groups
 


### PR DESCRIPTION
Follow-up sweep of the four PRs in release 1.46.0 (#889) for stale or duplicated comments, plus the wiki updates those changes call for.

**Comments**

- `types/reactQuery.ts`: the `keepTabOpen` doc still said "chains several GitHub writes", but the last commit in #891 broadened the rule to long reads (`useDownloadSubmission`). Now states both criteria, matching `hooks/mutations/README.md`. Same narrowing removed from `useBeforeUnloadGuard`.
- `vite.config.ts`: the tag-derived-version rationale was written twice (`resolveReleaseInfo` and `vpatReportPlugin`). Said once, where it is used.
- `Spinner.tsx`: the JSDoc restated the live-region rationale that lives in `lib/liveAnnouncer.ts`; trimmed to what a caller needs.
- `eslint.config.js`: re-flowed a comment line that ran long when #893 reworded it.

**Wiki** (`wiki/`, published by CI)

- FAQ: new "Is Classroom 50 accessible? Is there a VPAT?" entry pointing at `/accessibility`, now that #888 completed the report. The wiki had no mention of the page.
- How Classroom 50 Works and Web Teacher Guide: describe the close-tab confirmation for multi-write actions and the "Syncing with GitHub…" tag from #891.

No code changes; comments and Markdown only.