### PR TITLE
refactor(web): share the delete confirm, the group-repo filter, and the column-sort scaffold

### DIFF
--- a/web/src/domain/submissions/dashboard.ts
+++ b/web/src/domain/submissions/dashboard.ts
@@ -755,41 +755,25 @@ export function assignmentRepoNames(params: {
 // (the `<owner>` segment of `<classroom>-<assignment>-<owner>`).
 export type GroupRepo = { owner: string; repoName: string }
 
-// Group repos that exist for the assignment. Unlike individual acceptance, the
-// founder logins aren't known up front (group repos are named after whoever
-// created the group), so we must reverse-parse the `<classroom>-<assignment>-`
-// prefix rather than forward-construct per student. Prefix-stripping alone
-// over-matches a sibling whose slug extends this one (assignment "hw1" capturing
-// `cs101-hw1-bonus-alice` from "hw1-bonus"), so reject any repo that belongs to
-// a longer sibling assignment: `siblingSlugs` is the classroom's other slugs, and
-// a repo under `<classroom>-<sibling>-` where `<sibling>` extends `<assignment>-`
-// is that sibling's, not ours. Empty owner segments (a bare
-// `<classroom>-<assignment>-`) are rejected.
+// Group repos that exist for the assignment, keyed by the `<owner>` segment.
+// Unlike individual acceptance, the founder logins aren't known up front
+// (group repos are named after whoever created the group), so the set is the
+// reverse-parsed prefix match every repo-list signal shares
+// (existingAssignmentRepos, including its sibling-slug exclusion) rather than a
+// forward construction per student.
 export function existingGroupRepos(
   repos: GitHubRepo[] | null | undefined,
   classroom: string,
   assignment: string,
   siblingSlugs: readonly string[] = [],
 ): GroupRepo[] {
-  if (!repos) return []
   const prefix = `${classroom}-${assignment}-`.toLowerCase()
-  // Prefixes of sibling assignments whose slug strictly extends this one; a repo
-  // under any of these was created for the sibling, not this assignment.
-  const overlapPrefixes = siblingSlugs
-    .map((slug) => slug.toLowerCase())
-    .filter((slug) => slug !== assignment.toLowerCase())
-    .map((slug) => `${classroom}-${slug}-`.toLowerCase())
-    .filter((siblingPrefix) => siblingPrefix.startsWith(prefix))
-  const out: GroupRepo[] = []
-  for (const repo of repos) {
-    const name = repo.name.toLowerCase()
-    if (!name.startsWith(prefix)) continue
-    if (overlapPrefixes.some((sibling) => name.startsWith(sibling))) continue
-    const owner = name.slice(prefix.length)
-    if (!owner) continue
-    out.push({ owner, repoName: name })
-  }
-  return out
+  return existingAssignmentRepos(repos, classroom, assignment, [
+    ...siblingSlugs,
+  ]).map((repo) => {
+    const repoName = repo.name.toLowerCase()
+    return { owner: repoName.slice(prefix.length), repoName }
+  })
 }
 
 // Team-mode repos that exist for the assignment — the team analog of

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -23,7 +23,6 @@ import {
   Alert,
   Badge,
   Button,
-  EmphasisLtr,
   HelpTooltip,
   MetricBar,
   InlineSpinner,
@@ -127,7 +126,7 @@ import { useStaffCapabilities } from "@/hooks/useStaffCapabilities"
 import { useCollectController } from "./submissions/useCollectController"
 import useTriggerRegrade from "@/hooks/useTriggerRegrade"
 import { useSetAssignmentLock } from "@/hooks/mutations/useSetAssignmentLock"
-import { useDeleteAssignment } from "@/hooks/mutations/useDeleteAssignment"
+import { DeleteAssignmentConfirm } from "@/pages/assignments/AssignmentRowActions"
 import { useToast } from "@/context/notifications/NotificationProvider"
 import { RegradeCoordinatorProvider } from "@/context/regrade/RegradeCoordinator"
 import useGetLastCollectScoresRun from "@/hooks/useGetLastCollectScoresRun"
@@ -1125,9 +1124,6 @@ const SubmissionsPageContent = () => {
         : t("submissions.lock.unlockSuccess"),
     )
   })
-  // Same delete mechanism as the assignments table's manage hub (removes the
-  // assignments.json entry; student repos are kept).
-  const deleteAssignmentMutation = useDeleteAssignment()
   // `anyRegrading` covers the whole-assignment regrade AND every per-row
   // regrade (via the page coordinator), so collect/regrade controls disable
   // while any regrade is in flight.
@@ -1912,39 +1908,19 @@ const SubmissionsPageContent = () => {
         onClose={() => setLockConfirmOpen(false)}
       />
       {/* Delete-assignment confirm: the assignments table's typed-slug flow. */}
-      <ConfirmModal
+      <DeleteAssignmentConfirm
         open={deleteConfirmOpen}
-        title={t("assignments.table.deleteTitle")}
-        description={
-          <Trans
-            i18nKey="assignments.table.deleteDescription"
-            values={{
-              assignment: assignmentInfo?.name ?? assignment,
-              classroom: `${org}/${classroom}`,
-            }}
-            components={{
-              assignment: <EmphasisLtr className="text-base-content" />,
-              classroom: <EmphasisLtr className="text-base-content" />,
-            }}
-          />
-        }
-        confirmText={assignment}
-        confirmLabel={t("assignments.table.deleteConfirm")}
-        cancelLabel={t("assignments.table.deleteCancel")}
-        tone="error"
-        warning={t("assignments.table.deleteWarning")}
-        onConfirm={async () => {
-          await deleteAssignmentMutation.mutateAsync({
-            org,
-            classroom,
-            assignment,
-          })
-          await navigate({
+        onClose={() => setDeleteConfirmOpen(false)}
+        org={org}
+        classroom={classroom}
+        slug={assignment}
+        name={assignmentInfo?.name ?? assignment}
+        onDeleted={() =>
+          navigate({
             to: "/$org/$classroom/assignments",
             params: { org, classroom },
           })
-        }}
-        onClose={() => setDeleteConfirmOpen(false)}
+        }
       />
       <MetricsModal
         open={metricsOpen && !overlayCapable}

--- a/web/src/pages/assignments/AssignmentRowActions.tsx
+++ b/web/src/pages/assignments/AssignmentRowActions.tsx
@@ -390,6 +390,61 @@ export const LockAssignmentAction = ({
 }
 
 // Delete (hub only): typed-slug confirm; the hook refreshes the listing.
+// The typed-slug delete confirm, shared by the hub row here and the
+// submissions page's Actions menu. The hook refreshes the listing; `onDeleted`
+// is for the caller that must leave the page it is on.
+export const DeleteAssignmentConfirm = ({
+  open,
+  onClose,
+  org,
+  classroom,
+  slug,
+  name,
+  onDeleted,
+}: {
+  open: boolean
+  onClose: () => void
+  org: string
+  classroom: string
+  slug: string
+  name: string
+  onDeleted?: () => Promise<void> | void
+}) => {
+  const { t } = useTranslation()
+  const deleteAssignmentMutation = useDeleteAssignment()
+  return (
+    <ConfirmModal
+      open={open}
+      title={t("assignments.table.deleteTitle")}
+      description={
+        <Trans
+          i18nKey="assignments.table.deleteDescription"
+          values={{ assignment: name, classroom: `${org}/${classroom}` }}
+          components={{
+            assignment: <EmphasisLtr className="text-base-content" />,
+            classroom: <EmphasisLtr className="text-base-content" />,
+          }}
+        />
+      }
+      confirmText={slug}
+      confirmLabel={t("assignments.table.deleteConfirm")}
+      cancelLabel={t("assignments.table.deleteCancel")}
+      tone="error"
+      warning={t("assignments.table.deleteWarning")}
+      onConfirm={async () => {
+        await deleteAssignmentMutation.mutateAsync({
+          org,
+          classroom,
+          assignment: slug,
+        })
+        await onDeleted?.()
+      }}
+      onClose={onClose}
+    />
+  )
+}
+
+// Delete (hub only): the row that opens the shared confirm.
 export const DeleteAssignmentAction = ({
   org,
   classroom,
@@ -401,7 +456,6 @@ export const DeleteAssignmentAction = ({
 }) => {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
-  const deleteAssignmentMutation = useDeleteAssignment()
 
   return (
     <>
@@ -414,36 +468,13 @@ export const DeleteAssignmentAction = ({
           name: assignmentName(assignment),
         })}
       />
-
-      <ConfirmModal
+      <DeleteAssignmentConfirm
         open={open}
-        title={t("assignments.table.deleteTitle")}
-        description={
-          <Trans
-            i18nKey="assignments.table.deleteDescription"
-            values={{
-              assignment: assignmentName(assignment),
-              classroom: `${org}/${classroom}`,
-            }}
-            components={{
-              assignment: <EmphasisLtr className="text-base-content" />,
-              classroom: <EmphasisLtr className="text-base-content" />,
-            }}
-          />
-        }
-        confirmText={assignment.slug}
-        confirmLabel={t("assignments.table.deleteConfirm")}
-        cancelLabel={t("assignments.table.deleteCancel")}
-        tone="error"
-        warning={t("assignments.table.deleteWarning")}
-        onConfirm={async () => {
-          await deleteAssignmentMutation.mutateAsync({
-            org,
-            classroom,
-            assignment: assignment.slug,
-          })
-        }}
         onClose={() => setOpen(false)}
+        org={org}
+        classroom={classroom}
+        slug={assignment.slug}
+        name={assignmentName(assignment)}
       />
     </>
   )

--- a/web/src/util/orgMembers.ts
+++ b/web/src/util/orgMembers.ts
@@ -1,6 +1,7 @@
 import type { Student } from "@/types/classroom"
 import type { GitHubUser } from "@/github-core/types"
 import { memberIdSet, studentKey } from "@/util/identity"
+import { sortByColumn } from "./sortColumns"
 
 // Per-classroom enrollment state for an aggregated member, mirroring
 // buildTeamRoster so the two views agree:
@@ -257,11 +258,9 @@ const displayName = (row: OrgMemberRow) => row.username || row.name || row.email
 // What the Name cell shows: the name when known, else the avatar's fallbacks.
 const nameFirst = (row: OrgMemberRow) => row.name || row.username || row.email
 
-// Header-driven column sort for the Members table (mirroring
-// sortTeamRosterRowsBy). `desc` flips only the column comparison; ties fall
-// back to ascending display identity so a reversed column stays scannable.
-// `isOwner` backs the role column — ownership lives outside the row (the
-// admins read), so the caller supplies the predicate.
+// Header-driven column sort for the Members table (sortByColumn, like the
+// roster). `isOwner` backs the role column — ownership lives outside the row
+// (the admins read), so the caller supplies the predicate.
 export type OrgMembersSortColumn =
   "name" | "username" | "classrooms" | "role" | "status"
 export function sortOrgMemberRowsBy(
@@ -270,44 +269,41 @@ export function sortOrgMemberRowsBy(
   direction: "asc" | "desc",
   isOwner: (row: OrgMemberRow) => boolean = () => false,
 ): OrgMemberRow[] {
-  const flip = direction === "desc" ? -1 : 1
   const byName = (a: OrgMemberRow, b: OrgMemberRow) =>
     displayName(a).localeCompare(displayName(b), undefined, {
       sensitivity: "base",
       numeric: true,
     })
-  // Blank-last compare regardless of direction: the inner flip cancels the
-  // outer one, so "no data" never leads a reversed column.
-  const blankLast = (va: string, vb: string): number => {
-    if (!va || !vb) return flip * (va === vb ? 0 : va ? -1 : 1)
-    return va.localeCompare(vb, undefined, { numeric: true })
-  }
   const roleRank = (row: OrgMemberRow) =>
     isOwner(row) ? 2 : row.isMember ? 1 : 0
-  const byColumn = (a: OrgMemberRow, b: OrgMemberRow): number => {
-    switch (column) {
-      case "name":
-        return nameFirst(a).localeCompare(nameFirst(b), undefined, {
-          sensitivity: "base",
-          numeric: true,
-        })
-      case "username":
-        return blankLast(
-          a.username.trim().toLowerCase(),
-          b.username.trim().toLowerCase(),
-        )
-      case "classrooms":
-        return a.classrooms.length - b.classrooms.length
-      case "role":
-        return roleRank(b) - roleRank(a)
-      case "status":
-        return (
-          CLASSIFICATION_ORDER[a.classification] -
-          CLASSIFICATION_ORDER[b.classification]
-        )
-    }
-  }
-  return rows.toSorted((a, b) => flip * byColumn(a, b) || byName(a, b))
+  return sortByColumn(
+    rows,
+    direction,
+    (a, b, blankLast) => {
+      switch (column) {
+        case "name":
+          return nameFirst(a).localeCompare(nameFirst(b), undefined, {
+            sensitivity: "base",
+            numeric: true,
+          })
+        case "username":
+          return blankLast(
+            a.username.trim().toLowerCase(),
+            b.username.trim().toLowerCase(),
+          )
+        case "classrooms":
+          return a.classrooms.length - b.classrooms.length
+        case "role":
+          return roleRank(b) - roleRank(a)
+        case "status":
+          return (
+            CLASSIFICATION_ORDER[a.classification] -
+            CLASSIFICATION_ORDER[b.classification]
+          )
+      }
+    },
+    byName,
+  )
 }
 
 // The Members toolbar's "Show" facets (the roster's combined select). Status

--- a/web/src/util/sortColumns.ts
+++ b/web/src/util/sortColumns.ts
@@ -1,0 +1,29 @@
+export type SortDirection = "asc" | "desc"
+
+// Header-driven column sort shared by the roster and members tables. `desc`
+// flips only the column comparison; ties always fall back to the ascending
+// tie-break (display name) so a reversed column stays internally scannable.
+export function sortByColumn<T>(
+  rows: readonly T[],
+  direction: SortDirection,
+  byColumn: (a: T, b: T, blankLast: BlankLastCompare) => number,
+  tieBreak: (a: T, b: T) => number,
+): T[] {
+  const flip = direction === "desc" ? -1 : 1
+  const blankLast = compareBlankLast(flip)
+  return rows.toSorted(
+    (a, b) => flip * byColumn(a, b, blankLast) || tieBreak(a, b),
+  )
+}
+
+export type BlankLastCompare = (a: string, b: string) => number
+
+// Locale/numeric compare with blank values pinned last in EITHER direction: a
+// missing value is "no data", not "smallest". The inner flip cancels the outer
+// one the sort applies, so a reversed column never leads with its blanks.
+export const compareBlankLast =
+  (flip: 1 | -1): BlankLastCompare =>
+  (va, vb) => {
+    if (!va || !vb) return flip * (va === vb ? 0 : va ? -1 : 1)
+    return va.localeCompare(vb, undefined, { numeric: true })
+  }

--- a/web/src/util/teamRoster.ts
+++ b/web/src/util/teamRoster.ts
@@ -16,6 +16,7 @@ import {
   githubOrgRoleForRole,
   roleForGitHubOrgRole,
 } from "@/authz"
+import { sortByColumn } from "./sortColumns"
 
 // Role vocabulary is single-sourced in the authz module (authz/roles). Re-exported
 // here because the roster row logic below is its primary consumer and callers
@@ -575,35 +576,32 @@ export function sortTeamRosterRowsBy(
   column: RosterTableSortColumn,
   direction: "asc" | "desc",
 ): TeamRosterRow[] {
-  const flip = direction === "desc" ? -1 : 1
   const topRank = (row: TeamRosterRow) =>
     Math.max(0, ...row.roles.map((role) => ROLE_RANK[role]))
   const byName = (a: TeamRosterRow, b: TeamRosterRow) =>
     sortName(a).localeCompare(sortName(b), undefined, NAME_COLLATION)
-  // Blank-last compare regardless of direction: the inner flip cancels the
-  // outer one, so "no data" never leads a reversed column.
-  const blankLast = (va: string, vb: string): number => {
-    if (!va || !vb) return flip * (va === vb ? 0 : va ? -1 : 1)
-    return va.localeCompare(vb, undefined, { numeric: true })
-  }
-  const byColumn = (a: TeamRosterRow, b: TeamRosterRow): number => {
-    switch (column) {
-      case "member":
-        return byName(a, b)
-      case "username":
-        return blankLast(
-          a.username.trim().toLowerCase(),
-          b.username.trim().toLowerCase(),
-        )
-      case "role":
-        return topRank(b) - topRank(a)
-      case "section":
-        return blankLast(a.section.trim(), b.section.trim())
-      case "status":
-        return STATE_ORDER[a.state] - STATE_ORDER[b.state]
-    }
-  }
-  return rows.toSorted((a, b) => flip * byColumn(a, b) || byName(a, b))
+  return sortByColumn(
+    rows,
+    direction,
+    (a, b, blankLast) => {
+      switch (column) {
+        case "member":
+          return byName(a, b)
+        case "username":
+          return blankLast(
+            a.username.trim().toLowerCase(),
+            b.username.trim().toLowerCase(),
+          )
+        case "role":
+          return topRank(b) - topRank(a)
+        case "section":
+          return blankLast(a.section.trim(), b.section.trim())
+        case "status":
+          return STATE_ORDER[a.state] - STATE_ORDER[b.state]
+      }
+    },
+    byName,
+  )
 }
 
 // Project a roster row back to the display-metadata Student shape the grade


### PR DESCRIPTION
## Summary

Third quick-wins batch from the dedup map that #904 started (P5, H11, H9). Behavior-preserving; every existing test passes unchanged.

### `DeleteAssignmentConfirm` (P5)

`SubmissionsPage` rendered its own copy of the assignment hub's typed-slug delete `ConfirmModal`, identical down to the `assignments.table.*` keys. `DeleteAssignmentConfirm` in `AssignmentRowActions.tsx` is the one dialog; the hub's `DeleteAssignmentAction` renders it behind its row, and the submissions page renders it with an `onDeleted` that navigates to the assignments list (the hook already invalidates, since #904).

The lock confirm on the two surfaces was **not** unified: it uses different copy on each (`assignments.table.lock*` vs `submissions.lock.*`), so merging it would be a copy decision rather than a refactor.

### `existingGroupRepos` (H11)

`domain/submissions/dashboard.ts` re-implemented `domain/assignments/assignmentRepoPresence.existingAssignmentRepos` line for line (prefix match, sibling-slug exclusion, empty-owner rejection), differing only in mapping the result to `{ owner, repoName }`. It now maps over the shared filter, so the two repo-set signals cannot disagree.

### `sortByColumn` (H9)

`util/orgMembers.sortOrgMemberRowsBy` was documented as "mirroring `sortTeamRosterRowsBy`" and shared its `flip`, `blankLast` closure, and `toSorted(flip * byColumn || byName)` tail verbatim. `util/sortColumns.ts` owns that scaffold (`sortByColumn(rows, direction, byColumn, tieBreak)` with `blankLast` handed to the column comparator); both sorters keep only their per-column bodies. The "blank values pin last in either direction" reasoning lives once.

## Test plan

- [x] `cd web && npm run check`: tsc, eslint (0 errors, 25 warnings, unchanged), prettier, arch:validate, 5,325 node tests. Browser project run separately: 18 passed.
- [x] `dashboard.test.ts` and `assignmentRepoPresence.test.ts` (218 tests) pass unchanged, pinning the group-repo filter's sibling and empty-owner cases through the shared function.
- [x] `teamRoster.test.ts` and `orgMembers.test.ts` (111 tests) pass unchanged, including the blank-last-in-both-directions cases.
- [ ] Manual: delete an assignment from the submissions page Actions menu and confirm you land on the assignments list with the row gone; sort the roster and members tables by each column in both directions and confirm blanks stay last.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched (web `npm run check`; no Go or Python change).
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror. n/a.
- [x] If I added or changed a CLI command or flag, I documented it in the wiki. n/a.
- [x] My commits follow Conventional Commits.
