### PR TITLE
docs(wiki): document the over-the-limit group flag

### DIFF
--- a/wiki/Known-Limitations.md
+++ b/wiki/Known-Limitations.md
@@ -123,6 +123,10 @@ contains this instead of preventing it:
 
 - The teacher's group views flag the change as **Members changed since the
   last refresh**, against the recorded group info.
+- A group with more members than the maximum group size shows an
+  **Over the limit** error on the submissions page and the Manage groups
+  page, and the group's own members see a warning on their group page. The
+  teacher decides whether to remove members or grade the group as it is.
 - Grading credits only team members who are on the classroom roster, so an
   outside account is never credited.
 - The maximum group size is re-checked whenever a Classroom 50 client adds a

--- a/wiki/Web-Student-Guide.md
+++ b/wiki/Web-Student-Guide.md
@@ -162,6 +162,12 @@ changes. In a student-formed group:
   confirm, because you lose access to the group's repository (your work stays
   with the group), and rejoining takes another request and approval.
 
+The group page also shows how many members the group has against the
+assignment's maximum group size. If the group has more members than allowed
+(members can be added directly on GitHub, outside Classroom 50), the page
+shows a warning that your teacher can see too. Remove members until the group
+is within the limit, or ask your teacher to.
+
 ### Legacy group assignments
 
 For an assignment shown as **Group (legacy)**, there is no group team:

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -741,7 +741,7 @@ For a group assignment, open the assignment and click **Manage groups** in the
 sidebar (the submissions page has a **Manage groups** button too). The page
 lists every group with its display name, its members (with full names from the
 roster), its member count against the max group size, its repository status,
-and its visibility. Two badges need explaining:
+and its visibility. Three badges need explaining:
 
 - **No repository yet.** The group's shared repository is created when a
   group member accepts the assignment (**Repository created** replaces it
@@ -749,6 +749,10 @@ and its visibility. Two badges need explaining:
 - **Members changed since the last refresh.** The group's live membership on
   GitHub no longer matches the recorded group info; refresh to update the
   record.
+- **Over the limit.** The group has more members than the assignment's max
+  group size. Classroom 50 refuses to add a member past the limit, but a
+  group's maintainer can add members directly on GitHub. Click **Manage** to
+  remove members, or grade the group as it is.
 
 Above the list:
 
@@ -914,7 +918,9 @@ and who submitted), see [Reading results](Autograding-Basics#reading-results).
 
 On a group assignment, rows are titled by group name, and a **Members** column
 shows each group's live member count; click it to open the group's manage
-dialog. A group that hasn't accepted yet shows a **No repository yet** warning
+dialog. The count carries an **Over the limit** error when the group has more
+members than the max group size (see [Manage groups](#manage-groups)). A
+group that hasn't accepted yet shows a **No repository yet** warning
 (the repository is created when a member accepts), and **Group team missing**
 flags a group whose GitHub team was deleted; click it to recreate the team
 (see [Recover a deleted group team](#recover-a-deleted-group-team)).


### PR DESCRIPTION
Follow-up to #897 (fixes #896), which added the **Over the limit** flag for groups whose live membership exceeds `max_group_size`.

- **Known limitations**, "A group founder can change membership on GitHub": adds the flag to the list of ways Classroom 50 contains direct GitHub edits.
- **Web teacher guide**, Manage groups: the badge list grows from two to three, explaining what the badge means and what to do.
- **Web teacher guide**, submissions table: the Members column note mentions the error and links to Manage groups.
- **Web student guide**, group page: explains the member count against the maximum and the warning the group sees when it's over, routing to the teacher when the student can't act.

Docs only; no release entry.