### PR TITLE
refactor(web): adopt ExternalLink and DropdownMenu.Item where the recipe was hand-written

### DIFF
--- a/web/src/components/AboutDialog.tsx
+++ b/web/src/components/AboutDialog.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Link } from "@tanstack/react-router"
 import { LinkExternalIcon } from "@/components/ui/icons"
 
-import { CopyableDetails, Modal } from "@/components/ui"
+import { CopyableDetails, ExternalLink, Modal } from "@/components/ui"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import { buildDiagnostics } from "@/lib/diagnostics/snapshot"
 import {
@@ -96,15 +96,9 @@ export const AboutDialog = forwardRef<
         <dt className="text-base-content/60">{t("nav.aboutVersion")}</dt>
         <dd className="font-mono tabular-nums">
           {release ? (
-            <a
-              className="link link-info link-hover inline-flex items-center gap-1"
-              href={release}
-              target="_blank"
-              rel="noreferrer"
-            >
+            <ExternalLink className="link-info link-hover" href={release}>
               v{appVersion.version}
-              <LinkExternalIcon aria-hidden="true" className="size-4" />
-            </a>
+            </ExternalLink>
           ) : (
             <>v{appVersion.version}</>
           )}
@@ -112,15 +106,9 @@ export const AboutDialog = forwardRef<
 
         <dt className="text-base-content/60">{t("nav.aboutCommit")}</dt>
         <dd className="font-mono">
-          <a
-            className="link link-info link-hover inline-flex items-center gap-1"
-            href={commitUrl()}
-            target="_blank"
-            rel="noreferrer"
-          >
+          <ExternalLink className="link-info link-hover" href={commitUrl()}>
             {shortCommit()}
-            <LinkExternalIcon aria-hidden="true" className="size-4" />
-          </a>
+          </ExternalLink>
           <span className="ms-1 text-base-content/60">
             ({formatBuildDate()})
           </span>

--- a/web/src/components/AppVersionBadge.tsx
+++ b/web/src/components/AppVersionBadge.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "@/components/ui"
 import { appVersion, commitUrl, shortCommit } from "@/version"
 
 // Small, unobtrusive build identifier. The version is a build-time constant
@@ -12,14 +13,9 @@ export function AppVersionBadge({ className }: { className?: string }) {
       data-testid="app-version"
     >
       v{appVersion.version} ·{" "}
-      <a
-        className="link link-hover"
-        href={commitUrl()}
-        target="_blank"
-        rel="noreferrer"
-      >
+      <ExternalLink className="link-hover" href={commitUrl()} icon={false}>
         {shortCommit()}
-      </a>
+      </ExternalLink>
     </span>
   )
 }

--- a/web/src/components/BudgetCreatedBanner.tsx
+++ b/web/src/components/BudgetCreatedBanner.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence } from "motion/react"
 import { useTranslation } from "react-i18next"
 
 import { AppBanner } from "@/components/AppBanner"
-import { Button } from "@/components/ui"
+import { Button, ExternalLink } from "@/components/ui"
 import { orgBudgetsUrl } from "@/orgPolicy/budget"
 import {
   BUDGET_NOTICE_EVENT,
@@ -91,14 +91,13 @@ export function BudgetCreatedBanner() {
         >
           <p className="text-base-content/70">{t("budgetCreated.body")}</p>
           <div className="flex flex-wrap items-center gap-2">
-            <a
+            <ExternalLink
               href={orgBudgetsUrl(org)}
-              target="_blank"
-              rel="noreferrer"
-              className="link link-primary text-sm"
+              className="link-primary text-sm"
+              icon={false}
             >
               {t("budgetCreated.manage")}
-            </a>
+            </ExternalLink>
           </div>
           <Button
             variant="success"

--- a/web/src/components/GitHubLink.tsx
+++ b/web/src/components/GitHubLink.tsx
@@ -1,7 +1,9 @@
-import { LinkExternalIcon, MarkGithubIcon } from "@/components/ui/icons"
+import { ExternalLink } from "@/components/ui"
+import { MarkGithubIcon } from "@/components/ui/icons"
 
-// Shared "open on GitHub" deep-link, so the section headers that use it can't
-// drift in markup. `className` tunes layout per call site (e.g., `shrink-0`).
+// Shared "open on GitHub" deep-link for section headers: the muted ExternalLink
+// with the GitHub mark in front. `className` tunes layout per call site (e.g.,
+// `shrink-0`).
 export const GitHubLink = ({
   href,
   label,
@@ -15,17 +17,15 @@ export const GitHubLink = ({
   className?: string
   showLogo?: boolean
 }) => (
-  <a
+  <ExternalLink
     href={href}
-    target="_blank"
-    rel="noreferrer"
     title={title}
-    className={`inline-flex cursor-pointer items-center gap-1.5 text-sm text-base-content/70 hover:text-primary ${className}`}
+    variant="muted"
+    className={`cursor-pointer gap-1.5 text-sm ${className}`}
   >
     {showLogo && <MarkGithubIcon className="size-4" aria-hidden="true" />}
     {label}
-    <LinkExternalIcon className="size-4" aria-hidden="true" />
-  </a>
+  </ExternalLink>
 )
 
 export default GitHubLink

--- a/web/src/components/assignments/GroupTeamMembersPanel.tsx
+++ b/web/src/components/assignments/GroupTeamMembersPanel.tsx
@@ -3,14 +3,13 @@ import { useTranslation } from "react-i18next"
 import { useQuery } from "@tanstack/react-query"
 
 import {
-  LinkExternalIcon,
   MarkGithubIcon,
   PeopleIcon,
   PlusIcon,
   SignOutIcon,
   TrashIcon,
 } from "@/components/ui/icons"
-import { Alert, Badge, Button, Input, cx } from "@/components/ui"
+import { Alert, Badge, Button, cx, ExternalLink, Input } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import { Spinner } from "@/components/Spinner"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
@@ -297,15 +296,12 @@ export function GroupTeamMembersPanel({
               it — so both requesting and reviewing deep-link there. Reviewing
               is a maintainer power, so only managers get the link. */}
           {canManage ? (
-            <a
-              className="link link-hover inline-flex items-center gap-1.5 text-sm"
+            <ExternalLink
+              className="link-hover gap-1.5 text-sm"
               href={groupTeamUrl(org, teamSlug)}
-              target="_blank"
-              rel="noreferrer"
             >
               {t("components.groupTeamMembers.reviewJoinRequests")}
-              <LinkExternalIcon aria-hidden="true" className="size-3.5" />
-            </a>
+            </ExternalLink>
           ) : (
             <span />
           )}

--- a/web/src/components/modals/StudentProfileModal.tsx
+++ b/web/src/components/modals/StudentProfileModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { LinkExternalIcon, MarkGithubIcon } from "@/components/ui/icons"
 
-import { Badge, Button, Modal } from "@/components/ui"
+import { Badge, Button, ExternalLink, Modal } from "@/components/ui"
 import type { Student } from "@/types/classroom"
 import { getName, getInitials, firstGrapheme } from "@/util/students"
 
@@ -44,15 +44,14 @@ export const StudentProfileModal = ({
     {
       label: t("components.modals.studentProfile.github"),
       value: student.username ? (
-        <a
-          className="link link-hover inline-flex items-center gap-1"
+        <ExternalLink
+          className="link-hover"
           href={`https://github.com/${student.username}`}
-          target="_blank"
-          rel="noreferrer"
+          icon={false}
         >
           <MarkGithubIcon aria-hidden="true" className="size-4" />@
           {student.username}
-        </a>
+        </ExternalLink>
       ) : (
         <span className="text-base-content/70">
           {t("components.modals.studentProfile.notLinkedYet")}

--- a/web/src/components/modals/ViewRepositoryLink.tsx
+++ b/web/src/components/modals/ViewRepositoryLink.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "@/components/ui"
 import type { ReactNode } from "react"
 
 import { MarkGithubIcon } from "@/components/ui/icons"
@@ -15,14 +16,13 @@ export function ViewRepositoryLink({
   children: ReactNode
 }) {
   return (
-    <a
-      className="link mt-3 inline-flex w-fit items-center gap-1.5 text-sm"
+    <ExternalLink
+      className="mt-3 w-fit gap-1.5 text-sm"
       href={href}
-      target="_blank"
-      rel="noreferrer"
+      icon={false}
     >
       <MarkGithubIcon aria-hidden="true" className="size-4" />
       {children}
-    </a>
+    </ExternalLink>
   )
 }

--- a/web/src/components/status/ActionsBanner.tsx
+++ b/web/src/components/status/ActionsBanner.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "@/components/ui"
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
 import { InlineSpinner } from "@/components/Spinner"
 import { AnimatePresence, motion } from "motion/react"
@@ -5,7 +6,6 @@ import {
   AlertIcon,
   CheckCircleIcon,
   ChevronDownIcon,
-  LinkExternalIcon,
   SyncIcon,
   XIcon,
 } from "@/components/ui/icons"
@@ -109,15 +109,13 @@ const TrackerRow = ({
       </span>
       <ElapsedLabel tracker={tracker} now={now} />
       {tracker.htmlUrl && (
-        <a
+        <ExternalLink
           href={tracker.htmlUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="flex shrink-0 cursor-pointer items-center gap-1 text-xs font-medium opacity-80 hover:opacity-100"
+          variant="plain"
+          className="shrink-0 cursor-pointer text-xs font-medium opacity-80 hover:opacity-100"
         >
           {t("actionsBanner.viewRun")}
-          <LinkExternalIcon aria-hidden="true" className="size-4" />
-        </a>
+        </ExternalLink>
       )}
       {tracker.retriable && (
         <button

--- a/web/src/components/submissions/SubmissionDetailsModal.tsx
+++ b/web/src/components/submissions/SubmissionDetailsModal.tsx
@@ -8,7 +8,7 @@ import {
   TagIcon,
 } from "@/components/ui/icons"
 
-import { Button, Modal, MonoLtr, cx } from "@/components/ui"
+import { Button, cx, ExternalLink, Modal, MonoLtr } from "@/components/ui"
 
 // One row in the submission-details list. `kind` picks the icon and action
 // label ("View tag" vs "View commit"); `href` is the already-built, safe GitHub
@@ -218,28 +218,26 @@ export function SubmissionDetailsModal({
                 </span>
                 <span className="ms-auto flex shrink-0 items-center">
                   {item.href ? (
-                    <a
-                      className="link link-hover inline-flex items-center gap-1"
+                    <ExternalLink
+                      className="link-hover"
                       href={item.href}
-                      target="_blank"
-                      rel="noreferrer"
+                      icon={false}
                     >
                       {actionLabel}
-                    </a>
+                    </ExternalLink>
                   ) : (
                     <span className="text-base-content/50">
                       {t("submissions.details.unavailable")}
                     </span>
                   )}
                   {item.releaseHref ? (
-                    <a
-                      className="link link-hover ms-3 inline-flex items-center gap-1 text-base-content/70 before:me-1 before:text-base-content/30 before:content-['·']"
+                    <ExternalLink
+                      className="link-hover ms-3 text-base-content/70 before:me-1 before:text-base-content/30 before:content-['·']"
                       href={item.releaseHref}
-                      target="_blank"
-                      rel="noreferrer"
+                      icon={false}
                     >
                       {t("submissions.details.viewGrade")}
-                    </a>
+                    </ExternalLink>
                   ) : null}
                 </span>
               </li>

--- a/web/src/components/ui/DropdownMenu.tsx
+++ b/web/src/components/ui/DropdownMenu.tsx
@@ -46,11 +46,15 @@ export function closeDropdownMenu(): void {
   }
 }
 
+type MenuIcon = ComponentType<{
+  className?: string
+  "aria-hidden"?: boolean | "true" | "false"
+}>
+
 export type DropdownMenuItemProps = {
-  icon?: ComponentType<{
-    className?: string
-    "aria-hidden"?: boolean | "true" | "false"
-  }>
+  icon?: MenuIcon
+  // Extra classes on the icon (an `animate-spin` while the action runs).
+  iconClassName?: string
   label: ReactNode
   // Native disabled plus a guard in onClick: daisyUI's menu items are plain
   // buttons, and a disabled one still needs its title to explain why.
@@ -64,6 +68,7 @@ export type DropdownMenuItemProps = {
 // red text (the confirm dialog carries the danger tone).
 function DropdownMenuItem({
   icon: Icon,
+  iconClassName,
   label,
   disabled = false,
   title,
@@ -83,12 +88,40 @@ function DropdownMenuItem({
           onSelect()
         }}
       >
-        {Icon ? <Icon aria-hidden="true" className="size-4" /> : null}
+        {Icon ? (
+          <Icon aria-hidden="true" className={cx("size-4", iconClassName)} />
+        ) : null}
         {label}
       </button>
     </li>
   )
 }
 DropdownMenu.Item = DropdownMenuItem
+
+export type DropdownMenuLinkItemProps = {
+  icon?: MenuIcon
+  label: ReactNode
+  href: string
+  title?: string
+}
+
+// A menu item that opens an off-site page in a new tab (a run on GitHub). The
+// same row chrome as Item; the browser navigation is what closes the menu.
+function DropdownMenuLinkItem({
+  icon: Icon,
+  label,
+  href,
+  title,
+}: DropdownMenuLinkItemProps) {
+  return (
+    <li>
+      <a href={href} target="_blank" rel="noreferrer" title={title}>
+        {Icon ? <Icon aria-hidden="true" className="size-4" /> : null}
+        {label}
+      </a>
+    </li>
+  )
+}
+DropdownMenu.LinkItem = DropdownMenuLinkItem
 
 export default DropdownMenu

--- a/web/src/components/ui/ExternalLink.test.tsx
+++ b/web/src/components/ui/ExternalLink.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+
+import { ExternalLink } from "./ExternalLink"
+
+afterEach(cleanup)
+
+// ExternalLink is the one off-site text-link recipe, so these lock the
+// target/rel pair, the three variants, the gap default, and the glyph toggle.
+describe("ExternalLink", () => {
+  it("opens in a new tab with the referrer withheld, as a daisyUI link", () => {
+    render(<ExternalLink href="https://example.org">Docs</ExternalLink>)
+    const a = screen.getByRole("link", { name: "Docs" })
+    expect(a.getAttribute("href")).toBe("https://example.org")
+    expect(a.getAttribute("target")).toBe("_blank")
+    expect(a.getAttribute("rel")).toBe("noreferrer")
+    expect(a.className).toContain("link")
+    expect(a.className).toContain("inline-flex")
+    expect(a.className).toContain("gap-1")
+    expect(a.querySelector("svg")).not.toBeNull()
+  })
+
+  it("drops the glyph on request", () => {
+    render(
+      <ExternalLink href="https://example.org" icon={false}>
+        Docs
+      </ExternalLink>,
+    )
+    expect(screen.getByRole("link").querySelector("svg")).toBeNull()
+  })
+
+  it("muted and plain variants leave the daisyUI link class off", () => {
+    render(
+      <>
+        <ExternalLink href="https://a.test" variant="muted">
+          A
+        </ExternalLink>
+        <ExternalLink href="https://b.test" variant="plain">
+          B
+        </ExternalLink>
+      </>,
+    )
+    const muted = screen.getByRole("link", { name: "A" })
+    const plain = screen.getByRole("link", { name: "B" })
+    expect(muted.className.split(" ")).not.toContain("link")
+    expect(muted.className).toContain("hover:text-primary")
+    expect(plain.className.split(" ")).not.toContain("link")
+    expect(plain.className).toContain("inline-flex")
+  })
+
+  // cx can't merge Tailwind classes, so a caller's gap must replace, not join,
+  // the default.
+  it("yields the gap to a caller that sets one", () => {
+    render(
+      <ExternalLink href="https://example.org" className="gap-1.5">
+        Docs
+      </ExternalLink>,
+    )
+    const classes = screen.getByRole("link").className.split(" ")
+    expect(classes).toContain("gap-1.5")
+    expect(classes).not.toContain("gap-1")
+  })
+})

--- a/web/src/components/ui/ExternalLink.tsx
+++ b/web/src/components/ui/ExternalLink.tsx
@@ -1,25 +1,46 @@
 import type { AnchorHTMLAttributes, ReactNode } from "react"
 
 import { LinkExternalIcon } from "./icons"
-import { cx } from "./cx"
+import { cx, hasUtility } from "./cx"
 
-// A text link that opens off-site in a new tab: the daisyUI `link` recipe, the
-// `target`/`rel` pair that a new tab needs, and the trailing external-link
-// glyph, so the ~20 hand-written `<a className="link" target="_blank">` sites
-// can converge on one shape. In-app navigation is the router's `Link`, not this.
+// The three text-link recipes an off-site anchor takes in this app. Anything
+// else (a card, an avatar, a badge, a menu item) is not a text link and stays a
+// bare <a>.
+export type ExternalLinkVariant =
+  // The daisyUI `link` (underlined) text link.
+  | "link"
+  // The quiet "open on GitHub" affordance beside a settings section: muted
+  // until hovered, no underline.
+  | "muted"
+  // Only the layout, target/rel and glyph; the caller styles the text.
+  | "plain"
+
+const variantClass: Record<ExternalLinkVariant, string> = {
+  link: "link inline-flex items-center",
+  muted: "inline-flex items-center text-base-content/70 hover:text-primary",
+  plain: "inline-flex items-center",
+}
+
+// A text link that opens off-site in a new tab: the `target`/`rel` pair a new
+// tab needs, the inline-flex row, and the trailing external-link glyph, so the
+// hand-written `<a target="_blank" rel="noreferrer">` sites converge on one
+// shape. In-app navigation is the router's `Link`, not this.
 export type ExternalLinkProps = Omit<
   AnchorHTMLAttributes<HTMLAnchorElement>,
   "target" | "rel" | "children"
 > & {
   href: string
   children: ReactNode
-  // Drop the glyph where the surrounding text already says it opens elsewhere.
+  variant?: ExternalLinkVariant
+  // Drop the glyph where the surrounding text already says it opens elsewhere,
+  // or where a leading icon (the GitHub mark) carries that meaning.
   icon?: boolean
 }
 
 export function ExternalLink({
   href,
   children,
+  variant = "link",
   icon = true,
   className,
   ...rest
@@ -29,7 +50,11 @@ export function ExternalLink({
       href={href}
       target="_blank"
       rel="noreferrer"
-      className={cx("link inline-flex items-center gap-1", className)}
+      className={cx(
+        variantClass[variant],
+        !hasUtility("gap-", className) && "gap-1",
+        className,
+      )}
       {...rest}
     >
       {children}

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -13,7 +13,7 @@ export type {
 export { RouterButton } from "./RouterButton"
 
 export { ExternalLink } from "./ExternalLink"
-export type { ExternalLinkProps } from "./ExternalLink"
+export type { ExternalLinkProps, ExternalLinkVariant } from "./ExternalLink"
 
 export { SectionAnchorHeading } from "./SectionAnchorHeading"
 

--- a/web/src/pages/AssignmentSettingsPage.tsx
+++ b/web/src/pages/AssignmentSettingsPage.tsx
@@ -7,7 +7,14 @@ import PageHeader from "@/components/PageHeader"
 import PageShell from "@/components/PageShell"
 import { ArchivedClassroomNotice } from "@/components/ArchivedClassroomNotice"
 import { OrgRepoCreationNotice } from "@/components/OrgRepoCreationNotice"
-import { Alert, AnimatedAlert, Button, Card, Heading } from "@/components/ui"
+import {
+  Alert,
+  AnimatedAlert,
+  Button,
+  Card,
+  ExternalLink,
+  Heading,
+} from "@/components/ui"
 import { useDocumentTitle } from "@/hooks/useDocumentTitle"
 import { useClassroomRoleContext } from "@/context/classroomRole/ClassroomRoleProvider"
 import { can } from "@/authz"
@@ -167,15 +174,14 @@ const EditAssignmentFormStudent = ({
               <p className="text-sm font-medium text-base-content/70">
                 {t("assignmentSettings.groupMembers")}
               </p>
-              <a
-                className="link mt-1 inline-flex items-center gap-1.5 text-sm"
+              <ExternalLink
+                className="mt-1 gap-1.5 text-sm"
                 href={assignmentRepo.html_url}
-                target="_blank"
-                rel="noreferrer"
+                icon={false}
               >
                 <MarkGithubIcon aria-hidden="true" className="size-4" />
                 {t("assignmentSettings.viewRepository")}
-              </a>
+              </ExternalLink>
             </div>
           </div>
           <GroupTeamMembersPanel
@@ -209,15 +215,14 @@ const EditAssignmentFormStudent = ({
               <p className="text-sm font-medium text-base-content/70">
                 {t("assignmentSettings.groupMembers")}
               </p>
-              <a
-                className="link mt-1 inline-flex items-center gap-1.5 text-sm"
+              <ExternalLink
+                className="mt-1 gap-1.5 text-sm"
                 href={assignmentRepo.html_url}
-                target="_blank"
-                rel="noreferrer"
+                icon={false}
               >
                 <MarkGithubIcon aria-hidden="true" className="size-4" />
                 {t("assignmentSettings.viewRepository")}
-              </a>
+              </ExternalLink>
               <p className="mt-2 text-sm text-base-content/70">
                 <Trans
                   i18nKey="assignmentSettings.collaboratorsHint"

--- a/web/src/pages/OrgSettingsPage.tsx
+++ b/web/src/pages/OrgSettingsPage.tsx
@@ -3,11 +3,12 @@ import { Trans, useTranslation } from "react-i18next"
 import {
   AnimatedAlert,
   Button,
+  cx,
+  ExternalLink,
   FormField,
   HelpTooltip,
   Input,
   Modal,
-  cx,
 } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
@@ -400,15 +401,12 @@ function SetTokenModal({
         </Step>
 
         <div className="flex items-center justify-between gap-2 border-t border-base-content/10 pt-4">
-          <a
-            className="link inline-flex items-center gap-1 text-sm text-base-content/60 hover:text-base-content"
+          <ExternalLink
+            className="text-sm text-base-content/60 hover:text-base-content"
             href={`${WIKI_URL}/GitHub-Integration#4-fine-grained-pat-for-score-collection`}
-            target="_blank"
-            rel="noreferrer"
           >
             {t("orgSettings.serviceToken.learnMore")}
-            <LinkExternalIcon aria-hidden="true" className="size-4" />
-          </a>
+          </ExternalLink>
           <div className="flex gap-2">
             <Button variant="ghost" type="button" onClick={onClose}>
               {t("common.cancel")}

--- a/web/src/pages/OrgsPage.tsx
+++ b/web/src/pages/OrgsPage.tsx
@@ -44,12 +44,13 @@ import {
   Badge,
   Button,
   Card,
+  closeDropdownMenu,
+  cx,
   DropdownMenu,
+  Heading,
   InlineMessage,
   RouterButton,
   Toolbar,
-  cx,
-  Heading,
 } from "@/components/ui"
 import {
   CardGridSkeleton,
@@ -256,14 +257,6 @@ function HideOrgMenu({
     })
   }
 
-  // daisyUI keeps a focus-driven dropdown open until blur; blur the active item
-  // so the menu closes when opening the modal.
-  const closeMenu = () => {
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur()
-    }
-  }
-
   return (
     <>
       <div className={cx("dropdown dropdown-end", className)}>
@@ -282,31 +275,23 @@ function HideOrgMenu({
                 to="/$org/settings"
                 params={{ org: org.login }}
                 hash="service-token"
-                onClick={closeMenu}
+                onClick={closeDropdownMenu}
               >
                 <KeyIcon aria-hidden="true" className="size-4" />
                 {t("orgs.card.manageToken")}
               </Link>
             </li>
           )}
-          <li>
-            <button
-              type="button"
-              onClick={() => {
-                closeMenu()
-                setDetailsOpen(true)
-              }}
-            >
-              <InfoIcon aria-hidden="true" className="size-4" />
-              {t("orgs.card.details")}
-            </button>
-          </li>
-          <li>
-            <button type="button" onClick={handleHide}>
-              <EyeClosedIcon aria-hidden="true" className="size-4" />
-              {t("orgs.card.hide")}
-            </button>
-          </li>
+          <DropdownMenu.Item
+            icon={InfoIcon}
+            label={t("orgs.card.details")}
+            onSelect={() => setDetailsOpen(true)}
+          />
+          <DropdownMenu.Item
+            icon={EyeClosedIcon}
+            label={t("orgs.card.hide")}
+            onSelect={handleHide}
+          />
         </DropdownMenu>
       </div>
 

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -7,7 +7,6 @@ import {
   AlertIcon,
   CheckCircleIcon,
   InfoIcon,
-  LinkExternalIcon,
   MarkGithubIcon,
   QuestionIcon,
   SyncIcon,
@@ -31,7 +30,7 @@ import {
   InlineCode as Code,
   AutoLinkText,
 } from "@/components/InlineNote"
-import { Button, FormField } from "@/components/ui"
+import { Button, ExternalLink, FormField } from "@/components/ui"
 import { TemplateRepoPicker } from "./TemplateRepoPicker"
 import { canonicalTemplateRef, templateVerifyKey } from "./templateRefNormalize"
 import { templateForkNoteView } from "./templateNoteView"
@@ -490,18 +489,16 @@ function renderTemplateVerdict({
             }}
             components={{ branch: <Code />, important: <strong /> }}
           />
-          <a
+          <ExternalLink
             href={`https://github.com/${verification.owner}/${verification.repo}`}
-            target="_blank"
-            rel="noreferrer"
-            className="mt-1 flex items-center gap-1 font-semibold underline"
+            variant="plain"
+            className="mt-1 font-semibold underline"
           >
             {t("assignments.template.viewTemplateRepo", {
               owner: verification.owner,
               repo: verification.repo,
             })}
-            <LinkExternalIcon aria-hidden="true" className="size-4 shrink-0" />
-          </a>
+          </ExternalLink>
         </Note>
       )
     }
@@ -575,21 +572,16 @@ function renderTemplateVerdict({
                 </li>
                 <li>{t("assignments.template.restrictedItemOther")}</li>
               </ul>
-              <a
+              <ExternalLink
                 href={`https://github.com/${verification.owner}/${verification.repo}`}
-                target="_blank"
-                rel="noreferrer"
-                className="mt-1 flex items-center gap-1 font-semibold underline"
+                variant="plain"
+                className="mt-1 font-semibold underline"
               >
                 {t("assignments.template.viewTemplateRepo", {
                   owner: verification.owner,
                   repo: verification.repo,
                 })}
-                <LinkExternalIcon
-                  aria-hidden="true"
-                  className="size-4 shrink-0"
-                />
-              </a>
+              </ExternalLink>
             </>
           )}
           <span className="mt-1 block text-xs text-base-content/70">
@@ -671,15 +663,13 @@ const Note = ({
     <InlineNote tone={tone} icon={icon} className="mt-1.5">
       <span>{children}</span>
       {policy && (
-        <a
+        <ExternalLink
           href={policy.href}
-          target="_blank"
-          rel="noreferrer"
-          className="mt-1 flex items-center gap-1 font-semibold underline"
+          variant="plain"
+          className="mt-1 font-semibold underline"
         >
           {t("assignments.template.policyLink", { owner: policy.owner })}
-          <LinkExternalIcon aria-hidden="true" className="size-4 shrink-0" />
-        </a>
+        </ExternalLink>
       )}
     </InlineNote>
   )

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -2,8 +2,16 @@ import { useQuery } from "@tanstack/react-query"
 import { InlineSpinner } from "@/components/Spinner"
 import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
-import { LinkExternalIcon, SyncIcon } from "@/components/ui/icons"
-import { Alert, Button, cx, FormField, Radio, Select } from "@/components/ui"
+import { SyncIcon } from "@/components/ui/icons"
+import {
+  Alert,
+  Button,
+  cx,
+  ExternalLink,
+  FormField,
+  Radio,
+  Select,
+} from "@/components/ui"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
 import { repoContentsPathExists } from "@/domain/assignments"
 import {
@@ -345,15 +353,12 @@ function StudentPermissionField({ form }: { form: AssignmentForm }) {
                     : "assignments.form.studentPermission.help",
                 )}
                 labelExtra={
-                  <a
-                    className="link inline-flex items-center gap-1 text-sm font-normal text-base-content/60 hover:text-base-content"
+                  <ExternalLink
+                    className="text-sm font-normal text-base-content/60 hover:text-base-content"
                     href={REPO_ROLES_DOCS_URL}
-                    target="_blank"
-                    rel="noreferrer"
                   >
                     {t("assignments.form.studentPermission.learnMore")}
-                    <LinkExternalIcon aria-hidden="true" className="size-4" />
-                  </a>
+                  </ExternalLink>
                 }
               >
                 {({ id, describedById }) => (

--- a/web/src/pages/orgActivity/TimelineRow.tsx
+++ b/web/src/pages/orgActivity/TimelineRow.tsx
@@ -10,7 +10,7 @@ import {
   ZapIcon,
 } from "@/components/ui/icons"
 
-import { Badge, type BadgeTone, cx } from "@/components/ui"
+import { Badge, cx, ExternalLink, type BadgeTone } from "@/components/ui"
 import type { TimelineItem, TimelineStatus } from "@/lib/activity/timeline"
 import type { TFunction } from "i18next"
 
@@ -91,18 +91,18 @@ export function TimelineRow({ item }: { item: TimelineItem }) {
       <div className="min-w-0 flex-1">
         <p className="text-sm font-medium break-words text-base-content">
           {item.href ? (
-            <a
+            <ExternalLink
               href={item.href}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1 hover:underline"
+              variant="plain"
+              className="hover:underline"
+              icon={false}
             >
               {item.label}
               <LinkExternalIcon
                 aria-hidden="true"
                 className="size-4 opacity-60"
               />
-            </a>
+            </ExternalLink>
           ) : (
             item.label
           )}

--- a/web/src/pages/orgSettings/OrgActionsSection.tsx
+++ b/web/src/pages/orgSettings/OrgActionsSection.tsx
@@ -1,8 +1,13 @@
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
-import { LinkExternalIcon } from "@/components/ui/icons"
 
-import { Badge, OutcomeAlert, InlineSpinner, Toggle } from "@/components/ui"
+import {
+  Badge,
+  ExternalLink,
+  InlineSpinner,
+  OutcomeAlert,
+  Toggle,
+} from "@/components/ui"
 import type { AlertOutcome } from "@/components/ui"
 import { ConfirmModal } from "@/components/modals"
 import { CalloutDiv } from "@/lib/motionComponents"
@@ -102,15 +107,13 @@ const ActionsUsagePanel = ({ org }: { org: string }) => {
                     amount: budget.amount.toFixed(2),
                   })}
           </span>
-          <a
+          <ExternalLink
             href={orgBudgetsUrl(org)}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-0.5 text-base-content/60 hover:text-primary"
+            variant="plain"
+            className="gap-0.5 text-base-content/60 hover:text-primary"
           >
             {t("orgSettings.actions.budgetManage")}
-            <LinkExternalIcon aria-hidden="true" className="size-4" />
-          </a>
+          </ExternalLink>
         </p>
       )}
     </div>
@@ -190,15 +193,13 @@ const OrgActionsSection = ({
         )
       }
       action={
-        <a
+        <ExternalLink
           href={githubOrgActionsSettingsUrl(org)}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
+          variant="muted"
+          className="text-xs"
         >
           {t("orgSettings.actions.openSettings")}
-          <LinkExternalIcon aria-hidden="true" className="size-4" />
-        </a>
+        </ExternalLink>
       }
     >
       {isLoading ? (

--- a/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
+++ b/web/src/pages/orgSettings/OrgPolicyAuditPane.tsx
@@ -5,7 +5,6 @@ import {
   CheckCircleIcon,
   ChevronRightIcon,
   ChevronUpIcon,
-  LinkExternalIcon,
   XCircleIcon,
 } from "@/components/ui/icons"
 
@@ -15,6 +14,7 @@ import useRepairOrgPolicyConcern from "@/hooks/mutations/useRepairOrgPolicyConce
 import {
   Badge,
   Button,
+  ExternalLink,
   InlineSpinner,
   rtlFlip,
   type BadgeTone,
@@ -169,15 +169,13 @@ export function ConcernRow({
               {t("orgSettings.audit.couldntAutoConfigure")}
             </p>
           )}
-          <a
+          <ExternalLink
             href={concern.settingsUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="mt-1 inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
+            variant="muted"
+            className="mt-1 text-xs"
           >
             {t("orgSettings.audit.viewOnGitHub")}
-            <LinkExternalIcon aria-hidden="true" className="size-4" />
-          </a>
+          </ExternalLink>
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {showFix && (
@@ -215,15 +213,9 @@ export function ConcernRow({
             {t("orgSettings.audit.changeThemOn", {
               count: driftedDetails.length,
             })}{" "}
-            <a
-              href={concern.settingsUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="link inline-flex items-center gap-0.5"
-            >
+            <ExternalLink href={concern.settingsUrl} className="gap-0.5">
               {t("orgSettings.audit.gitHub")}
-              <LinkExternalIcon aria-hidden="true" className="size-4" />
-            </a>
+            </ExternalLink>
             {showFix ? t("orgSettings.audit.orUseFixIt") : ""}:
           </p>
           <UnenforcedDefaultsList items={driftedDetails} />
@@ -261,15 +253,13 @@ function RecommendationRow({
             ? t("orgSettings.audit.configBranchRec", { current: rec.detail })
             : t("orgSettings.audit.defaultBranchRec", { current: rec.detail })}
         </p>
-        <a
+        <ExternalLink
           href={rec.settingsUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="mt-1 inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
+          variant="muted"
+          className="mt-1 text-xs"
         >
           {t("orgSettings.audit.viewOnGitHub")}
-          <LinkExternalIcon aria-hidden="true" className="size-4" />
-        </a>
+        </ExternalLink>
       </div>
       <div className="flex shrink-0 items-center gap-2">
         {isConfigRepo && canFix && (
@@ -393,15 +383,13 @@ function AuditBody({
                   <div className="text-sm text-base-content/80">
                     {step.setting}
                   </div>
-                  <a
+                  <ExternalLink
                     href={step.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="mt-1 inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
+                    variant="muted"
+                    className="mt-1 text-xs"
                   >
                     {t("orgSettings.audit.viewOnGitHub")}
-                    <LinkExternalIcon aria-hidden="true" className="size-4" />
-                  </a>
+                  </ExternalLink>
                 </div>
                 <Badge tone="warning" className="shrink-0">
                   {t("orgSettings.audit.confirmManually")}

--- a/web/src/pages/orgSettings/TeamCreationSection.tsx
+++ b/web/src/pages/orgSettings/TeamCreationSection.tsx
@@ -1,9 +1,14 @@
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Badge, InlineSpinner, OutcomeAlert, Toggle } from "@/components/ui"
+import {
+  Badge,
+  ExternalLink,
+  InlineSpinner,
+  OutcomeAlert,
+  Toggle,
+} from "@/components/ui"
 import type { AlertOutcome } from "@/components/ui"
-import { LinkExternalIcon } from "@/components/ui/icons"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import useGetOrgPlanDetails from "@/hooks/useGetOrgPlanDetails"
 import useUpdateOrgTeamCreation from "@/hooks/mutations/useUpdateOrgTeamCreation"
@@ -55,15 +60,13 @@ const TeamCreationSection = ({
         )
       }
       action={
-        <a
+        <ExternalLink
           href={memberPrivilegesUrl(org)}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex items-center gap-1 text-xs text-base-content/70 hover:text-primary"
+          variant="muted"
+          className="text-xs"
         >
           {t("orgSettings.teamCreation.openSettings")}
-          <LinkExternalIcon aria-hidden="true" className="size-4" />
-        </a>
+        </ExternalLink>
       }
     >
       {isLoading ? (

--- a/web/src/pages/orgSettings/initStepBoard.tsx
+++ b/web/src/pages/orgSettings/initStepBoard.tsx
@@ -3,7 +3,6 @@ import {
   CheckCircleFillIcon,
   ChevronDownIcon,
   ChevronRightIcon,
-  LinkExternalIcon,
   XCircleFillIcon,
 } from "@/components/ui/icons"
 import { useEffect, useRef, useState, type ReactNode } from "react"
@@ -19,7 +18,13 @@ import {
   isOrgDefaultsStepData,
   unenforcedDefaultItems,
 } from "./orgDefaultsStepData"
-import { Badge, InlineSpinner, rtlFlip, type BadgeTone } from "@/components/ui"
+import {
+  Badge,
+  ExternalLink,
+  InlineSpinner,
+  rtlFlip,
+  type BadgeTone,
+} from "@/components/ui"
 import { CONFIG_REPO } from "@/util/configRepo"
 
 // Shared init "badge board" used by the org setup wizard (OrgSetupPage) and the
@@ -318,15 +323,13 @@ export const InitStep = ({
               </p>
               <p className="mt-1 text-base-content/70">{t(meta.remediation)}</p>
               {settingsUrl && (
-                <a
+                <ExternalLink
                   href={settingsUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="mt-2 inline-flex items-center gap-1 text-base-content/70 hover:text-primary"
+                  variant="muted"
+                  className="mt-2"
                 >
                   {t("orgSettings.steps.openGitHubSettings")}
-                  <LinkExternalIcon aria-hidden="true" className="size-4" />
-                </a>
+                </ExternalLink>
               )}
               {id === "orgDefaults" && isOrgDefaultsStepData(data) && (
                 <UnenforcedDefaultsList items={unenforcedDefaultItems(data)} />

--- a/web/src/pages/students/RosterMemberModal.tsx
+++ b/web/src/pages/students/RosterMemberModal.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import {
-  LinkExternalIcon,
   MarkGithubIcon,
   PaperAirplaneIcon,
   PersonAddIcon,
@@ -52,6 +51,7 @@ import {
   Button,
   Checkbox,
   EmphasisLtr,
+  ExternalLink,
   Modal,
   Select,
 } from "@/components/ui"
@@ -566,19 +566,17 @@ const RosterMemberModal = ({
             initials={displayInitials}
             subtitle={
               row.username ? (
-                <a
+                <ExternalLink
                   href={`https://github.com/${row.username}`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+                  variant="plain"
+                  className="gap-1.5 text-sm text-primary hover:underline"
                 >
                   <MarkGithubIcon
                     aria-hidden="true"
                     className="size-4 opacity-70"
                   />
                   <span className="font-mono">@{row.username}</span>
-                  <LinkExternalIcon aria-hidden="true" className="size-4" />
-                </a>
+                </ExternalLink>
               ) : row.email ? (
                 <span className="text-sm text-base-content/70">
                   {row.email}
@@ -837,16 +835,14 @@ const RosterMemberModal = ({
               {row.state === "enrolled" ? (
                 <div className="flex flex-col items-end gap-1">
                   {sortRolesByRank(row.roles).map((r) => (
-                    <a
+                    <ExternalLink
                       key={r}
                       href={`https://github.com/orgs/${org}/teams/${teamSlugByRole[r]}`}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="inline-flex items-center gap-1 font-mono text-sm text-primary hover:underline"
+                      variant="plain"
+                      className="font-mono text-sm text-primary hover:underline"
                     >
                       {teamSlugByRole[r]}
-                      <LinkExternalIcon aria-hidden="true" className="size-4" />
-                    </a>
+                    </ExternalLink>
                   ))}
                 </div>
               ) : (

--- a/web/src/pages/students/RosterParseProblems.tsx
+++ b/web/src/pages/students/RosterParseProblems.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { Alert, Button } from "@/components/ui"
+import { Alert, Button, ExternalLink } from "@/components/ui"
 import type { RosterCsvProblem } from "@/domain/students"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
 import { rosterPath } from "@/util/configRepoPaths"
@@ -35,19 +35,19 @@ export const RosterParseProblems = ({
             </li>
           ))}
         </ul>
-        <a
+        <ExternalLink
           href={`https://github.com/${encodeURIComponent(org)}/${CONFIG_REPO}/edit/${DEFAULT_BRANCH}/${rosterPath(
             classroom,
           )
             .split("/")
             .map(encodeURIComponent)
             .join("/")}`}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+          variant="plain"
+          className="text-sm font-medium text-primary hover:underline"
+          icon={false}
         >
           {t("students.rosterEditOnGitHub")}
-        </a>
+        </ExternalLink>
         {onRecheckRoster ? (
           <div>
             <Button

--- a/web/src/pages/submissions/ManageSubmissionModal.tsx
+++ b/web/src/pages/submissions/ManageSubmissionModal.tsx
@@ -2,7 +2,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { PeopleIcon, RepoIcon } from "@/components/ui/icons"
 
-import { Badge, Modal, MonoLtr, OutcomeAlert } from "@/components/ui"
+import {
+  Badge,
+  ExternalLink,
+  Modal,
+  MonoLtr,
+  OutcomeAlert,
+} from "@/components/ui"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import useGetRepo from "@/hooks/useGetRepo"
 import useGetRepoCollaborators from "@/hooks/useGetRepoCollaborators"
@@ -106,14 +112,13 @@ const SubmissionDetails = ({
       // Hyperlink to the latest commit when we can resolve it (somewhat
       // redundant with the commit action, but a convenient jump from the time).
       value: latestCommitHref ? (
-        <a
-          className="link link-hover"
+        <ExternalLink
+          className="link-hover"
           href={latestCommitHref}
-          target="_blank"
-          rel="noreferrer"
+          icon={false}
         >
           {pushed}
-        </a>
+        </ExternalLink>
       ) : (
         pushed
       ),
@@ -389,16 +394,15 @@ export const ManageSubmissionModal = ({
         onDismiss={() => setFeedback(null)}
       />
       {repoHref ? (
-        <a
-          className="link link-hover mt-2 inline-flex w-fit max-w-full items-center gap-1.5"
+        <ExternalLink
+          className="link-hover mt-2 w-fit max-w-full gap-1.5"
           href={repoHref}
-          target="_blank"
-          rel="noreferrer"
           title={t("submissions.table.viewRepo")}
+          icon={false}
         >
           <RepoIcon aria-hidden="true" className="size-4 shrink-0" />
           <MonoLtr className="truncate text-sm">{repo}</MonoLtr>
-        </a>
+        </ExternalLink>
       ) : (
         <p className="mt-2 inline-flex w-fit max-w-full items-center gap-1.5 text-base-content/50">
           <RepoIcon aria-hidden="true" className="size-4 shrink-0" />

--- a/web/src/pages/submissions/SubmissionsActionsMenu.tsx
+++ b/web/src/pages/submissions/SubmissionsActionsMenu.tsx
@@ -132,12 +132,6 @@ export function SubmissionsActionsMenu({
   const busy = collecting || regrading
   const disabledActions = busy || emptyRoster
 
-  const closeMenu = () => {
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur()
-    }
-  }
-
   const collectTitle = emptyRoster
     ? t("submissions.collect.titleEmptyRoster")
     : regrading
@@ -171,56 +165,35 @@ export function SubmissionsActionsMenu({
         )}
       </Button>
       <DropdownMenu className="w-64">
-        {/* Metrics — graded-snapshot stats; hidden in live view (onMetrics
+        {/* Metrics: graded-snapshot stats; hidden in live view (onMetrics
             omitted there). */}
         {onMetrics && (
-          <li>
-            <button
-              type="button"
-              onClick={() => {
-                closeMenu()
-                onMetrics()
-              }}
-            >
-              <GraphIcon aria-hidden="true" className="size-4" />
-              {t("submissions.menu.metrics")}
-            </button>
-          </li>
+          <>
+            <DropdownMenu.Item
+              icon={GraphIcon}
+              label={t("submissions.menu.metrics")}
+              onSelect={onMetrics}
+            />
+            <DropdownMenu.Separator />
+          </>
         )}
-        {onMetrics && (
-          <div
-            className="my-1 border-t border-base-content/10"
-            role="separator"
-          />
-        )}
-        {/* Open all Feedback PRs — the bulk PR action leads the menu. The page
-            owns the gate (owner-only, non-empty_repo): a no_autograder repo is
-            templated and PERMITS the PR, so no skipsGrading re-gate here. */}
+        {/* Open all Feedback PRs leads the menu. The page owns the gate
+            (owner-only, non-empty_repo): a no_autograder repo is templated and
+            PERMITS the PR, so no skipsGrading re-gate here. */}
         {onOpenAllPrs && (
           <>
-            <li>
-              <button
-                type="button"
-                disabled={disabledActions}
-                title={
-                  emptyRoster
-                    ? t("submissions.openAllPrs.titleEmptyRoster")
-                    : t("submissions.openAllPrs.title")
-                }
-                onClick={() => {
-                  closeMenu()
-                  if (disabledActions) return
-                  onOpenAllPrs()
-                }}
-              >
-                <GitPullRequestIcon aria-hidden="true" className="size-4" />
-                {t("submissions.openAllPrs.menuLabel")}
-              </button>
-            </li>
-            <div
-              className="my-1 border-t border-base-content/10"
-              role="separator"
+            <DropdownMenu.Item
+              icon={GitPullRequestIcon}
+              label={t("submissions.openAllPrs.menuLabel")}
+              disabled={disabledActions}
+              title={
+                emptyRoster
+                  ? t("submissions.openAllPrs.titleEmptyRoster")
+                  : t("submissions.openAllPrs.title")
+              }
+              onSelect={onOpenAllPrs}
             />
+            <DropdownMenu.Separator />
           </>
         )}
         {/* Collect stays for non-autograding assignments: it's org-wide and
@@ -228,337 +201,214 @@ export function SubmissionsActionsMenu({
             SubmissionsPage comment). Only grading actions hide. Omitted for a
             viewer who can't dispatch the workflow (a pull-only TA). */}
         {onCollect && (
-          <li>
-            <button
-              type="button"
-              disabled={disabledActions}
-              title={collectTitle}
-              onClick={() => {
-                closeMenu()
-                if (disabledActions) return
-                onCollect()
-              }}
-            >
-              <DownloadIcon aria-hidden="true" className="size-4" />
-              {collecting
+          <DropdownMenu.Item
+            icon={DownloadIcon}
+            label={
+              collecting
                 ? t("submissions.collect.active")
-                : t("submissions.collect.label")}
-            </button>
-          </li>
+                : t("submissions.collect.label")
+            }
+            disabled={disabledActions}
+            title={collectTitle}
+            onSelect={onCollect}
+          />
         )}
         {!skipsGrading && (
           <>
             {canRegradeAll && (
-              <li>
-                <button
-                  type="button"
-                  disabled={disabledActions}
-                  title={regradeTitle}
-                  onClick={() => {
-                    closeMenu()
-                    if (disabledActions) return
-                    onRegradeAll()
-                  }}
-                >
-                  <SyncIcon
-                    aria-hidden="true"
-                    className={`size-4 ${regradeAllActive ? "animate-spin" : ""}`}
-                  />
-                  {regradeAllActive
+              <DropdownMenu.Item
+                icon={SyncIcon}
+                iconClassName={regradeAllActive ? "animate-spin" : undefined}
+                label={
+                  regradeAllActive
                     ? t("submissions.regradeAll.active")
-                    : t("submissions.regradeAll.label")}
-                </button>
-              </li>
-            )}
-            <li>
-              <a href={viewHref} target="_blank" rel="noreferrer">
-                <LinkExternalIcon aria-hidden="true" className="size-4" />
-                {viewLabel}
-              </a>
-            </li>
-          </>
-        )}
-        <div
-          className="my-1 border-t border-base-content/10"
-          role="separator"
-        />
-        {/* Update student repo access — an authoring-tier action, grouped with
-            Lock/Unlock above the CSV export. */}
-        {onBulkAccess && (
-          <>
-            <li>
-              <button
-                type="button"
-                disabled={disabledActions}
-                title={
-                  emptyRoster
-                    ? t("submissions.bulkAccess.titleEmptyRoster")
-                    : t("submissions.bulkAccess.menuTitle")
+                    : t("submissions.regradeAll.label")
                 }
-                onClick={() => {
-                  closeMenu()
-                  if (disabledActions) return
-                  onBulkAccess()
-                }}
-              >
-                <ShieldCheckIcon aria-hidden="true" className="size-4" />
-                {t("submissions.bulkAccess.menuLabel")}
-              </button>
-            </li>
-            {onBulkFeatures && (
-              <li>
-                <button
-                  type="button"
-                  disabled={disabledActions}
-                  title={
-                    emptyRoster
-                      ? t("submissions.bulkFeatures.titleEmptyRoster")
-                      : t("submissions.bulkFeatures.menuTitle")
-                  }
-                  onClick={() => {
-                    closeMenu()
-                    if (disabledActions) return
-                    onBulkFeatures()
-                  }}
-                >
-                  <SlidersIcon aria-hidden="true" className="size-4" />
-                  {t("submissions.bulkFeatures.menuLabel")}
-                </button>
-              </li>
+                disabled={disabledActions}
+                title={regradeTitle}
+                onSelect={onRegradeAll}
+              />
             )}
-            {onBulkVisibility && (
-              <li>
-                <button
-                  type="button"
-                  disabled={disabledActions}
-                  title={
-                    emptyRoster
-                      ? t("submissions.bulkVisibility.titleEmptyRoster")
-                      : t("submissions.bulkVisibility.menuTitle")
-                  }
-                  onClick={() => {
-                    closeMenu()
-                    if (disabledActions) return
-                    onBulkVisibility()
-                  }}
-                >
-                  <GlobeIcon aria-hidden="true" className="size-4" />
-                  {t("submissions.bulkVisibility.menuLabel")}
-                </button>
-              </li>
-            )}
-            <div
-              className="my-1 border-t border-base-content/10"
-              role="separator"
+            <DropdownMenu.LinkItem
+              icon={LinkExternalIcon}
+              label={viewLabel}
+              href={viewHref}
             />
           </>
         )}
-        {/* Update autograding triggers — retrofits each repo's shim to the
+        <DropdownMenu.Separator />
+        {/* Update student repo access: an authoring-tier action, grouped with
+            Lock/Unlock above the CSV export. */}
+        {onBulkAccess && (
+          <>
+            <DropdownMenu.Item
+              icon={ShieldCheckIcon}
+              label={t("submissions.bulkAccess.menuLabel")}
+              disabled={disabledActions}
+              title={
+                emptyRoster
+                  ? t("submissions.bulkAccess.titleEmptyRoster")
+                  : t("submissions.bulkAccess.menuTitle")
+              }
+              onSelect={onBulkAccess}
+            />
+            {onBulkFeatures && (
+              <DropdownMenu.Item
+                icon={SlidersIcon}
+                label={t("submissions.bulkFeatures.menuLabel")}
+                disabled={disabledActions}
+                title={
+                  emptyRoster
+                    ? t("submissions.bulkFeatures.titleEmptyRoster")
+                    : t("submissions.bulkFeatures.menuTitle")
+                }
+                onSelect={onBulkFeatures}
+              />
+            )}
+            {onBulkVisibility && (
+              <DropdownMenu.Item
+                icon={GlobeIcon}
+                label={t("submissions.bulkVisibility.menuLabel")}
+                disabled={disabledActions}
+                title={
+                  emptyRoster
+                    ? t("submissions.bulkVisibility.titleEmptyRoster")
+                    : t("submissions.bulkVisibility.menuTitle")
+                }
+                onSelect={onBulkVisibility}
+              />
+            )}
+            <DropdownMenu.Separator />
+          </>
+        )}
+        {/* Update autograding triggers: retrofits each repo's shim to the
             assignment's submission_mode. Gated independently of bulk access
             (also requires the default autograder), but same authoring tier. */}
         {onBulkTrigger && (
           <>
-            <li>
-              <button
-                type="button"
-                disabled={disabledActions}
-                title={
-                  emptyRoster
-                    ? t("submissions.bulkTrigger.titleEmptyRoster")
-                    : t("submissions.bulkTrigger.menuTitle")
-                }
-                onClick={() => {
-                  closeMenu()
-                  if (disabledActions) return
-                  onBulkTrigger()
-                }}
-              >
-                <GitBranchIcon aria-hidden="true" className="size-4" />
-                {t("submissions.bulkTrigger.menuLabel")}
-              </button>
-            </li>
-            <div
-              className="my-1 border-t border-base-content/10"
-              role="separator"
+            <DropdownMenu.Item
+              icon={GitBranchIcon}
+              label={t("submissions.bulkTrigger.menuLabel")}
+              disabled={disabledActions}
+              title={
+                emptyRoster
+                  ? t("submissions.bulkTrigger.titleEmptyRoster")
+                  : t("submissions.bulkTrigger.menuTitle")
+              }
+              onSelect={onBulkTrigger}
             />
+            <DropdownMenu.Separator />
           </>
         )}
-        {/* Pause / Resume autograding — disables/enables each repo's autograde
+        {/* Pause / Resume autograding: disables/enables each repo's autograde
             workflow via the GitHub Actions state (no file edit). Same authoring
             tier + default-autograder gate as the trigger retrofit. */}
         {(onBulkPause || onBulkResume) && (
           <>
             {onBulkPause && (
-              <li>
-                <button
-                  type="button"
-                  disabled={disabledActions}
-                  title={
-                    emptyRoster
-                      ? t("submissions.bulkAutograde.pauseTitleEmptyRoster")
-                      : t("submissions.bulkAutograde.pauseMenuTitle")
-                  }
-                  onClick={() => {
-                    closeMenu()
-                    if (disabledActions) return
-                    onBulkPause()
-                  }}
-                >
-                  <PauseIcon aria-hidden="true" className="size-4" />
-                  {t("submissions.bulkAutograde.pauseMenuLabel")}
-                </button>
-              </li>
+              <DropdownMenu.Item
+                icon={PauseIcon}
+                label={t("submissions.bulkAutograde.pauseMenuLabel")}
+                disabled={disabledActions}
+                title={
+                  emptyRoster
+                    ? t("submissions.bulkAutograde.pauseTitleEmptyRoster")
+                    : t("submissions.bulkAutograde.pauseMenuTitle")
+                }
+                onSelect={onBulkPause}
+              />
             )}
             {onBulkResume && (
-              <li>
-                <button
-                  type="button"
-                  disabled={disabledActions}
-                  title={
-                    emptyRoster
-                      ? t("submissions.bulkAutograde.resumeTitleEmptyRoster")
-                      : t("submissions.bulkAutograde.resumeMenuTitle")
-                  }
-                  onClick={() => {
-                    closeMenu()
-                    if (disabledActions) return
-                    onBulkResume()
-                  }}
-                >
-                  <PlayIcon aria-hidden="true" className="size-4" />
-                  {t("submissions.bulkAutograde.resumeMenuLabel")}
-                </button>
-              </li>
+              <DropdownMenu.Item
+                icon={PlayIcon}
+                label={t("submissions.bulkAutograde.resumeMenuLabel")}
+                disabled={disabledActions}
+                title={
+                  emptyRoster
+                    ? t("submissions.bulkAutograde.resumeTitleEmptyRoster")
+                    : t("submissions.bulkAutograde.resumeMenuTitle")
+                }
+                onSelect={onBulkResume}
+              />
             )}
-            <div
-              className="my-1 border-t border-base-content/10"
-              role="separator"
-            />
+            <DropdownMenu.Separator />
           </>
         )}
-        {/* Close / Reopen submission — ends or reopens the submission window
+        {/* Close / Reopen submission: ends or reopens the submission window
             (blocks new accepts + sets repos read-only on close). Same
             authoring tier + per-repo bulk-access gate; independent of Lock. */}
         {onCloseToggle && (
           <>
-            <li>
-              <button
-                type="button"
-                disabled={disabledActions}
-                title={
-                  closed
-                    ? t("submissions.closeSubmission.reopenMenuTitle")
-                    : t("submissions.closeSubmission.menuTitle")
-                }
-                onClick={() => {
-                  closeMenu()
-                  if (disabledActions) return
-                  onCloseToggle()
-                }}
-              >
-                <CalendarIcon aria-hidden="true" className="size-4" />
-                {closed
+            <DropdownMenu.Item
+              icon={CalendarIcon}
+              label={
+                closed
                   ? t("submissions.closeSubmission.reopenLabel")
-                  : t("submissions.closeSubmission.menuLabel")}
-              </button>
-            </li>
-            <div
-              className="my-1 border-t border-base-content/10"
-              role="separator"
+                  : t("submissions.closeSubmission.menuLabel")
+              }
+              disabled={disabledActions}
+              title={
+                closed
+                  ? t("submissions.closeSubmission.reopenMenuTitle")
+                  : t("submissions.closeSubmission.menuTitle")
+              }
+              onSelect={onCloseToggle}
             />
+            <DropdownMenu.Separator />
           </>
         )}
-        {/* Lock / Unlock — an assignment-lifecycle action (teacher|hta), so the
+        {/* Lock / Unlock: an assignment-lifecycle action (teacher|hta), so the
             page omits onLockToggle for a viewer who can't author. Its own group,
             above the CSV export. */}
         {onLockToggle && (
           <>
-            <li>
-              <button
-                type="button"
-                disabled={lockPending}
-                title={
-                  locked
-                    ? t("submissions.lock.unlockTitle")
-                    : t("submissions.lock.lockTitle")
-                }
-                onClick={() => {
-                  closeMenu()
-                  if (lockPending) return
-                  onLockToggle()
-                }}
-              >
-                {locked ? (
-                  <UnlockIcon aria-hidden="true" className="size-4" />
-                ) : (
-                  <LockIcon aria-hidden="true" className="size-4" />
-                )}
-                {locked
+            <DropdownMenu.Item
+              icon={locked ? UnlockIcon : LockIcon}
+              label={
+                locked
                   ? t("submissions.lock.unlockLabel")
-                  : t("submissions.lock.lockLabel")}
-              </button>
-            </li>
-            <div
-              className="my-1 border-t border-base-content/10"
-              role="separator"
+                  : t("submissions.lock.lockLabel")
+              }
+              disabled={lockPending}
+              title={
+                locked
+                  ? t("submissions.lock.unlockTitle")
+                  : t("submissions.lock.lockTitle")
+              }
+              onSelect={onLockToggle}
             />
+            <DropdownMenu.Separator />
           </>
         )}
-        <li>
-          <button
-            type="button"
-            disabled={downloadDisabled}
-            onClick={() => {
-              closeMenu()
-              if (downloadDisabled) return
-              onDownloadCsv()
-            }}
-          >
-            <DownloadIcon aria-hidden="true" className="size-4" />
-            {t("submissions.downloadCsv")}
-          </button>
-        </li>
-        <li>
-          <button
-            type="button"
-            disabled={downloadAllDisabled}
-            title={
-              downloadAllDisabled
-                ? t("submissions.downloadAll.titleDisabled")
-                : t("submissions.downloadAll.title")
-            }
-            onClick={() => {
-              closeMenu()
-              if (downloadAllDisabled) return
-              onDownloadAll()
-            }}
-          >
-            <FileZipIcon aria-hidden="true" className="size-4" />
-            {t("submissions.downloadAll.menuLabel")}
-          </button>
-        </li>
-        {/* Delete assignment — destructive, so deliberately last and in its
+        <DropdownMenu.Item
+          icon={DownloadIcon}
+          label={t("submissions.downloadCsv")}
+          disabled={downloadDisabled}
+          onSelect={onDownloadCsv}
+        />
+        <DropdownMenu.Item
+          icon={FileZipIcon}
+          label={t("submissions.downloadAll.menuLabel")}
+          disabled={downloadAllDisabled}
+          title={
+            downloadAllDisabled
+              ? t("submissions.downloadAll.titleDisabled")
+              : t("submissions.downloadAll.title")
+          }
+          onSelect={onDownloadAll}
+        />
+        {/* Delete assignment: destructive, so deliberately last and in its
             own group. */}
         {onDelete && (
           <>
-            <div
-              className="my-1 border-t border-base-content/10"
-              role="separator"
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item
+              icon={TrashIcon}
+              label={t("submissions.deleteAssignment.menuLabel")}
+              title={t("submissions.deleteAssignment.menuTitle")}
+              destructive
+              onSelect={onDelete}
             />
-            <li>
-              <button
-                type="button"
-                className="text-error"
-                title={t("submissions.deleteAssignment.menuTitle")}
-                onClick={() => {
-                  closeMenu()
-                  onDelete()
-                }}
-              >
-                <TrashIcon aria-hidden="true" className="size-4" />
-                {t("submissions.deleteAssignment.menuLabel")}
-              </button>
-            </li>
           </>
         )}
       </DropdownMenu>

--- a/web/src/pages/submissions/SubmissionsRows.tsx
+++ b/web/src/pages/submissions/SubmissionsRows.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 import { getName, getDisplayName, getInitials } from "@/util/students"
 import { studentRepoUrl } from "@/util/studentRepo"
 import Avatar from "@/components/avatar"
-import { Badge, Button } from "@/components/ui"
+import { Badge, Button, ExternalLink } from "@/components/ui"
 import { nonSubmitterStatus } from "@/pages/submissions/dashboard"
 import {
   groupTeamUrl,
@@ -290,20 +290,19 @@ export const GroupMembers = ({
 
   return (
     <div className="flex flex-col gap-2">
-      <a
-        className="flex items-center gap-1.5 link link-hover w-fit font-medium"
+      <ExternalLink
+        className="link-hover w-fit gap-1.5 font-medium"
         href={repoHref}
-        target="_blank"
-        rel="noreferrer"
         title={
           labelIsRepoName ? t("submissions.table.openGroupRepo") : repoName
         }
+        icon={false}
       >
         <LabelIcon aria-hidden="true" className="size-4 shrink-0" />
         <span className={labelIsRepoName ? "font-mono text-sm" : "text-sm"}>
           {repoLabel}
         </span>
-      </a>
+      </ExternalLink>
 
       {showAvatars && (
         <div className="avatar-group -space-x-3">
@@ -683,16 +682,15 @@ export const TeamWithoutRepoRow = ({
   const cells = (
     <>
       <td>
-        <a
-          className="flex items-center gap-1.5 link link-hover w-fit font-medium"
+        <ExternalLink
+          className="link-hover w-fit gap-1.5 font-medium"
           href={groupTeamUrl(org, team.slug)}
-          target="_blank"
-          rel="noreferrer"
           title={t("submissions.table.openGroupTeam")}
+          icon={false}
         >
           <PeopleIcon aria-hidden="true" className="size-4 shrink-0" />
           <span className="text-sm">{label}</span>
-        </a>
+        </ExternalLink>
       </td>
       {/* Quarantined from the row's manage click like the other team rows. */}
       <td onClick={(event) => event.stopPropagation()}>{membersCell}</td>


### PR DESCRIPTION
## Summary

Unit A6 of the dedup map that #904 started: two "the primitive exists, adopt it" sweeps. Behavior-preserving; every existing test passes unchanged, −78 lines net.

### `ExternalLink`

`components/ui/ExternalLink.tsx` said in its own comment that it existed so the hand-written `<a target="_blank" rel="noreferrer">` sites could converge. It had one adopter and there were 73 raw anchors. This PR:

- Gives it three variants: `link` (the default, the daisyUI underlined link), `muted` (the quiet "open on GitHub" affordance beside a settings section, which was seven byte-identical copies across `orgSettings/`), and `plain` (layout, target/rel, and glyph only; the caller styles the text). It also yields its `gap-1` when a caller passes a `gap-` utility, via the existing `hasUtility`, since `cx` cannot merge Tailwind classes.
- Converts the 34 text-link sites: the `link`-class anchors, the muted settings links, and the plain styled links across `components/` and `pages/`. `GitHubLink` becomes a thin wrapper over the muted variant.
- Leaves the structural anchors as bare `<a>` on purpose: cards (`AboutDialog`), avatars (`GroupTeamMembersReadOnly`, `ClassroomStaffSection`), badges (`GroupRow`), nav items (`SidebarFooter`), the `btn`-styled anchor in `OrgSettingsPage`, the pencil button in `OrgDetailsModal`, `ClassroomCard`'s roving menu item (the audit's P7), and links inside prose (`InlineNote`, `Markdown`, `StatementSection`, `OrgRepoCreationNotice`'s `Trans` slot) where `inline-flex` would change line wrapping. Also skipped: anchors that carry `truncate` themselves, since `text-overflow` on an inline-flex box is not reliable.

Two visual normalizations worth knowing about: the trailing glyph is `size-3.5` on the primitive where a few sites used `size-4`, and `rel="noopener noreferrer"` becomes `rel="noreferrer"` (which implies noopener).

### `DropdownMenu.Item` in `SubmissionsActionsMenu` and `OrgsPage`

`DropdownMenu.Item` and `.Separator` (from #769) had 11 adopters, but `SubmissionsActionsMenu` re-implemented `closeDropdownMenu` and hand-rolled 16 `<li><button onClick={() => { closeMenu(); if (disabled) return; onX() }}>` items and 9 raw separator divs; `OrgsPage` re-implemented `closeMenu` and had two more. Both now use the primitives. Two small additions to the primitive for the two items that did not fit: `iconClassName` (the Regrade all `SyncIcon` spins while a regrade runs) and `DropdownMenu.LinkItem` (the "View run" anchor item, same row chrome, the navigation closes the menu). `SubmissionsActionsMenu` goes from 569 to 419 lines.

## Test plan

- [x] `cd web && npm run check`: tsc, eslint (0 errors, 25 warnings, unchanged), prettier, arch:validate, 5,329 node tests. Browser project run separately: 18 passed.
- [x] New `ExternalLink.test.tsx` (4): target/rel pair and glyph; glyph off; muted and plain omit the `link` class; a caller's `gap-` replaces the default rather than joining it.
- [x] `SubmissionsPage` and `OrgsPage` suites pass unchanged (they render these menus).
- [ ] Manual: open the submissions Actions menu and confirm every item still fires and closes the menu, the Regrade all icon spins during a run, and "View run" opens in a new tab; spot-check three converted links (an org settings "Open GitHub settings", the About dialog version link, a submissions row repo link) open in a new tab with the glyph.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched (web `npm run check`; no Go or Python change).
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror. n/a.
- [x] If I added or changed a CLI command or flag, I documented it in the wiki. n/a.
- [x] My commits follow Conventional Commits.
