### PR TITLE
refactor(web): one bulk-run machine for the fan-out modals and action bars

### DIFF
--- a/web/src/components/bulk/fanOut.test.ts
+++ b/web/src/components/bulk/fanOut.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { GitHubAPIError } from "@/github-core/errors"
+
+import { partitionOutcomes, runBulkFanOut } from "./fanOut"
+
+const t = ((key: string) => key) as never
+
+function apiError(status: number): GitHubAPIError {
+  return new GitHubAPIError({
+    status,
+    url: "/repos/o/r",
+    message: `HTTP ${status}`,
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter: null,
+    },
+  })
+}
+
+describe("runBulkFanOut", () => {
+  it("records ok, failed and progress in input order", async () => {
+    const seen: [number, string][] = []
+    const { outcomes, rateLimited } = await runBulkFanOut({
+      owners: ["a", "b", "c"],
+      isMounted: () => true,
+      onProgress: (n, owner) => seen.push([n, owner]),
+      t,
+      perOwner: async (owner) => {
+        if (owner === "b") throw new Error("nope")
+      },
+    })
+    expect(rateLimited).toBe(false)
+    expect(outcomes).toEqual([
+      { owner: "a", status: "ok" },
+      { owner: "b", status: "failed", detail: "nope" },
+      { owner: "c", status: "ok" },
+    ])
+    expect(seen.map(([n]) => n).sort()).toEqual([1, 2, 3])
+  })
+
+  it("stops launching after a rate limit and defers the rest", async () => {
+    const perOwner = vi.fn(async (owner: string) => {
+      if (owner === "a") throw apiError(429)
+    })
+    const { outcomes, rateLimited } = await runBulkFanOut({
+      owners: ["a", "b", "c"],
+      concurrency: 1,
+      isMounted: () => true,
+      onProgress: () => {},
+      t,
+      perOwner,
+    })
+    expect(rateLimited).toBe(true)
+    expect(outcomes.map((o) => o.status)).toEqual([
+      "deferred",
+      "deferred",
+      "deferred",
+    ])
+    // Only the first write was ever attempted.
+    expect(perOwner).toHaveBeenCalledTimes(1)
+  })
+
+  it("honours a caller stop condition and unmount without calling perOwner", async () => {
+    let stop = false
+    const perOwner = vi.fn(async (owner: string) => {
+      if (owner === "a") stop = true
+    })
+    const { outcomes } = await runBulkFanOut({
+      owners: ["a", "b"],
+      concurrency: 1,
+      shouldStop: () => stop,
+      isMounted: () => true,
+      onProgress: () => {},
+      t,
+      perOwner,
+    })
+    expect(outcomes.map((o) => o.status)).toEqual(["ok", "deferred"])
+    expect(perOwner).toHaveBeenCalledTimes(1)
+
+    const onProgress = vi.fn()
+    const { outcomes: unmounted } = await runBulkFanOut({
+      owners: ["a"],
+      isMounted: () => false,
+      onProgress,
+      t,
+      perOwner,
+    })
+    expect(unmounted[0].status).toBe("deferred")
+    // No progress reported to a component that is gone.
+    expect(onProgress).not.toHaveBeenCalled()
+  })
+
+  it("lets perOwner return a custom outcome", async () => {
+    type O =
+      | { owner: string; status: "ok" | "deferred" | "failed"; detail?: string }
+      | { owner: string; status: "skipped" }
+    const { outcomes } = await runBulkFanOut<O>({
+      owners: ["a"],
+      isMounted: () => true,
+      onProgress: () => {},
+      t,
+      perOwner: async (owner) => ({ owner, status: "skipped" }),
+    })
+    expect(outcomes).toEqual([{ owner: "a", status: "skipped" }])
+  })
+
+  it("describes a non-rate-limit GitHub error by status", async () => {
+    const { outcomes } = await runBulkFanOut({
+      owners: ["a"],
+      isMounted: () => true,
+      onProgress: () => {},
+      t,
+      perOwner: async () => {
+        throw apiError(500)
+      },
+    })
+    expect(outcomes[0]).toEqual({
+      owner: "a",
+      status: "failed",
+      detail: "components.modals.groupCollaborators.failure.httpStatus",
+    })
+  })
+})
+
+describe("partitionOutcomes", () => {
+  it("splits into the three result sections and keeps failure details typed", () => {
+    const { succeeded, deferred, failed } = partitionOutcomes([
+      { owner: "a", status: "ok" as const },
+      { owner: "b", status: "deferred" as const },
+      { owner: "c", status: "failed" as const, detail: "x" },
+    ])
+    expect(succeeded.map((o) => o.owner)).toEqual(["a"])
+    expect(deferred.map((o) => o.owner)).toEqual(["b"])
+    expect(failed[0].detail).toBe("x")
+  })
+})

--- a/web/src/components/bulk/fanOut.ts
+++ b/web/src/components/bulk/fanOut.ts
@@ -1,0 +1,107 @@
+import type { TFunction } from "i18next"
+
+import { describeWriteFailure } from "@/components/modals/collaboratorHelpers"
+import { GitHubAPIError } from "@/github-core/errors"
+import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
+import { mapWithConcurrency } from "@/util/concurrency"
+
+// The three outcomes every fan-out can produce. A caller may widen the union
+// with its own statuses by returning them from `perOwner`; the widened type
+// only has to keep the `owner` + `status` shape.
+export type AnyOutcome = { owner: string; status: string }
+export type FanOutOutcome =
+  | { owner: string; status: "ok" }
+  // Never launched: an earlier write tripped a secondary rate limit, the
+  // caller asked to stop, or the component unmounted.
+  | { owner: string; status: "deferred" }
+  | { owner: string; status: "failed"; detail?: string }
+
+export type FanOutResult<O> = {
+  outcomes: O[]
+  // True once a secondary rate-limit tripped: the remainder was marked
+  // deferred rather than launched, so the caller should offer a re-run.
+  rateLimited: boolean
+}
+
+type RunBulkFanOutParams<O> = {
+  owners: string[]
+  // One write per owner. Resolve with a custom outcome, or with nothing for a
+  // plain "ok". Throw to record a failure; a rate-limit throw stops the rest.
+  perOwner: (owner: string) => Promise<O | void>
+  // Defaults to the read limit; writes that GitHub throttles harder pass
+  // REPO_WRITE_CONCURRENCY.
+  concurrency?: number
+  // A caller-owned stop condition checked before each launch (e.g. a missing
+  // workflow scope that every later owner would also hit).
+  shouldStop?: () => boolean
+  isMounted: () => boolean
+  // After each owner is processed (ok, failed, or deferred), with the running
+  // count and the owner just handled.
+  onProgress: (processed: number, owner: string) => void
+  t: TFunction
+}
+
+// The bounded per-owner fan-out every bulk modal runs: launch up to
+// `concurrency` writes at once, stop launching new ones once a secondary rate
+// limit trips (hammering GitHub only deepens the throttle) or the component
+// unmounts, and report one outcome per owner in input order.
+export async function runBulkFanOut<O extends AnyOutcome = FanOutOutcome>({
+  owners,
+  perOwner,
+  concurrency = REPO_READ_CONCURRENCY,
+  shouldStop,
+  isMounted,
+  onProgress,
+  t,
+}: RunBulkFanOutParams<O>): Promise<FanOutResult<O>> {
+  let processed = 0
+  let rateLimited = false
+
+  const outcomes = await mapWithConcurrency(
+    owners,
+    concurrency,
+    async (owner): Promise<O> => {
+      if (rateLimited || shouldStop?.() || !isMounted()) {
+        processed += 1
+        if (isMounted()) onProgress(processed, owner)
+        const deferred: FanOutOutcome = { owner, status: "deferred" }
+        return deferred as unknown as O
+      }
+      try {
+        const custom = await perOwner(owner)
+        if (custom) return custom
+        const ok: FanOutOutcome = { owner, status: "ok" }
+        return ok as unknown as O
+      } catch (err) {
+        if (err instanceof GitHubAPIError && err.isRateLimited) {
+          rateLimited = true
+          const deferred: FanOutOutcome = { owner, status: "deferred" }
+          return deferred as unknown as O
+        }
+        const failed: FanOutOutcome = {
+          owner,
+          status: "failed",
+          detail: describeWriteFailure(err, t),
+        }
+        return failed as unknown as O
+      } finally {
+        processed += 1
+        if (isMounted()) onProgress(processed, owner)
+      }
+    },
+  )
+
+  return { outcomes, rateLimited }
+}
+
+// Split outcomes into the three sections every result view renders.
+export function partitionOutcomes<O extends AnyOutcome>(outcomes: O[]) {
+  return {
+    succeeded: outcomes.filter((o) => o.status === "ok"),
+    deferred: outcomes.filter((o) => o.status === "deferred"),
+    failed: outcomes.filter(
+      (o): o is O & { status: "failed"; detail?: string } =>
+        o.status === "failed",
+    ),
+  }
+}

--- a/web/src/components/bulk/repoAccessFanOut.ts
+++ b/web/src/components/bulk/repoAccessFanOut.ts
@@ -1,12 +1,11 @@
 import type { TFunction } from "i18next"
 
-import { describeGitHubApiFailure } from "@/components/modals/collaboratorHelpers"
-import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
+import { describeWriteFailure } from "@/components/modals/collaboratorHelpers"
 import { permissionSatisfies } from "@/domain/assignments/permissions"
-import { mapWithConcurrency } from "@/util/concurrency"
 import { studentRepoName } from "@/util/studentRepo"
-import { GitHubAPIError } from "@/github-core/errors"
 import type { RepoPermission } from "@/types/classroom"
+
+import { runBulkFanOut, type FanOutOutcome, type FanOutResult } from "./fanOut"
 
 // A verified write GitHub silently ignored: the PUT returned 204 but the
 // student's effective role didn't land on the target. Reported distinctly from
@@ -20,9 +19,7 @@ export class AccessNotAppliedError extends Error {
   }
 }
 
-// Map a rejected write to a localized reason for the result table. Reuses the
-// groupCollaborators failure vocabulary so every bulk-access dialog stays
-// consistent instead of assembling raw English.
+// The shared write-failure reasons plus the one this fan-out adds.
 export const describeAccessFailure = (
   reason: unknown,
   t: TFunction,
@@ -32,27 +29,11 @@ export const describeAccessFailure = (
       effective: reason.effective ?? "unknown",
     })
   }
-  const shared = describeGitHubApiFailure(reason, t)
-  if (shared) return shared
-  if (reason instanceof GitHubAPIError) {
-    return t("components.modals.groupCollaborators.failure.httpStatus", {
-      status: reason.status,
-    })
-  }
-  return reason instanceof Error ? reason.message : undefined
+  return describeWriteFailure(reason, t)
 }
 
-export type BulkAccessOutcome =
-  | { owner: string; status: "ok" }
-  | { owner: string; status: "deferred" }
-  | { owner: string; status: "failed"; detail?: string }
-
-export type BulkAccessResult = {
-  outcomes: BulkAccessOutcome[]
-  // True once a secondary rate-limit tripped: the remaining owners were marked
-  // deferred rather than launched, so the caller should offer a re-run.
-  rateLimited: boolean
-}
+export type BulkAccessOutcome = FanOutOutcome
+export type BulkAccessResult = FanOutResult<BulkAccessOutcome>
 
 type RunBulkRepoAccessParams = {
   owners: string[]
@@ -102,23 +83,12 @@ export async function runBulkRepoAccess({
   isMounted,
   onProgress,
 }: RunBulkRepoAccessParams): Promise<BulkAccessResult> {
-  let processed = 0
-  // Set once we hit a secondary rate-limit: stop launching NEW writes and
-  // report the untouched remainder as deferred rather than hammering GitHub
-  // into a deeper throttle.
-  let rateLimited = false
-
-  const outcomes = await mapWithConcurrency(
+  return runBulkFanOut<BulkAccessOutcome>({
     owners,
-    REPO_READ_CONCURRENCY,
-    async (owner): Promise<BulkAccessOutcome> => {
-      // The caller unmounted, or an earlier task tripped the rate limit: don't
-      // start another write; mark the rest deferred.
-      if (rateLimited || !isMounted()) {
-        processed += 1
-        if (isMounted()) onProgress(processed, owner)
-        return { owner, status: "deferred" }
-      }
+    isMounted,
+    onProgress,
+    t,
+    perOwner: async (owner) => {
       const repo = studentRepoName(classroom, assignment, owner)
       try {
         const { effective } = await setCollaborator({
@@ -141,23 +111,18 @@ export async function runBulkRepoAccess({
             effective.role_name || effective.permission,
           )
         }
-        return { owner, status: "ok" }
       } catch (err) {
-        if (err instanceof GitHubAPIError && err.isRateLimited) {
-          rateLimited = true
-          return { owner, status: "deferred" }
+        // The generic fan-out only knows the shared vocabulary; give the
+        // not-applied case its own line before it becomes a plain failure.
+        if (err instanceof AccessNotAppliedError) {
+          return {
+            owner,
+            status: "failed",
+            detail: describeAccessFailure(err, t),
+          }
         }
-        return {
-          owner,
-          status: "failed",
-          detail: describeAccessFailure(err, t),
-        }
-      } finally {
-        processed += 1
-        if (isMounted()) onProgress(processed, owner)
+        throw err
       }
     },
-  )
-
-  return { outcomes, rateLimited }
+  })
 }

--- a/web/src/components/bulk/resultView.tsx
+++ b/web/src/components/bulk/resultView.tsx
@@ -6,7 +6,16 @@
 
 import { useTranslation } from "react-i18next"
 
-import { Button, InlineSpinner, Spinner, TableShell } from "@/components/ui"
+import {
+  Alert,
+  Button,
+  InlineSpinner,
+  Modal,
+  Spinner,
+  TableShell,
+} from "@/components/ui"
+
+import type { BulkRun } from "./useBulkRun"
 
 // The lifecycle of a bulk run's modal: idle (closed) -> working (progress) ->
 // complete/error (results).
@@ -192,3 +201,125 @@ export const BulkProgressInline = ({
     <progress {...bulkProgressBarProps(progress, label)} />
   </div>
 )
+
+// The finished-run body every bulk modal renders: the headline as a success or
+// warning alert, then one section per outcome group. Rendered only once the
+// run has left "working".
+export const BulkResultBody = ({
+  phase,
+  result,
+  className = "mt-4 flex flex-col gap-4",
+  children,
+  after,
+}: {
+  phase: BulkPhase
+  result: BulkResultView | null
+  className?: string
+  // Rendered between the headline and the sections (a follow-up reminder).
+  children?: React.ReactNode
+  // Rendered after the sections (a recovery hint).
+  after?: React.ReactNode
+}) => {
+  if ((phase !== "complete" && phase !== "error") || !result) return null
+  return (
+    <div className={className}>
+      <Alert
+        tone={phase === "error" ? "warning" : "success"}
+        className="text-sm"
+      >
+        {result.headline}
+      </Alert>
+      {children}
+      {result.sections.map((section) => (
+        <BulkResultSection
+          key={section.title}
+          title={section.title}
+          rows={section.rows}
+        />
+      ))}
+      {after}
+    </div>
+  )
+}
+
+// The action bars' run modal (roster and org members): opened by the bar when
+// a run starts, it shows the progress row while working, the results when
+// complete, or the whole-run error. Closing is refused while working. The
+// modal stays mounted across runs; the bar owns `open` so a close does not
+// reset the last result mid-animation.
+export const BulkRunModal = ({
+  open,
+  onClose,
+  title,
+  run,
+  processedCaption,
+  keepTabOpenMessage,
+  fallbackError,
+  doneLabel,
+}: {
+  open: boolean
+  onClose: () => void
+  title: string
+  run: Pick<BulkRun, "phase" | "progress" | "result" | "error">
+  processedCaption: React.ReactNode
+  keepTabOpenMessage: string
+  fallbackError: string
+  doneLabel: string
+}) => {
+  const { t } = useTranslation()
+  const { phase, progress, result, error } = run
+  const busy = phase === "working"
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      closeDisabled={busy}
+      size="2xl"
+      title={title}
+      footer={
+        phase === "complete" ? (
+          <Button variant="primary" onClick={onClose}>
+            {doneLabel}
+          </Button>
+        ) : phase === "error" ? (
+          <Button variant="primary" onClick={onClose}>
+            {t("common.done")}
+          </Button>
+        ) : undefined
+      }
+    >
+      {busy && (
+        <BulkProgressRow
+          progress={progress}
+          processedCaption={processedCaption}
+          percentCaption={`${bulkProgressPct(progress)}%`}
+        >
+          <Alert tone="info" className="mt-6">
+            <span>{keepTabOpenMessage}</span>
+          </Alert>
+        </BulkProgressRow>
+      )}
+      {phase === "complete" && result && (
+        <div className="mt-6 space-y-4">
+          <Alert tone="success">
+            <span>{result.headline}</span>
+          </Alert>
+          {result.sections.map((section) => (
+            <BulkResultSection
+              key={section.title}
+              title={section.title}
+              rows={section.rows}
+            />
+          ))}
+        </div>
+      )}
+      {phase === "error" && (
+        <div className="mt-6">
+          <Alert tone="error">
+            <span>{error ?? fallbackError}</span>
+          </Alert>
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/web/src/components/bulk/useBulkRun.test.tsx
+++ b/web/src/components/bulk/useBulkRun.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/hooks/useBeforeUnloadGuard", () => ({
+  useBeforeUnloadGuard: vi.fn(),
+}))
+import { useBeforeUnloadGuard } from "@/hooks/useBeforeUnloadGuard"
+
+import { useBulkRun } from "./useBulkRun"
+
+const view = { headline: "done", sections: [] }
+
+describe("useBulkRun", () => {
+  it("walks idle -> working -> complete and holds the tab only while working", () => {
+    const { result } = renderHook(() => useBulkRun())
+    expect(result.current.phase).toBe("idle")
+    expect(useBeforeUnloadGuard).toHaveBeenLastCalledWith(false)
+
+    let started = false
+    act(() => {
+      started = result.current.begin(3, "starting")
+    })
+    expect(started).toBe(true)
+    expect(result.current.phase).toBe("working")
+    expect(result.current.busy).toBe(true)
+    expect(result.current.progress).toEqual({
+      processed: 0,
+      total: 3,
+      message: "starting",
+    })
+    expect(useBeforeUnloadGuard).toHaveBeenLastCalledWith(true)
+
+    act(() =>
+      result.current.setProgress({ processed: 2, total: 3, message: "b" }),
+    )
+    expect(result.current.progress.processed).toBe(2)
+
+    act(() => result.current.complete(view, "complete"))
+    expect(result.current.phase).toBe("complete")
+    expect(result.current.result).toBe(view)
+    expect(useBeforeUnloadGuard).toHaveBeenLastCalledWith(false)
+  })
+
+  it("refuses a second begin while a run is in flight", () => {
+    const { result } = renderHook(() => useBulkRun())
+    act(() => void result.current.begin(1))
+    let second: boolean | undefined
+    act(() => {
+      second = result.current.begin(5)
+    })
+    expect(second).toBe(false)
+    // The first run's progress is untouched.
+    expect(result.current.progress.total).toBe(1)
+    // A finished run frees the latch.
+    act(() => result.current.complete(view, "error"))
+    act(() => {
+      second = result.current.begin(5)
+    })
+    expect(second).toBe(true)
+  })
+
+  it("fail records the message and leaves no result", () => {
+    const { result } = renderHook(() => useBulkRun())
+    act(() => void result.current.begin(1))
+    act(() => result.current.fail("boom"))
+    expect(result.current.phase).toBe("error")
+    expect(result.current.error).toBe("boom")
+    expect(result.current.result).toBeNull()
+  })
+
+  it("resets when the reset flag turns true, not when it turns false", () => {
+    const { result, rerender } = renderHook(
+      ({ open }: { open: boolean }) => useBulkRun(open),
+      { initialProps: { open: true } },
+    )
+    act(() => void result.current.begin(1))
+    act(() => result.current.complete(view, "complete"))
+
+    // Closing keeps the last result visible through the exit animation.
+    rerender({ open: false })
+    expect(result.current.phase).toBe("complete")
+    expect(result.current.result).toBe(view)
+
+    // Reopening starts fresh.
+    rerender({ open: true })
+    expect(result.current.phase).toBe("idle")
+    expect(result.current.result).toBeNull()
+  })
+
+  it("reports unmounted and swallows completions after unmount", () => {
+    const { result, unmount } = renderHook(() => useBulkRun())
+    const run = result.current
+    act(() => void run.begin(1))
+    expect(run.isMounted()).toBe(true)
+    unmount()
+    expect(run.isMounted()).toBe(false)
+    // No throw, no setState on an unmounted component.
+    run.setProgress({ processed: 1, total: 1, message: "" })
+    run.complete(view, "complete")
+    run.fail("late")
+  })
+})

--- a/web/src/components/bulk/useBulkRun.ts
+++ b/web/src/components/bulk/useBulkRun.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { useBeforeUnloadGuard } from "@/hooks/useBeforeUnloadGuard"
+
+import type { BulkPhase, BulkProgress, BulkResultView } from "./resultView"
+
+const IDLE_PROGRESS: BulkProgress = { processed: 0, total: 0, message: "" }
+
+export interface BulkRun {
+  phase: BulkPhase
+  progress: BulkProgress
+  result: BulkResultView | null
+  // A whole-run failure (the bars' shape: the domain call threw before any
+  // per-row outcome existed). Rendered instead of `result`.
+  error: string | null
+  busy: boolean
+  // True while the component that started the run is still mounted. Fan-outs
+  // check it before every setState and before launching another write.
+  isMounted: () => boolean
+  // Enter "working". Returns false (and does nothing) when a run is already in
+  // flight, so a double-click can't start a second fan-out.
+  begin: (total: number, message?: string) => boolean
+  setProgress: (progress: BulkProgress) => void
+  // Leave "working" with per-row results; `phase` is "error" when any row
+  // failed or was deferred, so the caller decides that from its outcomes.
+  complete: (result: BulkResultView, phase: "complete" | "error") => void
+  // Leave "working" because the run itself threw.
+  fail: (message: string) => void
+  // Back to idle with nothing shown. Modals call this on open, never on close
+  // (see the close-animation note in ui/Modal).
+  reset: () => void
+}
+
+// The lifecycle every bulk modal and action bar drives: idle -> working ->
+// complete | error, with the progress line, the mounted/running guards, and
+// the tab-close hold while working. Callers own what the run does and how its
+// outcomes map to a BulkResultView; this owns everything else.
+//
+// `resetWhen` is the modal's `open` flag: the state resets as it turns true so
+// a reopened dialog starts fresh, while a close leaves the last result in
+// place through the exit animation.
+export function useBulkRun(resetWhen?: boolean): BulkRun {
+  const [phase, setPhase] = useState<BulkPhase>("idle")
+  const [progress, setProgressState] = useState<BulkProgress>(IDLE_PROGRESS)
+  const [result, setResult] = useState<BulkResultView | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const runningRef = useRef(false)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      runningRef.current = false
+    }
+  }, [])
+
+  const isMounted = useCallback(() => mountedRef.current, [])
+
+  const reset = useCallback(() => {
+    runningRef.current = false
+    setPhase("idle")
+    setResult(null)
+    setError(null)
+    setProgressState(IDLE_PROGRESS)
+  }, [])
+
+  useEffect(() => {
+    if (resetWhen) reset()
+  }, [resetWhen, reset])
+
+  const begin = useCallback((total: number, message = "") => {
+    if (runningRef.current) return false
+    runningRef.current = true
+    setPhase("working")
+    setResult(null)
+    setError(null)
+    setProgressState({ processed: 0, total, message })
+    return true
+  }, [])
+
+  const setProgress = useCallback((next: BulkProgress) => {
+    if (mountedRef.current) setProgressState(next)
+  }, [])
+
+  const complete = useCallback(
+    (view: BulkResultView, next: "complete" | "error") => {
+      runningRef.current = false
+      if (!mountedRef.current) return
+      setResult(view)
+      setPhase(next)
+    },
+    [],
+  )
+
+  const fail = useCallback((message: string) => {
+    runningRef.current = false
+    if (!mountedRef.current) return
+    setError(message)
+    setPhase("error")
+  }, [])
+
+  const busy = phase === "working"
+  useBeforeUnloadGuard(busy)
+
+  return {
+    phase,
+    progress,
+    result,
+    error,
+    busy,
+    isMounted,
+    begin,
+    setProgress,
+    complete,
+    fail,
+    reset,
+  }
+}

--- a/web/src/components/modals/BulkAutogradeStateModal.tsx
+++ b/web/src/components/modals/BulkAutogradeStateModal.tsx
@@ -1,27 +1,19 @@
-import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import type { TFunction } from "i18next"
 import { PauseIcon, PlayIcon } from "@/components/ui/icons"
 
 import { Alert, Modal, ModalIcon } from "@/components/ui"
 import {
   BulkPhaseFooter,
   BulkProgressBlock,
-  BulkResultSection,
-  type BulkPhase,
-  type BulkProgress,
-  type BulkResultView,
+  BulkResultBody,
 } from "@/components/bulk/resultView"
+import { runBulkFanOut, type FanOutOutcome } from "@/components/bulk/fanOut"
+import { useBulkRun } from "@/components/bulk/useBulkRun"
 import { setAutogradeState } from "@/github-core/mutations"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
-import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
-import { mapWithConcurrency } from "@/util/concurrency"
 import { studentRepoName } from "@/util/studentRepo"
 import { getName } from "@/util/students"
-import { describeGitHubApiFailure } from "@/components/modals/collaboratorHelpers"
-import { GitHubAPIError } from "@/github-core/errors"
 import type { Student } from "@/types/classroom"
-import { useBeforeUnloadGuard } from "@/hooks/useBeforeUnloadGuard"
 
 type BulkAutogradeStateModalProps = {
   open: boolean
@@ -36,16 +28,9 @@ type BulkAutogradeStateModalProps = {
   students?: Student[]
 }
 
-const describeFailure = (reason: unknown, t: TFunction): string | undefined => {
-  const shared = describeGitHubApiFailure(reason, t)
-  if (shared) return shared
-  if (reason instanceof GitHubAPIError) {
-    return t("components.modals.groupCollaborators.failure.httpStatus", {
-      status: reason.status,
-    })
-  }
-  return reason instanceof Error ? reason.message : undefined
-}
+// The shared outcomes plus "not gradable": the repo has no autograde workflow
+// to pause or resume, which is a report, not a failure.
+type Outcome = FanOutOutcome | { owner: string; status: "notGradable" }
 
 // Bulk pause/resume autograding across the selected accepted repos, in one
 // bounded fan-out. Each repo is a single idempotent PUT to GitHub's workflow
@@ -64,93 +49,30 @@ export function BulkAutogradeStateModal({
 }: BulkAutogradeStateModalProps) {
   const { t } = useTranslation()
   const client = useGitHubClient()
-  const runningRef = useRef(false)
-  const mountedRef = useRef(true)
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-      runningRef.current = false
-    }
-  }, [])
-
-  const [phase, setPhase] = useState<BulkPhase>("idle")
-  const [progress, setProgress] = useState<BulkProgress>({
-    processed: 0,
-    total: 0,
-    message: "",
-  })
-  const [result, setResult] = useState<BulkResultView | null>(null)
-
-  // Reset on open, never at close — see the close-animation note in ui/Modal.
-  useEffect(() => {
-    if (!open) return
-    runningRef.current = false
-    setPhase("idle")
-    setResult(null)
-    setProgress({ processed: 0, total: 0, message: "" })
-  }, [open])
+  const bulk = useBulkRun(open)
+  const { phase, progress, result, busy } = bulk
 
   const total = owners.length
   const displayFor = (login: string) => getName(login, students) || login
   const isPause = action === "pause"
 
-  type Outcome = { owner: string } & (
-    | { status: "ok" | "notGradable" }
-    | { status: "deferred" }
-    | { status: "failed"; detail?: string }
-  )
-
   const run = async () => {
-    if (runningRef.current || total === 0) return
-    runningRef.current = true
-    setPhase("working")
-    setResult(null)
-    let processed = 0
-    setProgress({ processed: 0, total, message: "" })
-    // Stop launching NEW requests once a secondary rate limit is hit — every
-    // remaining repo would fail the same way.
-    let rateLimited = false
+    if (total === 0) return
+    if (!bulk.begin(total)) return
 
-    const outcomes = await mapWithConcurrency(
+    const { outcomes } = await runBulkFanOut<Outcome>({
       owners,
-      REPO_READ_CONCURRENCY,
-      async (owner): Promise<Outcome> => {
-        if (rateLimited || !mountedRef.current) {
-          processed += 1
-          if (mountedRef.current) {
-            setProgress({ processed, total, message: displayFor(owner) })
-          }
-          return { owner, status: "deferred" }
-        }
+      isMounted: bulk.isMounted,
+      onProgress: (processed, owner) =>
+        bulk.setProgress({ processed, total, message: displayFor(owner) }),
+      t,
+      perOwner: async (owner) => {
         const repo = studentRepoName(classroom, assignment, owner)
-        try {
-          const outcome = await setAutogradeState({
-            client,
-            org,
-            repo,
-            action,
-          })
-          return { owner, status: outcome.status }
-        } catch (err) {
-          if (err instanceof GitHubAPIError && err.isRateLimited) {
-            rateLimited = true
-            return { owner, status: "deferred" }
-          }
-          return { owner, status: "failed", detail: describeFailure(err, t) }
-        } finally {
-          processed += 1
-          if (mountedRef.current) {
-            setProgress({ processed, total, message: displayFor(owner) })
-          }
-        }
+        const outcome = await setAutogradeState({ client, org, repo, action })
+        return { owner, status: outcome.status }
       },
-    )
-
-    if (!mountedRef.current) {
-      runningRef.current = false
-      return
-    }
+    })
+    if (!bulk.isMounted()) return
 
     const ok = outcomes.filter((o) => o.status === "ok")
     const notGradable = outcomes.filter((o) => o.status === "notGradable")
@@ -176,33 +98,31 @@ export function BulkAutogradeStateModal({
           ]
         : []
 
-    setResult({
-      headline: t(
-        isPause
-          ? "submissions.bulkAutograde.pauseResultHeadline"
-          : "submissions.bulkAutograde.resumeResultHeadline",
-        { done: ok.length, total },
-      ),
-      sections: [
-        ...section("submissions.bulkAutograde.failedSection", failed),
-        ...section(
-          "submissions.bulkAutograde.deferredSection",
-          deferred,
-          t("submissions.bulkAutograde.deferredDetail"),
+    bulk.complete(
+      {
+        headline: t(
+          isPause
+            ? "submissions.bulkAutograde.pauseResultHeadline"
+            : "submissions.bulkAutograde.resumeResultHeadline",
+          { done: ok.length, total },
         ),
-        ...section(
-          "submissions.bulkAutograde.notGradableSection",
-          notGradable,
-          t("submissions.bulkAutograde.notGradableDetail"),
-        ),
-      ],
-    })
-    setPhase(failed.length || deferred.length ? "error" : "complete")
-    runningRef.current = false
+        sections: [
+          ...section("submissions.bulkAutograde.failedSection", failed),
+          ...section(
+            "submissions.bulkAutograde.deferredSection",
+            deferred,
+            t("submissions.bulkAutograde.deferredDetail"),
+          ),
+          ...section(
+            "submissions.bulkAutograde.notGradableSection",
+            notGradable,
+            t("submissions.bulkAutograde.notGradableDetail"),
+          ),
+        ],
+      },
+      failed.length || deferred.length ? "error" : "complete",
+    )
   }
-
-  const busy = phase === "working"
-  useBeforeUnloadGuard(busy)
 
   return (
     <Modal
@@ -275,23 +195,7 @@ export function BulkAutogradeStateModal({
         />
       )}
 
-      {(phase === "complete" || phase === "error") && result && (
-        <div className="mt-4 flex flex-col gap-4">
-          <Alert
-            tone={phase === "error" ? "warning" : "success"}
-            className="text-sm"
-          >
-            {result.headline}
-          </Alert>
-          {result.sections.map((section) => (
-            <BulkResultSection
-              key={section.title}
-              title={section.title}
-              rows={section.rows}
-            />
-          ))}
-        </div>
-      )}
+      <BulkResultBody phase={phase} result={result} />
     </Modal>
   )
 }

--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ShieldCheckIcon } from "@/components/ui/icons"
 
@@ -6,17 +6,15 @@ import { Alert, Modal, ModalIcon, Select } from "@/components/ui"
 import {
   BulkPhaseFooter,
   BulkProgressBlock,
-  BulkResultSection,
-  type BulkPhase,
-  type BulkProgress,
-  type BulkResultView,
+  BulkResultBody,
 } from "@/components/bulk/resultView"
+import { partitionOutcomes } from "@/components/bulk/fanOut"
 import { runBulkRepoAccess } from "@/components/bulk/repoAccessFanOut"
+import { useBulkRun } from "@/components/bulk/useBulkRun"
 import useAddRepoCollaborator from "@/hooks/mutations/useAddRepoCollaborator"
 import { getName } from "@/util/students"
 import type { RepoPermission, Student } from "@/types/classroom"
 import { REPO_PERMISSIONS } from "@/types/classroom"
-import { useBeforeUnloadGuard } from "@/hooks/useBeforeUnloadGuard"
 
 type BulkRepoAccessModalProps = {
   open: boolean
@@ -44,36 +42,13 @@ export function BulkRepoAccessModal({
 }: BulkRepoAccessModalProps) {
   const { t } = useTranslation()
   const addCollaboratorMutation = useAddRepoCollaborator()
-  const runningRef = useRef(false)
-  // Guards setState after unmount and lets an in-flight run stop launching new
-  // writes when the modal closes mid-fan-out (there's no per-request cancel
-  // token on the mutation, so we skip the remaining owners instead).
-  const mountedRef = useRef(true)
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-      runningRef.current = false
-    }
-  }, [])
+  const bulk = useBulkRun(open)
+  const { phase, progress, result, busy } = bulk
 
   const [permission, setPermission] = useState<RepoPermission>("push")
-  const [phase, setPhase] = useState<BulkPhase>("idle")
-  const [progress, setProgress] = useState<BulkProgress>({
-    processed: 0,
-    total: 0,
-    message: "",
-  })
-  const [result, setResult] = useState<BulkResultView | null>(null)
-
-  // Reset on open, never at close — see the close-animation note in ui/Modal.
+  // The form state resets with the run state, on open (see useBulkRun).
   useEffect(() => {
-    if (!open) return
-    runningRef.current = false
-    setPermission("push")
-    setPhase("idle")
-    setResult(null)
-    setProgress({ processed: 0, total: 0, message: "" })
+    if (open) setPermission("push")
   }, [open])
 
   const total = owners.length
@@ -83,11 +58,8 @@ export function BulkRepoAccessModal({
     t(`assignments.form.studentPermission.levels.${level}`)
 
   const run = async () => {
-    if (runningRef.current || total === 0) return
-    runningRef.current = true
-    setPhase("working")
-    setResult(null)
-    setProgress({ processed: 0, total, message: "" })
+    if (total === 0) return
+    if (!bulk.begin(total)) return
 
     const { outcomes, rateLimited } = await runBulkRepoAccess({
       owners,
@@ -101,74 +73,61 @@ export function BulkRepoAccessModal({
       // lower) role was silently ignored — the over-access a lockdown must catch.
       treatRequestedAsFloor: false,
       t,
-      isMounted: () => mountedRef.current,
-      onProgress: (processed) => {
-        if (mountedRef.current) {
-          setProgress({ processed, total, message: "" })
-        }
+      isMounted: bulk.isMounted,
+      onProgress: (processed) =>
+        bulk.setProgress({ processed, total, message: "" }),
+    })
+    if (!bulk.isMounted()) return
+
+    const { succeeded, deferred, failed } = partitionOutcomes(outcomes)
+
+    bulk.complete(
+      {
+        headline: rateLimited
+          ? t("submissions.bulkAccess.resultHeadlineThrottled", {
+              count: succeeded.length,
+              total,
+              level: permissionLabel(permission),
+            })
+          : t("submissions.bulkAccess.resultHeadline", {
+              count: succeeded.length,
+              total,
+              level: permissionLabel(permission),
+            }),
+        sections: [
+          ...(failed.length
+            ? [
+                {
+                  title: t("submissions.bulkAccess.failedSection", {
+                    count: failed.length,
+                  }),
+                  rows: failed.map((o) => ({
+                    key: o.owner,
+                    label: displayFor(o.owner),
+                    detail: o.detail,
+                  })),
+                },
+              ]
+            : []),
+          ...(deferred.length
+            ? [
+                {
+                  title: t("submissions.bulkAccess.deferredSection", {
+                    count: deferred.length,
+                  }),
+                  rows: deferred.map((o) => ({
+                    key: o.owner,
+                    label: displayFor(o.owner),
+                    detail: t("submissions.bulkAccess.deferredDetail"),
+                  })),
+                },
+              ]
+            : []),
+        ],
       },
-    })
-
-    // The modal was closed mid-run: the fan-out finished (or bailed) but there's
-    // no live component to show a result on.
-    if (!mountedRef.current) {
-      runningRef.current = false
-      return
-    }
-
-    const succeeded = outcomes.filter((o) => o.status === "ok")
-    const deferred = outcomes.filter((o) => o.status === "deferred")
-    const failed = outcomes.filter((o) => o.status === "failed")
-
-    setResult({
-      headline: rateLimited
-        ? t("submissions.bulkAccess.resultHeadlineThrottled", {
-            count: succeeded.length,
-            total,
-            level: permissionLabel(permission),
-          })
-        : t("submissions.bulkAccess.resultHeadline", {
-            count: succeeded.length,
-            total,
-            level: permissionLabel(permission),
-          }),
-      sections: [
-        ...(failed.length
-          ? [
-              {
-                title: t("submissions.bulkAccess.failedSection", {
-                  count: failed.length,
-                }),
-                rows: failed.map((o) => ({
-                  key: o.owner,
-                  label: displayFor(o.owner),
-                  detail: "detail" in o ? o.detail : undefined,
-                })),
-              },
-            ]
-          : []),
-        ...(deferred.length
-          ? [
-              {
-                title: t("submissions.bulkAccess.deferredSection", {
-                  count: deferred.length,
-                }),
-                rows: deferred.map((o) => ({
-                  key: o.owner,
-                  label: displayFor(o.owner),
-                  detail: t("submissions.bulkAccess.deferredDetail"),
-                })),
-              },
-            ]
-          : []),
-      ],
-    })
-    setPhase(failed.length || deferred.length ? "error" : "complete")
-    runningRef.current = false
+      failed.length || deferred.length ? "error" : "complete",
+    )
   }
-
-  const busy = phase === "working"
-  useBeforeUnloadGuard(busy)
 
   return (
     <Modal
@@ -247,23 +206,7 @@ export function BulkRepoAccessModal({
         />
       )}
 
-      {(phase === "complete" || phase === "error") && result && (
-        <div className="mt-4 flex flex-col gap-4">
-          <Alert
-            tone={phase === "error" ? "warning" : "success"}
-            className="text-sm"
-          >
-            {result.headline}
-          </Alert>
-          {result.sections.map((section) => (
-            <BulkResultSection
-              key={section.title}
-              title={section.title}
-              rows={section.rows}
-            />
-          ))}
-        </div>
-      )}
+      <BulkResultBody phase={phase} result={result} />
     </Modal>
   )
 }

--- a/web/src/components/modals/BulkRepoFeaturesModal.tsx
+++ b/web/src/components/modals/BulkRepoFeaturesModal.tsx
@@ -1,27 +1,20 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import type { TFunction } from "i18next"
 import { SlidersIcon } from "@/components/ui/icons"
 
 import { Alert, Modal, ModalIcon, Select } from "@/components/ui"
 import {
   BulkPhaseFooter,
   BulkProgressBlock,
-  BulkResultSection,
-  type BulkPhase,
-  type BulkProgress,
-  type BulkResultView,
+  BulkResultBody,
 } from "@/components/bulk/resultView"
+import { partitionOutcomes, runBulkFanOut } from "@/components/bulk/fanOut"
+import { useBulkRun } from "@/components/bulk/useBulkRun"
 import useSetRepoFeatures from "@/hooks/mutations/useSetRepoFeatures"
 import type { RepoFeaturePatch } from "@/github-core/mutations"
-import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
-import { mapWithConcurrency } from "@/util/concurrency"
 import { studentRepoName } from "@/util/studentRepo"
 import { getName } from "@/util/students"
-import { describeGitHubApiFailure } from "@/components/modals/collaboratorHelpers"
-import { GitHubAPIError } from "@/github-core/errors"
 import type { Student } from "@/types/classroom"
-import { useBeforeUnloadGuard } from "@/hooks/useBeforeUnloadGuard"
 
 type BulkRepoFeaturesModalProps = {
   open: boolean
@@ -59,20 +52,6 @@ function choicesToPatch(
   return patch
 }
 
-// Map a rejected write to a localized reason for the result table. Reuses the
-// shared groupCollaborators failure vocabulary (rate-limit/403/404) like the
-// sibling BulkRepoAccessModal, then falls back to the HTTP status / raw message.
-const describeFailure = (reason: unknown, t: TFunction): string | undefined => {
-  const shared = describeGitHubApiFailure(reason, t)
-  if (shared) return shared
-  if (reason instanceof GitHubAPIError) {
-    return t("components.modals.groupCollaborators.failure.httpStatus", {
-      status: reason.status,
-    })
-  }
-  return reason instanceof Error ? reason.message : undefined
-}
-
 // Whole-assignment repo-feature editor: set Issues/Wiki/Projects/Pull-requests
 // across every accepted student's repo in one bounded fan-out. The way to
 // reconcile existing repos with an assignment's settings, since repo_features
@@ -88,40 +67,21 @@ export function BulkRepoFeaturesModal({
 }: BulkRepoFeaturesModalProps) {
   const { t } = useTranslation()
   const setFeaturesMutation = useSetRepoFeatures()
-  const runningRef = useRef(false)
-  const mountedRef = useRef(true)
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-      runningRef.current = false
-    }
-  }, [])
+  const bulk = useBulkRun(open)
+  const { phase, progress, result, busy } = bulk
 
   const [choices, setChoices] = useState<
     Record<(typeof FEATURES)[number]["key"], FeatureChoice>
   >({ issues: "keep", wiki: "keep", projects: "keep", pull_requests: "keep" })
-  const [phase, setPhase] = useState<BulkPhase>("idle")
-  const [progress, setProgress] = useState<BulkProgress>({
-    processed: 0,
-    total: 0,
-    message: "",
-  })
-  const [result, setResult] = useState<BulkResultView | null>(null)
-
-  // Reset on open, never at close — see the close-animation note in ui/Modal.
+  // The form state resets with the run state, on open (see useBulkRun).
   useEffect(() => {
     if (!open) return
-    runningRef.current = false
     setChoices({
       issues: "keep",
       wiki: "keep",
       projects: "keep",
       pull_requests: "keep",
     })
-    setPhase("idle")
-    setResult(null)
-    setProgress({ processed: 0, total: 0, message: "" })
   }, [open])
 
   const total = owners.length
@@ -129,108 +89,70 @@ export function BulkRepoFeaturesModal({
   const patch = useMemo(() => choicesToPatch(choices), [choices])
   const nothingSelected = Object.keys(patch).length === 0
 
-  type Outcome =
-    | { owner: string; status: "ok" }
-    | { owner: string; status: "deferred" }
-    | { owner: string; status: "failed"; detail?: string }
-
   const run = async () => {
-    if (runningRef.current || total === 0 || nothingSelected) return
-    runningRef.current = true
-    setPhase("working")
-    setResult(null)
-    let processed = 0
-    setProgress({ processed: 0, total, message: "" })
-    // Stop launching NEW writes on a secondary-rate-limit; report the rest as
-    // deferred (mirrors BulkRepoAccessModal).
-    let rateLimited = false
+    if (total === 0 || nothingSelected) return
+    if (!bulk.begin(total)) return
 
-    const outcomes = await mapWithConcurrency(
+    const { outcomes, rateLimited } = await runBulkFanOut({
       owners,
-      REPO_READ_CONCURRENCY,
-      async (owner): Promise<Outcome> => {
-        if (rateLimited || !mountedRef.current) {
-          processed += 1
-          if (mountedRef.current) {
-            setProgress({ processed, total, message: displayFor(owner) })
-          }
-          return { owner, status: "deferred" }
-        }
+      isMounted: bulk.isMounted,
+      onProgress: (processed, owner) =>
+        bulk.setProgress({ processed, total, message: displayFor(owner) }),
+      t,
+      perOwner: async (owner) => {
         const repo = studentRepoName(classroom, assignment, owner)
-        try {
-          await setFeaturesMutation.mutateAsync({ org, repo, features: patch })
-          return { owner, status: "ok" }
-        } catch (err) {
-          if (err instanceof GitHubAPIError && err.isRateLimited) {
-            rateLimited = true
-            return { owner, status: "deferred" }
-          }
-          return { owner, status: "failed", detail: describeFailure(err, t) }
-        } finally {
-          processed += 1
-          if (mountedRef.current) {
-            setProgress({ processed, total, message: displayFor(owner) })
-          }
-        }
+        await setFeaturesMutation.mutateAsync({ org, repo, features: patch })
       },
-    )
-
-    if (!mountedRef.current) {
-      runningRef.current = false
-      return
-    }
-
-    const succeeded = outcomes.filter((o) => o.status === "ok")
-    const deferred = outcomes.filter((o) => o.status === "deferred")
-    const failed = outcomes.filter((o) => o.status === "failed")
-
-    setResult({
-      headline: rateLimited
-        ? t("submissions.bulkFeatures.resultHeadlineThrottled", {
-            count: succeeded.length,
-            total,
-          })
-        : t("submissions.bulkFeatures.resultHeadline", {
-            count: succeeded.length,
-            total,
-          }),
-      sections: [
-        ...(failed.length
-          ? [
-              {
-                title: t("submissions.bulkFeatures.failedSection", {
-                  count: failed.length,
-                }),
-                rows: failed.map((o) => ({
-                  key: o.owner,
-                  label: displayFor(o.owner),
-                  detail: "detail" in o ? o.detail : undefined,
-                })),
-              },
-            ]
-          : []),
-        ...(deferred.length
-          ? [
-              {
-                title: t("submissions.bulkFeatures.deferredSection", {
-                  count: deferred.length,
-                }),
-                rows: deferred.map((o) => ({
-                  key: o.owner,
-                  label: displayFor(o.owner),
-                  detail: t("submissions.bulkFeatures.deferredDetail"),
-                })),
-              },
-            ]
-          : []),
-      ],
     })
-    setPhase(failed.length || deferred.length ? "error" : "complete")
-    runningRef.current = false
-  }
+    if (!bulk.isMounted()) return
 
-  const busy = phase === "working"
-  useBeforeUnloadGuard(busy)
+    const { succeeded, deferred, failed } = partitionOutcomes(outcomes)
+
+    bulk.complete(
+      {
+        headline: rateLimited
+          ? t("submissions.bulkFeatures.resultHeadlineThrottled", {
+              count: succeeded.length,
+              total,
+            })
+          : t("submissions.bulkFeatures.resultHeadline", {
+              count: succeeded.length,
+              total,
+            }),
+        sections: [
+          ...(failed.length
+            ? [
+                {
+                  title: t("submissions.bulkFeatures.failedSection", {
+                    count: failed.length,
+                  }),
+                  rows: failed.map((o) => ({
+                    key: o.owner,
+                    label: displayFor(o.owner),
+                    detail: o.detail,
+                  })),
+                },
+              ]
+            : []),
+          ...(deferred.length
+            ? [
+                {
+                  title: t("submissions.bulkFeatures.deferredSection", {
+                    count: deferred.length,
+                  }),
+                  rows: deferred.map((o) => ({
+                    key: o.owner,
+                    label: displayFor(o.owner),
+                    detail: t("submissions.bulkFeatures.deferredDetail"),
+                  })),
+                },
+              ]
+            : []),
+        ],
+      },
+      failed.length || deferred.length ? "error" : "complete",
+    )
+  }
 
   return (
     <Modal
@@ -313,23 +235,7 @@ export function BulkRepoFeaturesModal({
         />
       )}
 
-      {(phase === "complete" || phase === "error") && result && (
-        <div className="mt-4 flex flex-col gap-4">
-          <Alert
-            tone={phase === "error" ? "warning" : "success"}
-            className="text-sm"
-          >
-            {result.headline}
-          </Alert>
-          {result.sections.map((section) => (
-            <BulkResultSection
-              key={section.title}
-              title={section.title}
-              rows={section.rows}
-            />
-          ))}
-        </div>
-      )}
+      <BulkResultBody phase={phase} result={result} />
     </Modal>
   )
 }

--- a/web/src/components/modals/BulkRepoVisibilityModal.tsx
+++ b/web/src/components/modals/BulkRepoVisibilityModal.tsx
@@ -1,26 +1,19 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import type { TFunction } from "i18next"
 import { GlobeIcon } from "@/components/ui/icons"
 
 import { Alert, Modal, ModalIcon, Select } from "@/components/ui"
 import {
   BulkPhaseFooter,
   BulkProgressBlock,
-  BulkResultSection,
-  type BulkPhase,
-  type BulkProgress,
-  type BulkResultView,
+  BulkResultBody,
 } from "@/components/bulk/resultView"
+import { partitionOutcomes, runBulkFanOut } from "@/components/bulk/fanOut"
+import { useBulkRun } from "@/components/bulk/useBulkRun"
 import useSetRepoVisibility from "@/hooks/mutations/useSetRepoVisibility"
-import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
-import { mapWithConcurrency } from "@/util/concurrency"
 import { studentRepoName } from "@/util/studentRepo"
 import { getName } from "@/util/students"
-import { describeGitHubApiFailure } from "@/components/modals/collaboratorHelpers"
-import { GitHubAPIError } from "@/github-core/errors"
 import type { RepoVisibility, Student } from "@/types/classroom"
-import { useBeforeUnloadGuard } from "@/hooks/useBeforeUnloadGuard"
 
 type BulkRepoVisibilityModalProps = {
   open: boolean
@@ -36,21 +29,6 @@ type BulkRepoVisibilityModalProps = {
 // The visibility choice. "keep" (the default) leaves every repo untouched, so
 // Apply stays disabled until the teacher deliberately picks a direction.
 type VisibilityChoice = "keep" | RepoVisibility
-
-// Map a rejected write to a localized reason for the result table. Reuses the
-// shared groupCollaborators failure vocabulary (rate-limit/403/404) like the
-// sibling BulkRepoFeaturesModal, then falls back to the HTTP status / raw
-// message.
-const describeFailure = (reason: unknown, t: TFunction): string | undefined => {
-  const shared = describeGitHubApiFailure(reason, t)
-  if (shared) return shared
-  if (reason instanceof GitHubAPIError) {
-    return t("components.modals.groupCollaborators.failure.httpStatus", {
-      status: reason.status,
-    })
-  }
-  return reason instanceof Error ? reason.message : undefined
-}
 
 // Whole-assignment repo-visibility editor (issue #766): make every accepted
 // student's repo public (peer review / portfolio / showcase) or private again,
@@ -68,142 +46,84 @@ export function BulkRepoVisibilityModal({
 }: BulkRepoVisibilityModalProps) {
   const { t } = useTranslation()
   const setVisibilityMutation = useSetRepoVisibility()
-  const runningRef = useRef(false)
-  const mountedRef = useRef(true)
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-      runningRef.current = false
-    }
-  }, [])
+  const bulk = useBulkRun(open)
+  const { phase, progress, result, busy } = bulk
 
   const [choice, setChoice] = useState<VisibilityChoice>("keep")
-  const [phase, setPhase] = useState<BulkPhase>("idle")
-  const [progress, setProgress] = useState<BulkProgress>({
-    processed: 0,
-    total: 0,
-    message: "",
-  })
-  const [result, setResult] = useState<BulkResultView | null>(null)
-
-  // Reset on open, never at close — see the close-animation note in ui/Modal.
+  // The form state resets with the run state, on open (see useBulkRun).
   useEffect(() => {
-    if (!open) return
-    runningRef.current = false
-    setChoice("keep")
-    setPhase("idle")
-    setResult(null)
-    setProgress({ processed: 0, total: 0, message: "" })
+    if (open) setChoice("keep")
   }, [open])
 
   const total = owners.length
   const displayFor = (login: string) => getName(login, students) || login
   const nothingSelected = choice === "keep"
 
-  type Outcome =
-    | { owner: string; status: "ok" }
-    | { owner: string; status: "deferred" }
-    | { owner: string; status: "failed"; detail?: string }
-
   const run = async () => {
-    if (runningRef.current || total === 0 || nothingSelected) return
+    if (total === 0 || nothingSelected) return
     const visibility = choice
-    runningRef.current = true
-    setPhase("working")
-    setResult(null)
-    let processed = 0
-    setProgress({ processed: 0, total, message: "" })
-    // Stop launching NEW writes on a secondary-rate-limit; report the rest as
-    // deferred (mirrors BulkRepoFeaturesModal).
-    let rateLimited = false
+    if (!bulk.begin(total)) return
 
-    const outcomes = await mapWithConcurrency(
+    const { outcomes, rateLimited } = await runBulkFanOut({
       owners,
-      REPO_READ_CONCURRENCY,
-      async (owner): Promise<Outcome> => {
-        if (rateLimited || !mountedRef.current) {
-          processed += 1
-          if (mountedRef.current) {
-            setProgress({ processed, total, message: displayFor(owner) })
-          }
-          return { owner, status: "deferred" }
-        }
+      isMounted: bulk.isMounted,
+      onProgress: (processed, owner) =>
+        bulk.setProgress({ processed, total, message: displayFor(owner) }),
+      t,
+      perOwner: async (owner) => {
         const repo = studentRepoName(classroom, assignment, owner)
-        try {
-          await setVisibilityMutation.mutateAsync({ org, repo, visibility })
-          return { owner, status: "ok" }
-        } catch (err) {
-          if (err instanceof GitHubAPIError && err.isRateLimited) {
-            rateLimited = true
-            return { owner, status: "deferred" }
-          }
-          return { owner, status: "failed", detail: describeFailure(err, t) }
-        } finally {
-          processed += 1
-          if (mountedRef.current) {
-            setProgress({ processed, total, message: displayFor(owner) })
-          }
-        }
+        await setVisibilityMutation.mutateAsync({ org, repo, visibility })
       },
-    )
-
-    if (!mountedRef.current) {
-      runningRef.current = false
-      return
-    }
-
-    const succeeded = outcomes.filter((o) => o.status === "ok")
-    const deferred = outcomes.filter((o) => o.status === "deferred")
-    const failed = outcomes.filter((o) => o.status === "failed")
-
-    setResult({
-      headline: rateLimited
-        ? t("submissions.bulkVisibility.resultHeadlineThrottled", {
-            count: succeeded.length,
-            total,
-          })
-        : t("submissions.bulkVisibility.resultHeadline", {
-            count: succeeded.length,
-            total,
-          }),
-      sections: [
-        ...(failed.length
-          ? [
-              {
-                title: t("submissions.bulkVisibility.failedSection", {
-                  count: failed.length,
-                }),
-                rows: failed.map((o) => ({
-                  key: o.owner,
-                  label: displayFor(o.owner),
-                  detail: "detail" in o ? o.detail : undefined,
-                })),
-              },
-            ]
-          : []),
-        ...(deferred.length
-          ? [
-              {
-                title: t("submissions.bulkVisibility.deferredSection", {
-                  count: deferred.length,
-                }),
-                rows: deferred.map((o) => ({
-                  key: o.owner,
-                  label: displayFor(o.owner),
-                  detail: t("submissions.bulkVisibility.deferredDetail"),
-                })),
-              },
-            ]
-          : []),
-      ],
     })
-    setPhase(failed.length || deferred.length ? "error" : "complete")
-    runningRef.current = false
-  }
+    if (!bulk.isMounted()) return
 
-  const busy = phase === "working"
-  useBeforeUnloadGuard(busy)
+    const { succeeded, deferred, failed } = partitionOutcomes(outcomes)
+
+    bulk.complete(
+      {
+        headline: rateLimited
+          ? t("submissions.bulkVisibility.resultHeadlineThrottled", {
+              count: succeeded.length,
+              total,
+            })
+          : t("submissions.bulkVisibility.resultHeadline", {
+              count: succeeded.length,
+              total,
+            }),
+        sections: [
+          ...(failed.length
+            ? [
+                {
+                  title: t("submissions.bulkVisibility.failedSection", {
+                    count: failed.length,
+                  }),
+                  rows: failed.map((o) => ({
+                    key: o.owner,
+                    label: displayFor(o.owner),
+                    detail: o.detail,
+                  })),
+                },
+              ]
+            : []),
+          ...(deferred.length
+            ? [
+                {
+                  title: t("submissions.bulkVisibility.deferredSection", {
+                    count: deferred.length,
+                  }),
+                  rows: deferred.map((o) => ({
+                    key: o.owner,
+                    label: displayFor(o.owner),
+                    detail: t("submissions.bulkVisibility.deferredDetail"),
+                  })),
+                },
+              ]
+            : []),
+        ],
+      },
+      failed.length || deferred.length ? "error" : "complete",
+    )
+  }
 
   return (
     <Modal
@@ -290,23 +210,7 @@ export function BulkRepoVisibilityModal({
         />
       )}
 
-      {(phase === "complete" || phase === "error") && result && (
-        <div className="mt-4 flex flex-col gap-4">
-          <Alert
-            tone={phase === "error" ? "warning" : "success"}
-            className="text-sm"
-          >
-            {result.headline}
-          </Alert>
-          {result.sections.map((section) => (
-            <BulkResultSection
-              key={section.title}
-              title={section.title}
-              rows={section.rows}
-            />
-          ))}
-        </div>
-      )}
+      <BulkResultBody phase={phase} result={result} />
     </Modal>
   )
 }

--- a/web/src/components/modals/BulkSubmissionTriggerModal.tsx
+++ b/web/src/components/modals/BulkSubmissionTriggerModal.tsx
@@ -1,30 +1,23 @@
-import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import type { TFunction } from "i18next"
 import { GitBranchIcon } from "@/components/ui/icons"
 
 import { Alert, Modal, ModalIcon } from "@/components/ui"
 import {
   BulkPhaseFooter,
   BulkProgressBlock,
-  BulkResultSection,
-  type BulkPhase,
-  type BulkProgress,
-  type BulkResultView,
+  BulkResultBody,
 } from "@/components/bulk/resultView"
+import { runBulkFanOut, type FanOutOutcome } from "@/components/bulk/fanOut"
+import { useBulkRun } from "@/components/bulk/useBulkRun"
 import {
   updateShimSubmissionMode,
   type ShimUpdateOutcome,
 } from "@/domain/assignments/submissionTrigger"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { REPO_WRITE_CONCURRENCY } from "@/github-core/queries"
-import { mapWithConcurrency } from "@/util/concurrency"
 import { studentRepoName } from "@/util/studentRepo"
 import { getName } from "@/util/students"
-import { describeGitHubApiFailure } from "@/components/modals/collaboratorHelpers"
-import { GitHubAPIError } from "@/github-core/errors"
 import type { Student, SubmissionMode } from "@/types/classroom"
-import { useBeforeUnloadGuard } from "@/hooks/useBeforeUnloadGuard"
 
 type BulkSubmissionTriggerModalProps = {
   open: boolean
@@ -43,16 +36,10 @@ type BulkSubmissionTriggerModalProps = {
   students?: Student[]
 }
 
-const describeFailure = (reason: unknown, t: TFunction): string | undefined => {
-  const shared = describeGitHubApiFailure(reason, t)
-  if (shared) return shared
-  if (reason instanceof GitHubAPIError) {
-    return t("components.modals.groupCollaborators.failure.httpStatus", {
-      status: reason.status,
-    })
-  }
-  return reason instanceof Error ? reason.message : undefined
-}
+// The shared outcomes plus the shim writer's own verdicts.
+type Outcome =
+  | FanOutOutcome
+  | { owner: string; status: ShimUpdateOutcome["status"]; detail?: string }
 
 // Whole-assignment autograding-trigger retrofit: rewrite each accepted
 // student repo's shim to match the assignment's stored submission_mode, in
@@ -72,32 +59,8 @@ export function BulkSubmissionTriggerModal({
 }: BulkSubmissionTriggerModalProps) {
   const { t } = useTranslation()
   const client = useGitHubClient()
-  const runningRef = useRef(false)
-  const mountedRef = useRef(true)
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-      runningRef.current = false
-    }
-  }, [])
-
-  const [phase, setPhase] = useState<BulkPhase>("idle")
-  const [progress, setProgress] = useState<BulkProgress>({
-    processed: 0,
-    total: 0,
-    message: "",
-  })
-  const [result, setResult] = useState<BulkResultView | null>(null)
-
-  // Reset on open, never at close — see the close-animation note in ui/Modal.
-  useEffect(() => {
-    if (!open) return
-    runningRef.current = false
-    setPhase("idle")
-    setResult(null)
-    setProgress({ processed: 0, total: 0, message: "" })
-  }, [open])
+  const bulk = useBulkRun(open)
+  const { phase, progress, result, busy } = bulk
 
   const total = owners.length
   const displayFor = (login: string) => getName(login, students) || login
@@ -107,76 +70,45 @@ export function BulkSubmissionTriggerModal({
       : "assignments.form.submissionMode.choices.everyPush",
   )
 
-  type Outcome = { owner: string } & (
-    | { status: ShimUpdateOutcome["status"]; detail?: string }
-    | { status: "deferred" }
-    | { status: "failed"; detail?: string }
-  )
-
   const run = async () => {
-    if (runningRef.current || total === 0) return
-    runningRef.current = true
-    setPhase("working")
-    setResult(null)
-    let processed = 0
-    setProgress({ processed: 0, total, message: "" })
-    // Stop launching NEW writes on a secondary-rate-limit or a confirmed
-    // missing workflow scope (every remaining repo would fail identically).
-    let rateLimited = false
+    if (total === 0) return
+    if (!bulk.begin(total)) return
+    // A confirmed missing workflow scope stops the rest: every remaining repo
+    // would fail identically.
     let missingScope = false
 
-    const outcomes = await mapWithConcurrency(
+    const { outcomes } = await runBulkFanOut<Outcome>({
       owners,
       // Each iteration is a 3-step git-data WRITE (tree + commit + ref) into
-      // a different repo — GitHub's secondary-rate-limit guidance is to avoid
+      // a different repo. GitHub's secondary-rate-limit guidance is to avoid
       // concurrent content writes (the CLI retrofit loop is serial for the
       // same reason), unlike the sibling bulk modals' single PATCH/PUT calls,
-      // which safely share REPO_READ_CONCURRENCY.
-      REPO_WRITE_CONCURRENCY,
-      async (owner): Promise<Outcome> => {
-        if (rateLimited || missingScope || !mountedRef.current) {
-          processed += 1
-          if (mountedRef.current) {
-            setProgress({ processed, total, message: displayFor(owner) })
-          }
-          return { owner, status: "deferred" }
-        }
+      // which safely share the read limit.
+      concurrency: REPO_WRITE_CONCURRENCY,
+      shouldStop: () => missingScope,
+      isMounted: bulk.isMounted,
+      onProgress: (processed, owner) =>
+        bulk.setProgress({ processed, total, message: displayFor(owner) }),
+      t,
+      perOwner: async (owner) => {
         const repo = studentRepoName(classroom, assignment, owner)
-        try {
-          const outcome = await updateShimSubmissionMode({
-            client,
-            org,
-            repo,
-            mode: submissionMode,
-            tags: submissionTags,
-          })
-          if (outcome.status === "missingWorkflowScope") {
-            missingScope = true
-            return { owner, status: "missingWorkflowScope" }
-          }
-          if (outcome.status === "unrecognized") {
-            return { owner, status: "unrecognized", detail: outcome.reason }
-          }
-          return { owner, status: outcome.status }
-        } catch (err) {
-          if (err instanceof GitHubAPIError && err.isRateLimited) {
-            rateLimited = true
-            return { owner, status: "deferred" }
-          }
-          return { owner, status: "failed", detail: describeFailure(err, t) }
-        } finally {
-          processed += 1
-          if (mountedRef.current) {
-            setProgress({ processed, total, message: displayFor(owner) })
-          }
+        const outcome = await updateShimSubmissionMode({
+          client,
+          org,
+          repo,
+          mode: submissionMode,
+          tags: submissionTags,
+        })
+        if (outcome.status === "missingWorkflowScope") missingScope = true
+        return {
+          owner,
+          status: outcome.status,
+          detail:
+            outcome.status === "unrecognized" ? outcome.reason : undefined,
         }
       },
-    )
-
-    if (!mountedRef.current) {
-      runningRef.current = false
-      return
-    }
+    })
+    if (!bulk.isMounted()) return
 
     const updated = outcomes.filter((o) => o.status === "updated")
     const current = outcomes.filter((o) => o.status === "current")
@@ -205,40 +137,39 @@ export function BulkSubmissionTriggerModal({
           ]
         : []
 
-    setResult({
-      headline: t("submissions.bulkTrigger.resultHeadline", {
-        updated: updated.length,
-        current: current.length,
-        total,
-      }),
-      sections: [
-        ...section(
-          "submissions.bulkTrigger.scopeSection",
-          scope,
-          t("submissions.bulkTrigger.scopeDetail"),
-        ),
-        ...section("submissions.bulkTrigger.failedSection", failed),
-        ...section("submissions.bulkTrigger.unrecognizedSection", unrecognized),
-        ...section(
-          "submissions.bulkTrigger.deferredSection",
-          deferred,
-          t("submissions.bulkTrigger.deferredDetail"),
-        ),
-        ...section(
-          "submissions.bulkTrigger.notAcceptedSection",
-          notAccepted,
-          t("submissions.bulkTrigger.notAcceptedDetail"),
-        ),
-      ],
-    })
-    setPhase(
+    bulk.complete(
+      {
+        headline: t("submissions.bulkTrigger.resultHeadline", {
+          updated: updated.length,
+          current: current.length,
+          total,
+        }),
+        sections: [
+          ...section(
+            "submissions.bulkTrigger.scopeSection",
+            scope,
+            t("submissions.bulkTrigger.scopeDetail"),
+          ),
+          ...section("submissions.bulkTrigger.failedSection", failed),
+          ...section(
+            "submissions.bulkTrigger.unrecognizedSection",
+            unrecognized,
+          ),
+          ...section(
+            "submissions.bulkTrigger.deferredSection",
+            deferred,
+            t("submissions.bulkTrigger.deferredDetail"),
+          ),
+          ...section(
+            "submissions.bulkTrigger.notAcceptedSection",
+            notAccepted,
+            t("submissions.bulkTrigger.notAcceptedDetail"),
+          ),
+        ],
+      },
       failed.length || scope.length || deferred.length ? "error" : "complete",
     )
-    runningRef.current = false
   }
-
-  const busy = phase === "working"
-  useBeforeUnloadGuard(busy)
 
   return (
     <Modal
@@ -301,26 +232,11 @@ export function BulkSubmissionTriggerModal({
         />
       )}
 
-      {(phase === "complete" || phase === "error") && result && (
-        <div className="mt-4 flex flex-col gap-4">
-          <Alert
-            tone={phase === "error" ? "warning" : "success"}
-            className="text-sm"
-          >
-            {result.headline}
-          </Alert>
-          <Alert tone="info" className="text-sm">
-            {t("submissions.bulkTrigger.repullReminder")}
-          </Alert>
-          {result.sections.map((section) => (
-            <BulkResultSection
-              key={section.title}
-              title={section.title}
-              rows={section.rows}
-            />
-          ))}
-        </div>
-      )}
+      <BulkResultBody phase={phase} result={result}>
+        <Alert tone="info" className="text-sm">
+          {t("submissions.bulkTrigger.repullReminder")}
+        </Alert>
+      </BulkResultBody>
     </Modal>
   )
 }

--- a/web/src/components/modals/CloseSubmissionModal.tsx
+++ b/web/src/components/modals/CloseSubmissionModal.tsx
@@ -1,21 +1,16 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { CalendarIcon } from "@/components/ui/icons"
 
 import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
-import {
-  BulkProgressBlock,
-  BulkResultSection,
-  type BulkPhase,
-  type BulkProgress,
-  type BulkResultView,
-} from "@/components/bulk/resultView"
+import { BulkProgressBlock, BulkResultBody } from "@/components/bulk/resultView"
+import { partitionOutcomes } from "@/components/bulk/fanOut"
 import { runBulkRepoAccess } from "@/components/bulk/repoAccessFanOut"
+import { useBulkRun } from "@/components/bulk/useBulkRun"
 import useAddRepoCollaborator from "@/hooks/mutations/useAddRepoCollaborator"
 import useSetAssignmentClosed from "@/hooks/mutations/useSetAssignmentClosed"
 import { getName } from "@/util/students"
 import type { RepoPermission, Student } from "@/types/classroom"
-import { useBeforeUnloadGuard } from "@/hooks/useBeforeUnloadGuard"
 
 type CloseSubmissionModalProps = {
   open: boolean
@@ -52,23 +47,10 @@ export function CloseSubmissionModal({
   const permission: RepoPermission = closing ? "pull" : "push"
   const addCollaboratorMutation = useAddRepoCollaborator()
   const setClosed = useSetAssignmentClosed(org, classroom)
-  const runningRef = useRef(false)
-  const mountedRef = useRef(true)
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-      runningRef.current = false
-    }
-  }, [])
-
-  const [phase, setPhase] = useState<BulkPhase>("idle")
-  const [progress, setProgress] = useState<BulkProgress>({
-    processed: 0,
-    total: 0,
-    message: "",
-  })
-  const [result, setResult] = useState<BulkResultView | null>(null)
+  const bulk = useBulkRun(open)
+  const { phase, progress, result, busy } = bulk
+  // The flag write failed before any repo was touched; `bulk.error` carries
+  // the phase, this carries which alert to show.
   const [flagError, setFlagError] = useState(false)
   // True after a close run that flipped the flag but left some repos not
   // read-only (deferred/failed). The flag is committed (new accepts are
@@ -77,15 +59,11 @@ export function CloseSubmissionModal({
   // closing" affordance so a throttled close isn't stuck offering only Reopen.
   const [fanOutIncomplete, setFanOutIncomplete] = useState(false)
 
-  // Reset on open, never at close — see the close-animation note in ui/Modal.
+  // The modal's own flags reset with the run state, on open (see useBulkRun).
   useEffect(() => {
     if (!open) return
-    runningRef.current = false
-    setPhase("idle")
-    setResult(null)
     setFlagError(false)
     setFanOutIncomplete(false)
-    setProgress({ processed: 0, total: 0, message: "" })
   }, [open])
 
   const total = owners.length
@@ -95,10 +73,7 @@ export function CloseSubmissionModal({
   // full close/reopen (flag flip first, then fan-out); `finishOnly` skips the
   // flag flip and re-runs just the fan-out to finish an interrupted close.
   const run = async ({ flipFlag }: { flipFlag: boolean }) => {
-    if (runningRef.current) return
-    runningRef.current = true
-    setPhase("working")
-    setResult(null)
+    if (!bulk.begin(total)) return
     setFlagError(false)
     setFanOutIncomplete(false)
 
@@ -114,16 +89,11 @@ export function CloseSubmissionModal({
           closed: closing,
         })
       } catch {
-        if (mountedRef.current) {
-          setFlagError(true)
-          setPhase("error")
-        }
-        runningRef.current = false
+        if (bulk.isMounted()) setFlagError(true)
+        bulk.fail(t("submissions.closeSubmission.flagError"))
         return
       }
     }
-
-    setProgress({ processed: 0, total, message: "" })
 
     const { outcomes, rateLimited } = await runBulkRepoAccess({
       owners,
@@ -139,22 +109,13 @@ export function CloseSubmissionModal({
       // than push isn't a false failure.
       treatRequestedAsFloor: !closing,
       t,
-      isMounted: () => mountedRef.current,
-      onProgress: (processed) => {
-        if (mountedRef.current) {
-          setProgress({ processed, total, message: "" })
-        }
-      },
+      isMounted: bulk.isMounted,
+      onProgress: (processed) =>
+        bulk.setProgress({ processed, total, message: "" }),
     })
+    if (!bulk.isMounted()) return
 
-    if (!mountedRef.current) {
-      runningRef.current = false
-      return
-    }
-
-    const succeeded = outcomes.filter((o) => o.status === "ok")
-    const deferred = outcomes.filter((o) => o.status === "deferred")
-    const failed = outcomes.filter((o) => o.status === "failed")
+    const { succeeded, deferred, failed } = partitionOutcomes(outcomes)
 
     const headlineKey = rateLimited
       ? closing
@@ -164,48 +125,46 @@ export function CloseSubmissionModal({
         ? "submissions.closeSubmission.resultHeadline"
         : "submissions.closeSubmission.reopenResultHeadline"
 
-    setResult({
-      headline: t(headlineKey, { count: succeeded.length, total }),
-      sections: [
-        ...(failed.length
-          ? [
-              {
-                title: t("submissions.closeSubmission.failedSection", {
-                  count: failed.length,
-                }),
-                rows: failed.map((o) => ({
-                  key: o.owner,
-                  label: displayFor(o.owner),
-                  detail: "detail" in o ? o.detail : undefined,
-                })),
-              },
-            ]
-          : []),
-        ...(deferred.length
-          ? [
-              {
-                title: t("submissions.closeSubmission.deferredSection", {
-                  count: deferred.length,
-                }),
-                rows: deferred.map((o) => ({
-                  key: o.owner,
-                  label: displayFor(o.owner),
-                  detail: t("submissions.closeSubmission.deferredDetail"),
-                })),
-              },
-            ]
-          : []),
-      ],
-    })
     // Closing left some repos not read-only: the flag is committed, so offer a
     // finish-only re-run (no reopen) instead of stranding the teacher.
     setFanOutIncomplete(closing && (failed.length > 0 || deferred.length > 0))
-    setPhase(failed.length || deferred.length ? "error" : "complete")
-    runningRef.current = false
+    bulk.complete(
+      {
+        headline: t(headlineKey, { count: succeeded.length, total }),
+        sections: [
+          ...(failed.length
+            ? [
+                {
+                  title: t("submissions.closeSubmission.failedSection", {
+                    count: failed.length,
+                  }),
+                  rows: failed.map((o) => ({
+                    key: o.owner,
+                    label: displayFor(o.owner),
+                    detail: o.detail,
+                  })),
+                },
+              ]
+            : []),
+          ...(deferred.length
+            ? [
+                {
+                  title: t("submissions.closeSubmission.deferredSection", {
+                    count: deferred.length,
+                  }),
+                  rows: deferred.map((o) => ({
+                    key: o.owner,
+                    label: displayFor(o.owner),
+                    detail: t("submissions.closeSubmission.deferredDetail"),
+                  })),
+                },
+              ]
+            : []),
+        ],
+      },
+      failed.length || deferred.length ? "error" : "complete",
+    )
   }
-
-  const busy = phase === "working"
-  useBeforeUnloadGuard(busy)
 
   return (
     <Modal
@@ -310,28 +269,17 @@ export function CloseSubmissionModal({
         </div>
       )}
 
-      {(phase === "complete" || phase === "error") && result && (
-        <div className="mt-4 flex flex-col gap-4">
-          <Alert
-            tone={phase === "error" ? "warning" : "success"}
-            className="text-sm"
-          >
-            {result.headline}
-          </Alert>
-          {result.sections.map((section) => (
-            <BulkResultSection
-              key={section.title}
-              title={section.title}
-              rows={section.rows}
-            />
-          ))}
-          {fanOutIncomplete && (
+      <BulkResultBody
+        phase={phase}
+        result={result}
+        after={
+          fanOutIncomplete ? (
             <Alert tone="info" className="text-sm">
               {t("submissions.closeSubmission.finishHint")}
             </Alert>
-          )}
-        </div>
-      )}
+          ) : null
+        }
+      />
     </Modal>
   )
 }

--- a/web/src/components/modals/GroupCollaboratorsModal.tsx
+++ b/web/src/components/modals/GroupCollaboratorsModal.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
-import type { TFunction } from "i18next"
 import {
   MarkGithubIcon,
   PeopleIcon,
@@ -28,26 +27,12 @@ import useRemoveRepoCollaborator from "@/hooks/mutations/useRemoveRepoCollaborat
 import { useBeforeUnloadGuard } from "@/hooks/useBeforeUnloadGuard"
 import {
   CollaboratorIdentity,
-  describeGitHubApiFailure,
+  describeCollaboratorFailure,
   normalizeUsername,
   rejectedItems,
 } from "@/components/modals/collaboratorHelpers"
-import { GitHubAPIError } from "@/github-core/errors"
 import type { Student } from "@/types/classroom"
 import { GROUP_SIZE_MIN } from "@/types/classroom"
-
-// Map a rejected add/remove to a human-readable reason. Collapsing every status
-// into "bad username" would hide real causes like a 429 or a 403.
-const describeFailure = (reason: unknown, t: TFunction): string | null => {
-  const shared = describeGitHubApiFailure(reason, t)
-  if (shared) return shared
-  if (reason instanceof GitHubAPIError) {
-    if (reason.status === 422)
-      return t("components.modals.groupCollaborators.failure.conflict")
-    return reason.message
-  }
-  return reason instanceof Error ? reason.message : null
-}
 
 type GroupCollaboratorsModalProps = {
   open: boolean
@@ -293,7 +278,7 @@ export function GroupCollaboratorsModal({
           ) ?? null
         const detail =
           firstReason && firstReason.status === "rejected"
-            ? describeFailure(firstReason.reason, t)
+            ? describeCollaboratorFailure(firstReason.reason, t)
             : null
         const suffix = detail ? ` ${detail}` : ""
 

--- a/web/src/components/modals/RepoAccessModal.tsx
+++ b/web/src/components/modals/RepoAccessModal.tsx
@@ -28,13 +28,12 @@ import useRemoveRepoCollaborator from "@/hooks/mutations/useRemoveRepoCollaborat
 import { useBeforeUnloadGuard } from "@/hooks/useBeforeUnloadGuard"
 import {
   CollaboratorIdentity,
-  describeGitHubApiFailure,
+  describeCollaboratorFailure,
   normalizeUsername,
   permissionFromFlags,
   rejectedItems,
 } from "@/components/modals/collaboratorHelpers"
 import { permissionSatisfies } from "@/domain/assignments/permissions"
-import { GitHubAPIError } from "@/github-core/errors"
 import type { RepoPermission, Student } from "@/types/classroom"
 import { REPO_PERMISSIONS } from "@/types/classroom"
 
@@ -59,22 +58,14 @@ class RepoAccessNotAppliedError extends Error {
   }
 }
 
-// Map a rejected write to a human reason; reuses the groupCollaborators failure
-// vocabulary so the two dialogs stay consistent.
+// The shared collaborator reasons plus this dialog's verified-write miss.
 const describeFailure = (reason: unknown, t: TFunction): string | null => {
   if (reason instanceof RepoAccessNotAppliedError) {
     return t("components.modals.repoAccess.notApplied", {
       effective: reason.effective ?? "unknown",
     })
   }
-  const shared = describeGitHubApiFailure(reason, t)
-  if (shared) return shared
-  if (reason instanceof GitHubAPIError) {
-    if (reason.status === 422)
-      return t("components.modals.groupCollaborators.failure.conflict")
-    return reason.message
-  }
-  return reason instanceof Error ? reason.message : null
+  return describeCollaboratorFailure(reason, t)
 }
 
 // One row's draft state: its target role, and whether it's staged for removal.

--- a/web/src/components/modals/collaboratorHelpers.tsx
+++ b/web/src/components/modals/collaboratorHelpers.tsx
@@ -49,6 +49,39 @@ export const describeGitHubApiFailure = (
   return undefined
 }
 
+// The shared reasons plus the fallbacks every bulk result table wants: the
+// HTTP status for any other GitHub error, else the thrown message.
+export const describeWriteFailure = (
+  reason: unknown,
+  t: TFunction,
+): string | undefined => {
+  const shared = describeGitHubApiFailure(reason, t)
+  if (shared) return shared
+  if (reason instanceof GitHubAPIError) {
+    return t("components.modals.groupCollaborators.failure.httpStatus", {
+      status: reason.status,
+    })
+  }
+  return reason instanceof Error ? reason.message : undefined
+}
+
+// The per-repo collaborator dialogs' variant: a 422 is a conflict (the user is
+// already a collaborator, or can't be one), and any other GitHub error shows its
+// own message rather than a bare status.
+export const describeCollaboratorFailure = (
+  reason: unknown,
+  t: TFunction,
+): string | null => {
+  const shared = describeGitHubApiFailure(reason, t)
+  if (shared) return shared
+  if (reason instanceof GitHubAPIError) {
+    if (reason.status === 422)
+      return t("components.modals.groupCollaborators.failure.conflict")
+    return reason.message
+  }
+  return reason instanceof Error ? reason.message : null
+}
+
 // Two-line identity when we have a roster name (name + @handle), else just the
 // @handle. Shared by owner, member, and marked-for-removal rows.
 export const CollaboratorIdentity = ({

--- a/web/src/pages/orgMembers/BulkActionsBar.tsx
+++ b/web/src/pages/orgMembers/BulkActionsBar.tsx
@@ -2,14 +2,7 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { PlusIcon, SignOutIcon, XCircleIcon } from "@/components/ui/icons"
 
-import {
-  Alert,
-  Button,
-  DropdownMenu,
-  FormField,
-  Modal,
-  Select,
-} from "@/components/ui"
+import { DropdownMenu, FormField, Select } from "@/components/ui"
 import { BulkSelectionCluster } from "@/components/bulk/BulkSelectionCluster"
 import type { GitHubUser } from "@/github-core/types"
 import type { OrgMemberRow } from "@/util/orgMembers"
@@ -20,14 +13,8 @@ import { useBulkRemoveFromOrg } from "@/hooks/mutations/useBulkRemoveFromOrg"
 import { ConfirmModal } from "@/components/modals"
 import { useDeferredRun } from "@/hooks/useDeferredRun"
 import { logger } from "@/lib/logger"
-import {
-  BulkProgressRow,
-  BulkResultSection,
-  bulkProgressPct,
-  type BulkPhase,
-  type BulkProgress,
-  type BulkResultView,
-} from "@/components/bulk/resultView"
+import { BulkRunModal, type BulkResultView } from "@/components/bulk/resultView"
+import { useBulkRun } from "@/components/bulk/useBulkRun"
 import {
   buildAddResult,
   buildOrgRemoveResult,
@@ -80,14 +67,8 @@ const BulkActionsBar = ({
   const [action, setAction] = useState<"add" | "remove" | "remove-org" | null>(
     null,
   )
-  const [phase, setPhase] = useState<BulkPhase>("idle")
-  const [progress, setProgress] = useState<BulkProgress>({
-    processed: 0,
-    total: 0,
-    message: "",
-  })
-  const [result, setResult] = useState<BulkResultView | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  const bulk = useBulkRun()
+  const { progress } = bulk
   // Gates the destructive remove behind a confirmation. Scope is the menu
   // route: classroom-scoped (which the #664 checkbox can escalate) or the
   // direct org removal (no checkbox — the escalation IS the action).
@@ -135,33 +116,27 @@ const BulkActionsBar = ({
   const deferRun = useDeferredRun()
 
   const closeModal = () => {
-    if (phase === "working") return
+    if (bulk.busy) return
     setModalOpen(false)
   }
 
   const run = async (which: "add" | "remove" | "remove-org") => {
     if (selectedRows.length === 0) return
     if (which !== "remove-org" && !target) return
+    if (!bulk.begin(selectedRows.length, t("orgMembers.bulk.starting"))) return
     setAction(which)
-    setPhase("working")
     setModalOpen(true)
-    setError(null)
-    setResult(null)
-    setProgress({
-      processed: 0,
-      total: selectedRows.length,
-      message: t("orgMembers.bulk.starting"),
-    })
 
     try {
+      let result: BulkResultView
       if (which === "add") {
         const res = await bulkAdd.mutateAsync({
           classroom: target,
           rows: selectedRows,
           members,
-          onProgress: setProgress,
+          onProgress: bulk.setProgress,
         })
-        setResult(buildAddResult(res, targetName, t))
+        result = buildAddResult(res, targetName, t)
         onDone({
           classroom: target,
           action: "add",
@@ -172,9 +147,9 @@ const BulkActionsBar = ({
         const res = await bulkRemove.mutateAsync({
           classroom: target,
           rows: selectedRows,
-          onProgress: setProgress,
+          onProgress: bulk.setProgress,
         })
-        setResult(buildRemoveResult(res, targetName, t))
+        result = buildRemoveResult(res, targetName, t)
         onDone({
           classroom: target,
           action: "remove",
@@ -185,9 +160,9 @@ const BulkActionsBar = ({
       } else {
         const res = await bulkRemoveOrg.mutateAsync({
           rows: selectedRows,
-          onProgress: setProgress,
+          onProgress: bulk.setProgress,
         })
-        setResult(buildOrgRemoveResult(res, org, t))
+        result = buildOrgRemoveResult(res, org, t)
         onDone({
           action: "remove-org",
           affectedKeys: res.outcomes
@@ -198,11 +173,10 @@ const BulkActionsBar = ({
             .map((o) => ({ key: o.key, classrooms: o.unenrolledClassrooms })),
         })
       }
-      setPhase("complete")
+      bulk.complete(result, "complete")
     } catch (err) {
       log.error("bulk action failed", { err, record: true })
-      setError(errorText(t, err))
-      setPhase("error")
+      bulk.fail(errorText(t, err))
     }
   }
 
@@ -346,11 +320,10 @@ const BulkActionsBar = ({
         </div>
       </ConfirmModal>
 
-      <Modal
+      <BulkRunModal
         open={isOpen}
         onClose={closeModal}
-        closeDisabled={phase === "working"}
-        size="2xl"
+        run={bulk}
         title={
           action === "remove-org"
             ? t("orgMembers.bulk.removeOrgTitle", { org })
@@ -362,56 +335,14 @@ const BulkActionsBar = ({
                   classroom: targetName,
                 })
         }
-        footer={
-          phase === "complete" ? (
-            <Button variant="primary" onClick={closeModal}>
-              {t("orgMembers.bulk.done")}
-            </Button>
-          ) : phase === "error" ? (
-            <Button variant="primary" onClick={closeModal}>
-              {t("common.done")}
-            </Button>
-          ) : undefined
-        }
-      >
-        {phase === "working" && (
-          <BulkProgressRow
-            progress={progress}
-            processedCaption={t("orgMembers.bulk.progressProcessed", {
-              processed: progress.processed,
-              total: progress.total,
-            })}
-            percentCaption={`${bulkProgressPct(progress)}%`}
-          >
-            <Alert tone="info" className="mt-6">
-              <span>{t("orgMembers.bulk.keepTabOpen")}</span>
-            </Alert>
-          </BulkProgressRow>
-        )}
-
-        {phase === "complete" && result && (
-          <div className="mt-6 space-y-4">
-            <Alert tone="success">
-              <span>{result.headline}</span>
-            </Alert>
-            {result.sections.map((section) => (
-              <BulkResultSection
-                key={section.title}
-                title={section.title}
-                rows={section.rows}
-              />
-            ))}
-          </div>
-        )}
-
-        {phase === "error" && (
-          <div className="mt-6">
-            <Alert tone="error">
-              <span>{error ?? t("orgMembers.somethingWrong")}</span>
-            </Alert>
-          </div>
-        )}
-      </Modal>
+        processedCaption={t("orgMembers.bulk.progressProcessed", {
+          processed: progress.processed,
+          total: progress.total,
+        })}
+        keepTabOpenMessage={t("orgMembers.bulk.keepTabOpen")}
+        fallbackError={t("orgMembers.somethingWrong")}
+        doneLabel={t("orgMembers.bulk.done")}
+      />
     </>
   )
 }

--- a/web/src/pages/students/RosterBulkActionsBar.tsx
+++ b/web/src/pages/students/RosterBulkActionsBar.tsx
@@ -11,8 +11,7 @@ import type { GitHubClient } from "@/github-core/client"
 import { ConfirmModal } from "@/components/modals"
 import { BulkSelectionCluster } from "@/components/bulk/BulkSelectionCluster"
 import { useDeferredRun } from "@/hooks/useDeferredRun"
-import { useBeforeUnloadGuard } from "@/hooks/useBeforeUnloadGuard"
-import { Alert, Button, DropdownMenu, Modal } from "@/components/ui"
+import { DropdownMenu } from "@/components/ui"
 import { GitHubAPIError } from "@/github-core/errors"
 import { cancelOrgInvitation } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
@@ -28,14 +27,8 @@ import {
 } from "@/domain/students"
 import { isMalformedGitHubId, resolveGitHubId } from "@/util/students"
 import { sortRolesByRank } from "@/util/teamRoster"
-import {
-  BulkProgressRow,
-  BulkResultSection,
-  bulkProgressPct,
-  type BulkPhase,
-  type BulkProgress,
-  type BulkResultView,
-} from "@/components/bulk/resultView"
+import { BulkRunModal, type BulkResultView } from "@/components/bulk/resultView"
+import { useBulkRun } from "@/components/bulk/useBulkRun"
 import type { TeamRosterRow } from "@/util/teamRoster"
 import { canTargetForUnenroll } from "@/util/classroomRoleUI"
 import { logger } from "@/lib/logger"
@@ -136,15 +129,8 @@ const RosterBulkActionsBar = ({
   const [action, setAction] = useState<
     "unenroll" | "invite" | "cancel" | "removeRows" | null
   >(null)
-  const [phase, setPhase] = useState<BulkPhase>("idle")
-  const [progress, setProgress] = useState<BulkProgress>({
-    processed: 0,
-    total: 0,
-    message: "",
-  })
-  useBeforeUnloadGuard(phase === "working")
-  const [result, setResult] = useState<BulkResultView | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  const bulk = useBulkRun()
+  const { progress } = bulk
   const [confirmingUnenroll, setConfirmingUnenroll] = useState(false)
   const [confirmingInvite, setConfirmingInvite] = useState(false)
   const [confirmingCancel, setConfirmingCancel] = useState(false)
@@ -176,7 +162,7 @@ const RosterBulkActionsBar = ({
   const deferRun = useDeferredRun()
 
   const closeModal = () => {
-    if (phase === "working") return
+    if (bulk.busy) return
     setModalOpen(false)
   }
 
@@ -186,25 +172,18 @@ const RosterBulkActionsBar = ({
     // dialog opened before a sync armed could otherwise fire mid-sync.
     if (disabled) return
     if (unenrollableSelected.length === 0) return
+    if (!bulk.begin(unenrollableSelected.length, t("students.bulk.starting")))
+      return
     setAction("unenroll")
-    setPhase("working")
     setModalOpen(true)
-    setError(null)
-    setResult(null)
-    setProgress({
-      processed: 0,
-      total: unenrollableSelected.length,
-      message: t("students.bulk.starting"),
-    })
     try {
       const res = await bulkUnenrollRoster(client, {
         org,
         classroom,
         rows: unenrollableSelected,
-        onProgress: setProgress,
+        onProgress: bulk.setProgress,
       })
-      setResult(buildUnenrollResult(res, t))
-      setPhase("complete")
+      bulk.complete(buildUnenrollResult(res, t), "complete")
       // Pass only the CONFIRMED-removed rows so the page suppresses the
       // automatic backfills for exactly those (a still-active org member left by
       // a classroom-scoped unenroll would otherwise be team-added back). Rows
@@ -220,24 +199,16 @@ const RosterBulkActionsBar = ({
       )
     } catch (err) {
       log.error("bulk unenroll failed", { err, record: true })
-      setError(getErrorMessage(err))
-      setPhase("error")
+      bulk.fail(getErrorMessage(err))
     }
   }
 
   const runInvite = async () => {
     if (disabled) return
     if (invitableSelected === 0) return
+    if (!bulk.begin(invitableSelected, t("students.bulk.starting"))) return
     setAction("invite")
-    setPhase("working")
     setModalOpen(true)
-    setError(null)
-    setResult(null)
-    setProgress({
-      processed: 0,
-      total: invitableSelected,
-      message: t("students.bulk.starting"),
-    })
 
     const invited: { key: string; label: string; detail?: string }[] = []
     const skipped: { key: string; label: string; detail?: string }[] = []
@@ -247,7 +218,7 @@ const RosterBulkActionsBar = ({
     let processed = 0
     const tick = (label: string) => {
       processed += 1
-      setProgress({ processed, total: invitableSelected, message: label })
+      bulk.setProgress({ processed, total: invitableSelected, message: label })
     }
 
     // Pending rows: cancel + re-send the existing invite (resendOrgInvitation).
@@ -317,24 +288,23 @@ const RosterBulkActionsBar = ({
           ...deferred,
         ],
       })
-    setResult({
-      headline: t("students.bulk.invitedHeadline", { count: invited.length }),
-      sections,
-    })
-    setPhase("complete")
+    bulk.complete(
+      {
+        headline: t("students.bulk.invitedHeadline", { count: invited.length }),
+        sections,
+      },
+      "complete",
+    )
     onDone("invite")
   }
 
   const runCancel = async () => {
     if (disabled) return
     if (cancellableSelected.length === 0) return
-    setAction("cancel")
-    setPhase("working")
-    setModalOpen(true)
-    setError(null)
-    setResult(null)
     const total = cancellableSelected.length
-    setProgress({ processed: 0, total, message: t("students.bulk.starting") })
+    if (!bulk.begin(total, t("students.bulk.starting"))) return
+    setAction("cancel")
+    setModalOpen(true)
 
     const cancelled: { key: string; label: string }[] = []
     const alreadyGone: { key: string; label: string }[] = []
@@ -368,7 +338,7 @@ const RosterBulkActionsBar = ({
         failed.push({ key: row.key, label, detail: getErrorMessage(err) })
       }
       processed += 1
-      setProgress({ processed, total, message: label })
+      bulk.setProgress({ processed, total, message: label })
     }
 
     // An email-only invite leaves a metadata team holding the address and a
@@ -389,29 +359,25 @@ const RosterBulkActionsBar = ({
       })
     if (failed.length > 0)
       sections.push({ title: t("students.bulk.resultFailed"), rows: failed })
-    setResult({
-      headline: t("students.bulk.cancelledHeadline", {
-        count: cancelled.length,
-      }),
-      sections,
-    })
-    setPhase("complete")
+    bulk.complete(
+      {
+        headline: t("students.bulk.cancelledHeadline", {
+          count: cancelled.length,
+        }),
+        sections,
+      },
+      "complete",
+    )
     onDone("cancel")
   }
 
   const runRemoveRows = async () => {
     if (disabled) return
     if (unlinkedSelected.length === 0) return
+    if (!bulk.begin(unlinkedSelected.length, t("students.bulk.starting")))
+      return
     setAction("removeRows")
-    setPhase("working")
     setModalOpen(true)
-    setError(null)
-    setResult(null)
-    setProgress({
-      processed: 0,
-      total: unlinkedSelected.length,
-      message: t("students.bulk.starting"),
-    })
     try {
       // One commit for the whole batch; rows that gained an identity since the
       // selection are skipped server-side and reported as missed.
@@ -420,7 +386,7 @@ const RosterBulkActionsBar = ({
         classroom,
         rowRefs: unlinkedSelected.map((r) => unlinkedRowRef(r)),
       })
-      setProgress({
+      bulk.setProgress({
         processed: unlinkedSelected.length,
         total: unlinkedSelected.length,
         message: "",
@@ -439,18 +405,19 @@ const RosterBulkActionsBar = ({
           ],
         })
       }
-      setResult({
-        headline: t("students.bulk.removedRowsHeadline", {
-          count: res.removed,
-        }),
-        sections,
-      })
-      setPhase("complete")
+      bulk.complete(
+        {
+          headline: t("students.bulk.removedRowsHeadline", {
+            count: res.removed,
+          }),
+          sections,
+        },
+        "complete",
+      )
       onDone("removeRows")
     } catch (err) {
       log.error("bulk remove unlinked rows failed", { err, record: true })
-      setError(getErrorMessage(err))
-      setPhase("error")
+      bulk.fail(getErrorMessage(err))
     }
   }
 
@@ -599,11 +566,10 @@ const RosterBulkActionsBar = ({
         onClose={() => setConfirmingCancel(false)}
       />
 
-      <Modal
+      <BulkRunModal
         open={isOpen}
         onClose={closeModal}
-        closeDisabled={phase === "working"}
-        size="2xl"
+        run={bulk}
         title={
           action === "invite"
             ? t("students.bulk.inviteTitle")
@@ -613,56 +579,14 @@ const RosterBulkActionsBar = ({
                 ? t("students.bulk.removeRowsTitle")
                 : t("students.bulk.unenrollTitle")
         }
-        footer={
-          phase === "complete" ? (
-            <Button variant="primary" onClick={closeModal}>
-              {t("students.bulk.done")}
-            </Button>
-          ) : phase === "error" ? (
-            <Button variant="primary" onClick={closeModal}>
-              {t("common.done")}
-            </Button>
-          ) : undefined
-        }
-      >
-        {phase === "working" && (
-          <BulkProgressRow
-            progress={progress}
-            processedCaption={t("students.bulk.progressProcessed", {
-              processed: progress.processed,
-              total: progress.total,
-            })}
-            percentCaption={`${bulkProgressPct(progress)}%`}
-          >
-            <Alert tone="info" className="mt-6">
-              <span>{t("students.bulk.keepTabOpen")}</span>
-            </Alert>
-          </BulkProgressRow>
-        )}
-
-        {phase === "complete" && result && (
-          <div className="mt-6 space-y-4">
-            <Alert tone="success">
-              <span>{result.headline}</span>
-            </Alert>
-            {result.sections.map((section) => (
-              <BulkResultSection
-                key={section.title}
-                title={section.title}
-                rows={section.rows}
-              />
-            ))}
-          </div>
-        )}
-
-        {phase === "error" && (
-          <div className="mt-6">
-            <Alert tone="error">
-              <span>{error ?? t("students.somethingWentWrong")}</span>
-            </Alert>
-          </div>
-        )}
-      </Modal>
+        processedCaption={t("students.bulk.progressProcessed", {
+          processed: progress.processed,
+          total: progress.total,
+        })}
+        keepTabOpenMessage={t("students.bulk.keepTabOpen")}
+        fallbackError={t("students.somethingWentWrong")}
+        doneLabel={t("students.bulk.done")}
+      />
     </>
   )
 }


### PR DESCRIPTION
## Summary

Unit A5 of the dedup map that #904 started, and the finish of the bulk-progress consolidation the August plans began (#758, #760). Six modals (`BulkRepoVisibility`, `BulkRepoFeatures`, `BulkAutogradeState`, `BulkSubmissionTrigger`, `BulkRepoAccess`, `CloseSubmission`) and the two bulk action bars (roster, org members) each hand-rolled the same run lifecycle. 104 lines were byte-identical across the five `Bulk*` modals. Behavior-preserving; every existing test passes unchanged, and −519 lines net.

### What each caller used to own, and where it lives now

| Was in every caller | Now |
| --- | --- |
| `runningRef` + `mountedRef` + the unmount effect; `phase` / `progress` / `result` state; the reset-on-open effect; `useBeforeUnloadGuard(busy)` | `components/bulk/useBulkRun.ts`: `begin(total)` (refuses a second run in flight), `setProgress`, `complete(view, phase)`, `fail(message)`, `isMounted()`, `reset()`. Takes the modal's `open` flag and resets as it turns true, never as it turns false, so the close animation keeps the last result (the `ui/Modal` note). |
| A local `Outcome` union, the `mapWithConcurrency(owners, REPO_READ_CONCURRENCY, …)` loop with the `rateLimited` short-circuit, `processed` counter and `finally { setProgress }` | `components/bulk/fanOut.ts`: `runBulkFanOut<O>({ owners, perOwner, concurrency?, shouldStop?, isMounted, onProgress, t })`. `perOwner` resolves for ok, throws for failed (a rate-limit throw stops the rest), or returns a custom outcome to widen the union (`notGradable`, the shim writer's verdicts). `partitionOutcomes` splits into the three sections. `runBulkRepoAccess` is now a thin adapter over it. |
| The headline alert + `result.sections.map(BulkResultSection)` block | `BulkResultBody` in `resultView.tsx`, with `children` (the trigger modal's re-pull reminder) and `after` (the close modal's finish hint) slots. |
| The bars' `<Modal>` with the working / complete / error branches, differing only in i18n keys | `BulkRunModal` in `resultView.tsx`. |
| Six copies of `describeFailure` (shared vocabulary, then HTTP status, then `Error.message`) | `describeWriteFailure` in `collaboratorHelpers.tsx`; `describeAccessFailure` adds only its not-applied branch on top. The two per-repo dialogs (`RepoAccessModal`, `GroupCollaboratorsModal`) had a different recipe (422 → conflict, raw message, `null` return) and share it as `describeCollaboratorFailure`. Output is unchanged for every caller. |

### Three things that are not purely mechanical

- **The org members bar gains the tab-close hold.** `RosterBulkActionsBar` called `useBeforeUnloadGuard(phase === "working")`; `orgMembers/BulkActionsBar` never did. `useBulkRun` holds the tab for both, so a teacher closing the tab mid bulk-remove now gets the browser's leave prompt there too. The audit flagged this as the one asymmetry unifying would (correctly) fix.
- **The bars gain the in-flight latch.** They had no `runningRef`; `begin()` returns false if a run is already working, so a double-click on a bar menu item can't start a second fan-out. The modals already had this.
- **`CloseSubmissionModal`'s progress resets at `begin()`**, before the flag flip, instead of after it. The progress block only renders while working and uses `indeterminateUntilFirst`, so nothing visible changes.

### Also

Seven of the 26 baseline `react-hooks/set-state-in-effect` warnings came from the reset-on-open effect in these modals. The hook carries one; the remaining per-modal effects that reset form choices (`setChoice("keep")` and the like) keep theirs. Net 25.

## Not in this PR

`BulkReuseAssignmentsModal` is a single batched commit with a slug-planning form, not a per-owner fan-out; it shares `BulkPhaseFooter` already and has no loop to adopt. The `ExternalLink` and `DropdownMenu.Item` sweeps are unit A6.

## Test plan

- [x] `cd web && npm run check`: tsc, eslint (0 errors, 25 warnings), prettier, arch:validate, 5,320 node tests. Browser project run separately: 18 passed.
- [x] Every existing test for the rewritten files passes unchanged: `BulkRepoFeaturesModal.test.tsx`, `repoAccessFanOut.test.ts`, `resultView.test.tsx`, `BulkActionsBar.test.tsx`, the roster page suites (382 tests across `components/bulk`, `components/modals`, `pages/students`, `pages/orgMembers`).
- [x] New `useBulkRun.test.tsx` (5): the phase walk and tab hold; second `begin` refused while working and allowed after; `fail` leaves no result; reset on open-true only; post-unmount calls are swallowed.
- [x] New `fanOut.test.ts` (6): outcomes in input order; rate limit stops launching and defers the rest; `shouldStop` and unmount defer without calling `perOwner` or reporting progress; custom outcomes pass through; non-rate-limit GitHub errors describe by status; `partitionOutcomes` keeps failure details typed.
- [ ] Manual: on a dev org, run each of the six modals against a small assignment (features, visibility, pause/resume, trigger retrofit, access, close/reopen) and confirm progress, results, and that a second Apply click during a run is ignored; run a bulk unenroll from the roster and a bulk remove from members and confirm the leave prompt fires if you try to close the tab mid-run.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched (web `npm run check`; no Go or Python change).
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror. n/a.
- [x] If I added or changed a CLI command or flag, I documented it in the wiki. n/a.
- [x] My commits follow Conventional Commits.
