### PR TITLE
refactor(web): share the table error row, the list search rule, and the split button

### DIFF
--- a/web/src/components/ui/SplitButton.tsx
+++ b/web/src/components/ui/SplitButton.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react"
+
+import { Button } from "./Button"
+import { DropdownMenu } from "./DropdownMenu"
+import { TriangleDownIcon } from "./icons"
+
+// A primary action with a caret that opens secondary actions beside it (the
+// "New assignment ▾" and "Upload roster ▾" toolbar controls). The caller
+// renders the primary control (a Button or RouterButton with `join-item`) and
+// the menu items; this owns the join chrome, the caret button, and the menu.
+//
+// The caret's wrapper is deliberately NOT a join-item: daisyUI's join rounds
+// its direct children, and the dropdown wrapper would take the rounding instead
+// of the caret button inside it. The negative margin closes the 1px seam that
+// leaves, and the inset border draws the divider the join would have drawn.
+export function SplitButton({
+  primary,
+  caretLabel,
+  disabled = false,
+  size = "sm",
+  children,
+}: {
+  primary: ReactNode
+  caretLabel: string
+  disabled?: boolean
+  size?: "sm" | "md"
+  children: ReactNode
+}) {
+  return (
+    <div className="join">
+      {primary}
+      <div className="dropdown dropdown-end -ms-px">
+        <Button
+          variant="primary"
+          size={size}
+          tabIndex={0}
+          disabled={disabled}
+          className="join-item h-full border-s border-primary-content/20 px-2"
+          aria-label={caretLabel}
+        >
+          <TriangleDownIcon aria-hidden="true" className="size-4" />
+        </Button>
+        <DropdownMenu className="w-max">{children}</DropdownMenu>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/ui/TableShell.tsx
+++ b/web/src/components/ui/TableShell.tsx
@@ -1,7 +1,9 @@
 import type { ReactNode } from "react"
 
 import { EnterDiv } from "@/lib/motionComponents"
+import { Button } from "./Button"
 import { SkeletonCell } from "./SkeletonCell"
+import { AlertIcon } from "./icons"
 import { cx } from "./cx"
 
 // The one table frame for the assignment/submission lists: a scrollable
@@ -97,6 +99,43 @@ export function SkeletonRows({
         </tr>
       ))}
     </>
+  )
+}
+
+// The one "the list failed to load" row: an alert line and a ghost Retry,
+// spanning the table. Announced via role="alert" because it replaces the rows
+// the reader was about to hear.
+export function TableErrorRow({
+  colSpan,
+  message,
+  retryLabel,
+  onRetry,
+}: {
+  colSpan: number
+  message: ReactNode
+  retryLabel: ReactNode
+  // Optional so a caller that has no way to retry can still show the alert.
+  onRetry?: () => void
+}) {
+  return (
+    <tr>
+      <td colSpan={colSpan} className="px-6 py-10 text-center">
+        <span
+          role="alert"
+          className="inline-flex items-center gap-2 text-sm text-error"
+        >
+          <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
+          {message}
+        </span>
+        {onRetry && (
+          <div className="mt-3">
+            <Button variant="ghost" size="sm" onClick={onRetry}>
+              {retryLabel}
+            </Button>
+          </div>
+        )}
+      </td>
+    </tr>
   )
 }
 

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -97,7 +97,7 @@ export type {
 export { SkeletonCell } from "./SkeletonCell"
 export type { SkeletonCellProps } from "./SkeletonCell"
 
-export { TableShell, SkeletonRows } from "./TableShell"
+export { SkeletonRows, TableErrorRow, TableShell } from "./TableShell"
 export type { TableShellProps } from "./TableShell"
 
 export { TablePagination } from "./TablePagination"
@@ -130,3 +130,4 @@ export { hasUtility } from "./cx"
 
 export { rtlFlip } from "./icons"
 export { ActionListRow } from "./ActionListRow"
+export { SplitButton } from "./SplitButton"

--- a/web/src/pages/AssignmentsPage.tsx
+++ b/web/src/pages/AssignmentsPage.tsx
@@ -1,5 +1,5 @@
 import { Link, useParams } from "@tanstack/react-router"
-import { TriangleDownIcon, CopyIcon, PlusIcon } from "@/components/ui/icons"
+import { CopyIcon, PlusIcon } from "@/components/ui/icons"
 import { useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 
@@ -18,10 +18,10 @@ import {
 } from "@/pages/assignments/assignmentList"
 import {
   Badge,
-  Button,
   DropdownMenu,
   EmphasisLtr,
   RouterButton,
+  SplitButton,
 } from "@/components/ui"
 import {
   NoSearchResults,
@@ -68,46 +68,27 @@ const NewAssignmentButton = ({
 
   return (
     <>
-      <div className="join">
-        <RouterButton
-          to="/$org/$classroom/assignments/new"
-          params={{ org, classroom }}
-          variant="primary"
-          size="sm"
-          className="join-item"
-        >
-          <PlusIcon aria-hidden="true" className="size-4" />{" "}
-          {t("assignments.newButton.assignment")}
-        </RouterButton>
-        {/* Not a join-item: see NewClassroomButton in ClassesPage.tsx. */}
-        <div className="dropdown dropdown-end -ms-px">
-          <Button
+      <SplitButton
+        caretLabel={t("assignments.newButton.moreOptions")}
+        primary={
+          <RouterButton
+            to="/$org/$classroom/assignments/new"
+            params={{ org, classroom }}
             variant="primary"
             size="sm"
-            tabIndex={0}
-            className="join-item h-full border-s border-primary-content/20 px-2"
-            aria-label={t("assignments.newButton.moreOptions")}
+            className="join-item"
           >
-            <TriangleDownIcon aria-hidden="true" className="size-4" />
-          </Button>
-          <DropdownMenu className="w-max">
-            <li>
-              <button
-                type="button"
-                onClick={() => {
-                  // Close the dropdown before opening the modal so focus
-                  // doesn't fight the dialog.
-                  ;(document.activeElement as HTMLElement | null)?.blur()
-                  setReuseOpen(true)
-                }}
-              >
-                <CopyIcon aria-hidden="true" className="size-4" />{" "}
-                {t("assignments.newButton.reuse")}
-              </button>
-            </li>
-          </DropdownMenu>
-        </div>
-      </div>
+            <PlusIcon aria-hidden="true" className="size-4" />{" "}
+            {t("assignments.newButton.assignment")}
+          </RouterButton>
+        }
+      >
+        <DropdownMenu.Item
+          icon={CopyIcon}
+          label={t("assignments.newButton.reuse")}
+          onSelect={() => setReuseOpen(true)}
+        />
+      </SplitButton>
 
       {reuseOpen ? (
         <ReuseFromClassroomModal

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -3,7 +3,6 @@ import { EmptyState } from "@/components/list"
 import { Trans, useTranslation } from "react-i18next"
 import { useParams } from "@tanstack/react-router"
 import {
-  AlertIcon,
   ChevronRightIcon,
   FilterIcon,
   LinkExternalIcon,
@@ -15,13 +14,14 @@ import {
   AnimatedAlert,
   Button,
   Checkbox,
+  rtlFlip,
   SelectAllCheckbox,
   SelectSeparatorOption,
   SkeletonRows,
   SortableTh,
+  TableErrorRow,
   TableShell,
   Toolbar,
-  rtlFlip,
 } from "@/components/ui"
 import PageShell from "@/components/PageShell"
 import PageHeader, { OrgLink } from "@/components/PageHeader"
@@ -59,6 +59,7 @@ import {
   runInviteMember,
 } from "@/pages/orgMembers/memberPresentation"
 import useGetClasses from "@/hooks/useGetClasses"
+import { matchesQuery } from "@/util/textMatch"
 
 // Sentinel classroom-filter value for "members on no roster". A real classroom
 // path can't collide (paths don't contain a leading colon).
@@ -179,15 +180,9 @@ const OrgMembersPage = () => {
     (Boolean(row.github_id) && ownerIds.has(row.github_id)) || isSelf(row)
 
   const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase()
     const base = filterOrgMemberRows(
       rows.filter((row) => {
-        if (
-          q &&
-          ![row.username, row.name, row.email].some((field) =>
-            field.toLowerCase().includes(q),
-          )
-        ) {
+        if (!matchesQuery(query, row.username, row.name, row.email)) {
           return false
         }
         // Classroom filter: all / no-classroom / a specific classroom.
@@ -522,32 +517,12 @@ const OrgMembersPage = () => {
               >
                 {isLoading && <SkeletonRows rows={6} bars={SKELETON_BARS} />}
                 {!isLoading && isError && (
-                  <tr>
-                    <td
-                      colSpan={MEMBERS_COL_COUNT}
-                      className="px-6 py-10 text-center"
-                    >
-                      <span
-                        role="alert"
-                        className="inline-flex items-center gap-2 text-sm text-error"
-                      >
-                        <AlertIcon
-                          aria-hidden="true"
-                          className="size-4 shrink-0"
-                        />
-                        {t("orgMembers.loadError")}
-                      </span>
-                      <div className="mt-3">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={refetchMembers}
-                        >
-                          {t("orgMembers.retry")}
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
+                  <TableErrorRow
+                    colSpan={MEMBERS_COL_COUNT}
+                    message={t("orgMembers.loadError")}
+                    retryLabel={t("orgMembers.retry")}
+                    onRetry={refetchMembers}
+                  />
                 )}
                 {!isLoading && !isError && filtered.length === 0 && (
                   <tr>

--- a/web/src/pages/accessibility/VpatSection.tsx
+++ b/web/src/pages/accessibility/VpatSection.tsx
@@ -25,6 +25,7 @@ import {
   tabClass,
   useVpatReport,
 } from "./data"
+import { matchesQuery } from "@/util/textMatch"
 
 type VpatFilter = ConformanceLevel | "all"
 type VpatSort = "criterion" | "status"
@@ -263,16 +264,11 @@ export function VpatSection() {
 
   const visibleCriteria = useMemo(() => {
     if (!vpat) return []
-    const q = query.trim().toLowerCase()
-    const filtered = vpat.criteria.filter((c) => {
-      if (filter !== "all" && c.status !== filter) return false
-      if (!q) return true
-      return (
-        c.id.toLowerCase().includes(q) ||
-        c.name.toLowerCase().includes(q) ||
-        c.remark.toLowerCase().includes(q)
-      )
-    })
+    const filtered = vpat.criteria.filter(
+      (c) =>
+        (filter === "all" || c.status === filter) &&
+        matchesQuery(query, c.id, c.name, c.remark),
+    )
     if (sort === "status") {
       return [...filtered].sort(
         (a, b) => STATUS_SORT_WEIGHT[a.status] - STATUS_SORT_WEIGHT[b.status],

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -42,12 +42,13 @@ import {
   Badge,
   Button,
   Checkbox,
-  MetricCount,
   MetricBar,
+  MetricCount,
   RouterButton,
   SelectAllCheckbox,
   SkeletonRows,
   SortableTh,
+  TableErrorRow,
   TableShell,
 } from "@/components/ui"
 
@@ -340,25 +341,12 @@ const AssignmentsTable = ({
         >
           {loading && <SkeletonRows bars={SKELETON_BARS} />}
           {!loading && loadError && (
-            <tr>
-              <td
-                colSpan={selectable ? DATA_COLUMNS + 1 : DATA_COLUMNS}
-                className="px-6 py-10 text-center"
-              >
-                <span
-                  role="alert"
-                  className="inline-flex items-center gap-2 text-sm text-error"
-                >
-                  <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
-                  {t("assignments.table.loadError")}
-                </span>
-                <div className="mt-3">
-                  <Button variant="ghost" size="sm" onClick={onRetryLoad}>
-                    {t("assignments.table.retry")}
-                  </Button>
-                </div>
-              </td>
-            </tr>
+            <TableErrorRow
+              colSpan={selectable ? DATA_COLUMNS + 1 : DATA_COLUMNS}
+              message={t("assignments.table.loadError")}
+              retryLabel={t("assignments.table.retry")}
+              onRetry={onRetryLoad}
+            />
           )}
           {!loading && !loadError && !assignments?.length && (
             <tr>

--- a/web/src/pages/assignments/assignmentList.ts
+++ b/web/src/pages/assignments/assignmentList.ts
@@ -4,6 +4,7 @@
 
 import type { Assignment } from "@/types/classroom"
 import { dueDeadlineInstant } from "@/util/formatDate"
+import { matchesQuery } from "@/util/textMatch"
 
 export type AssignmentSort =
   "name-asc" | "name-desc" | "due-asc" | "due-desc" | "type"
@@ -30,14 +31,8 @@ export const DEFAULT_FILTERS: AssignmentFilters = {
 const dueInstant = (assignment: Assignment): Date | null =>
   assignment.due ? dueDeadlineInstant(assignment.due) : null
 
-const matchesQuery = (assignment: Assignment, query: string): boolean => {
-  const q = query.trim().toLowerCase()
-  if (!q) return true
-  return (
-    assignment.name.toLowerCase().includes(q) ||
-    assignment.slug.toLowerCase().includes(q)
-  )
-}
+const matchesAssignment = (assignment: Assignment, query: string): boolean =>
+  matchesQuery(query, assignment.name, assignment.slug)
 
 const matchesFilters = (
   assignment: Assignment,
@@ -120,7 +115,7 @@ export function filterAndSortAssignments(
   },
 ): Assignment[] {
   const filtered = assignments.filter(
-    (a) => matchesQuery(a, query) && matchesFilters(a, filters, now),
+    (a) => matchesAssignment(a, query) && matchesFilters(a, filters, now),
   )
   return sortAssignments(filtered, sort)
 }

--- a/web/src/pages/classes/ClassroomList.tsx
+++ b/web/src/pages/classes/ClassroomList.tsx
@@ -28,6 +28,7 @@ import {
 import { useListPrefsState } from "@/lib/listPrefs"
 import { ClassroomCard, ClassroomRow } from "@/pages/classes/ClassroomCard"
 import { StudentCountProbes } from "@/pages/classes/StudentCountProbes"
+import { matchesQuery, normalizeQuery } from "@/util/textMatch"
 
 type ClassFilter = "active" | "archived" | "all"
 
@@ -89,7 +90,6 @@ const ClassroomList = ({
   const activeTerm =
     termFilter !== "all" && !terms.includes(termFilter) ? "all" : termFilter
 
-  const query = search.trim().toLowerCase()
   const filtered = useMemo(
     () =>
       summaries.filter((s) => {
@@ -98,14 +98,9 @@ const ClassroomList = ({
         if (filter === "archived" && !s.archived) return false
         if (activeTerm !== "all" && (s.term?.trim() ?? "") !== activeTerm)
           return false
-        if (!query) return true
-        return (
-          classroomDisplayName(s).toLowerCase().includes(query) ||
-          s.path.toLowerCase().includes(query) ||
-          (s.term ?? "").toLowerCase().includes(query)
-        )
+        return matchesQuery(search, classroomDisplayName(s), s.path, s.term)
       }),
-    [summaries, filter, activeTerm, query],
+    [summaries, filter, activeTerm, search],
   )
 
   const sorted = useMemo(() => {
@@ -151,8 +146,10 @@ const ClassroomList = ({
   }, [])
 
   const anyResolved = summaries.some((s) => !s.loading)
-  const noResults = anyResolved && query.length > 0 && sorted.length === 0
-  const emptyFilter = anyResolved && query.length === 0 && sorted.length === 0
+  const noResults =
+    anyResolved && normalizeQuery(search).length > 0 && sorted.length === 0
+  const emptyFilter =
+    anyResolved && normalizeQuery(search).length === 0 && sorted.length === 0
 
   return (
     <div className="space-y-4">

--- a/web/src/pages/classes/StudentClassroomList.tsx
+++ b/web/src/pages/classes/StudentClassroomList.tsx
@@ -31,6 +31,7 @@ import {
   type StudentClassroomSortKey,
 } from "@/lib/studentClassroomListPrefs"
 import type { StudentClassroomSummary } from "@/hooks/useStudentClassroomSummaries"
+import { matchesQuery, normalizeQuery } from "@/util/textMatch"
 
 const SORT_OPTIONS: { key: StudentClassroomSortKey; labelKey: string }[] = [
   { key: "name-asc", labelKey: "classes.student.toolbar.sort.nameAsc" },
@@ -169,17 +170,10 @@ export function StudentClassroomList({
     studentClassroomListPrefs,
   )
   const [search, setSearch] = useState("")
-  const query = search.trim().toLowerCase()
-
   const filtered = useMemo(() => {
-    const list = summaries.filter((s) => {
-      if (!query) return true
-      return (
-        classroomTitle(s).toLowerCase().includes(query) ||
-        s.classroom.toLowerCase().includes(query) ||
-        (s.term ?? "").toLowerCase().includes(query)
-      )
-    })
+    const list = summaries.filter((s) =>
+      matchesQuery(search, classroomTitle(s), s.classroom, s.term),
+    )
     const byName = (a: StudentClassroomSummary, b: StudentClassroomSummary) =>
       classroomTitle(a).localeCompare(classroomTitle(b))
     return list.toSorted((a, b) =>
@@ -187,12 +181,12 @@ export function StudentClassroomList({
         ? b.acceptedCount - a.acceptedCount || byName(a, b)
         : byName(a, b),
     )
-  }, [summaries, query, sortKey])
+  }, [summaries, search, sortKey])
 
   if (loading) return <ClassroomsSkeleton />
 
-  const noResults = query.length > 0 && filtered.length === 0
-  const empty = query.length === 0 && summaries.length === 0
+  const noResults = normalizeQuery(search).length > 0 && filtered.length === 0
+  const empty = normalizeQuery(search).length === 0 && summaries.length === 0
 
   return (
     <div className="space-y-4">

--- a/web/src/pages/students/AddStudentButtons.tsx
+++ b/web/src/pages/students/AddStudentButtons.tsx
@@ -1,13 +1,12 @@
 import { useTranslation } from "react-i18next"
 import {
-  TriangleDownIcon,
   PencilIcon,
   PlusIcon,
   ShareAndroidIcon,
   UploadIcon,
 } from "@/components/ui/icons"
 
-import { Button, DropdownMenu, closeDropdownMenu } from "@/components/ui"
+import { Button, DropdownMenu, SplitButton } from "@/components/ui"
 import type { AddStudentActions } from "@/pages/students/RosterBulkActionsBar"
 
 // The roster's add-students trigger cluster — Share (classroom links), Edit
@@ -50,45 +49,28 @@ export function AddStudentButtons({
           {t("students.editRoster.button")}
         </Button>
       ) : null}
-      <div className="join">
-        <Button
-          variant="primary"
-          size="sm"
-          disabled={disabled}
-          className="join-item"
-          onClick={addActions.onUploadRoster}
-        >
-          <UploadIcon aria-hidden="true" className="size-4" />
-          {t("students.uploadTitle")}
-        </Button>
-        {/* Not a join-item itself: see NewClassroomButton in ClassesPage.tsx. */}
-        <div className="dropdown dropdown-end -ms-px">
+      <SplitButton
+        caretLabel={t("students.addMoreOptions")}
+        disabled={disabled}
+        primary={
           <Button
             variant="primary"
             size="sm"
-            tabIndex={0}
             disabled={disabled}
-            className="join-item h-full border-s border-primary-content/20 px-2"
-            aria-label={t("students.addMoreOptions")}
+            className="join-item"
+            onClick={addActions.onUploadRoster}
           >
-            <TriangleDownIcon aria-hidden="true" className="size-4" />
+            <UploadIcon aria-hidden="true" className="size-4" />
+            {t("students.uploadTitle")}
           </Button>
-          <DropdownMenu className="w-max">
-            <li>
-              <button
-                type="button"
-                onClick={() => {
-                  closeDropdownMenu()
-                  addActions.onAddStudent()
-                }}
-              >
-                <PlusIcon aria-hidden="true" className="size-4" />
-                {t("students.addTitle")}
-              </button>
-            </li>
-          </DropdownMenu>
-        </div>
-      </div>
+        }
+      >
+        <DropdownMenu.Item
+          icon={PlusIcon}
+          label={t("students.addTitle")}
+          onSelect={addActions.onAddStudent}
+        />
+      </SplitButton>
     </>
   )
 }

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -4,12 +4,11 @@ import { useTranslation } from "react-i18next"
 
 import {
   Alert,
-  Button,
   SkeletonRows,
+  TableErrorRow,
   TableShell,
   Toolbar,
 } from "@/components/ui"
-import { AlertIcon } from "@/components/ui/icons"
 import { RoleBadges } from "./RoleBadges"
 import { StudentSortSelect } from "./StudentSortSelect"
 import { coerceImportRole } from "./rosterImportParse"
@@ -83,22 +82,12 @@ const CsvRosterView = ({
           {loading ? (
             <SkeletonRows rows={3} bars={["w-40", "w-16", "w-20"]} />
           ) : loadError ? (
-            <tr>
-              <td colSpan={3} className="px-6 py-10 text-center">
-                <span
-                  role="alert"
-                  className="inline-flex items-center gap-2 text-sm text-error"
-                >
-                  <AlertIcon aria-hidden="true" className="size-4 shrink-0" />
-                  {t("students.rosterLoadError")}
-                </span>
-                <div className="mt-3">
-                  <Button variant="ghost" size="sm" onClick={onRetryLoad}>
-                    {t("students.rosterRetry")}
-                  </Button>
-                </div>
-              </td>
-            </tr>
+            <TableErrorRow
+              colSpan={3}
+              message={t("students.rosterLoadError")}
+              retryLabel={t("students.rosterRetry")}
+              onRetry={onRetryLoad}
+            />
           ) : rows.length === 0 ? (
             <tr>
               <td colSpan={3}>

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -1,5 +1,4 @@
 import {
-  AlertIcon,
   PaperAirplaneIcon,
   PeopleIcon,
   SyncIcon,
@@ -9,12 +8,13 @@ import {
 import {
   Alert,
   AnimatedAlert,
-  OutcomeAlert,
   Badge,
   Button,
+  OutcomeAlert,
   SelectAllCheckbox,
   SkeletonRows,
   SortableTh,
+  TableErrorRow,
   TableShell,
 } from "@/components/ui"
 import { EmptyState } from "@/components/list"
@@ -1049,29 +1049,12 @@ const EnrolledStudents = ({
               </tbody>
             ) : isError ? (
               <tbody>
-                <tr>
-                  <td colSpan={colCount} className="px-6 py-10 text-center">
-                    <span
-                      role="alert"
-                      className="inline-flex items-center gap-2 text-sm text-error"
-                    >
-                      <AlertIcon
-                        aria-hidden="true"
-                        className="size-4 shrink-0"
-                      />
-                      {t("students.rosterLoadError")}
-                    </span>
-                    <div className="mt-3">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => refetchRoster()}
-                      >
-                        {t("students.rosterRetry")}
-                      </Button>
-                    </div>
-                  </td>
-                </tr>
+                <TableErrorRow
+                  colSpan={colCount}
+                  message={t("students.rosterLoadError")}
+                  retryLabel={t("students.rosterRetry")}
+                  onRetry={() => refetchRoster()}
+                />
               </tbody>
             ) : isEmpty ? (
               <tbody>

--- a/web/src/pages/students/MemberLinkPicker.tsx
+++ b/web/src/pages/students/MemberLinkPicker.tsx
@@ -1,5 +1,6 @@
 import { Combobox, type InputSize } from "@/components/ui"
 import type { DirectoryMember } from "@/domain/students"
+import { matchesQuery } from "@/util/textMatch"
 
 // The one member-link picker recipe, shared by the roster detail modal and
 // batch Edit mode: the typed-query filter (login OR classroom, case-
@@ -51,14 +52,9 @@ export function MemberLinkPicker({
   onOpenChange: (open: boolean) => void
   onSelect: (member: DirectoryMember) => void
 }) {
-  const query = value.trim().toLowerCase()
-  const filtered = query
-    ? items.filter(
-        (m) =>
-          m.login.toLowerCase().includes(query) ||
-          m.classrooms.some((c) => c.toLowerCase().includes(query)),
-      )
-    : items
+  const filtered = items.filter((m) =>
+    matchesQuery(value, m.login, ...m.classrooms),
+  )
 
   return (
     <Combobox

--- a/web/src/pages/students/rosterFilter.ts
+++ b/web/src/pages/students/rosterFilter.ts
@@ -4,6 +4,7 @@ import type {
   TeamRosterRow,
   TeamRosterRowState,
 } from "@/util/teamRoster"
+import { matchesQuery } from "@/util/textMatch"
 
 // The unlabeled section bucket. Shared by the filter and the group-by-section
 // view so a row with no section is treated identically in both.
@@ -29,7 +30,6 @@ export function filterRosterRows(
   rows: TeamRosterRow[],
   { query, statusFilter, roleFilter, sectionFilter }: RosterFilterInput,
 ): TeamRosterRow[] {
-  const q = query.trim().toLowerCase()
   return rows.filter((row) => {
     if (statusFilter !== "all" && row.state !== statusFilter) return false
     if (roleFilter !== "all" && !row.roles.includes(roleFilter)) return false
@@ -37,10 +37,11 @@ export function filterRosterRows(
       const section = row.section.trim() || NO_SECTION
       if (section !== sectionFilter) return false
     }
-    if (!q) return true
-    const name = nameFromParts(row.first_name, row.last_name)
-    return [row.username, name, row.email].some((field) =>
-      field.toLowerCase().includes(q),
+    return matchesQuery(
+      query,
+      row.username,
+      nameFromParts(row.first_name, row.last_name),
+      row.email,
     )
   })
 }

--- a/web/src/util/textMatch.test.ts
+++ b/web/src/util/textMatch.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { matchesQuery, normalizeQuery } from "./textMatch"
+
+describe("matchesQuery", () => {
+  it("is a trimmed, case-insensitive substring match over any field", () => {
+    expect(matchesQuery("  ANN ", "hannah", "x")).toBe(true)
+    expect(matchesQuery("ann", "Bob", "Ann Lee")).toBe(true)
+    expect(matchesQuery("zed", "Bob", "Ann Lee")).toBe(false)
+  })
+  it("matches everything on an empty query and skips absent fields", () => {
+    expect(matchesQuery("   ")).toBe(true)
+    expect(matchesQuery("a", null, undefined, "")).toBe(false)
+  })
+  it("normalizeQuery is the same rule, exposed for callers that pre-compute", () => {
+    expect(normalizeQuery("  Foo ")).toBe("foo")
+  })
+})

--- a/web/src/util/textMatch.ts
+++ b/web/src/util/textMatch.ts
@@ -1,0 +1,15 @@
+// The list filters' one search rule: trimmed, case-insensitive substring over
+// a row's searchable fields. An empty query matches every row.
+export const normalizeQuery = (query: string): string =>
+  query.trim().toLowerCase()
+
+export function matchesQuery(
+  query: string,
+  ...fields: Array<string | null | undefined>
+): boolean {
+  const q = normalizeQuery(query)
+  if (!q) return true
+  return fields.some(
+    (field) => Boolean(field) && field!.toLowerCase().includes(q),
+  )
+}


### PR DESCRIPTION
## Summary

Second quick-wins batch from the dedup map that #904 started (P6, P9, P11). Three small primitives, each replacing a recipe that was copied verbatim. Behavior-preserving; every existing test passes unchanged.

### `TableErrorRow` (P6)

`OrgMembersPage`, `AssignmentsTable`, `EnrolledStudents` and `CsvRosterView` each rendered the same 22-line "the list failed to load" row: a `colSpan` cell, a `role="alert"` line with the alert icon, and a ghost Retry button. `TableErrorRow({ colSpan, message, retryLabel, onRetry? })` in `ui/TableShell.tsx` (beside `SkeletonRows`) owns it. `onRetry` is optional because two callers received an optional handler and passed it straight to the button; the Retry renders only when a handler exists.

### `matchesQuery` (P9)

Ten list filters spelled `const q = query.trim().toLowerCase(); … field.toLowerCase().includes(q)` by hand, with small variations in how they handled the empty query and nullable fields. `util/textMatch.ts` exports `matchesQuery(query, ...fields)` (empty query matches everything; null/undefined/empty fields never match) and `normalizeQuery` for the two pages that also use the trimmed query for their empty-state check. Adopted in `assignmentList`, `OrgMembersPage`, `VpatSection`, `rosterFilter`, `MemberLinkPicker`, `StudentClassroomList`, `ClassroomList`. The three sites in `dashboard.ts` and `SubmissionsPage` do more than a field match (roster-name lookups, group-repo naming) and are left as they are.

### `SplitButton` (P11)

`AssignmentsPage`'s "New assignment ▾" and `AddStudentButtons`' "Upload roster ▾" carried an identical `join` + `dropdown dropdown-end -ms-px` + caret button + menu recipe, the only two sites of that class string in `src/`. Both had a comment saying "Not a join-item: see `NewClassroomButton` in `ClassesPage.tsx`", which no longer exists. `ui/SplitButton` takes the primary control as a slot (one is a `RouterButton`, one a `Button`) and owns the caret and menu; the why-not-a-join-item reasoning lives once in its comment. Both menus' hand-rolled `<li><button>` become `DropdownMenu.Item`.

### Considered and left alone

P10, the toolbar `hasActiveFilter` / `clearAll` triple across six pages: each site clears a different set of state setters, so a shared helper would take a setter list per page and remove little. Not worth the indirection.

## Test plan

- [x] `cd web && npm run check`: tsc, eslint (0 errors, 25 warnings, unchanged), prettier, arch:validate, 5,328 node tests. Browser project run separately: 18 passed.
- [x] The suites for every touched page pass unchanged (`pages/classes`, `pages/students`, `pages/OrgMembersPage`, `pages/assignments`, `pages/accessibility`: 719 tests).
- [x] New `textMatch.test.ts` (3): trimmed case-insensitive substring over any field; empty query matches all and absent fields never match; `normalizeQuery` is the same rule.
- [ ] Manual: force a roster load error (offline) and confirm the alert row and Retry render; type into the assignments, roster, members and classes search boxes and confirm filtering is unchanged; open both split-button menus.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched (web `npm run check`; no Go or Python change).
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror. n/a.
- [x] If I added or changed a CLI command or flag, I documented it in the wiki. n/a.
- [x] My commits follow Conventional Commits.
