### PR TITLE
fix(web): flag groups whose membership exceeds max_group_size

### DIFF
--- a/web/src/components/assignments/GroupOverCapacityBadge.tsx
+++ b/web/src/components/assignments/GroupOverCapacityBadge.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "@/components/ui"
+import { AlertIcon } from "@/components/ui/icons"
+import { isGroupOverCapacity } from "@/domain/teams/groupTeams"
+
+// Error chip for a group whose live membership exceeds max_group_size
+// (#896): a student maintainer can add members on GitHub directly, past the
+// cap every Classroom 50 client enforces. Renders nothing while the group is
+// within the cap, so rows stay quiet in the normal case. `plain` drops the
+// badge's own title + sr-only detail when an interactive parent owns the
+// accessible name.
+export function GroupOverCapacityBadge({
+  count,
+  max,
+  plain = false,
+}: {
+  count?: number
+  max?: number
+  plain?: boolean
+}) {
+  const { t } = useTranslation()
+  if (count === undefined || !isGroupOverCapacity(count, max)) return null
+  const detail = t("components.groupOverCapacity.title", { count, max })
+  return (
+    <Badge
+      tone="error"
+      size="sm"
+      className="whitespace-nowrap"
+      title={plain ? undefined : detail}
+    >
+      <AlertIcon aria-hidden="true" className="size-3" />
+      {t("components.groupOverCapacity.badge")}
+      {!plain && <span className="sr-only">{detail}</span>}
+    </Badge>
+  )
+}
+
+export default GroupOverCapacityBadge

--- a/web/src/components/assignments/GroupTeamMembersPanel.tsx
+++ b/web/src/components/assignments/GroupTeamMembersPanel.tsx
@@ -10,7 +10,7 @@ import {
   SignOutIcon,
   TrashIcon,
 } from "@/components/ui/icons"
-import { Alert, Badge, Button, Input } from "@/components/ui"
+import { Alert, Badge, Button, Input, cx } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import { Spinner } from "@/components/Spinner"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
@@ -18,7 +18,7 @@ import { teamMembersQuery } from "@/github-core/queries"
 import useAddGroupTeamMember from "@/hooks/mutations/useAddGroupTeamMember"
 import useRemoveGroupTeamMember from "@/hooks/mutations/useRemoveGroupTeamMember"
 import useLeaveGroupTeam from "@/hooks/mutations/useLeaveGroupTeam"
-import { groupTeamUrl } from "@/domain/teams/groupTeams"
+import { groupTeamUrl, isGroupOverCapacity } from "@/domain/teams/groupTeams"
 import { errorText } from "@/types/localizedMessage"
 import { normalizeUsername } from "@/components/modals/collaboratorHelpers"
 import type { TeamFormation } from "@/types/classroom"
@@ -78,6 +78,7 @@ export function GroupTeamMembersPanel({
     addMember.isPending || removeMember.isPending || leaveTeam.isPending
 
   const isFull = maxGroupSize !== undefined && members.length >= maxGroupSize
+  const overCapacity = isGroupOverCapacity(members.length, maxGroupSize)
   const viewerMember = viewerLogin
     ? members.find(
         (m) => normalizeUsername(m.login) === normalizeUsername(viewerLogin),
@@ -142,7 +143,12 @@ export function GroupTeamMembersPanel({
           <PeopleIcon aria-hidden="true" className="size-4" />
           {groupName}
         </span>
-        <span className="text-xs text-base-content/70">
+        <span
+          className={cx(
+            "text-xs",
+            overCapacity ? "font-medium text-warning" : "text-base-content/70",
+          )}
+        >
           {maxGroupSize !== undefined
             ? t("components.groupTeamMembers.memberCountOfMax", {
                 count: members.length,
@@ -153,6 +159,19 @@ export function GroupTeamMembersPanel({
               })}
         </span>
       </div>
+
+      {/* Members added on GitHub directly can push the group past the cap
+          (#896); the teacher sees the same flag, so tell the group first. */}
+      {overCapacity ? (
+        <Alert tone="warning" className="text-sm">
+          {t(
+            canManage
+              ? "components.groupTeamMembers.overCapacityManage"
+              : "components.groupTeamMembers.overCapacity",
+            { count: members.length, max: maxGroupSize ?? 0 },
+          )}
+        </Alert>
+      ) : null}
 
       {actionError ? (
         <Alert tone="error" className="text-sm">
@@ -234,7 +253,10 @@ export function GroupTeamMembersPanel({
         </ul>
       )}
 
+      {/* The over-capacity alert already asks for removals, so the "full"
+          note would only repeat it. */}
       {canManage &&
+        !overCapacity &&
         (isFull ? (
           <p className="text-xs text-base-content/70">
             {t("components.groupTeamMembers.groupFull", {

--- a/web/src/domain/teams/groupTeams.test.ts
+++ b/web/src/domain/teams/groupTeams.test.ts
@@ -7,6 +7,7 @@ import {
   createGroupTeam,
   deleteGroupTeam,
   findMyGroupTeam,
+  isGroupOverCapacity,
   leaveGroupTeam,
   listAssignmentGroupTeams,
   lowestFreeCounter,
@@ -101,6 +102,19 @@ describe("assertGroupMemberAddable", () => {
         rosterLogins: new Set(["alice"]),
       }),
     ).not.toThrow()
+  })
+})
+
+describe("isGroupOverCapacity", () => {
+  it("flags only a count strictly past the cap", () => {
+    expect(isGroupOverCapacity(4, 3)).toBe(true)
+    // At the cap is full, not over: the badge must not fire on a normal group.
+    expect(isGroupOverCapacity(3, 3)).toBe(false)
+    expect(isGroupOverCapacity(2, 3)).toBe(false)
+  })
+
+  it("never flags without a cap", () => {
+    expect(isGroupOverCapacity(50, undefined)).toBe(false)
   })
 })
 

--- a/web/src/domain/teams/groupTeams.ts
+++ b/web/src/domain/teams/groupTeams.ts
@@ -471,6 +471,17 @@ export function unassignedRosterStudents<T extends { username: string }>(
   })
 }
 
+// Whether a live group exceeds max_group_size. Every Classroom 50 client
+// refuses an add past the cap, but a student maintainer can still add members
+// on GitHub directly (#896), so surfaces flag an oversize group rather than
+// assume it can't happen.
+export function isGroupOverCapacity(
+  memberCount: number,
+  maxGroupSize?: number,
+): boolean {
+  return maxGroupSize !== undefined && memberCount > maxGroupSize
+}
+
 // Pure add-member gate: max_group_size (owner included) and the roster. Throws
 // localized errors so the view renders the remedy in the student's language.
 // `rosterLogins` undefined = no roster available to check (the caller decides

--- a/web/src/domain/teams/membershipDraft.test.ts
+++ b/web/src/domain/teams/membershipDraft.test.ts
@@ -18,6 +18,7 @@ describe("resolveMembershipDraft", () => {
       resultingCount: 3,
       hasChanges: false,
       atCapacity: false,
+      overCapacity: false,
     })
   })
 
@@ -81,5 +82,29 @@ describe("resolveMembershipDraft", () => {
       additions: ["dave", "erin"],
     })
     expect(draft.atCapacity).toBe(false)
+    expect(draft.overCapacity).toBe(false)
+  })
+
+  it("flags a live group past the cap until pending removals bring it back", () => {
+    // 4 live members against a cap of 3 (added on GitHub directly, #896).
+    const live = ["alice", "bob", "carol", "dave"]
+    const over = resolveMembershipDraft({
+      currentMembers: live,
+      removals: new Set(),
+      additions: [],
+      maxGroupSize: 3,
+    })
+    expect(over.overCapacity).toBe(true)
+    expect(over.atCapacity).toBe(true)
+
+    // One pending removal lands exactly on the cap: full, no longer over.
+    const fixed = resolveMembershipDraft({
+      currentMembers: live,
+      removals: new Set(["dave"]),
+      additions: [],
+      maxGroupSize: 3,
+    })
+    expect(fixed.overCapacity).toBe(false)
+    expect(fixed.atCapacity).toBe(true)
   })
 })

--- a/web/src/domain/teams/membershipDraft.ts
+++ b/web/src/domain/teams/membershipDraft.ts
@@ -1,3 +1,5 @@
+import { isGroupOverCapacity } from "./groupTeams"
+
 // Pure draft math for the per-group manage dialog: membership edits are
 // staged (pending adds/removals) and applied only on Save, mirroring
 // GroupCollaboratorsModal's interaction model. Kept out of component state
@@ -13,6 +15,9 @@ export type MembershipDraftChanges = {
   hasChanges: boolean
   // Gate for further adds, on the DRAFT count (not the live one).
   atCapacity: boolean
+  // The draft still exceeds max_group_size (members added outside Classroom
+  // 50, #896): the dialog asks for removals instead of saying "full".
+  overCapacity: boolean
 }
 
 // Resolve a draft against the live member list. `removals` holds lowercased
@@ -50,5 +55,6 @@ export function resolveMembershipDraft(input: {
     resultingCount,
     hasChanges: toRemove.length > 0 || toAdd.length > 0,
     atCapacity: maxGroupSize !== undefined && resultingCount >= maxGroupSize,
+    overCapacity: isGroupOverCapacity(resultingCount, maxGroupSize),
   }
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1940,7 +1940,8 @@
       "pendingNote": "Counts include unsaved changes.",
       "membersError": "Some membership changes couldn't be saved: {{error}} The unsaved changes are still listed. Save again to retry them.",
       "dangerHeading": "Danger zone",
-      "dangerBody": "Deleting this group removes its GitHub team and the access it granted. The group's repository is not deleted."
+      "dangerBody": "Deleting this group removes its GitHub team and the access it granted. The group's repository is not deleted.",
+      "overCapacity": "This group has {{count}} members, but this assignment allows {{max}}. Someone added members directly on GitHub. Remove members until the group has {{max}} or fewer, then select Save changes."
     },
     "copy": {
       "button": "Copy groups",
@@ -3846,7 +3847,13 @@
       "leave": "Leave group",
       "leaveTitle": "Leave {{name}}?",
       "leaveBody": "You lose access to the group's repository and your work stays with the group. Rejoining takes extra steps: you must request to join again on GitHub and wait for the group or your teacher to approve it.",
-      "leaveConfirm": "Leave group"
+      "leaveConfirm": "Leave group",
+      "overCapacity": "This group has {{count}} members, but this assignment allows {{max}}. Your teacher can see this warning too. Ask the group's maintainer, or your teacher, to remove members until the group has {{max}} or fewer.",
+      "overCapacityManage": "This group has {{count}} members, but this assignment allows {{max}}. Your teacher can see this warning too. Remove members until the group has {{max}} or fewer."
+    },
+    "groupOverCapacity": {
+      "badge": "Over the limit",
+      "title": "This group has {{count}} members, but this assignment allows {{max}}. Someone added members directly on GitHub. Remove members from the group, or grade the group as it is."
     }
   },
   "formatDate": {

--- a/web/src/pages/manageGroups/GroupRow.tsx
+++ b/web/src/pages/manageGroups/GroupRow.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next"
 
 import { Badge, Button } from "@/components/ui"
 import { LinkExternalIcon, RepoIcon } from "@/components/ui/icons"
+import { GroupOverCapacityBadge } from "@/components/assignments/GroupOverCapacityBadge"
 import type { GitHubUser } from "@/github-core/types"
 import type { GroupTeamRef } from "@/domain/teams/groupTeams"
 
@@ -55,6 +56,7 @@ export function GroupRow({
               {t("manageGroups.driftBadge")}
             </Badge>
           )}
+          <GroupOverCapacityBadge count={members.length} max={maxGroupSize} />
         </div>
 
         {members.length === 0 ? (

--- a/web/src/pages/manageGroups/ManageGroupDialog.tsx
+++ b/web/src/pages/manageGroups/ManageGroupDialog.tsx
@@ -527,7 +527,16 @@ export function ManageGroupDialog({
               )}
             </ul>
 
-            {draft.atCapacity ? (
+            {draft.overCapacity ? (
+              // Over the cap (members added on GitHub directly, #896): "full"
+              // would understate it, so ask for removals until it fits.
+              <Alert tone="warning" className="text-sm">
+                {t("manageGroups.manage.overCapacity", {
+                  count: draft.resultingCount,
+                  max: maxGroupSize ?? 0,
+                })}
+              </Alert>
+            ) : draft.atCapacity ? (
               <p className="text-xs text-base-content/70">
                 {t("manageGroups.groupFull", { max: maxGroupSize ?? 0 })}
               </p>

--- a/web/src/pages/submissions/SubmissionsRows.tsx
+++ b/web/src/pages/submissions/SubmissionsRows.tsx
@@ -6,7 +6,12 @@ import { studentRepoUrl } from "@/util/studentRepo"
 import Avatar from "@/components/avatar"
 import { Badge, Button } from "@/components/ui"
 import { nonSubmitterStatus } from "@/pages/submissions/dashboard"
-import { groupTeamUrl, type GroupTeamRef } from "@/domain/teams/groupTeams"
+import {
+  groupTeamUrl,
+  isGroupOverCapacity,
+  type GroupTeamRef,
+} from "@/domain/teams/groupTeams"
+import { GroupOverCapacityBadge } from "@/components/assignments/GroupOverCapacityBadge"
 import { ScoreCell } from "@/pages/submissions/ScoreCell"
 import type { ScoreOverrideCapability } from "@/pages/submissions/ScoreOverrideModal"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
@@ -342,14 +347,18 @@ export const GroupMembers = ({
 // never resolve, so `missing` renders the error badge in this column instead
 // of that dash-forever — as a click-through to the recovery dialog when the
 // caller supplies `missingLabel` (the recover affordance's accessible name).
+// A count past `max` gains the over-capacity warning chip (#896).
 export const TeamMembersCountCell = ({
   count,
+  max,
   label,
   onClick,
   missing = false,
   missingLabel,
 }: {
   count?: number
+  // The assignment's max_group_size; absent, no over-capacity check.
+  max?: number
   // Accessible name carrying the group's display name.
   label: string
   onClick: () => void
@@ -360,6 +369,7 @@ export const TeamMembersCountCell = ({
   // the badge renders inert (a host without a recovery flow).
   missingLabel?: string
 }) => {
+  const { t } = useTranslation()
   if (missing) {
     if (!missingLabel) return <TeamMissingBadge />
     return (
@@ -378,17 +388,25 @@ export const TeamMembersCountCell = ({
   if (count === undefined) {
     return <span className="text-base-content/50">—</span>
   }
+  // The button's aria-label hides its children from the accessible name, so
+  // the over-capacity detail is folded into the label rather than left to the
+  // chip's sr-only text.
+  const overDetail = isGroupOverCapacity(count, max)
+    ? t("components.groupOverCapacity.title", { count, max })
+    : undefined
+  const fullLabel = overDetail ? `${label}. ${overDetail}` : label
   return (
     <Button
       variant="ghost"
       size="sm"
       className="gap-1.5 font-medium"
-      aria-label={label}
-      title={label}
+      aria-label={fullLabel}
+      title={fullLabel}
       onClick={onClick}
     >
       <PeopleIcon aria-hidden="true" className="size-4" />
       {count}
+      <GroupOverCapacityBadge count={count} max={max} plain />
     </Button>
   )
 }

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -1187,6 +1187,67 @@ describe("SubmissionsTable team/repo mismatch indicators", () => {
   })
 })
 
+// A student maintainer can add members on GitHub directly, past the cap every
+// Classroom 50 client enforces (#896). The Members column flags the oversize
+// so the teacher sees it before grading.
+describe("SubmissionsTable over-capacity groups", () => {
+  const team: GroupTeamRef = {
+    slug: "classroom50-group-abc123-1",
+    id: 101,
+    n: 1,
+    name: "Rocket",
+  }
+  const overProps = {
+    ...baseProps,
+    isGroup: true,
+    isTeam: true,
+    teamsSettled: true,
+    teamsByOwner: new Map([["group-1", team]]),
+    scores: [scoreRow({ owner: "group-1", usernames: ["alice"] })],
+  }
+
+  it("flags a team row with more members than max_group_size", () => {
+    render(
+      <SubmissionsTable
+        {...overProps}
+        groupMemberLogins={
+          new Map([["group-1", ["alice", "bob", "carol", "dave"]]])
+        }
+        maxGroupSize={3}
+      />,
+    )
+    expect(screen.getByText("components.groupOverCapacity.badge")).toBeTruthy()
+    // The count click-through carries the explanation in its accessible name.
+    expect(
+      screen.getByRole("button", {
+        name: /components\.groupOverCapacity\.title/,
+      }),
+    ).toBeTruthy()
+  })
+
+  it("stays quiet for a group at or under the cap, or with no cap", () => {
+    const { unmount } = render(
+      <SubmissionsTable
+        {...overProps}
+        groupMemberLogins={new Map([["group-1", ["alice", "bob", "carol"]]])}
+        maxGroupSize={3}
+      />,
+    )
+    expect(screen.queryByText("components.groupOverCapacity.badge")).toBeNull()
+    unmount()
+
+    render(
+      <SubmissionsTable
+        {...overProps}
+        groupMemberLogins={
+          new Map([["group-1", ["alice", "bob", "carol", "dave"]]])
+        }
+      />,
+    )
+    expect(screen.queryByText("components.groupOverCapacity.badge")).toBeNull()
+  })
+})
+
 // Teaching staff who accepted an assignment (to test it) sit in the roster
 // spine beside students; their rows carry role chips so a teacher can tell a
 // staff test grade from a student's at a glance.

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -715,6 +715,7 @@ const SubmissionsTable = ({
           <td onClick={(event) => event.stopPropagation()}>
             <TeamMembersCountCell
               count={teamMembers(rest.owner)?.length}
+              max={maxGroupSize}
               label={t("submissions.table.manageMembersLabel", {
                 name: groupLabel(rest.owner, repo),
               })}
@@ -1123,6 +1124,7 @@ const SubmissionsTable = ({
                     membersCell={
                       <TeamMembersCountCell
                         count={teamMembers(teamOwner)?.length}
+                        max={maxGroupSize}
                         label={t("submissions.table.manageMembersLabel", {
                           name: label,
                         })}
@@ -1167,6 +1169,7 @@ const SubmissionsTable = ({
                     isTeam ? (
                       <TeamMembersCountCell
                         count={teamMembers(owner)?.length}
+                        max={maxGroupSize}
                         label={t("submissions.table.manageMembersLabel", {
                           name: groupLabel(owner, repoName),
                         })}


### PR DESCRIPTION
Closes #896.

A team-mode group's accepting student becomes the GitHub team's maintainer and can add members directly on GitHub, past the `max_group_size` cap that every Classroom 50 client enforces at add time. Since the app is client-only there is no way to block that write, so this does what the `assignments-v1` schema already promises for the field: surface the oversize wherever the group is shown, instead of assuming the cap can't be exceeded.

**Domain**

- `isGroupOverCapacity(count, max)` in `domain/teams/groupTeams.ts` is the single predicate (strictly greater than; at the cap is full, not over).
- `resolveMembershipDraft` gains `overCapacity`, so the manage dialog tracks pending removals.

**Where the flag appears**

- Submissions page, Members column: an "Over the limit" error chip inside the member-count button on every team row, with the explanation folded into the button's accessible name and hover title.
- Manage groups page: the same chip on each group row, beside the drift badge.
- Manage group dialog: a warning alert asking for removals replaces the misleading "Group is full" note while the draft is still over the cap.
- Student assignment settings: the member count turns warning-toned and an alert tells the group their teacher can see the oversize. Maintainers are told to remove members; plain members are told to ask their maintainer or teacher.

The chip is one shared component (`components/assignments/GroupOverCapacityBadge.tsx`) that renders nothing while the group is within the cap, so rows stay quiet in the normal case.

This is a warning, not a block: the teacher may decide to grade an oversize group as it is, and the chip's tooltip says so.

**Tests**

- Predicate boundaries and the no-cap case.
- Draft `overCapacity` flips off once pending removals land on the cap.
- `SubmissionsTable`: chip renders for 4 of 3, stays absent at 3 of 3 or with no cap.

`npm run check` and `audit_i18n.py --strict` pass.