### PR TITLE
refactor(web): one config-repo read-modify-write helper for the domain writers

### DIFF
--- a/web/src/domain/assignments/assignmentsWrite.ts
+++ b/web/src/domain/assignments/assignmentsWrite.ts
@@ -1,0 +1,85 @@
+import type { GitHubClient } from "@/github-core/client"
+import { assignmentsFilePath } from "@/util/configRepoPaths"
+
+import {
+  commitConfigRepoFiles,
+  jsonFileEntry,
+  readConfigRepoHead,
+  readConfigRepoHeadAt,
+  type ConfigRepoCommitResult,
+  type ConfigRepoHead,
+} from "../configRepoWrite"
+import {
+  getAssignmentsFile,
+  type AssignmentsFile,
+} from "../queries/assignments"
+
+// The read half of every assignments.json write: the config-repo head plus the
+// file as it stands at that head. Shared so no writer can read the file at one
+// ref and commit against another.
+export type AssignmentsWriteContext = ConfigRepoHead & {
+  path: string
+  current: AssignmentsFile
+}
+
+export async function readAssignmentsForWrite(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+): Promise<AssignmentsWriteContext> {
+  const head = await readConfigRepoHead(client, org, classroom)
+  return readAssignmentsAtHead(client, org, classroom, head)
+}
+
+// For writers that resolved the branch themselves (to overlap it with other
+// reads) or must skip the archive guard.
+export async function readAssignmentsForWriteAt(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+  configBranch: string,
+): Promise<AssignmentsWriteContext> {
+  const head = await readConfigRepoHeadAt(client, org, configBranch)
+  return readAssignmentsAtHead(client, org, classroom, head)
+}
+
+async function readAssignmentsAtHead(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+  head: ConfigRepoHead,
+): Promise<AssignmentsWriteContext> {
+  const path = assignmentsFilePath(classroom)
+  const current = await getAssignmentsFile(client, {
+    org,
+    path,
+    ref: head.headSha,
+  })
+  return { ...head, path, current }
+}
+
+// The write half: assignments.json is the only file in the tree.
+export function commitAssignments(
+  client: GitHubClient,
+  org: string,
+  ctx: AssignmentsWriteContext,
+  next: AssignmentsFile,
+  message: string,
+): Promise<ConfigRepoCommitResult> {
+  return commitConfigRepoFiles(
+    client,
+    org,
+    ctx,
+    [jsonFileEntry(ctx.path, next)],
+    message,
+  )
+}
+
+// The entry the caller named, or the shared not-found error.
+export function requireAssignment(ctx: AssignmentsWriteContext, slug: string) {
+  const target = ctx.current.assignments.find((a) => a.slug === slug)
+  if (!target) {
+    throw new Error(`Existing assignment matching ${slug} was not found.`)
+  }
+  return target
+}

--- a/web/src/domain/assignments/bulkActions.ts
+++ b/web/src/domain/assignments/bulkActions.ts
@@ -1,28 +1,14 @@
 import type { GitHubClient } from "@/github-core/client"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
-import {
-  createGitCommit,
-  createGitTree,
-  updateRef,
-} from "@/github-core/mutations"
-import { prefixCommit } from "@/util/commit"
-import { assignmentsFilePath } from "@/util/configRepoPaths"
 import type { Assignment } from "@/types/classroom"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
 import { getRepo } from "@/github-core/repoReads"
 import { mapWithConcurrency } from "@/util/concurrency"
 
-import {
-  getAssignmentsFile,
-  type AssignmentsFile,
-} from "../queries/assignments"
-import { assertClassroomNotArchived, withGitConflictRetry } from "../classrooms"
+import type { AssignmentsFile } from "../queries/assignments"
+import { withGitConflictRetry } from "../classrooms"
 import { log } from "./accessPrimitives"
+import { commitAssignments, readAssignmentsForWrite } from "./assignmentsWrite"
 import {
   assertSlugFreeInTarget,
   buildReusedEntry,
@@ -58,72 +44,6 @@ export type BulkLockResult = {
 // Below REPO_READ_CONCURRENCY (8): each reconcile is a team permission write,
 // and GitHub's secondary rate limits bite on concurrent writes.
 const RECONCILE_CONCURRENCY = 4
-
-// The read half of the config-repo write, shared so the batched writers
-// cannot drift in what they read.
-type AssignmentsWriteContext = {
-  configBranch: string
-  headSha: string
-  baseTreeSha: string
-  path: string
-  current: Awaited<ReturnType<typeof getAssignmentsFile>>
-}
-
-async function readAssignmentsForWrite(
-  client: GitHubClient,
-  org: string,
-  classroom: string,
-): Promise<AssignmentsWriteContext> {
-  const [, configBranch] = await Promise.all([
-    assertClassroomNotArchived(client, org, classroom),
-    getConfigRepoBranch(client, org),
-  ])
-  const ref = await getBranchRef(client, org, configBranch)
-  const commit = await getCommit(client, org, ref.object.sha)
-  const path = assignmentsFilePath(classroom)
-  const current = await getAssignmentsFile(client, {
-    org,
-    path,
-    ref: ref.object.sha,
-  })
-  return {
-    configBranch,
-    headSha: ref.object.sha,
-    baseTreeSha: commit.tree.sha,
-    path,
-    current,
-  }
-}
-
-// The write half: one tree, one commit, one ref move.
-async function commitAssignments(
-  client: GitHubClient,
-  org: string,
-  ctx: AssignmentsWriteContext,
-  next: unknown,
-  message: string,
-): Promise<string> {
-  const tree = await createGitTree(client, {
-    org,
-    base_tree: ctx.baseTreeSha,
-    tree: [
-      {
-        path: ctx.path,
-        mode: "100644",
-        type: "blob",
-        content: JSON.stringify(next, null, 2) + "\n",
-      },
-    ],
-  })
-  const newCommit = await createGitCommit(client, {
-    org,
-    message: prefixCommit(message),
-    tree_sha: tree.sha,
-    parents: [ctx.headSha],
-  })
-  await updateRef(client, org, newCommit.sha, ctx.configBranch)
-  return newCommit.sha
-}
 
 const assignmentCount = (n: number) => `${n} assignment${n === 1 ? "" : "s"}`
 
@@ -173,15 +93,17 @@ export async function setAssignmentsLock(
       }),
     }
 
-    newCommitSha = await commitAssignments(
-      client,
-      org,
-      ctx,
-      nextAssignments,
-      `${locked ? "Lock" : "Unlock"} ${assignmentCount(
-        changed.length,
-      )}: ${classroom}`,
-    )
+    newCommitSha = (
+      await commitAssignments(
+        client,
+        org,
+        ctx,
+        nextAssignments,
+        `${locked ? "Lock" : "Unlock"} ${assignmentCount(
+          changed.length,
+        )}: ${classroom}`,
+      )
+    ).newCommitSha
   }
 
   // Reconcile every present assignment, not only the changed ones: a previous
@@ -286,7 +208,7 @@ export async function deleteAssignments(
     assignments: ctx.current.assignments.filter((a) => !removing.has(a.slug)),
   }
 
-  const newCommitSha = await commitAssignments(
+  const { newCommitSha } = await commitAssignments(
     client,
     org,
     ctx,
@@ -409,7 +331,7 @@ export async function copyAssignments(
 
   if (entries.length === 0) return { outcomes, newCommitSha: null }
 
-  const newCommitSha = await commitAssignments(
+  const { newCommitSha } = await commitAssignments(
     client,
     org,
     ctx,

--- a/web/src/domain/assignments/copyReuse.ts
+++ b/web/src/domain/assignments/copyReuse.ts
@@ -1,26 +1,16 @@
 import type { GitHubClient } from "@/github-core/client"
 import type { Assignment } from "@/types/classroom"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
-import { prefixCommit } from "@/util/commit"
-import { assignmentsFilePath as assignmentsFile } from "@/util/configRepoPaths"
+import { getConfigRepoBranch } from "@/github-core/configRepoReads"
 import { nextAvailableSlug } from "@/util/slug"
 import { validateReleaseAssets } from "@/util/releaseAssets"
-import {
-  createGitCommit,
-  createGitTree,
-  updateRef,
-} from "@/github-core/mutations"
 import { getRepo } from "@/github-core/repoReads"
-import {
-  getAssignmentsFile,
-  type AssignmentsFile,
-} from "../queries/assignments"
+import type { AssignmentsFile } from "../queries/assignments"
 import { withGitConflictRetry, assertClassroomNotArchived } from "../classrooms"
 import { log } from "./accessPrimitives"
+import {
+  commitAssignments,
+  readAssignmentsForWriteAt,
+} from "./assignmentsWrite"
 import { resolveTemplateGrant, type CreateAssignmentResult } from "./createEdit"
 
 export type CopyAssignmentInput = {
@@ -208,7 +198,12 @@ export async function copyAssignmentToClassroom(
       : Promise.resolve(null),
     getConfigRepoBranch(client, org),
   ])
-  const ref = await getBranchRef(client, org, configBranch)
+  const ctx = await readAssignmentsForWriteAt(
+    client,
+    org,
+    targetClassroom,
+    configBranch,
+  )
 
   const needsTeamGrant = reuseTemplateNeedsGrant(
     org,
@@ -217,43 +212,20 @@ export async function copyAssignmentToClassroom(
     repo,
   )
 
-  const commit = await getCommit(client, org, ref.object.sha)
-
-  const assignmentsFilePath = assignmentsFile(targetClassroom)
-  const currentAssignments = await getAssignmentsFile(client, {
-    org,
-    path: assignmentsFilePath,
-    ref: ref.object.sha,
-  })
-
-  assertSlugFreeInTarget(entry.slug, currentAssignments, targetClassroom)
+  assertSlugFreeInTarget(entry.slug, ctx.current, targetClassroom)
 
   const nextAssignments: AssignmentsFile = {
-    ...currentAssignments,
-    assignments: [...currentAssignments.assignments, entry],
+    ...ctx.current,
+    assignments: [...ctx.current.assignments, entry],
   }
 
-  const tree = await createGitTree(client, {
+  const written = await commitAssignments(
+    client,
     org,
-    base_tree: commit.tree.sha,
-    tree: [
-      {
-        path: assignmentsFilePath,
-        mode: "100644",
-        type: "blob",
-        content: JSON.stringify(nextAssignments, null, 2) + "\n",
-      },
-    ],
-  })
-  const newCommit = await createGitCommit(client, {
-    org,
-    message: prefixCommit(
-      `Reuse assignment: ${source.slug} -> ${targetClassroom}/${entry.slug}`,
-    ),
-    tree_sha: tree.sha,
-    parents: [ref.object.sha],
-  })
-  const updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
+    ctx,
+    nextAssignments,
+    `Reuse assignment: ${source.slug} -> ${targetClassroom}/${entry.slug}`,
+  )
 
   // A locked source copies as locked, so withhold the grant like create and
   // the CLI's reuse do; unlocking the copy grants it.
@@ -270,11 +242,9 @@ export async function copyAssignmentToClassroom(
   }
 
   return {
-    previousCommitSha: ref.object.sha,
-    baseTreeSha: commit.tree.sha,
-    newTreeSha: tree.sha,
-    newCommitSha: newCommit.sha,
-    updatedRef,
+    previousCommitSha: ctx.headSha,
+    baseTreeSha: ctx.baseTreeSha,
+    ...written,
     templateGrantWarning,
   }
 }

--- a/web/src/domain/assignments/createEdit.ts
+++ b/web/src/domain/assignments/createEdit.ts
@@ -15,12 +15,7 @@ import {
   assertTeamFormation,
   defaultStudentPermission,
 } from "@/types/classroom"
-import {
-  getBranchRef,
-  getClassroomJson,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
+import { getClassroomJson } from "@/github-core/configRepoReads"
 import { classroomTeamSlug } from "@/util/teamSlug"
 import { GitHubAPIError } from "@/github-core/errors"
 import {
@@ -29,8 +24,6 @@ import {
   validateTestTimeout,
 } from "@/util/assignmentTests"
 import { buildDueFields } from "@/util/formatDate"
-import { prefixCommit } from "@/util/commit"
-import { assignmentsFilePath as assignmentsFile } from "@/util/configRepoPaths"
 import {
   parseRunnerLabels,
   isRunnerLabelShapeValid,
@@ -54,21 +47,11 @@ import {
   addRepositoryToTeam,
   removeRepositoryFromTeam,
   isDeletableClassroomTeamRef,
-  createGitCommit,
-  createGitTree,
-  updateRef,
 } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import { getRepo } from "@/github-core/repoReads"
-import {
-  getAssignmentsFile,
-  type AssignmentsFile,
-} from "../queries/assignments"
-import {
-  withGitConflictRetry,
-  assertClassroomNotArchived,
-  type CreateClassroomResult,
-} from "../classrooms"
+import type { AssignmentsFile } from "../queries/assignments"
+import { withGitConflictRetry, type CreateClassroomResult } from "../classrooms"
 import {
   log,
   parseTemplateRef,
@@ -77,6 +60,12 @@ import {
 } from "./accessPrimitives"
 import { CONFIG_REPO } from "@/util/configRepo"
 import type { CreateAssignmentInput } from "./repoCreation"
+import {
+  commitAssignments,
+  readAssignmentsForWrite,
+  requireAssignment,
+  type AssignmentsWriteContext,
+} from "./assignmentsWrite"
 import { resolveSubmissionMode } from "./submissionDetection"
 
 export type CreateAssignmentResult = CreateClassroomResult & {
@@ -225,29 +214,9 @@ export async function editAssignment(
 
   log.info("edit assignment: started", { org, classroom, slug })
 
-  // The archive guard is independent of the org ref read, so run them
-  // concurrently — Promise.all rejects on the first rejection, so an archived
-  // classroom still fails closed before any write.
-  const [, configBranch] = await Promise.all([
-    assertClassroomNotArchived(client, org, classroom),
-    getConfigRepoBranch(client, org),
-  ])
-  const ref = await getBranchRef(client, org, configBranch)
-  const commit = await getCommit(client, org, ref.object.sha)
-
-  const assignmentsFilePath = assignmentsFile(classroom)
-  const currentAssignments = await getAssignmentsFile(client, {
-    org,
-    path: assignmentsFilePath,
-    ref: ref.object.sha,
-  })
-
-  const targetAssignment = currentAssignments.assignments.find(
-    (a) => a.slug === slug,
-  )
-  if (!targetAssignment) {
-    throw new Error(`Existing assignment matching ${slug} was not found.`)
-  }
+  const ctx = await readAssignmentsForWrite(client, org, classroom)
+  const currentAssignments = ctx.current
+  const targetAssignment = requireAssignment(ctx, slug)
 
   // Provisioning-class settings (empty_repo, no_autograder, init_shim) and the
   // grading.mode are no longer blocked on edit: student repos are provisioned
@@ -294,30 +263,12 @@ export async function editAssignment(
     ),
   }
 
-  const tree = await createGitTree(client, {
-    org: input.org,
-    base_tree: commit.tree.sha,
-    tree: [
-      {
-        path: assignmentsFilePath,
-        mode: "100644",
-        type: "blob",
-        content: JSON.stringify(nextAssignments, null, 2) + "\n",
-      },
-    ],
-  })
-
-  const newCommit = await createGitCommit(client, {
-    org: input.org,
-    message: prefixCommit(`Edit assignment: ${input.classroom}/${slug}`),
-    tree_sha: tree.sha,
-    parents: [ref.object.sha],
-  })
-  const updatedRef = await updateRef(
+  const written = await commitAssignments(
     client,
-    input.org,
-    newCommit.sha,
-    configBranch,
+    org,
+    ctx,
+    nextAssignments,
+    `Edit assignment: ${input.classroom}/${slug}`,
   )
 
   // Grant the (possibly changed) in-org private template a team read — a
@@ -359,11 +310,9 @@ export async function editAssignment(
   }
 
   return {
-    previousCommitSha: ref.object.sha,
-    baseTreeSha: commit.tree.sha,
-    newTreeSha: tree.sha,
-    newCommitSha: newCommit.sha,
-    updatedRef,
+    previousCommitSha: ctx.headSha,
+    baseTreeSha: ctx.baseTreeSha,
+    ...written,
     templateGrantWarning,
     templateAccessWarning,
   }
@@ -1157,25 +1106,14 @@ export async function createAssignment(
     classroom: input.classroom,
     slug: input.slug,
   })
-  // The archive guard, entry build, and org ref read are independent, so run
-  // them concurrently — Promise.all rejects on the first rejection, so an
-  // archived classroom still fails closed before any write.
-  const [, { entry: assignmentBody, needsTeamGrant }, configBranch] =
-    await Promise.all([
-      assertClassroomNotArchived(client, input.org, input.classroom),
-      buildAssignmentEntry(client, input),
-      getConfigRepoBranch(client, input.org),
-    ])
-  const ref = await getBranchRef(client, input.org, configBranch)
-
-  const commit = await getCommit(client, input.org, ref.object.sha)
-
-  const assignmentsFilePath = assignmentsFile(input.classroom)
-  const currentAssignments = await getAssignmentsFile(client, {
-    org: input.org,
-    path: assignmentsFilePath,
-    ref: ref.object.sha,
-  })
+  // The entry build (template probe) is independent of the config-repo read,
+  // so they overlap; Promise.all rejects on the first rejection, so an archived
+  // classroom or a bad template still fails closed before any write.
+  const [{ entry: assignmentBody, needsTeamGrant }, ctx] = await Promise.all([
+    buildAssignmentEntry(client, input),
+    readAssignmentsForWrite(client, input.org, input.classroom),
+  ])
+  const currentAssignments = ctx.current
 
   if (
     currentAssignments.assignments.some(
@@ -1203,31 +1141,12 @@ export async function createAssignment(
     assignments: [...currentAssignments.assignments, assignmentBody],
   }
 
-  const tree = await createGitTree(client, {
-    ...input,
-    base_tree: commit.tree.sha,
-    tree: [
-      {
-        path: assignmentsFilePath,
-        mode: "100644",
-        type: "blob",
-        content: JSON.stringify(nextAssignments, null, 2) + "\n",
-      },
-    ],
-  })
-  const newCommit = await createGitCommit(client, {
-    org: input.org,
-    message: prefixCommit(
-      `Create assignment: ${input.classroom}/${assignmentBody.slug}`,
-    ),
-    tree_sha: tree.sha,
-    parents: [ref.object.sha],
-  })
-  const updatedRef = await updateRef(
+  const written = await commitAssignments(
     client,
     input.org,
-    newCommit.sha,
-    configBranch,
+    ctx,
+    nextAssignments,
+    `Create assignment: ${input.classroom}/${assignmentBody.slug}`,
   )
 
   // A locked create deliberately hands students no template read: the grant
@@ -1246,11 +1165,9 @@ export async function createAssignment(
   }
 
   return {
-    previousCommitSha: ref.object.sha,
-    baseTreeSha: commit.tree.sha,
-    newTreeSha: tree.sha,
-    newCommitSha: newCommit.sha,
-    updatedRef,
+    previousCommitSha: ctx.headSha,
+    baseTreeSha: ctx.baseTreeSha,
+    ...written,
     templateGrantWarning,
   }
 }
@@ -1374,12 +1291,60 @@ async function revokeStudentTeamTemplateRead(
   }
 }
 
+// Flip one boolean entry flag (`locked` or `closed`) in assignments.json.
+// Skips the commit when the entry is already in the requested state (a
+// double-click or stale tab), mirroring the CLI's no-op, and reports the head
+// as the "no change" result so callers can still seed their caches. Collapses a
+// false flag to absent (the CLI's omitempty), so clearing drops the key rather
+// than writing `false`.
+async function setAssignmentFlag(
+  client: GitHubClient,
+  ctx: AssignmentsWriteContext,
+  org: string,
+  slug: string,
+  flag: "locked" | "closed",
+  value: boolean,
+  message: string,
+): Promise<{
+  target: Assignment
+  next: AssignmentsFile
+  result: Omit<CreateClassroomResult, "updatedRef"> & {
+    updatedRef?: CreateClassroomResult["updatedRef"]
+  }
+}> {
+  const target = requireAssignment(ctx, slug)
+  const noChange = {
+    previousCommitSha: ctx.headSha,
+    baseTreeSha: ctx.baseTreeSha,
+    newTreeSha: ctx.baseTreeSha,
+    newCommitSha: ctx.headSha,
+  }
+  if (Boolean(target[flag]) === value) {
+    return { target, next: ctx.current, result: noChange }
+  }
+
+  const updatedEntry: Assignment = { ...target, [flag]: value }
+  if (!value) delete updatedEntry[flag]
+  const next: AssignmentsFile = {
+    ...ctx.current,
+    assignments: replaceAssignmentEntry(
+      ctx.current.assignments,
+      slug,
+      updatedEntry,
+    ),
+  }
+  const written = await commitAssignments(client, org, ctx, next, message)
+  return { target, next, result: { ...noChange, ...written } }
+}
+
 // Flip an assignment's `locked` flag in assignments.json and reconcile the
 // private-template student-team access: locking removes the student team's read
 // on a private in-org template, unlocking re-grants it (student + staff, via
 // the shared grant path). Public/absent/out-of-org templates are a UX-gate-only
 // lock with no GitHub access change. The template side effect never throws (the
-// commit already landed); its failure returns a non-fatal warning.
+// commit already landed); its failure returns a non-fatal warning, and it runs
+// even on a no-op flip since a prior run may have flipped the flag yet failed
+// the grant/revoke.
 export async function setAssignmentLock(
   client: GitHubClient,
   input: SetAssignmentLockInput,
@@ -1387,74 +1352,16 @@ export async function setAssignmentLock(
   const { org, classroom, slug, locked } = input
   log.info("set assignment lock: started", { org, classroom, slug, locked })
 
-  const [, configBranch] = await Promise.all([
-    assertClassroomNotArchived(client, org, classroom),
-    getConfigRepoBranch(client, org),
-  ])
-  const ref = await getBranchRef(client, org, configBranch)
-  const commit = await getCommit(client, org, ref.object.sha)
-
-  const assignmentsFilePath = assignmentsFile(classroom)
-  const currentAssignments = await getAssignmentsFile(client, {
+  const ctx = await readAssignmentsForWrite(client, org, classroom)
+  const { target, result } = await setAssignmentFlag(
+    client,
+    ctx,
     org,
-    path: assignmentsFilePath,
-    ref: ref.object.sha,
-  })
-
-  const target = currentAssignments.assignments.find((a) => a.slug === slug)
-  if (!target) {
-    throw new Error(`Existing assignment matching ${slug} was not found.`)
-  }
-
-  const alreadyInState = Boolean(target.locked) === locked
-
-  // Skip the commit when already in the requested state (a double-click or
-  // stale tab), mirroring the CLI's no-op — but still reconcile template access
-  // below, since a prior run may have flipped the flag yet failed the
-  // grant/revoke. Reuse the current ref/tree as the "no change" result.
-  let newCommitSha = ref.object.sha
-  let newTreeSha = commit.tree.sha
-  let updatedRef: CreateClassroomResult["updatedRef"] | undefined
-
-  if (!alreadyInState) {
-    const updatedEntry: Assignment = { ...target, locked }
-    // Collapse to the wire's absent-is-false shape (matches the CLI's
-    // omitempty), so unlocking drops the key rather than writing `locked: false`.
-    if (!locked) delete updatedEntry.locked
-
-    const nextAssignments: AssignmentsFile = {
-      ...currentAssignments,
-      assignments: replaceAssignmentEntry(
-        currentAssignments.assignments,
-        slug,
-        updatedEntry,
-      ),
-    }
-
-    const tree = await createGitTree(client, {
-      org,
-      base_tree: commit.tree.sha,
-      tree: [
-        {
-          path: assignmentsFilePath,
-          mode: "100644",
-          type: "blob",
-          content: JSON.stringify(nextAssignments, null, 2) + "\n",
-        },
-      ],
-    })
-    const newCommit = await createGitCommit(client, {
-      org,
-      message: prefixCommit(
-        `${locked ? "Lock" : "Unlock"} assignment: ${classroom}/${slug}`,
-      ),
-      tree_sha: tree.sha,
-      parents: [ref.object.sha],
-    })
-    updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
-    newCommitSha = newCommit.sha
-    newTreeSha = tree.sha
-  }
+    slug,
+    "locked",
+    locked,
+    `${locked ? "Lock" : "Unlock"} assignment: ${classroom}/${slug}`,
+  )
 
   const templateAccessWarning = await reconcileLockTemplateAccess(
     client,
@@ -1463,18 +1370,10 @@ export async function setAssignmentLock(
     slug,
     target.template,
     locked,
-    currentAssignments.assignments,
+    ctx.current.assignments,
   )
 
-  return {
-    previousCommitSha: ref.object.sha,
-    baseTreeSha: commit.tree.sha,
-    newTreeSha,
-    newCommitSha,
-    updatedRef,
-    locked,
-    templateAccessWarning,
-  }
+  return { ...result, locked, templateAccessWarning }
 }
 
 // Reconcile the private in-org template's student-team read after a lock flip:
@@ -1560,79 +1459,17 @@ export async function setAssignmentClosed(
   const { org, classroom, slug, closed } = input
   log.info("set assignment closed: started", { org, classroom, slug, closed })
 
-  const [, configBranch] = await Promise.all([
-    assertClassroomNotArchived(client, org, classroom),
-    getConfigRepoBranch(client, org),
-  ])
-  const ref = await getBranchRef(client, org, configBranch)
-  const commit = await getCommit(client, org, ref.object.sha)
-
-  const assignmentsFilePath = assignmentsFile(classroom)
-  const currentAssignments = await getAssignmentsFile(client, {
+  const ctx = await readAssignmentsForWrite(client, org, classroom)
+  const { result } = await setAssignmentFlag(
+    client,
+    ctx,
     org,
-    path: assignmentsFilePath,
-    ref: ref.object.sha,
-  })
-
-  const target = currentAssignments.assignments.find((a) => a.slug === slug)
-  if (!target) {
-    throw new Error(`Existing assignment matching ${slug} was not found.`)
-  }
-
-  const alreadyInState = Boolean(target.closed) === closed
-
-  let newCommitSha = ref.object.sha
-  let newTreeSha = commit.tree.sha
-  let updatedRef: CreateClassroomResult["updatedRef"] | undefined
-
-  if (!alreadyInState) {
-    const updatedEntry: Assignment = { ...target, closed }
-    // Collapse to the wire's absent-is-false shape (matches the CLI's
-    // omitempty), so reopening drops the key rather than writing `closed: false`.
-    if (!closed) delete updatedEntry.closed
-
-    const nextAssignments: AssignmentsFile = {
-      ...currentAssignments,
-      assignments: replaceAssignmentEntry(
-        currentAssignments.assignments,
-        slug,
-        updatedEntry,
-      ),
-    }
-
-    const tree = await createGitTree(client, {
-      org,
-      base_tree: commit.tree.sha,
-      tree: [
-        {
-          path: assignmentsFilePath,
-          mode: "100644",
-          type: "blob",
-          content: JSON.stringify(nextAssignments, null, 2) + "\n",
-        },
-      ],
-    })
-    const newCommit = await createGitCommit(client, {
-      org,
-      message: prefixCommit(
-        `${closed ? "Close" : "Reopen"} assignment: ${classroom}/${slug}`,
-      ),
-      tree_sha: tree.sha,
-      parents: [ref.object.sha],
-    })
-    updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
-    newCommitSha = newCommit.sha
-    newTreeSha = tree.sha
-  }
-
-  return {
-    previousCommitSha: ref.object.sha,
-    baseTreeSha: commit.tree.sha,
-    newTreeSha,
-    newCommitSha,
-    updatedRef,
+    slug,
+    "closed",
     closed,
-  }
+    `${closed ? "Close" : "Reopen"} assignment: ${classroom}/${slug}`,
+  )
+  return { ...result, closed }
 }
 
 // Same concurrency story as setAssignmentLock: the write hits classroom50's

--- a/web/src/domain/assignments/deleteAssignment.ts
+++ b/web/src/domain/assignments/deleteAssignment.ts
@@ -1,19 +1,10 @@
 import type { GitHubClient } from "@/github-core/client"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
-import { prefixCommit } from "@/util/commit"
-import { assignmentsFilePath as assignmentsFile } from "@/util/configRepoPaths"
-import {
-  createGitCommit,
-  createGitTree,
-  updateRef,
-} from "@/github-core/mutations"
-import { getAssignmentsFile } from "../queries/assignments"
-import { assertClassroomNotArchived } from "../classrooms"
 import { log } from "./accessPrimitives"
+import {
+  commitAssignments,
+  readAssignmentsForWrite,
+  requireAssignment,
+} from "./assignmentsWrite"
 
 export type DeleteAssignmentInput = {
   org: string
@@ -28,68 +19,25 @@ export async function deleteAssignment(
 
   log.info("delete assignment: started", { org, classroom, slug })
 
-  // Refuse a delete into an archived classroom (write-path guard); run the
-  // check concurrently with the ref read.
-  const [, configBranch] = await Promise.all([
-    assertClassroomNotArchived(client, org, classroom),
-    getConfigRepoBranch(client, org),
-  ])
-  const ref = await getBranchRef(client, org, configBranch)
-  const commit = await getCommit(client, org, ref.object.sha)
-
-  const assignmentsFilePath = assignmentsFile(classroom)
-  const currentAssignments = await getAssignmentsFile(client, {
-    org,
-    path: assignmentsFilePath,
-    ref: ref.object.sha,
-  })
-
-  const targetAssignment = currentAssignments.assignments.find(
-    (a) => a.slug === slug,
-  )
-
-  if (!targetAssignment) {
-    throw new Error(`Existing assignment matching ${slug} was not found.`)
-  }
+  const ctx = await readAssignmentsForWrite(client, org, classroom)
+  requireAssignment(ctx, slug)
 
   const nextAssignments = {
-    ...currentAssignments,
-    assignments: [
-      ...currentAssignments.assignments.filter((a) => a.slug !== slug),
-    ],
+    ...ctx.current,
+    assignments: ctx.current.assignments.filter((a) => a.slug !== slug),
   }
 
-  const tree = await createGitTree(client, {
-    org: input.org,
-    base_tree: commit.tree.sha,
-    tree: [
-      {
-        path: assignmentsFilePath,
-        mode: "100644",
-        type: "blob",
-        content: JSON.stringify(nextAssignments, null, 2) + "\n",
-      },
-    ],
-  })
-
-  const newCommit = await createGitCommit(client, {
-    org: input.org,
-    message: prefixCommit(`Edit assignment: ${input.classroom}/${slug}`),
-    tree_sha: tree.sha,
-    parents: [ref.object.sha],
-  })
-  const updatedRef = await updateRef(
+  const written = await commitAssignments(
     client,
-    input.org,
-    newCommit.sha,
-    configBranch,
+    org,
+    ctx,
+    nextAssignments,
+    `Delete assignment: ${classroom}/${slug}`,
   )
 
   return {
-    previousCommitSha: ref.object.sha,
-    baseTreeSha: commit.tree.sha,
-    newTreeSha: tree.sha,
-    newCommitSha: newCommit.sha,
-    updatedRef,
+    previousCommitSha: ctx.headSha,
+    baseTreeSha: ctx.baseTreeSha,
+    ...written,
   }
 }

--- a/web/src/domain/assignments/rename.ts
+++ b/web/src/domain/assignments/rename.ts
@@ -12,21 +12,14 @@ import { parseDocument, isMap, isScalar } from "yaml"
 
 import type { GitHubClient } from "@/github-core/client"
 import type { Assignment } from "@/types/classroom"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
+import { getConfigRepoBranch } from "@/github-core/configRepoReads"
 import {
   getAssignmentsFile,
   type AssignmentsFile,
 } from "../queries/assignments"
 import {
-  createGitCommit,
-  createGitTree,
   createCommitRepo,
   createTreeRepo,
-  updateRef,
   updateRefForRepo,
   renameRepo,
   getRepoTreeRecursive,
@@ -55,6 +48,15 @@ import {
   type LocalizedParam,
 } from "@/types/localizedMessage"
 import { log } from "./accessPrimitives"
+import {
+  commitConfigRepoFiles,
+  jsonFileEntry,
+  readConfigRepoHeadAt,
+} from "../configRepoWrite"
+import {
+  commitAssignments,
+  readAssignmentsForWriteAt,
+} from "./assignmentsWrite"
 
 // The `<classroom>-<slug>-` repo-name prefix every student repo of an
 // assignment shares. Routed through studentRepoName (the cross-binary naming
@@ -238,19 +240,17 @@ async function commitRenameConfig(
   const scoresPath = scoresFilePath(classroom)
 
   await withGitConflictRetry(async () => {
-    const ref = await getBranchRef(client, org, branch)
-    // The three parent-pinned reads are independent — fetch them together.
+    const head = await readConfigRepoHeadAt(client, org, branch)
+    // The two parent-pinned reads are independent — fetch them together.
     // The scores read tolerates 404 (no file — nothing was ever collected).
-    const [commit, file, scoresRaw] = await Promise.all([
-      getCommit(client, org, ref.object.sha),
+    const [file, scoresRaw] = await Promise.all([
       getAssignmentsFile(client, {
         org,
         path: assignmentsPath,
-        ref: ref.object.sha,
+        ref: head.headSha,
       }),
       tolerateGitHubError(
-        () =>
-          getRawFile(client, { org, path: scoresPath, ref: ref.object.sha }),
+        () => getRawFile(client, { org, path: scoresPath, ref: head.headSha }),
         null,
       ),
     ])
@@ -299,12 +299,7 @@ async function commitRenameConfig(
     }
 
     const tree: GitTreeEntry[] = [
-      {
-        path: assignmentsPath,
-        mode: "100644",
-        type: "blob",
-        content: JSON.stringify(nextAssignments, null, 2) + "\n",
-      },
+      jsonFileEntry(assignmentsPath, nextAssignments),
     ]
 
     // scores.json bucket re-key (skipped when the file or the old bucket is
@@ -330,7 +325,7 @@ async function commitRenameConfig(
       client,
       owner: org,
       repo: CONFIG_REPO,
-      treeSha: commit.tree.sha,
+      treeSha: head.baseTreeSha,
     })
     if (truncated) {
       // A truncated listing would move a PARTIAL directory — refuse.
@@ -347,20 +342,13 @@ async function commitRenameConfig(
       tree.push({ path: entry.path, mode: "100644", type: "blob", sha: null })
     }
 
-    const newTree = await createGitTree(client, {
+    await commitConfigRepoFiles(
+      client,
       org,
-      base_tree: commit.tree.sha,
+      head,
       tree,
-    })
-    const newCommit = await createGitCommit(client, {
-      org,
-      message: prefixCommit(
-        `Rename assignment ${oldSlug} to ${newSlug}: ${classroom}`,
-      ),
-      tree_sha: newTree.sha,
-      parents: [ref.object.sha],
-    })
-    await updateRef(client, org, newCommit.sha, branch)
+      `Rename assignment ${oldSlug} to ${newSlug}: ${classroom}`,
+    )
   })
 }
 
@@ -374,16 +362,10 @@ async function setRenamedEntryLocked(
   locked: boolean,
 ): Promise<void> {
   const { org, classroom, newSlug } = input
-  const assignmentsPath = assignmentsFilePath(classroom)
 
   await withGitConflictRetry(async () => {
-    const ref = await getBranchRef(client, org, branch)
-    const commit = await getCommit(client, org, ref.object.sha)
-    const file = await getAssignmentsFile(client, {
-      org,
-      path: assignmentsPath,
-      ref: ref.object.sha,
-    })
+    const ctx = await readAssignmentsForWriteAt(client, org, classroom, branch)
+    const file = ctx.current
     const target = file.assignments.find((a) => a.slug === newSlug)
     if (!target) {
       throw renameError("assignments.rename.error.notFound", {
@@ -404,27 +386,13 @@ async function setRenamedEntryLocked(
         return entry
       }),
     }
-    const tree = await createGitTree(client, {
+    await commitAssignments(
+      client,
       org,
-      base_tree: commit.tree.sha,
-      tree: [
-        {
-          path: assignmentsPath,
-          mode: "100644",
-          type: "blob",
-          content: JSON.stringify(nextAssignments, null, 2) + "\n",
-        },
-      ],
-    })
-    const newCommit = await createGitCommit(client, {
-      org,
-      message: prefixCommit(
-        `Restore lock state of ${newSlug} after rename: ${classroom}`,
-      ),
-      tree_sha: tree.sha,
-      parents: [ref.object.sha],
-    })
-    await updateRef(client, org, newCommit.sha, branch)
+      ctx,
+      nextAssignments,
+      `Restore lock state of ${newSlug} after rename: ${classroom}`,
+    )
   })
 }
 

--- a/web/src/domain/assignments/scoreOverride.ts
+++ b/web/src/domain/assignments/scoreOverride.ts
@@ -1,20 +1,14 @@
 import type { GitHubClient } from "@/github-core/client"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
-import {
-  createGitCommit,
-  createGitTree,
-  updateRef,
-} from "@/github-core/mutations"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { scoresFilePath } from "@/util/configRepoPaths"
 import { decodeBase64Utf8 } from "@/util/github"
 import { GitHubAPIError } from "@/github-core/errors"
-import { prefixCommit } from "@/util/commit"
-import { withGitConflictRetry, assertClassroomNotArchived } from "../classrooms"
+import { withGitConflictRetry } from "../classrooms"
+import {
+  commitConfigRepoFiles,
+  jsonFileEntry,
+  readConfigRepoHead,
+} from "../configRepoWrite"
 
 // A stored submission record inside scores.json (classroom50/result/v1 payload
 // minus the bucket-key `assignment`). We only type the fields the override path
@@ -184,14 +178,8 @@ export async function editScoreOverride(
   const { org, classroom, assignment, owner } = input
 
   return withGitConflictRetry(async () => {
-    const [, configBranch] = await Promise.all([
-      assertClassroomNotArchived(client, org, classroom),
-      getConfigRepoBranch(client, org),
-    ])
-    const ref = await getBranchRef(client, org, configBranch)
-    const commit = await getCommit(client, org, ref.object.sha)
-
-    const scores = await readScoresFile(client, org, classroom, ref.object.sha)
+    const head = await readConfigRepoHead(client, org, classroom)
+    const scores = await readScoresFile(client, org, classroom, head.headSha)
     const bucket: AssignmentBucket = scores.assignments[assignment] ?? {
       type: input.assignmentType,
       entries: [],
@@ -285,29 +273,17 @@ export async function editScoreOverride(
       scores.assignments[assignment] = bucket
     }
 
-    const tree = await createGitTree(client, {
-      org,
-      base_tree: commit.tree.sha,
-      tree: [
-        {
-          path: scoresFilePath(classroom),
-          mode: "100644",
-          type: "blob",
-          content: JSON.stringify(scores, null, 2) + "\n",
-        },
-      ],
-    })
     const message = input.clear
       ? `Clear score override: ${classroom}/${assignment} (${owner})`
       : `Set score override: ${classroom}/${assignment} (${owner})`
-    const newCommit = await createGitCommit(client, {
+    const { newCommitSha } = await commitConfigRepoFiles(
+      client,
       org,
-      message: prefixCommit(message),
-      tree_sha: tree.sha,
-      parents: [ref.object.sha],
-    })
-    await updateRef(client, org, newCommit.sha, configBranch)
+      head,
+      [jsonFileEntry(scoresFilePath(classroom), scores)],
+      message,
+    )
 
-    return { newCommitSha: newCommit.sha }
+    return { newCommitSha }
   })
 }

--- a/web/src/domain/configRepoWrite.test.ts
+++ b/web/src/domain/configRepoWrite.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { GitHubClient } from "@/github-core/client"
+
+vi.mock("@/github-core/configRepoReads", () => ({
+  getConfigRepoBranch: vi.fn(async () => "main"),
+  getBranchRef: vi.fn(async () => ({ object: { sha: "REF" } })),
+  getCommit: vi.fn(async () => ({ tree: { sha: "BASETREE" } })),
+}))
+const assertClassroomNotArchived = vi.fn(async () => undefined)
+vi.mock("./classrooms", () => ({
+  assertClassroomNotArchived: (...args: unknown[]) =>
+    assertClassroomNotArchived(...(args as [])),
+}))
+const createGitTree = vi.fn(async () => ({ sha: "NEWTREE" }))
+const createGitCommit = vi.fn(async () => ({ sha: "NEWCOMMIT" }))
+const updateRef = vi.fn(async () => ({ ref: "refs/heads/main" }))
+vi.mock("@/github-core/mutations", () => ({
+  createGitTree: (...args: unknown[]) => createGitTree(...(args as [])),
+  createGitCommit: (...args: unknown[]) => createGitCommit(...(args as [])),
+  updateRef: (...args: unknown[]) => updateRef(...(args as [])),
+}))
+
+import {
+  commitConfigRepoFiles,
+  jsonFileEntry,
+  readConfigRepoHead,
+  readConfigRepoHeadAt,
+} from "./configRepoWrite"
+
+const client = {} as GitHubClient
+
+beforeEach(() => {
+  assertClassroomNotArchived.mockClear()
+  createGitTree.mockClear()
+  createGitCommit.mockClear()
+  updateRef.mockClear()
+})
+
+describe("readConfigRepoHead", () => {
+  it("runs the archive guard and returns the branch, head and base tree", async () => {
+    const head = await readConfigRepoHead(client, "acme", "cs50")
+    expect(assertClassroomNotArchived).toHaveBeenCalledWith(
+      client,
+      "acme",
+      "cs50",
+    )
+    expect(head).toEqual({
+      configBranch: "main",
+      headSha: "REF",
+      baseTreeSha: "BASETREE",
+    })
+  })
+
+  it("the At variant skips the guard for callers that resolved the branch", async () => {
+    const head = await readConfigRepoHeadAt(client, "acme", "release")
+    expect(assertClassroomNotArchived).not.toHaveBeenCalled()
+    expect(head.configBranch).toBe("release")
+  })
+
+  it("fails closed on an archived classroom before any read", async () => {
+    assertClassroomNotArchived.mockRejectedValueOnce(new Error("archived"))
+    await expect(readConfigRepoHead(client, "acme", "cs50")).rejects.toThrow(
+      "archived",
+    )
+  })
+})
+
+describe("commitConfigRepoFiles", () => {
+  it("builds the tree on the head, parents the commit on it, moves the ref, and prefixes the message", async () => {
+    const head = { configBranch: "main", headSha: "REF", baseTreeSha: "BASE" }
+    const tree = [jsonFileEntry("cs50/x.json", { a: 1 })]
+    const result = await commitConfigRepoFiles(
+      client,
+      "acme",
+      head,
+      tree,
+      "Do a thing",
+    )
+    expect(createGitTree).toHaveBeenCalledWith(client, {
+      org: "acme",
+      base_tree: "BASE",
+      tree,
+    })
+    expect(createGitCommit).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        org: "acme",
+        tree_sha: "NEWTREE",
+        parents: ["REF"],
+        message: expect.stringMatching(/Do a thing$/),
+      }),
+    )
+    const message = (
+      createGitCommit.mock.calls[0] as unknown as [unknown, { message: string }]
+    )[1].message
+    expect(message).not.toBe("Do a thing")
+    expect(updateRef).toHaveBeenCalledWith(client, "acme", "NEWCOMMIT", "main")
+    expect(result).toEqual({
+      newTreeSha: "NEWTREE",
+      newCommitSha: "NEWCOMMIT",
+      updatedRef: { ref: "refs/heads/main" },
+    })
+  })
+})
+
+describe("jsonFileEntry", () => {
+  // Byte-identical to what the CLI and a hand edit produce: 2-space indent and
+  // a trailing newline.
+  it("serializes with the shared JSON shape", () => {
+    expect(jsonFileEntry("p.json", { b: [1, 2] })).toEqual({
+      path: "p.json",
+      mode: "100644",
+      type: "blob",
+      content: '{\n  "b": [\n    1,\n    2\n  ]\n}\n',
+    })
+  })
+})

--- a/web/src/domain/configRepoWrite.ts
+++ b/web/src/domain/configRepoWrite.ts
@@ -1,0 +1,100 @@
+import type { GitHubClient } from "@/github-core/client"
+import {
+  getBranchRef,
+  getCommit,
+  getConfigRepoBranch,
+} from "@/github-core/configRepoReads"
+import {
+  createGitCommit,
+  createGitTree,
+  updateRef,
+  type GitTreeEntry,
+} from "@/github-core/mutations"
+import type { GitHubMoveBranch } from "@/github-core/types"
+import { prefixCommit } from "@/util/commit"
+
+import { assertClassroomNotArchived } from "./classrooms"
+
+// The head of the config repo's default branch, read once per write attempt.
+// Every field a writer needs to build a tree on top of it and move the ref.
+export type ConfigRepoHead = {
+  configBranch: string
+  headSha: string
+  baseTreeSha: string
+}
+
+// The archive guard is independent of the ref read, so they run concurrently;
+// Promise.all rejects on the first rejection, so an archived classroom still
+// fails closed before any write.
+export async function readConfigRepoHead(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+): Promise<ConfigRepoHead> {
+  const [, configBranch] = await Promise.all([
+    assertClassroomNotArchived(client, org, classroom),
+    getConfigRepoBranch(client, org),
+  ])
+  return readConfigRepoHeadAt(client, org, configBranch)
+}
+
+// Same read without the archive guard, for writers that already resolved the
+// branch (or must write to an archived classroom, such as a rename resume).
+export async function readConfigRepoHeadAt(
+  client: GitHubClient,
+  org: string,
+  configBranch: string,
+): Promise<ConfigRepoHead> {
+  const ref = await getBranchRef(client, org, configBranch)
+  const commit = await getCommit(client, org, ref.object.sha)
+  return { configBranch, headSha: ref.object.sha, baseTreeSha: commit.tree.sha }
+}
+
+export type ConfigRepoCommitResult = {
+  newTreeSha: string
+  newCommitSha: string
+  updatedRef: GitHubMoveBranch
+}
+
+// The write half every config-repo mutation shares: one tree on the head's
+// base tree, one commit with the head as parent, one ref move. The message is
+// prefixed here so no writer can forget it. A concurrent write to the same
+// branch surfaces as a non-fast-forward 409 from updateRef; callers wrap the
+// read + commit in withGitConflictRetry to re-read and try again.
+export async function commitConfigRepoFiles(
+  client: GitHubClient,
+  org: string,
+  head: ConfigRepoHead,
+  tree: GitTreeEntry[],
+  message: string,
+): Promise<ConfigRepoCommitResult> {
+  const newTree = await createGitTree(client, {
+    org,
+    base_tree: head.baseTreeSha,
+    tree,
+  })
+  const newCommit = await createGitCommit(client, {
+    org,
+    message: prefixCommit(message),
+    tree_sha: newTree.sha,
+    parents: [head.headSha],
+  })
+  const updatedRef = await updateRef(
+    client,
+    org,
+    newCommit.sha,
+    head.configBranch,
+  )
+  return { newTreeSha: newTree.sha, newCommitSha: newCommit.sha, updatedRef }
+}
+
+// The one JSON serialization every config-repo file uses (2-space, trailing
+// newline), so a hand-edit and a web write produce identical bytes.
+export function jsonFileEntry(path: string, value: unknown): GitTreeEntry {
+  return {
+    path,
+    mode: "100644",
+    type: "blob",
+    content: JSON.stringify(value, null, 2) + "\n",
+  }
+}

--- a/web/src/domain/teams/teamsFile.ts
+++ b/web/src/domain/teams/teamsFile.ts
@@ -1,21 +1,16 @@
 import type { GitHubClient } from "@/github-core/client"
 import type { TeamFormation } from "@/types/classroom"
 import { GitHubAPIError } from "@/github-core/errors"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
-import {
-  createGitCommit,
-  createGitTree,
-  updateRef,
-} from "@/github-core/mutations"
+import { getConfigRepoBranch } from "@/github-core/configRepoReads"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { teamsFilePath } from "@/util/configRepoPaths"
 import { decodeBase64Utf8 } from "@/util/github"
-import { prefixCommit } from "@/util/commit"
 import { withGitConflictRetry } from "../classrooms"
+import {
+  commitConfigRepoFiles,
+  jsonFileEntry,
+  readConfigRepoHeadAt,
+} from "../configRepoWrite"
 import { listTeamMembers } from "@/github-core/queries"
 import { listAssignmentGroupTeams } from "./groupTeams"
 
@@ -122,10 +117,11 @@ export function removeTeamFromSnapshot(
   )
 }
 
-// Commit an updated teams.json via the same git tree/commit path as the
-// assignment writes. `update` maps the freshly-read file to the next one; the
-// whole read -> update -> commit runs inside withGitConflictRetry, so a
-// concurrent config-repo write is re-read and retried rather than lost.
+// Commit an updated teams.json. `update` maps the freshly-read file to the next
+// one; the whole read -> update -> commit runs inside withGitConflictRetry, so
+// a concurrent config-repo write is re-read and retried rather than lost. No
+// archive guard: group-team bookkeeping stays writable on an archived classroom
+// (teardown records deletions here).
 export async function writeTeamsFile(
   client: GitHubClient,
   input: {
@@ -138,34 +134,19 @@ export async function writeTeamsFile(
   const { org, classroom, message, update } = input
   await withGitConflictRetry(async () => {
     const configBranch = await getConfigRepoBranch(client, org)
-    const ref = await getBranchRef(client, org, configBranch)
-    const commit = await getCommit(client, org, ref.object.sha)
+    const head = await readConfigRepoHeadAt(client, org, configBranch)
     const current = await getTeamsFile(client, {
       org,
       classroom,
-      ref: ref.object.sha,
+      ref: head.headSha,
     })
-    const next = update(current)
-
-    const tree = await createGitTree(client, {
+    await commitConfigRepoFiles(
+      client,
       org,
-      base_tree: commit.tree.sha,
-      tree: [
-        {
-          path: teamsFilePath(classroom),
-          mode: "100644",
-          type: "blob",
-          content: JSON.stringify(next, null, 2) + "\n",
-        },
-      ],
-    })
-    const newCommit = await createGitCommit(client, {
-      org,
-      message: prefixCommit(message),
-      tree_sha: tree.sha,
-      parents: [ref.object.sha],
-    })
-    await updateRef(client, org, newCommit.sha, configBranch)
+      head,
+      [jsonFileEntry(teamsFilePath(classroom), update(current))],
+      message,
+    )
   })
 }
 


### PR DESCRIPTION
## Summary

Unit A4 of the dedup map that #904 started. Ten `domain/` functions each hand-rolled the same config-repo read-modify-write sequence (archive guard, branch, ref, commit, read file, build tree, create commit, move ref), and the one shared read/write pair that existed (`readAssignmentsForWrite` / `commitAssignments` in `bulkActions.ts`) was module-private, so the eight single-assignment writers beside it could not use it. Behavior-preserving; every existing domain test passes unchanged.

### What moved where

- **`domain/configRepoWrite.ts`** (new): `readConfigRepoHead(client, org, classroom)` runs the archive guard concurrently with the branch read and returns `{ configBranch, headSha, baseTreeSha }`; `readConfigRepoHeadAt(branch)` is the same without the guard, for writers that resolved the branch themselves to overlap it with other reads (`copyReuse`'s template probe) or that must write to an archived classroom (`teamsFile`, rename resume). `commitConfigRepoFiles(head, tree, message)` is the write half: one tree on the base tree, one commit parented on the head, one ref move, message prefixed so no writer can forget. `jsonFileEntry(path, value)` is the one JSON serialization (12 copies of `JSON.stringify(x, null, 2) + "\n"` collapse into it).
- **`domain/assignments/assignmentsWrite.ts`** (new): the `bulkActions.ts` pair, promoted and typed. `readAssignmentsForWrite` / `readAssignmentsForWriteAt` layer the `assignments.json` read on the head; `commitAssignments` writes it; `requireAssignment` is the shared not-found lookup.
- **Adopted by**: `createAssignment`, `editAssignment`, `setAssignmentLock`, `setAssignmentClosed`, `copyAssignmentToClassroom`, `deleteAssignment`, `commitRenameConfig`, `setRenamedEntryLocked`, `editScoreOverride`, `writeTeamsFile`, and the three batched writers in `bulkActions.ts`.

### `setAssignmentLock` and `setAssignmentClosed` are one flag flip

They were 85% identical (the audit's D5). A private `setAssignmentFlag(ctx, slug, "locked" | "closed", value, message)` owns the no-op skip when already in state (reporting the head as the "no change" result so callers can still seed caches), the omitempty collapse (a false flag drops the key rather than writing `false`), and the commit. `setAssignmentLock` wraps it and adds the template reconcile, which still runs on a no-op flip since a prior run may have flipped the flag yet failed the grant. `setAssignmentClosed` wraps it and adds nothing. `setRenamedEntryLocked` stays separate on purpose (its comment: the rename lock must not touch template access) but now uses the shared writer.

### Two things that are not purely mechanical

- `deleteAssignment` committed with the message `Edit assignment: <classroom>/<slug>`, a copy-paste from `editAssignment`. It now says `Delete assignment: ...`. No test or CLI string depended on the old text.
- `createAssignment` used to run the archive guard, the entry build, and the branch read in one `Promise.all`, then the ref/commit/file reads serially. It now runs the entry build concurrently with `readAssignmentsForWrite` (which itself overlaps the guard and the branch read), so the template probe overlaps more of the config-repo read than before. Same failure semantics: `Promise.all` rejects on the first rejection, so an archived classroom or a bad template still fails closed before any write.

### Not in this PR

The roster writers (`enrollment.ts`, `bulkEnrollment.ts`, `unenroll.ts`, `updateStudent.ts`, `rosterSync.ts`) bypass their own shared helper (`rosterPrimitives.withRosterRewrite`) with a different parse mode (lenient `parseStudentsCsv` vs the helper's strict `parseRosterCsv`), so adopting them needs a `strict` flag decision first and is its own PR. `deleteClassroom` and `createClassroomFiles` write multi-file trees with 409-passthrough semantics the team rollback relies on; also separate. The `gitObjects.ts` wrapper collapse (11 wrappers for 3 endpoints) is unit A8.

## Test plan

- [x] `cd web && npm run check`: tsc, eslint (0 errors, 26 warnings identical to `main`), prettier, arch:validate, 5,314 node tests. Browser project run separately: 18 passed.
- [x] Every existing test for the rewritten writers passes unchanged (`createEdit`, `copyReuse`, `deleteAssignment`, `rename`, `scoreOverride`, `bulkActions`, `teamsFile`: 925 domain tests). Those tests mock the git primitives at the module paths the shared writer now calls through, so they exercise the real sequence.
- [x] New `domain/configRepoWrite.test.ts`: guard runs and fails closed; the `At` variant skips it; tree built on the base tree, commit parented on the head, ref moved, message prefixed; `jsonFileEntry` produces the 2-space + trailing-newline shape.
- [ ] Manual: on a dev org, create an assignment, edit it, lock and unlock it (confirm the second click of the same state is a no-op with no new commit), close and reopen it, reuse it into another classroom, rename it, set a score override, and delete it. Each should land as one commit with the expected message.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched (web `npm run check`; no Go or Python change).
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror. n/a: the written `assignments.json`, `scores.json` and `teams.json` bytes are unchanged.
- [x] If I added or changed a CLI command or flag, I documented it in the wiki. n/a.
- [x] My commits follow Conventional Commits.
