### PR TITLE
docs(wiki): tighten the 1.47.0 bulk assignment actions section

### DIFF
--- a/wiki/Course-Lifecycle-and-End-of-Term.md
+++ b/wiki/Course-Lifecycle-and-End-of-Term.md
@@ -92,9 +92,10 @@ What that means in practice:
 Wrap up a finished course in this order:
 
 1. Close or lock the assignments. **Close submission** per assignment
-   freezes student work (read-only, no new accepts). To lock every
-   assignment in one step, select them all on the **Assignments** page and
-   choose **Lock** from the **Actions** menu; see
+   freezes student work (read-only, no new accepts). **Lock** hides an
+   assignment from students instead and applies to a whole selection at
+   once: select every assignment on the **Assignments** page and choose
+   **Lock** from the **Actions** menu; see
    [Act on several assignments at once](Web-Teacher-Guide#act-on-several-assignments-at-once).
 2. Collect and export. Run a final collection, then **Download scores
    (CSV)**. For the work itself, **Download all submissions** bundles the

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -1125,63 +1125,52 @@ so a mistyped domain can't lock students out of a working site.
 
 ### Act on several assignments at once
 
-Select the checkbox on any row of the **Assignments** page and the toolbar shows
-how many are selected, an **Actions** menu, and a **Clear selection** button,
-the same cluster the roster and organization members pages use.
-
-Click one checkbox, then shift-click another to select everything in between.
-Selecting the box in the header selects every assignment the current search and
-filters show. A selection survives searching and filtering: a row the search is
-hiding stays selected and is still acted on, so the count tells you how many
-assignments the next action really covers. **Clear selection** (the X) empties it.
+Selecting rows on the **Assignments** page (with the row checkboxes, or the
+select-all in the header) replaces the toolbar's left side with the selected
+count, one **Actions** menu, and **Clear selection**, as on the roster and
+organization members pages. Shift-click selects a range, and the header
+checkbox selects every assignment the current search and filters show. A
+selection survives searching and filtering: a row the search hides stays
+selected and is still acted on, so the count is always what the next action
+covers.
 
 The **Actions** menu offers:
 
-- **Lock** / **Unlock.** Lock every selected assignment so students can't
-  access or accept it, or unlock them again. Where a private template is used,
-  locking removes the student team's read on it and unlocking restores it. The
-  read is kept while another unlocked assignment in the classroom uses the same
-  template, so that assignment keeps working. If the access change fails for
-  some assignments, a warning names them; run the same action on those again. Each verb is disabled when it has nothing to do,
-  so a selection that is already fully locked offers only **Unlock**.
-- **Reuse.** Copy the selection into another classroom in the same
-  organization, including back into its own.
+- **Lock** / **Unlock.** The row's lock toggle, applied to every selected
+  assignment: students can't access or accept a locked assignment, and for a
+  private template the student team's read is removed on lock and restored on
+  unlock. A read that another unlocked assignment in the classroom still uses
+  is kept. Each entry is disabled when it has nothing to do, so a fully locked
+  selection offers only **Unlock**.
+- **Reuse.** Copy the selection into another classroom in the organization,
+  or back into this one; see below.
 - **Delete.** Remove the selected assignments from the classroom. Student
-  repositories are **not** deleted; they stay in the organization and can still
-  be reached by name.
+  repositories are kept. You type `delete` to confirm, since this is the one
+  action here with no undo in the app.
 
-Every action writes the whole selection in a **single commit**: lock, unlock,
-and delete to the classroom's `assignments.json`, reuse to the target
-classroom's. The classroom's history gets one entry per action. For lock,
-unlock, and delete a half-applied selection is impossible: either every
-selected assignment changes or none does. Reuse can leave a copy out (see
-below), but the copies it makes all land together. Deleting asks you to type
-`delete` first, since it is the one action here with no undo in the app.
-
-An assignment that vanished between selecting it and confirming (deleted in
-another tab, say) is reported as skipped rather than failing the whole action.
+Each action is one commit: lock, unlock, and delete to this classroom's
+`assignments.json`, reuse to the target's. For lock, unlock, and delete, either
+every selected assignment changes or none does. An assignment deleted
+meanwhile (in another tab, say) is skipped and reported. If the template
+access change after a lock or unlock fails for some assignments, a warning
+names them; run the action on those again.
 
 #### Reusing several assignments
 
 **Reuse** works like the single-assignment **Reuse in another classroom**, once
-per selected assignment. Pick the target classroom, and a slug field appears for
-each copy, pre-filled with the slug it would take. Where that slug is already
-used in the target, a numbered suffix is filled in: copying `hw1` into a
-classroom that already has one gives you `hw1-2`. You can overwrite any of them
-before starting.
+per selected assignment. Pick the target classroom and a slug field appears for
+each copy, pre-filled with the slug it would take: where the target already
+uses it, a numbered suffix is added (`hw1` becomes `hw1-2`). Edit any of them
+before copying. A slug blocks the copy while it:
 
-The field turns red, and the copy can't start, while a slug:
-
-- is already used in the target classroom,
-- is reserved by a renamed assignment there,
+- is already used, or reserved by a renamed assignment, in the target,
 - exceeds the classroom's repository-name budget, or
-- collides with another copy in the same run.
+- repeats another copy's slug in the same run.
 
-All the copies land in one commit to the target classroom. A copy that can't
-be made (its template is no longer visible, or its slug was taken since the
-form loaded) is left out and reported; the others still land. Where a private
-template is used, the target classroom's student team is then granted read on
-it; keep the tab open until the dialog reports the result.
+The copies land together in one commit to the target classroom. A copy whose
+template is no longer visible, or whose slug was taken since the form loaded,
+is left out and reported; the others still land. For a private template, the
+target classroom's student team is then granted read on it.
 
 ### Updating an over-budget assignment slug
 


### PR DESCRIPTION
## Summary

Wiki review for the 1.47.0 release (#900): #769 bulk assignment actions, #755 in-place assignment rows, #902 `gh teacher download --pull`.

The `--pull` docs in `gh-teacher.md` and `CLI-Teacher-Guide.md` match the shipped `--help` text and need no change. #755 needs no wiki change: nothing in the wiki described `assignments.json` row order or the web app's old move-to-end behavior.

The bulk-actions section #769 added to `Web-Teacher-Guide.md` is trimmed from 60 lines to 47 with no fact removed that a teacher acts on:

- Opens with the same register as the roster page's selection paragraph, and drops the separate "(the X)" sentence.
- Fixes a broken line wrap in the Lock / Unlock bullet and reorders it so the template-access rule reads once.
- States the one-commit guarantee once instead of three times, and folds the vanished-assignment and template-warning notes into that paragraph.
- Drops "keep the tab open until the dialog reports the result": since #891 the app itself holds the tab during that write.
- The reuse subsection keeps the slug-blocking rules as a list (three parallel points) and merges "already used" with "reserved by a renamed assignment", which behave identically to the teacher.

`Course-Lifecycle-and-End-of-Term.md` step 1 previously read as if **Lock** were the bulk form of **Close submission**. It now says what Lock does (hides the assignment) before pointing at the bulk action.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched: n/a, wiki Markdown only.
- [ ] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror: n/a.
- [ ] If I added or changed a CLI command or flag, I documented it in the wiki: n/a, no CLI change.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).