### PR TITLE
refactor(web): reuse the github-core retry, read, verdict and page primitives

### DIFF
--- a/web/src/domain/assignments/scoreOverride.ts
+++ b/web/src/domain/assignments/scoreOverride.ts
@@ -1,14 +1,12 @@
 import type { GitHubClient } from "@/github-core/client"
-import { CONFIG_REPO } from "@/util/configRepo"
 import { scoresFilePath } from "@/util/configRepoPaths"
-import { decodeBase64Utf8 } from "@/util/github"
-import { GitHubAPIError } from "@/github-core/errors"
 import { withGitConflictRetry } from "../classrooms"
 import {
   commitConfigRepoFiles,
   jsonFileEntry,
   readConfigRepoHead,
 } from "../configRepoWrite"
+import { readConfigJson } from "@/github-core/queries"
 
 // A stored submission record inside scores.json (classroom50/result/v1 payload
 // minus the bucket-key `assignment`). We only type the fields the override path
@@ -134,32 +132,17 @@ async function readScoresFile(
   classroom: string,
   ref: string,
 ): Promise<ScoresFile> {
-  let file: { type: "file"; encoding: "base64"; content: string }
-  try {
-    file = await client.request<{
-      type: "file"
-      encoding: "base64"
-      content: string
-    }>(
-      `/repos/${org}/${CONFIG_REPO}/contents/${scoresFilePath(
-        classroom,
-      )}?ref=${encodeURIComponent(ref)}`,
-    )
-  } catch (err) {
-    // ONLY a genuine 404 means the file is absent (never collected) — scaffold
-    // so an override can seed it. Any other error (5xx / rate-limit / network)
-    // is NOT proof of absence: swallowing it here would let the caller commit a
-    // full-content blob that replaces the whole gradebook with this scaffold.
-    // Rethrow so the write fails loudly and the caller can retry, mirroring
-    // assertClassroomNotArchived's non-404 rethrow.
-    if (err instanceof GitHubAPIError && err.isNotFound) {
-      return { schema: SCORES_SCHEMA, assignments: {} }
-    }
-    throw err
-  }
-  // Decode/parse OUTSIDE the 404-tolerated region: a truncated or malformed
-  // body must fail the save, not scaffold an empty gradebook over real scores.
-  const parsed = JSON.parse(decodeBase64Utf8(file.content)) as ScoresFile
+  // ONLY a genuine 404 means the file is absent (never collected), so an
+  // override can seed it. Any other error (5xx / rate-limit / network) is NOT
+  // proof of absence: swallowing it would let the caller commit a scaffold over
+  // the whole gradebook. readConfigJson rethrows those and parses outside the
+  // tolerated region, so a malformed body fails the save too.
+  const parsed = await readConfigJson<ScoresFile>(client, {
+    org,
+    path: scoresFilePath(classroom),
+    ref,
+    onMissing: () => ({ schema: SCORES_SCHEMA, assignments: {} }),
+  })
   if (!parsed.assignments) parsed.assignments = {}
   return parsed
 }

--- a/web/src/domain/classrooms.ts
+++ b/web/src/domain/classrooms.ts
@@ -8,7 +8,7 @@ import {
   getCommit,
   getConfigRepoBranch,
 } from "@/github-core/configRepoReads"
-import { sleep } from "@/github-core/queries"
+import { withRetry } from "@/github-core/queries"
 import { isClassroomArchived } from "@/types/classroom"
 import {
   createCommit,
@@ -227,26 +227,21 @@ export async function withGitConflictRetry<T>(
   // loses the race. fn re-reads the ref + file each attempt, so retrying either
   // is safe; jittered backoff lets the winning write land and avoids lock-step
   // collisions between racing clients.
-  const attempts = 4
-  let lastError: unknown
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    try {
-      return await fn()
-    } catch (err) {
-      lastError = err
-      const isConflict =
-        (err instanceof GitHubAPIError && err.status === 409) ||
-        isNonFastForward(err)
-      if (!isConflict || attempt === attempts) {
-        throw err
-      }
-      log.debug("git conflict, retrying commit", { attempt })
-      await sleep(300 * attempt + Math.random() * 400)
-    }
-  }
-
-  throw lastError
+  return withRetry(fn, {
+    attempts: 4,
+    shouldRetry: (err) =>
+      (err instanceof GitHubAPIError && err.status === 409) ||
+      isNonFastForward(err),
+    waitMs: conflictBackoffMs,
+    onRetry: (attempt) =>
+      log.debug("git conflict, retrying commit", { attempt: attempt + 1 }),
+  })
 }
+
+// 300ms, 600ms, 900ms plus up to 400ms of jitter: enough for a racing write to
+// land, spread so two clients don't collide again on the same beat.
+const conflictBackoffMs = (_err: unknown, attempt: number) =>
+  300 * (attempt + 1) + Math.random() * 400
 
 export type CreateClassroomInput = {
   org: string
@@ -306,29 +301,23 @@ export async function assertClassroomNotArchived(
 // A transient read can't determine archive state and shouldn't fail-closed on
 // the first blip; retry once before giving up so a single rate-limit/5xx/network
 // hiccup doesn't block an otherwise-valid mutation.
-async function readClassroomJsonForGuard(
+function readClassroomJsonForGuard(
   client: GitHubClient,
   org: string,
   classroom: string,
 ) {
-  try {
-    return await getClassroomJson(client, { org, classroom })
-  } catch (err) {
-    if (isTransientReadError(err)) {
-      await sleep(300)
-      return await getClassroomJson(client, { org, classroom })
-    }
-    throw err
-  }
+  return withRetry(() => getClassroomJson(client, { org, classroom }), {
+    attempts: 2,
+    shouldRetry: isTransientReadError,
+    waitMs: () => 300,
+  })
 }
 
 // Errors that don't prove the classroom's state: rate limiting, 5xx, and
 // non-HTTP (network) failures. A 404 is determinate (handled by the caller as
 // legacy/active) and is therefore NOT transient.
 function isTransientReadError(err: unknown): boolean {
-  if (err instanceof GitHubAPIError) {
-    return err.isRateLimited || err.status >= 500
-  }
+  if (err instanceof GitHubAPIError) return err.isTransient
   // A thrown non-GitHubAPIError here is a network/parse failure, not a
   // determinate API answer — treat as transient.
   return err instanceof Error
@@ -350,39 +339,28 @@ export type DeleteClassroomInput = {
 // Whether a failed team delete is worth retrying: a rate limit or 5xx is a
 // transient blip; everything else is permanent and recorded without retrying.
 function isTransientDeleteError(err: unknown): boolean {
-  return (
-    err instanceof GitHubAPIError && (err.isRateLimited || err.status >= 500)
-  )
+  return err instanceof GitHubAPIError && err.isTransient
 }
 
 // Delete one classroom team, retrying a transient failure a few times with
 // jittered backoff so a single hiccup doesn't strand a team. A permanent
 // refusal throws immediately (the caller records it as a non-fatal warning).
-async function deleteClassroomTeamWithRetry(
+function deleteClassroomTeamWithRetry(
   client: GitHubClient,
   org: string,
   team: ClassroomTeamRef,
 ): Promise<void> {
-  const attempts = 4
-  let lastError: unknown
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    try {
-      await deleteClassroomTeam(client, org, team)
-      return
-    } catch (err) {
-      lastError = err
-      if (!isTransientDeleteError(err) || attempt === attempts) {
-        throw err
-      }
+  return withRetry(() => deleteClassroomTeam(client, org, team), {
+    attempts: 4,
+    shouldRetry: isTransientDeleteError,
+    waitMs: conflictBackoffMs,
+    onRetry: (attempt) =>
       log.debug("team delete transient failure, retrying", {
         org,
         teamSlug: team.slug,
-        attempt,
-      })
-      await sleep(300 * attempt + Math.random() * 400)
-    }
-  }
-  throw lastError
+        attempt: attempt + 1,
+      }),
+  })
 }
 
 export async function deleteClassroom(

--- a/web/src/domain/queries/assignments.ts
+++ b/web/src/domain/queries/assignments.ts
@@ -1,8 +1,6 @@
 import type { GitHubClient } from "@/github-core/client"
-import { fetchPagesAssignments } from "@/github-core/queries"
+import { fetchPagesAssignments, readConfigJson } from "@/github-core/queries"
 import type { Assignment } from "@/types/classroom"
-import { decodeBase64Utf8 } from "@/util/github"
-import { CONFIG_REPO } from "@/util/configRepo"
 import { localizedError, type LocalizedMessage } from "@/types/localizedMessage"
 
 export type GetAssignmentsFileInput = {
@@ -18,23 +16,7 @@ export async function getAssignmentsFile(
   client: GitHubClient,
   input: GetAssignmentsFileInput,
 ): Promise<AssignmentsFile> {
-  const { org, path, ref } = input
-
-  const file = await client.request<{
-    type: "file"
-    encoding: "base64"
-    content: string
-  }>(
-    `/repos/${org}/${CONFIG_REPO}/contents/${path}?ref=${encodeURIComponent(ref)}`,
-  )
-
-  if (file.type !== "file") {
-    throw new Error(`${path} is not a file`)
-  }
-
-  const json = decodeBase64Utf8(file.content)
-
-  return JSON.parse(json) as AssignmentsFile
+  return readConfigJson<AssignmentsFile>(client, input)
 }
 
 // `label` names what failed for the reader (e.g. the autograder). It is a

--- a/web/src/domain/teams/teamsFile.ts
+++ b/web/src/domain/teams/teamsFile.ts
@@ -1,17 +1,14 @@
 import type { GitHubClient } from "@/github-core/client"
 import type { TeamFormation } from "@/types/classroom"
-import { GitHubAPIError } from "@/github-core/errors"
 import { getConfigRepoBranch } from "@/github-core/configRepoReads"
-import { CONFIG_REPO } from "@/util/configRepo"
 import { teamsFilePath } from "@/util/configRepoPaths"
-import { decodeBase64Utf8 } from "@/util/github"
 import { withGitConflictRetry } from "../classrooms"
 import {
   commitConfigRepoFiles,
   jsonFileEntry,
   readConfigRepoHeadAt,
 } from "../configRepoWrite"
-import { listTeamMembers } from "@/github-core/queries"
+import { listTeamMembers, readConfigJson } from "@/github-core/queries"
 import { listAssignmentGroupTeams } from "./groupTeams"
 
 // Schema sentinel for <classroom>/teams.json (classroom50/teams/v1) — the
@@ -55,24 +52,12 @@ export async function getTeamsFile(
   input: { org: string; classroom: string; ref?: string },
 ): Promise<TeamsFile> {
   const { org, classroom, ref } = input
-  const path = teamsFilePath(classroom)
-  let file: { type: string; content: string }
-  try {
-    file = await client.request<{ type: string; content: string }>(
-      `/repos/${org}/${CONFIG_REPO}/contents/${path}${
-        ref ? `?ref=${encodeURIComponent(ref)}` : ""
-      }`,
-    )
-  } catch (err) {
-    if (err instanceof GitHubAPIError && err.isNotFound) {
-      return emptyTeamsFile()
-    }
-    throw err
-  }
-  if (file.type !== "file") {
-    throw new Error(`${path} is not a file`)
-  }
-  const parsed = JSON.parse(decodeBase64Utf8(file.content)) as TeamsFile
+  const parsed = await readConfigJson<TeamsFile>(client, {
+    org,
+    path: teamsFilePath(classroom),
+    ref,
+    onMissing: emptyTeamsFile,
+  })
   // A hand-edited file may lack the map; normalize so callers can index it.
   if (!parsed.assignments || typeof parsed.assignments !== "object") {
     return { ...parsed, schema: TEAMS_SCHEMA_V1, assignments: {} }

--- a/web/src/github-core/errors.test.ts
+++ b/web/src/github-core/errors.test.ts
@@ -375,3 +375,32 @@ describe("githubValidationReasons", () => {
     expect(githubValidationReasons("nope")).toBeUndefined()
   })
 })
+
+describe("GitHubAPIError verdict predicates", () => {
+  const make = (status: number) =>
+    new GitHubAPIError({
+      status,
+      url: "/x",
+      message: `HTTP ${status}`,
+      body: null,
+      rateLimit: {
+        limit: null,
+        remaining: null,
+        used: null,
+        reset: null,
+        resource: null,
+        retryAfter: null,
+      },
+    })
+  it("isTransient is a rate limit or a 5xx, never another 4xx", () => {
+    expect(make(429).isTransient).toBe(true)
+    expect(make(502).isTransient).toBe(true)
+    expect(make(404).isTransient).toBe(false)
+    expect(make(422).isTransient).toBe(false)
+  })
+  it("isDefinitiveAccessDenied is 403 or 404, the two answers a private read gives", () => {
+    expect(make(403).isDefinitiveAccessDenied).toBe(true)
+    expect(make(404).isDefinitiveAccessDenied).toBe(true)
+    expect(make(401).isDefinitiveAccessDenied).toBe(false)
+  })
+})

--- a/web/src/github-core/errors.ts
+++ b/web/src/github-core/errors.ts
@@ -98,6 +98,22 @@ export class GitHubAPIError extends Error {
     )
   }
 
+  get isServerError() {
+    return this.status >= 500
+  }
+
+  // GitHub 404s a private resource the token can't see exactly like a missing
+  // one, so for "can this viewer read it" the two answers are one verdict.
+  get isDefinitiveAccessDenied() {
+    return this.status === 403 || this.status === 404
+  }
+
+  // A blip worth one more attempt: throttled, or GitHub's side failed. A 4xx
+  // other than a rate limit is an answer, not a blip.
+  get isTransient() {
+    return this.isRateLimited || this.isServerError
+  }
+
   // The org/enterprise enforces SAML SSO and this token has no live SSO session
   // for it. GitHub signals this via X-GitHub-SSO (a 403 carrying `required;
   // url=…`, or `partial-results; organizations=…` on multi-org reads). Scoped to

--- a/web/src/github-core/mutations/provisioning.ts
+++ b/web/src/github-core/mutations/provisioning.ts
@@ -779,7 +779,7 @@ export async function ensureReusableWorkflowAccess(
   } catch (err) {
     const message = getErrorMessage(err)
     if (err instanceof GitHubAPIError) {
-      if (err.status === 403) {
+      if (err.isForbidden) {
         return {
           status: "warning",
           repo: `${owner}/${repo}`,
@@ -896,7 +896,7 @@ export async function ensureBranchProtection(
     const message = getErrorMessage(err)
 
     if (err instanceof GitHubAPIError) {
-      if (err.status === 403) {
+      if (err.isForbidden) {
         return {
           status: "warning",
           repo: `${owner}/${repo}`,
@@ -907,7 +907,7 @@ export async function ensureBranchProtection(
         }
       }
 
-      if (err.status === 404) {
+      if (err.isNotFound) {
         return {
           status: "warning",
           repo: `${owner}/${repo}`,
@@ -1083,7 +1083,7 @@ export async function ensureOrgActionsEnabled(
         }
       }
 
-      if (err.status === 403) {
+      if (err.isForbidden) {
         return {
           status: "warning",
           org,
@@ -1202,7 +1202,7 @@ function setOrgActionsModeWarning(
   const settingsUrl = githubOrgActionsSettingsUrl(org)
   const message = getErrorMessage(err)
   if (err instanceof GitHubAPIError) {
-    if (err.status === 403)
+    if (err.isForbidden)
       return {
         status: "warning",
         org,
@@ -1473,7 +1473,7 @@ export async function ensureOrgActionsBudgetCap(
       },
     })
   } catch (err) {
-    const permission = err instanceof GitHubAPIError && err.status === 403
+    const permission = err instanceof GitHubAPIError && err.isForbidden
     return {
       status: "warning",
       org,
@@ -1567,12 +1567,12 @@ export async function ensureOrgCanCreatePullRequests(
   } catch (err) {
     if (
       err instanceof GitHubAPIError &&
-      (err.status === 403 || err.status === 409)
+      (err.isForbidden || err.status === 409)
     ) {
       return {
         status: "warning",
         org,
-        reason: err.status === 403 ? "permission_denied" : "policy_conflict",
+        reason: err.isForbidden ? "permission_denied" : "policy_conflict",
         settingsUrl,
         message: `${org}: couldn't enable Actions-created pull requests (${getErrorMessage(
           err,

--- a/web/src/github-core/mutations/secrets.ts
+++ b/web/src/github-core/mutations/secrets.ts
@@ -109,9 +109,9 @@ export async function validateServiceToken(
     }>(`/repos/${org}/${CONFIG_REPO}`)
   } catch (err) {
     if (err instanceof GitHubAPIError) {
-      if (err.status === 401) throw fail("invalid", {}, err)
-      if (err.status === 403) throw fail("noAccess", { hint }, err)
-      if (err.status === 404) throw fail("configRepoMissing", {}, err)
+      if (err.isUnauthorized) throw fail("invalid", {}, err)
+      if (err.isForbidden) throw fail("noAccess", { hint }, err)
+      if (err.isNotFound) throw fail("configRepoMissing", {}, err)
     }
     // A fetch that never reached GitHub (network/CORS) throws a TypeError, not a
     // GitHubAPIError — don't blame the token for that.
@@ -148,10 +148,7 @@ export async function validateServiceToken(
       `/orgs/${encodeURIComponent(org)}/members?per_page=1`,
     )
   } catch (err) {
-    if (
-      err instanceof GitHubAPIError &&
-      (err.status === 403 || err.status === 404)
-    ) {
+    if (err instanceof GitHubAPIError && err.isDefinitiveAccessDenied) {
       throw fail("noMembersRead", { hint }, err)
     }
     // Inconclusive (401/5xx/network) — proceed; the repo read already proved the
@@ -193,7 +190,7 @@ async function assertTokenReachesOtherRepos(
       `/repos/${encodeURIComponent(org)}/${encodeURIComponent(probe.name)}`,
     )
   } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 404) {
+    if (err instanceof GitHubAPIError && err.isNotFound) {
       const failure = localizedError({
         key: VALIDATE_KEYS.selectedRepos,
         params: { org, repo: CONFIG_REPO, probe: probe.name },
@@ -256,7 +253,7 @@ export async function putRepoVariable(
       body: { name, value },
     })
   } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 404) {
+    if (err instanceof GitHubAPIError && err.isNotFound) {
       await client.request(`/repos/${owner}/${repo}/actions/variables`, {
         method: "POST",
         body: { name, value },

--- a/web/src/github-core/mutations/teams.ts
+++ b/web/src/github-core/mutations/teams.ts
@@ -296,7 +296,7 @@ export async function deleteClassroomTeam(
       })
     }
   } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 404) {
+    if (err instanceof GitHubAPIError && err.isNotFound) {
       return
     }
     throw err

--- a/web/src/github-core/orgChecks.ts
+++ b/web/src/github-core/orgChecks.ts
@@ -72,7 +72,7 @@ export function readFailedDetail(err: unknown): CheckDetail {
 }
 
 function unreadableFrom(err: unknown): CheckVerdict {
-  if (err instanceof GitHubAPIError && err.status === 404) {
+  if (err instanceof GitHubAPIError && err.isNotFound) {
     return {
       state: "unenforced",
       detail: { key: "orgSettings.audit.detail.notConfigured" },
@@ -508,7 +508,7 @@ export async function repairOrgDefaults(
     }
     if (
       err instanceof GitHubAPIError &&
-      (err.status === 403 || err.status === 422)
+      (err.isForbidden || err.status === 422)
     ) {
       const fallback = await repairOrgDefaultsPerField(client, org, settings)
       rejected = fallback.rejected

--- a/web/src/github-core/paginate.test.ts
+++ b/web/src/github-core/paginate.test.ts
@@ -70,6 +70,28 @@ const apiError = (status: number, retryAfter: number | null = null) =>
     },
   })
 
+describe("paginateAll with an envelope", () => {
+  // The runners endpoint wraps each page in `{ total_count, runners }`.
+  it("picks the items field off every page and tolerates a missing one", async () => {
+    const full = Array.from({ length: 100 }, (_, i) => i)
+    const request = vi.fn(async (path: string) => {
+      const page = Number(/[?&]page=(\d+)/.exec(path)?.[1] ?? 1)
+      if (page === 1) return { total_count: 101, runners: full }
+      if (page === 2) return { total_count: 101, runners: [100] }
+      return { total_count: 101 }
+    })
+    const client = { request } as unknown as GitHubClient
+    const items = await paginateAll<number>(
+      client,
+      (page) => `${BASE}&page=${page}`,
+      { pick: "runners" },
+    )
+    // No Link header: one page at a time, stopping on the first short page.
+    expect(items).toEqual([...full, 100])
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+})
+
 describe("paginateAll", () => {
   const makePath = (page: number) => `${BASE}&page=${page}`
 

--- a/web/src/github-core/paginate.ts
+++ b/web/src/github-core/paginate.ts
@@ -31,6 +31,9 @@ export type PaginateOptions = {
   // and let the user retry; a long walk opts in so one late page out of ninety
   // doesn't send the whole listing back to page 1.
   retryPages?: boolean
+  // For endpoints that wrap the page in an envelope (`{ total_count, runners }`)
+  // instead of returning the array: the field holding the items.
+  pick?: string
 }
 
 // Page 1 of a list endpoint plus the page count its `Link: rel="last"` names
@@ -141,9 +144,17 @@ function fetchPage<T>(
   options: PaginateOptions,
   onHeaders?: (headers: Headers) => void,
 ): Promise<T[]> {
-  const { signal, retryPages = false } = options
-  const read = () =>
-    client.request<T[]>(path, { method: "GET", signal, onHeaders })
+  const { signal, retryPages = false, pick } = options
+  const read = async () => {
+    const body = await client.request<T[] | Record<string, unknown>>(path, {
+      method: "GET",
+      signal,
+      onHeaders,
+    })
+    if (pick === undefined) return body as T[]
+    const items = (body as Record<string, unknown>)[pick]
+    return Array.isArray(items) ? (items as T[]) : []
+  }
   return retryPages ? withTransientRetry(read, signal) : read()
 }
 
@@ -194,9 +205,7 @@ function retryWaitMs(err: unknown, attempt: number): number | null {
 }
 
 function isTransientPageError(err: unknown): boolean {
-  if (err instanceof GitHubAPIError) {
-    return err.isRateLimited || err.status >= 500
-  }
+  if (err instanceof GitHubAPIError) return err.isTransient
   // A timeout (`TimeoutError` DOMException) or network failure.
   return !(err instanceof DOMException && err.name === "AbortError")
 }

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -14,6 +14,8 @@ export {
 } from "./queries/keys"
 export {
   sleep,
+  withRetry,
+  type RetryOptions,
   isFreshRepoLagError,
   withFreshRepoRetry,
   REPO_READ_CONCURRENCY,
@@ -75,6 +77,7 @@ export {
   csvFileQuery,
   rosterRawFileQuery,
   getRawFile,
+  readConfigJson,
   getClassroom50Yaml,
   getRepoFileAtRef,
 } from "./queries/fileReads"

--- a/web/src/github-core/queries/fileReads.ts
+++ b/web/src/github-core/queries/fileReads.ts
@@ -208,25 +208,52 @@ export function rosterRawFileQuery(
   })
 }
 
-export async function getRawFile(
+export function getRawFile(
   client: GitHubClient,
   input: GetAssignmentsFileInput,
 ): Promise<string> {
-  const { org, path, ref } = input
+  return readConfigFileText(client, input.org, input.path, input.ref)
+}
 
+// The contents-API read behind every config-repo file: base64 body decoded to
+// text, pinned to `ref` when given. A directory at the path is an error, not
+// a file.
+async function readConfigFileText(
+  client: GitHubClient,
+  org: string,
+  path: string,
+  ref?: string,
+): Promise<string> {
   const file = await client.request<{
     type: "file"
     encoding: "base64"
     content: string
   }>(
-    `/repos/${org}/${CONFIG_REPO}/contents/${path}?ref=${encodeURIComponent(ref)}`,
+    `/repos/${org}/${CONFIG_REPO}/contents/${path}${
+      ref ? `?ref=${encodeURIComponent(ref)}` : ""
+    }`,
   )
-
   if (file.type !== "file") {
     throw new Error(`${path} is not a file`)
   }
-
   return decodeBase64Utf8(file.content)
+}
+
+// A config-repo JSON file at a pinned ref, parsed. `onMissing` makes a 404
+// return a scaffold instead of throwing (a classroom has no teams.json or
+// scores.json until the first write). The decode and parse run OUTSIDE the
+// tolerated region on purpose: a truncated or malformed body must fail the
+// caller, not scaffold an empty file over real data. Every other error
+// propagates so a transient failure is never misread as "missing".
+export async function readConfigJson<T>(
+  client: GitHubClient,
+  input: { org: string; path: string; ref?: string; onMissing?: () => T },
+): Promise<T> {
+  const { org, path, ref, onMissing } = input
+  const read = () => readConfigFileText(client, org, path, ref)
+  const text = onMissing ? await tolerateGitHubError(read, null) : await read()
+  if (text === null) return onMissing!()
+  return JSON.parse(text) as T
 }
 
 export async function getClassroom50Yaml(

--- a/web/src/github-core/queries/orgReads.ts
+++ b/web/src/github-core/queries/orgReads.ts
@@ -35,37 +35,21 @@ export function orgRunnersQuery(client: GitHubClient, org: string) {
     queryKey: githubKeys.orgRunners(org),
     queryFn: async ({ signal }) => {
       try {
-        const runners: OrgRunner[] = []
-        let page = 1
-
-        while (true) {
-          const data = await client.request<{
-            total_count: number
-            runners: OrgRunner[]
-          }>(
+        const runners = await paginateAll<OrgRunner>(
+          client,
+          (page) =>
             `/orgs/${encodeURIComponent(
               org,
             )}/actions/runners?per_page=100&page=${page}`,
-            { method: "GET", signal },
-          )
-
-          const batch = data.runners ?? []
-          runners.push(...batch)
-
-          if (batch.length < 100) break
-          page++
-        }
-
+          { signal, pick: "runners" },
+        )
         return { available: true, runners }
       } catch (error) {
         // Let cancellations propagate; don't cache them as a verdict.
         if (signal?.aborted) throw error
         // 403 (no admin:org) / 404 (no access) mean "can't read the list",
         // not "the runner doesn't exist".
-        if (
-          error instanceof GitHubAPIError &&
-          (error.status === 403 || error.status === 404)
-        ) {
+        if (error instanceof GitHubAPIError && error.isDefinitiveAccessDenied) {
           return { available: false, reason: "no-access" }
         }
         return { available: false, reason: "error" }

--- a/web/src/github-core/queries/pagesReads.ts
+++ b/web/src/github-core/queries/pagesReads.ts
@@ -255,7 +255,7 @@ export async function verifyClassroom50ConfigRepo(
     )
     return true
   } catch (error) {
-    if (error instanceof GitHubAPIError && error.status === 404) {
+    if (error instanceof GitHubAPIError && error.isNotFound) {
       return false
     }
     log.warn("config-repo marker read failed, failing open", { org, error })
@@ -294,7 +294,7 @@ export async function getClassroom50OrgSummary(
     // checked only when a specific org is opened (teacher preflight on
     // ClassesPage).
   } catch (error) {
-    if (error instanceof GitHubAPIError && error.status === 404) {
+    if (error instanceof GitHubAPIError && error.isNotFound) {
       canAccessRepo = false
 
       if (isActiveAdmin) {

--- a/web/src/github-core/queries/releaseRunReads.ts
+++ b/web/src/github-core/queries/releaseRunReads.ts
@@ -232,7 +232,7 @@ export async function getServiceTokenStatus(
     }
   } catch (err) {
     if (err instanceof GitHubAPIError) {
-      if (err.status === 404) {
+      if (err.isNotFound) {
         return {
           status: "missing",
           secretName: SERVICE_TOKEN_SECRET_NAME,
@@ -240,7 +240,7 @@ export async function getServiceTokenStatus(
         }
       }
 
-      if (err.status === 403) {
+      if (err.isForbidden) {
         return {
           status: "unknown",
           secretName: SERVICE_TOKEN_SECRET_NAME,

--- a/web/src/github-core/queries/shared.ts
+++ b/web/src/github-core/queries/shared.ts
@@ -167,7 +167,7 @@ function isNotFoundError(error: unknown) {
 // non-fast-forward updateRef), so the 409 branch is gated on the message.
 export function isFreshRepoLagError(error: unknown) {
   if (error instanceof GitHubAPIError) {
-    if (error.status === 404) {
+    if (error.isNotFound) {
       return true
     }
     if (error.status === 409) {

--- a/web/src/github-core/repoReads.ts
+++ b/web/src/github-core/repoReads.ts
@@ -45,7 +45,7 @@ export async function hasAnyCommits(
     // A malformed non-array 200 body is inconclusive, not "has commits".
     return Array.isArray(branches) ? branches.length > 0 : null
   } catch (err) {
-    if (err instanceof GitHubAPIError && err.status === 404) {
+    if (err instanceof GitHubAPIError && err.isNotFound) {
       return false
     }
     return null


### PR DESCRIPTION
## Summary

The `github-core` group from the dedup map that #904 started (D6, D7, D8, D9). Four places where a primitive existed and callers had re-implemented it beside it. Behavior-preserving; every existing test passes unchanged, including the retry-count and 404-scaffold tests that pin these paths.

### Retry loops → `withRetry` (D6)

`domain/classrooms.ts` had three hand-rolled loops: `withGitConflictRetry` (4 attempts, `300*attempt + rand*400` jitter, 409-or-non-fast-forward), `deleteClassroomTeamWithRetry` (same loop and jitter, transient predicate), and `readClassroomJsonForGuard` (retry once after 300ms). Each is now `withRetry(fn, policy)` from `github-core/queries/shared.ts`, with the jitter written once as `conflictBackoffMs`. `withGitConflictRetry` keeps its name and signature (14 importers). The skeleton-refresh loop in `provisioning.ts` was **not** converted: it carries per-attempt state (re-diff on retry, early exit on an empty diff), so it is a loop, not a retry wrapper.

`GitHubAPIError` gains `isServerError` and `isTransient` (rate limit or 5xx); `paginate.isTransientPageError` and the two `classrooms.ts` predicates use it for their API-error half. Their non-API-error tails differ on purpose (a network failure is transient for the guard read, an abort is not for a page) and stay per site.

### Config JSON readers → `readConfigJson` (D7)

`getAssignmentsFile`, `getTeamsFile` and `readScoresFile` each spelled the contents-API read, base64 decode, `JSON.parse`, and (for two of them) the 404-to-scaffold catch. `readConfigJson<T>(client, { org, path, ref?, onMissing? })` in `fileReads.ts` owns it, sharing one `readConfigFileText` with `getRawFile`. The invariant `readScoresFile`'s comment insisted on is kept structurally: only the read is inside the tolerated region, so a malformed body still fails the save rather than scaffolding an empty gradebook over real scores. `getAssignmentsFile` passes no `onMissing` and still throws on 404.

### Status ladders → `GitHubAPIError` predicates (D8)

24 `err.status === 401 | 403 | 404` checks across nine files become `isUnauthorized` / `isForbidden` / `isNotFound`, which already existed. The three `403 || 404` pairs (`orgReads`, `secrets`, and `provisioning`) use a new `isDefinitiveAccessDenied`, named for why the two are one verdict: GitHub 404s a private resource the token cannot see exactly like a missing one. The `response.status === 404` checks in `pagesReads` are `fetch` Responses, not API errors, and stay.

### `page++` walker → `paginateAll` (D9)

`orgRunnersQuery` walked pages by hand because the runners endpoint wraps each page in `{ total_count, runners }`. `PaginateOptions` gains `pick`, the envelope field holding the items, and the query uses `paginateAll` with it. It gains `Link`-header page sizing and the walker's abort handling for free; the stop-on-short-page behavior is the same as before.

## Test plan

- [x] `cd web && npm run check`: tsc, eslint (0 errors, 25 warnings, unchanged), prettier, arch:validate, 5,331 node tests. Browser project run separately: 18 passed.
- [x] `domain/classrooms.test.ts`, `paginate.test.ts`, `errors.test.ts`, and the `github-core` + `domain` suites (1,622 tests) pass unchanged, including the tests that count retry attempts and pin the teams/scores 404 scaffolds.
- [x] New tests: `paginate.test.ts` envelope pick (full first page continues, short second page stops, missing field reads as empty); `errors.test.ts` `isTransient` (429/5xx yes, 404/422 no) and `isDefinitiveAccessDenied` (403/404 yes, 401 no).
- [ ] Manual: on a dev org, save two assignment edits from two tabs within a second and confirm the loser retries and lands; open the assignment form's runner picker on an org where the token lacks `admin:org` and confirm the "couldn't verify" degrade.

## Type of change

- [x] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched (web `npm run check`; no Go or Python change).
- [x] Cross-binary contract: n/a.
- [x] CLI docs: n/a.
- [x] My commits follow Conventional Commits.
