### PR TITLE
refactor(web): share the assignment form's field wiring and label recipe

### DIFF
--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -2,7 +2,13 @@ import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ShieldCheckIcon } from "@/components/ui/icons"
 
-import { Alert, Modal, ModalIcon, Select } from "@/components/ui"
+import {
+  Alert,
+  fieldLabelClass,
+  Modal,
+  ModalIcon,
+  Select,
+} from "@/components/ui"
 import {
   BulkPhaseFooter,
   BulkProgressBlock,
@@ -162,7 +168,7 @@ export function BulkRepoAccessModal({
           ) : (
             <>
               <label className="flex flex-col gap-1.5">
-                <span className="label font-bold">
+                <span className={fieldLabelClass}>
                   {t("submissions.bulkAccess.roleLabel")}
                 </span>
                 <Select

--- a/web/src/components/modals/BulkRepoFeaturesModal.tsx
+++ b/web/src/components/modals/BulkRepoFeaturesModal.tsx
@@ -2,7 +2,13 @@ import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { SlidersIcon } from "@/components/ui/icons"
 
-import { Alert, Modal, ModalIcon, Select } from "@/components/ui"
+import {
+  Alert,
+  fieldLabelClass,
+  Modal,
+  ModalIcon,
+  Select,
+} from "@/components/ui"
 import {
   BulkPhaseFooter,
   BulkProgressBlock,
@@ -190,7 +196,7 @@ export function BulkRepoFeaturesModal({
               <div className="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2">
                 {FEATURES.map(({ key }) => (
                   <label key={key} className="flex flex-col gap-1.5">
-                    <span className="label font-bold">
+                    <span className={fieldLabelClass}>
                       {t(`assignments.form.repoFeatures.${key}.label`)}
                     </span>
                     <Select

--- a/web/src/components/modals/BulkRepoVisibilityModal.tsx
+++ b/web/src/components/modals/BulkRepoVisibilityModal.tsx
@@ -2,7 +2,13 @@ import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { GlobeIcon } from "@/components/ui/icons"
 
-import { Alert, Modal, ModalIcon, Select } from "@/components/ui"
+import {
+  Alert,
+  fieldLabelClass,
+  Modal,
+  ModalIcon,
+  Select,
+} from "@/components/ui"
 import {
   BulkPhaseFooter,
   BulkProgressBlock,
@@ -159,7 +165,7 @@ export function BulkRepoVisibilityModal({
           ) : (
             <>
               <label className="flex flex-col gap-1.5 sm:max-w-xs">
-                <span className="label font-bold">
+                <span className={fieldLabelClass}>
                   {t("submissions.bulkVisibility.choiceLabel")}
                 </span>
                 <Select

--- a/web/src/components/ui/FormField.tsx
+++ b/web/src/components/ui/FormField.tsx
@@ -75,6 +75,10 @@ type FieldRenderArgs = {
 // the `aria-describedby` target (error/help), and `invalid` so the control can
 // wire its a11y attributes; pass the field's error into `error` (a truthy value
 // switches the field into the invalid state).
+// The one bold field-label recipe, for the label FormField renders and for the
+// legends and composite-control labels that sit outside a FormField.
+export const fieldLabelClass = "label font-bold"
+
 export function FormField({
   label,
   htmlFor,
@@ -113,7 +117,7 @@ export function FormField({
   return (
     <div className={cx("flex flex-col gap-1.5", className)}>
       <div className="flex items-center gap-1.5">
-        <label htmlFor={id} className="label font-bold">
+        <label htmlFor={id} className={fieldLabelClass}>
           {label}
           {required ? (
             <span className="text-error" aria-hidden="true">

--- a/web/src/components/ui/ToggleField.tsx
+++ b/web/src/components/ui/ToggleField.tsx
@@ -1,4 +1,4 @@
-import { HelpTooltip } from "./FormField"
+import { fieldLabelClass, HelpTooltip } from "./FormField"
 import { Toggle } from "./Toggle"
 
 // A boolean toggle rendered as a DaisyUI switch with a bold label and an
@@ -31,7 +31,7 @@ export function ToggleField({
         onBlur={onBlur}
         onChange={(e) => onChange(e.target.checked)}
       />
-      <span className="label font-bold">{label}</span>
+      <span className={fieldLabelClass}>{label}</span>
       {help ? <HelpTooltip help={help} /> : null}
     </label>
   )

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -41,7 +41,7 @@ export type { ComboboxProps } from "./Combobox"
 export { Textarea } from "./Textarea"
 export type { TextareaProps } from "./Textarea"
 
-export { FormField, HelpTooltip } from "./FormField"
+export { FormField, HelpTooltip, fieldLabelClass } from "./FormField"
 export { ToggleField } from "./ToggleField"
 export type { HelpTooltipPosition } from "./FormField"
 export { Heading, headingVariantClass } from "./Heading"

--- a/web/src/pages/assignments/AdvancedRuntimeFields.tsx
+++ b/web/src/pages/assignments/AdvancedRuntimeFields.tsx
@@ -11,7 +11,13 @@ import {
 } from "@/components/ui/icons"
 import { orgRunnersQuery } from "@/github-core/queries"
 import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
-import { Button, DropdownMenu, HelpTooltip, Input } from "@/components/ui"
+import {
+  Button,
+  DropdownMenu,
+  fieldLabelClass,
+  HelpTooltip,
+  Input,
+} from "@/components/ui"
 import type { HelpTooltipPosition } from "@/components/ui"
 import {
   isKnownHostedRunnerLabel,
@@ -28,9 +34,10 @@ import {
   type RuntimeLanguage,
 } from "@/util/runtime"
 import {
+  fieldError,
   normalizeOnBlur,
-  useDebouncedValue,
   type StringField,
+  useDebouncedValue,
 } from "./formFieldHelpers"
 import type { AssignmentForm } from "./assignmentFormModel"
 
@@ -54,7 +61,7 @@ export const FieldLabel = ({
   helpPosition?: HelpTooltipPosition
 }) => (
   <div className="mb-1.5 flex items-center gap-1.5">
-    <label htmlFor={htmlFor} className="label font-bold">
+    <label htmlFor={htmlFor} className={fieldLabelClass}>
       {label}
     </label>
     {help ? <HelpTooltip help={help} position={helpPosition} /> : null}
@@ -82,7 +89,7 @@ export const LanguageVersionField = ({
   return (
     <form.Field name={fieldName}>
       {(field) => {
-        const error = field.state.meta.errors[0] as string | undefined
+        const error = fieldError(field)
         const current = field.state.value.trim()
         return (
           <div>
@@ -320,7 +327,7 @@ export const AptField = ({
     <form.Field name="runtime_apt">
       {(field) => {
         const packages = parseAptPackages(field.state.value)
-        const error = field.state.meta.errors[0] as string | undefined
+        const error = fieldError(field)
         return (
           <div className="mt-4">
             <FieldLabel

--- a/web/src/pages/assignments/AdvancedSection.tsx
+++ b/web/src/pages/assignments/AdvancedSection.tsx
@@ -1,5 +1,13 @@
 import { useTranslation } from "react-i18next"
-import { FormField, Input, Radio, Textarea, Toggle } from "@/components/ui"
+import {
+  cx,
+  fieldLabelClass,
+  FormField,
+  Input,
+  Radio,
+  Textarea,
+  Toggle,
+} from "@/components/ui"
 import { parseAllowedFiles } from "@/util/allowedFiles"
 import { parseReleaseAssets } from "@/util/releaseAssets"
 import { RUNTIME_LANGUAGES } from "@/util/runtime"
@@ -15,7 +23,11 @@ import {
   ContainerFields,
   AptField,
 } from "./AdvancedRuntimeFields"
-import { normalizeOnBlur } from "./formFieldHelpers"
+import {
+  fieldControlProps,
+  fieldError,
+  normalizeOnBlur,
+} from "./formFieldHelpers"
 import { deriveFormShape } from "./formShape"
 import { CollapsibleAdvanced } from "./sections/CollapsibleAdvanced"
 import { PASS_THRESHOLD_MAX, PASS_THRESHOLD_MIN } from "@/types/classroom"
@@ -37,7 +49,7 @@ export const AdvancedSection = ({
       <form.Field name="runtime_env">
         {(field) => (
           <fieldset className="mb-4">
-            <legend className="label font-bold mb-2">
+            <legend className={cx(fieldLabelClass, "mb-2")}>
               {t("assignments.form.runtime.envLegend")}
             </legend>
             <div className="flex flex-wrap gap-x-6 gap-y-2">
@@ -98,7 +110,7 @@ export const AdvancedSection = ({
                 <div className="mb-1.5 flex items-center gap-1.5">
                   {/* Group heading, not a form label — it has no single
                       control to point at. */}
-                  <span className="label font-bold">
+                  <span className={fieldLabelClass}>
                     {t("assignments.form.runtime.languagesHeading")}
                   </span>
                   <HelpTooltip
@@ -160,14 +172,14 @@ export const AdvancedSection = ({
                         >
                           {({ id, describedById, invalid }) => (
                             <Input
-                              id={id}
-                              name={commandField.name}
+                              {...fieldControlProps(commandField, {
+                                id,
+                                describedById,
+                                invalid,
+                              })}
                               placeholder={t(
                                 "assignments.form.setupCommandPlaceholder",
                               )}
-                              aria-describedby={describedById}
-                              invalid={invalid}
-                              value={commandField.state.value}
                               onBlur={normalizeOnBlur(commandField)}
                               onChange={(e) =>
                                 commandField.handleChange(e.target.value)
@@ -178,8 +190,7 @@ export const AdvancedSection = ({
 
                         <form.Field name="setup_timeout">
                           {(field) => {
-                            const error = field.state.meta.errors[0] as
-                              string | undefined
+                            const error = fieldError(field)
                             return (
                               <FormField
                                 htmlFor={field.name}
@@ -230,7 +241,7 @@ export const AdvancedSection = ({
               <form.Field name="allowed_files">
                 {(field) => {
                   const patterns = parseAllowedFiles(field.state.value)
-                  const error = field.state.meta.errors[0] as string | undefined
+                  const error = fieldError(field)
                   return (
                     <FormField
                       className="mt-4"
@@ -254,16 +265,15 @@ export const AdvancedSection = ({
                     >
                       {({ id, describedById, invalid }) => (
                         <Textarea
-                          id={id}
-                          name={field.name}
+                          {...fieldControlProps(field, {
+                            id,
+                            describedById,
+                            invalid,
+                          })}
                           className="font-mono"
                           rows={4}
                           spellCheck={false}
                           placeholder={"*\n!hello.py"}
-                          aria-describedby={describedById}
-                          invalid={invalid}
-                          value={field.state.value}
-                          onBlur={field.handleBlur}
                           onChange={(e) => field.handleChange(e.target.value)}
                         />
                       )}
@@ -275,7 +285,7 @@ export const AdvancedSection = ({
               <form.Field name="release_assets">
                 {(field) => {
                   const paths = parseReleaseAssets(field.state.value)
-                  const error = field.state.meta.errors[0] as string | undefined
+                  const error = fieldError(field)
                   return (
                     <FormField
                       className="mt-4"
@@ -293,18 +303,17 @@ export const AdvancedSection = ({
                     >
                       {({ id, describedById, invalid }) => (
                         <Textarea
-                          id={id}
-                          name={field.name}
+                          {...fieldControlProps(field, {
+                            id,
+                            describedById,
+                            invalid,
+                          })}
                           className="font-mono"
                           rows={3}
                           spellCheck={false}
                           placeholder={t(
                             "assignments.form.releaseAssetsPlaceholder",
                           )}
-                          aria-describedby={describedById}
-                          invalid={invalid}
-                          value={field.state.value}
-                          onBlur={field.handleBlur}
                           onChange={(event) =>
                             field.handleChange(event.target.value)
                           }
@@ -338,8 +347,7 @@ export const AdvancedSection = ({
                     {toggle.state.value && (
                       <form.Field name="pass_threshold">
                         {(field) => {
-                          const error = field.state.meta.errors[0] as
-                            string | undefined
+                          const error = fieldError(field)
                           return (
                             <div className="mt-3">
                               <div className="flex items-center gap-2">

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -14,12 +14,13 @@ import type { AssignmentForm } from "./assignmentFormModel"
 import { TeacherFilesModal } from "./TeacherFilesModal"
 
 import {
-  FormField,
-  HelpTooltip,
   Badge,
   Button,
   Collapse,
   cx,
+  fieldLabelClass,
+  FormField,
+  HelpTooltip,
   Input,
   Modal,
   Select,
@@ -189,7 +190,7 @@ const AutogradingTestModal = ({
         </FormField>
 
         <fieldset>
-          <legend className="label font-bold">
+          <legend className={fieldLabelClass}>
             {t("assignments.autograder.testType")}
           </legend>
           <div className="join w-full">
@@ -420,7 +421,7 @@ const AutogradingTestModal = ({
             {t("assignments.autograder.reportOptions")}
           </legend>
           <div className="flex items-center gap-1.5">
-            <span className="label font-bold" aria-hidden="true">
+            <span className={fieldLabelClass} aria-hidden="true">
               {t("assignments.autograder.reportOptions")}
             </span>
             <HelpTooltip
@@ -773,7 +774,7 @@ const AutogradingTestsPane = ({
                   materialized tests.json as `defaults`). Framed like the
                   table above so the two read as one tests unit. */}
               <div className="mt-4 rounded-box border border-base-300 p-4">
-                <span className="label font-bold">
+                <span className={fieldLabelClass}>
                   {t("assignments.autograder.defaults.heading")}
                 </span>
                 <p className="mt-0.5 text-sm text-base-content/70">

--- a/web/src/pages/assignments/formFieldHelpers.ts
+++ b/web/src/pages/assignments/formFieldHelpers.ts
@@ -10,6 +10,32 @@ export type StringField = {
   handleChange: (value: string) => void
 }
 
+// The first validation error, as the string FormField renders. TanStack types
+// errors as unknown[] because a validator may return anything; every validator
+// in this form returns a translated string.
+export const fieldError = (field: {
+  state: { meta: { errors: unknown[] } }
+}): string | undefined => {
+  const [first] = field.state.meta.errors
+  return first === undefined ? undefined : String(first)
+}
+
+// The props every control inside a FormField repeats: the ids FormField
+// minted, the field's name and value, and the blur that marks it touched.
+// Spread first so a caller can still override any of them (a normalizing
+// onBlur, a different value mapping).
+export const fieldControlProps = <V>(
+  field: { name: string; state: { value: V }; handleBlur: () => void },
+  args: { id: string; describedById: string | undefined; invalid: boolean },
+) => ({
+  id: args.id,
+  name: field.name,
+  "aria-describedby": args.describedById,
+  invalid: args.invalid,
+  value: field.state.value,
+  onBlur: field.handleBlur,
+})
+
 // onBlur handler that normalizes (default: trim), writing back only on change.
 export const normalizeOnBlur = (
   field: StringField,

--- a/web/src/pages/assignments/sections/DetailsSection.tsx
+++ b/web/src/pages/assignments/sections/DetailsSection.tsx
@@ -4,6 +4,8 @@ import { assignmentSlugBudget } from "@/util/repoNameBudget"
 import {
   Alert,
   Badge,
+  cx,
+  fieldLabelClass,
   FormField,
   HelpTooltip,
   Input,
@@ -19,6 +21,7 @@ import { slugBudgetError, type AssignmentForm } from "../assignmentFormModel"
 import { deriveFormShape } from "../formShape"
 import { SectionCard } from "./SectionCard"
 import useOrgTeamCreationAllowed from "@/hooks/useOrgTeamCreationAllowed"
+import { fieldControlProps, fieldError } from "../formFieldHelpers"
 
 // Assignment Details (IA overhaul U4): the assignment's identity — name, slug,
 // description, and type. Repository source, autograding, features, and schedule
@@ -74,10 +77,7 @@ export function DetailsSection({
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <form.Field name="name">
           {(field) => {
-            const nameError =
-              field.state.meta.errors.length > 0
-                ? String(field.state.meta.errors[0])
-                : undefined
+            const nameError = fieldError(field)
             return (
               <FormField
                 htmlFor={field.name}
@@ -87,15 +87,14 @@ export function DetailsSection({
               >
                 {({ id, describedById, invalid }) => (
                   <Input
-                    id={id}
-                    name={field.name}
+                    {...fieldControlProps(field, {
+                      id,
+                      describedById,
+                      invalid,
+                    })}
                     required
                     aria-required="true"
-                    invalid={invalid}
-                    aria-describedby={describedById}
                     placeholder={t("assignments.form.namePlaceholder")}
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
                     onChange={(e) => {
                       field.handleChange(e.target.value)
                       if (!edit && !slugTouched) {
@@ -120,10 +119,7 @@ export function DetailsSection({
 
         <form.Field name="slug">
           {(field) => {
-            const submitError =
-              !edit && field.state.meta.errors.length > 0
-                ? String(field.state.meta.errors[0])
-                : undefined
+            const submitError = !edit && fieldError(field)
             // Live budget + collision checks (#691) so a manual override warns
             // as-you-type rather than only at submit (which stays
             // authoritative). The auto-fill is already budget-bounded and
@@ -171,16 +167,16 @@ export function DetailsSection({
               >
                 {({ id, describedById, invalid }) => (
                   <Input
-                    id={id}
-                    name={field.name}
+                    {...fieldControlProps(field, {
+                      id,
+                      describedById,
+                      invalid,
+                    })}
                     aria-required={!edit}
                     // The slug is the assignment's repo-path identity; renaming
                     // isn't supported, so it's read-only on edit.
                     disabled={edit}
-                    invalid={invalid}
-                    aria-describedby={describedById}
                     placeholder={t("assignments.form.slugPlaceholder")}
-                    value={field.state.value}
                     onBlur={(e) => {
                       // Normalize on blur so what the teacher sees is what's
                       // saved (the repo path segment). An emptied slug falls
@@ -249,7 +245,7 @@ export function DetailsSection({
       <form.Field name="mode">
         {(field) => (
           <fieldset className="mt-4">
-            <legend className="label font-bold mb-2">
+            <legend className={cx(fieldLabelClass, "mb-2")}>
               {t("assignments.form.type")}
             </legend>
             <div className="flex flex-wrap gap-x-6 gap-y-2">
@@ -310,13 +306,10 @@ export function DetailsSection({
           showTeamFormation ? (
             <form.Field name="team_formation">
               {(field) => {
-                const formationError =
-                  field.state.meta.errors.length > 0
-                    ? String(field.state.meta.errors[0])
-                    : undefined
+                const formationError = fieldError(field)
                 return (
                   <fieldset className="mt-4 border-s-2 border-base-300 ps-4">
-                    <legend className="label font-bold mb-2">
+                    <legend className={cx(fieldLabelClass, "mb-2")}>
                       {t("assignments.form.teamFormation")}
                     </legend>
                     <div className="flex flex-col gap-2">

--- a/web/src/pages/assignments/sections/RepositorySetupSection.tsx
+++ b/web/src/pages/assignments/sections/RepositorySetupSection.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   cx,
   ExternalLink,
+  fieldLabelClass,
   FormField,
   Radio,
   Select,
@@ -81,7 +82,7 @@ export function RepositorySetupSection({
           <form.Field name="repo_source">
             {(field) => (
               <fieldset>
-                <legend className="label font-bold mb-2">
+                <legend className={cx(fieldLabelClass, "mb-2")}>
                   {t("assignments.form.repoSource.label")}
                 </legend>
                 <div className="flex flex-col gap-2">

--- a/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
+++ b/web/src/pages/assignments/sections/SubmissionGradingSection.tsx
@@ -7,6 +7,7 @@ import { deriveFormShape } from "../formShape"
 import { SectionCard } from "./SectionCard"
 import { SubmissionsSubsection } from "./SubmissionsSubsection"
 import { AutograderConfig } from "./AutograderConfig"
+import { fieldControlProps, fieldError } from "../formFieldHelpers"
 
 // Submission and Grading: what counts as a submission (the Submissions
 // subsection — shown first, since grading is downstream of it), how the
@@ -176,7 +177,7 @@ function ManualMaxPointsField({ form }: { form: AssignmentForm }) {
   return (
     <form.Field name="grading_max_points">
       {(field) => {
-        const error = field.state.meta.errors[0] as string | undefined
+        const error = fieldError(field)
         return (
           <FormField
             htmlFor={field.name}
@@ -186,17 +187,12 @@ function ManualMaxPointsField({ form }: { form: AssignmentForm }) {
           >
             {({ id, describedById, invalid }) => (
               <Input
-                id={id}
-                name={field.name}
+                {...fieldControlProps(field, { id, describedById, invalid })}
                 type="number"
                 inputMode="numeric"
                 min={GRADING_MAX_POINTS_MIN}
                 step={1}
                 className="w-28"
-                aria-describedby={describedById}
-                invalid={invalid}
-                value={field.state.value}
-                onBlur={field.handleBlur}
                 onChange={(e) => field.handleChange(Number(e.target.value))}
               />
             )}

--- a/web/src/pages/assignments/sections/SubmissionsSubsection.tsx
+++ b/web/src/pages/assignments/sections/SubmissionsSubsection.tsx
@@ -5,6 +5,7 @@ import {
   validateSubmissionTags,
 } from "@/util/submissionTags"
 import type { AssignmentForm } from "../assignmentFormModel"
+import { fieldControlProps, fieldError } from "../formFieldHelpers"
 
 // Submissions: the single source of truth for what counts as a submission.
 //
@@ -134,7 +135,7 @@ function SubmissionTagsField({
   return (
     <form.Field name="submission_tags">
       {(field) => {
-        const error = field.state.meta.errors[0] as string | undefined
+        const error = fieldError(field)
         return (
           <div>
             <FormField
@@ -145,16 +146,11 @@ function SubmissionTagsField({
             >
               {({ id, describedById, invalid }) => (
                 <Textarea
-                  id={id}
-                  name={field.name}
+                  {...fieldControlProps(field, { id, describedById, invalid })}
                   className="font-mono w-full sm:max-w-xs"
                   rows={3}
                   spellCheck={false}
                   placeholder={"phase1\nphase2\ncomplete"}
-                  aria-describedby={describedById}
-                  invalid={invalid}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
                   onChange={(e) => field.handleChange(e.target.value)}
                 />
               )}


### PR DESCRIPTION
## Summary

Unit A7 of the dedup map that #904 started, scoped to `pages/assignments/` plus one class string that leaked into `components/`. Behavior-preserving; every existing test passes unchanged.

### Field wiring

Each TanStack `form.Field` in the assignment form did the same two things by hand: pulled the first validation error with `field.state.meta.errors[0] as string | undefined` (or the three-line `length > 0 ? String(...) : undefined` variant), and wired the control with `id={id} name={field.name} aria-describedby={describedById} invalid={invalid} value={field.state.value} onBlur={field.handleBlur}`. `formFieldHelpers.ts` (which already owned `normalizeOnBlur`) gains:

- `fieldError(field)`: the first error as a string, or undefined. 14 sites.
- `fieldControlProps(field, { id, describedById, invalid })`: the six-prop spread. It is spread first, so the two fields with a normalizing `onBlur` (`AdvancedSection`'s setup command, `DetailsSection`'s slug) keep theirs by listing it after. 11 sites.

Controls that map their value or use a differently named field variable (`readmeField`, `branchesField`, the `Combobox` in `TemplateRepoPicker`) were left as they are rather than forced to fit.

### `fieldLabelClass`

`"label font-bold"` was spelled in ten places: `ui/FormField`, `ui/ToggleField`, three bulk modals, and five legends and composite labels in the form. AGENTS.md's "one recipe, one source" rule applies, so `FormField` exports `fieldLabelClass` and every site uses it (`cx(fieldLabelClass, "mb-2")` where a margin was appended). `AdvancedRuntimeFields.FieldLabel` stays as its own component; its comment explains why composite controls cannot use `FormField`, and it now spells the class once through the constant.

## Test plan

- [x] `cd web && npm run check`: tsc, eslint (0 errors, 25 warnings, unchanged), prettier, arch:validate, 5,329 node tests. Browser project run separately: 18 passed.
- [x] The 18 test files under `pages/assignments/` (407 tests, covering every section and the form model) pass unchanged.
- [ ] Manual: open the assignment form, leave the name blank and confirm the error renders under the field and the input is marked invalid; blur the slug and setup-command fields with surrounding whitespace and confirm they normalize.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched (web `npm run check`; no Go or Python change).
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror. n/a.
- [x] If I added or changed a CLI command or flag, I documented it in the wiki. n/a.
- [x] My commits follow Conventional Commits.
