### PR TITLE
test(web): let the src/** scanners skip the boundary tests' probe dirs

### DIFF
--- a/web/src/test/walkSource.ts
+++ b/web/src/test/walkSource.ts
@@ -1,0 +1,57 @@
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import path from "node:path"
+
+// Source-tree walk for the guard tests that scan src/** (contrast tiers, VPAT
+// architectural claims, config-repo path templates). Two things every scanner
+// needs and none should hand-roll:
+//
+// - Skip the `__*_probe_*` directories the boundary tests (eslintBoundaries,
+//   dependencyCruiser, noCycleGuard, authz/boundaryGuard) create and delete
+//   under src/ while they run. Vitest shards run in parallel, so a scanner in
+//   one shard can list a probe file that a prober in another shard removes
+//   before the read; that race was a CI-only ENOENT.
+// - Tolerate a file vanishing between the listing and the read for the same
+//   reason: a missing file is not a scan finding.
+const PROBE_DIR = /^__\w+_probe_/
+
+export function walkSourceFiles(
+  root: string,
+  match: (name: string) => boolean,
+): string[] {
+  const out: string[] = []
+  const visit = (dir: string) => {
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      return
+    }
+    for (const name of entries) {
+      if (PROBE_DIR.test(name)) continue
+      const full = path.join(dir, name)
+      let isDir: boolean
+      try {
+        isDir = statSync(full).isDirectory()
+      } catch {
+        continue
+      }
+      if (isDir) visit(full)
+      else if (match(name)) out.push(full)
+    }
+  }
+  visit(root)
+  return out
+}
+
+// The file's text, or null if it vanished after the walk listed it.
+export function readSourceFile(file: string): string | null {
+  try {
+    return readFileSync(file, "utf8")
+  } catch {
+    return null
+  }
+}
+
+// The common case: non-test TypeScript sources.
+export const isSourceTs = (name: string) =>
+  /\.tsx?$/.test(name) && !/\.test\.tsx?$/.test(name)

--- a/web/src/util/a11y/contrastSource.test.ts
+++ b/web/src/util/a11y/contrastSource.test.ts
@@ -1,8 +1,10 @@
-import { readdirSync, readFileSync, statSync } from "node:fs"
+import { readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import path from "node:path"
 
 import { describe, expect, it } from "vitest"
+
+import { isSourceTs, readSourceFile, walkSourceFiles } from "@/test/walkSource"
 
 import {
   DARK,
@@ -117,20 +119,9 @@ function usedTiers(prefix: string): Set<number> {
   const out = new Set<number>()
   // Match `text-base-content/40` as written in JSX className strings.
   const re = new RegExp(`${prefix}/(\\d+)`, "g")
-  const srcDir = path.join(repoWeb, "src")
-  const walk = (dir: string): string[] => {
-    const entries = readdirSync(dir)
-    const files: string[] = []
-    for (const e of entries) {
-      const full = path.join(dir, e)
-      if (statSync(full).isDirectory()) files.push(...walk(full))
-      else if (e.endsWith(".tsx") || e.endsWith(".ts")) files.push(full)
-    }
-    return files
-  }
-  for (const file of walk(srcDir)) {
-    if (file.endsWith(".test.ts") || file.endsWith(".test.tsx")) continue
-    const text = readFileSync(file, "utf8")
+  for (const file of walkSourceFiles(path.join(repoWeb, "src"), isSourceTs)) {
+    const text = readSourceFile(file)
+    if (text === null) continue
     let m: RegExpExecArray | null
     while ((m = re.exec(text)) !== null) out.add(parseInt(m[1], 10))
   }
@@ -172,19 +163,9 @@ function usedTextSemantics(): Set<string> {
   // `text-error` / `text-primary`, but NOT `text-error-content`, `text-primary/40`,
   // or a longer word like `text-primaryish` (word-boundary the tail).
   const re = new RegExp(`text-(${names})(?![\\w/-])`, "g")
-  const srcDir = path.join(repoWeb, "src")
-  const walk = (dir: string): string[] => {
-    const files: string[] = []
-    for (const e of readdirSync(dir)) {
-      const full = path.join(dir, e)
-      if (statSync(full).isDirectory()) files.push(...walk(full))
-      else if (e.endsWith(".tsx") || e.endsWith(".ts")) files.push(full)
-    }
-    return files
-  }
-  for (const file of walk(srcDir)) {
-    if (file.endsWith(".test.ts") || file.endsWith(".test.tsx")) continue
-    const text = readFileSync(file, "utf8")
+  for (const file of walkSourceFiles(path.join(repoWeb, "src"), isSourceTs)) {
+    const text = readSourceFile(file)
+    if (text === null) continue
     let m: RegExpExecArray | null
     while ((m = re.exec(text)) !== null) out.add(m[1])
   }

--- a/web/src/util/a11y/vpatArchitectural.test.ts
+++ b/web/src/util/a11y/vpatArchitectural.test.ts
@@ -1,8 +1,9 @@
-import { readdirSync, readFileSync, statSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import path from "node:path"
 
 import { describe, expect, it } from "vitest"
+
+import { readSourceFile, walkSourceFiles } from "@/test/walkSource"
 
 import { CRITERIA } from "./vpatModel"
 
@@ -15,24 +16,15 @@ import { CRITERIA } from "./vpatModel"
 const here = path.dirname(fileURLToPath(import.meta.url))
 const srcRoot = path.resolve(here, "..", "..")
 
-function walk(dir: string, out: string[] = []): string[] {
-  for (const name of readdirSync(dir)) {
-    const full = path.join(dir, name)
-    if (statSync(full).isDirectory()) walk(full, out)
-    else if (/\.(tsx?|css|html)$/.test(name) && !/\.test\./.test(name))
-      out.push(full)
-  }
-  return out
-}
-
 // The a11y model itself and the /assess guidance name these tokens in prose.
-const files = walk(srcRoot).filter(
-  (f) => !f.includes(`${path.sep}a11y${path.sep}`),
-)
-const sources = files.map((f) => ({
-  file: path.relative(srcRoot, f),
-  text: readFileSync(f, "utf8"),
-}))
+const files = walkSourceFiles(
+  srcRoot,
+  (name) => /\.(tsx?|css|html)$/.test(name) && !/\.test\./.test(name),
+).filter((f) => !f.includes(`${path.sep}a11y${path.sep}`))
+const sources = files.flatMap((f) => {
+  const text = readSourceFile(f)
+  return text === null ? [] : [{ file: path.relative(srcRoot, f), text }]
+})
 
 const hits = (re: RegExp) =>
   sources.filter((s) => re.test(s.text)).map((s) => s.file)

--- a/web/src/util/configRepoPaths.test.ts
+++ b/web/src/util/configRepoPaths.test.ts
@@ -1,6 +1,7 @@
-import { readdirSync, readFileSync, statSync } from "node:fs"
 import { join, relative } from "node:path"
 import { describe, expect, it } from "vitest"
+
+import { isSourceTs, readSourceFile, walkSourceFiles } from "@/test/walkSource"
 import {
   assignmentsFilePath,
   classroomFilePath,
@@ -31,21 +32,13 @@ describe("config-repo file paths", () => {
     const template =
       /`\$\{[^}]+\}\/(assignments\.json|classroom\.json|scores\.json|teams\.json|roster\.csv)`/
     const offenders: string[] = []
-    const walk = (dir: string) => {
-      for (const name of readdirSync(dir)) {
-        const full = join(dir, name)
-        if (statSync(full).isDirectory()) {
-          walk(full)
-          continue
-        }
-        if (!/\.(ts|tsx)$/.test(name) || /\.test\.tsx?$/.test(name)) continue
-        if (full.endsWith("configRepoPaths.ts")) continue
-        if (template.test(readFileSync(full, "utf8"))) {
-          offenders.push(relative(srcRoot, full))
-        }
+    for (const full of walkSourceFiles(srcRoot, isSourceTs)) {
+      if (full.endsWith("configRepoPaths.ts")) continue
+      const text = readSourceFile(full)
+      if (text !== null && template.test(text)) {
+        offenders.push(relative(srcRoot, full))
       }
     }
-    walk(srcRoot)
     expect(offenders).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

Fixes a CI-only flake, seen on #911's node shard 4 and once locally during #908:

```
FAIL src/util/a11y/contrastSource.test.ts > text-neutral-content/NN tiers are all audited
Error: ENOENT: no such file or directory, open '.../src/components/__boundaries_probe_s7JHDo/compDownward.ts'
```

Four guard tests (`eslintBoundaries`, `dependencyCruiser`, `github-core/noCycleGuard`, `authz/boundaryGuard`) create temporary `__*_probe_*` directories inside `src/` and delete them when done. Three other tests (`contrastSource`, `vpatArchitectural`, `configRepoPaths`) walk `src/**` reading every source file. Vitest shards run in parallel, so a walker in one shard can list a probe file that a prober in another shard removes before the read.

`src/test/walkSource.ts` is one walker for the scanners: it skips any `__*_probe_*` directory and treats a file that vanishes between listing and read as absent rather than an error. The three scanners adopt it, which also removes three hand-rolled `readdirSync`/`statSync` recursions.

Nothing about what the scanners check changes; only what they skip.

## Test plan

- [x] `cd web && npm run check`: 5,325 node tests pass; the three scanners and the four probers run green together in one invocation.
- [x] `npx vitest run` on the seven files alone, repeatedly, no ENOENT.
- [ ] CI shard 4 on the next PR that lands on top of this stays green (this is the one that failed).

## Type of change

- [x] Refactor / maintenance (test infrastructure)

## Checklist

- [x] I built, tested, and linted the module(s) I touched (web `npm run check`).
- [x] Cross-binary contract: n/a.
- [x] CLI docs: n/a.
- [x] My commits follow Conventional Commits.
