### PR TITLE
fix(web): restore two visuals and eight tests the dedup PRs changed

### DIFF
--- a/web/src/components/bulk/fanOut.ts
+++ b/web/src/components/bulk/fanOut.ts
@@ -35,8 +35,6 @@ type RunBulkFanOutParams<O> = {
   // workflow scope that every later owner would also hit).
   shouldStop?: () => boolean
   isMounted: () => boolean
-  // After each owner is processed (ok, failed, or deferred), with the running
-  // count and the owner just handled.
   onProgress: (processed: number, owner: string) => void
   t: TFunction
 }

--- a/web/src/components/bulk/resultView.tsx
+++ b/web/src/components/bulk/resultView.tsx
@@ -242,11 +242,9 @@ export const BulkResultBody = ({
   )
 }
 
-// The action bars' run modal (roster and org members): opened by the bar when
-// a run starts, it shows the progress row while working, the results when
-// complete, or the whole-run error. Closing is refused while working. The
-// modal stays mounted across runs; the bar owns `open` so a close does not
-// reset the last result mid-animation.
+// The action bars' run modal: progress while working, then results or the
+// whole-run error. The bar owns `open`, so a close never resets the last
+// result mid-animation.
 export const BulkRunModal = ({
   open,
   onClose,

--- a/web/src/components/bulk/useBulkRun.ts
+++ b/web/src/components/bulk/useBulkRun.ts
@@ -14,31 +14,27 @@ export interface BulkRun {
   // per-row outcome existed). Rendered instead of `result`.
   error: string | null
   busy: boolean
-  // True while the component that started the run is still mounted. Fan-outs
-  // check it before every setState and before launching another write.
+  // Fan-outs check this before each setState and before launching a write.
   isMounted: () => boolean
-  // Enter "working". Returns false (and does nothing) when a run is already in
-  // flight, so a double-click can't start a second fan-out.
+  // False (and a no-op) while a run is in flight, so a double-click can't
+  // start a second fan-out.
   begin: (total: number, message?: string) => boolean
   setProgress: (progress: BulkProgress) => void
-  // Leave "working" with per-row results; `phase` is "error" when any row
-  // failed or was deferred, so the caller decides that from its outcomes.
+  // The caller passes "error" when any row failed or was deferred.
   complete: (result: BulkResultView, phase: "complete" | "error") => void
-  // Leave "working" because the run itself threw.
+  // The run itself threw, before any per-row outcome existed.
   fail: (message: string) => void
   // Back to idle with nothing shown. Modals call this on open, never on close
   // (see the close-animation note in ui/Modal).
   reset: () => void
 }
 
-// The lifecycle every bulk modal and action bar drives: idle -> working ->
-// complete | error, with the progress line, the mounted/running guards, and
-// the tab-close hold while working. Callers own what the run does and how its
-// outcomes map to a BulkResultView; this owns everything else.
+// The run lifecycle every bulk modal and action bar drives (idle, working,
+// complete or error) plus the guards around it. Callers own what the run does
+// and how outcomes map to a BulkResultView.
 //
-// `resetWhen` is the modal's `open` flag: the state resets as it turns true so
-// a reopened dialog starts fresh, while a close leaves the last result in
-// place through the exit animation.
+// `resetWhen` is the modal's `open` flag: reset as it turns true, never as it
+// turns false, so the last result stays visible through the exit animation.
 export function useBulkRun(resetWhen?: boolean): BulkRun {
   const [phase, setPhase] = useState<BulkPhase>("idle")
   const [progress, setProgressState] = useState<BulkProgress>(IDLE_PROGRESS)

--- a/web/src/components/ui/ExternalLink.test.tsx
+++ b/web/src/components/ui/ExternalLink.test.tsx
@@ -61,4 +61,17 @@ describe("ExternalLink", () => {
     expect(classes).toContain("gap-1.5")
     expect(classes).not.toContain("gap-1")
   })
+
+  // A note's follow-up link sits on its own line under the message; the
+  // caller says so with `flex`, and the primitive must not fight it.
+  it("yields inline-flex to a caller that sets flex", () => {
+    render(
+      <ExternalLink href="https://example.org" className="mt-1 flex">
+        Docs
+      </ExternalLink>,
+    )
+    const classes = screen.getByRole("link").className.split(" ")
+    expect(classes).toContain("flex")
+    expect(classes).not.toContain("inline-flex")
+  })
 })

--- a/web/src/components/ui/ExternalLink.tsx
+++ b/web/src/components/ui/ExternalLink.tsx
@@ -16,9 +16,9 @@ export type ExternalLinkVariant =
   | "plain"
 
 const variantClass: Record<ExternalLinkVariant, string> = {
-  link: "link inline-flex items-center",
-  muted: "inline-flex items-center text-base-content/70 hover:text-primary",
-  plain: "inline-flex items-center",
+  link: "link items-center",
+  muted: "items-center text-base-content/70 hover:text-primary",
+  plain: "items-center",
 }
 
 // A text link that opens off-site in a new tab: the `target`/`rel` pair a new
@@ -37,6 +37,9 @@ export type ExternalLinkProps = Omit<
   icon?: boolean
 }
 
+const setsDisplay = (className: string | undefined) =>
+  Boolean(className && /(^|\s)(inline-)?flex(\s|$)/.test(className))
+
 export function ExternalLink({
   href,
   children,
@@ -52,6 +55,9 @@ export function ExternalLink({
       rel="noreferrer"
       className={cx(
         variantClass[variant],
+        // A caller that sets `flex` gets a block-level link on its own line
+        // (a note's follow-up link); otherwise the link flows inline.
+        !setsDisplay(className) && "inline-flex",
         !hasUtility("gap-", className) && "gap-1",
         className,
       )}

--- a/web/src/components/ui/SplitButton.tsx
+++ b/web/src/components/ui/SplitButton.tsx
@@ -4,15 +4,13 @@ import { Button } from "./Button"
 import { DropdownMenu } from "./DropdownMenu"
 import { TriangleDownIcon } from "./icons"
 
-// A primary action with a caret that opens secondary actions beside it (the
-// "New assignment ▾" and "Upload roster ▾" toolbar controls). The caller
-// renders the primary control (a Button or RouterButton with `join-item`) and
-// the menu items; this owns the join chrome, the caret button, and the menu.
+// A primary action with a caret that opens secondary actions beside it. The
+// caller renders the primary control (with `join-item`) and the menu items.
 //
-// The caret's wrapper is deliberately NOT a join-item: daisyUI's join rounds
-// its direct children, and the dropdown wrapper would take the rounding instead
-// of the caret button inside it. The negative margin closes the 1px seam that
-// leaves, and the inset border draws the divider the join would have drawn.
+// The caret's dropdown wrapper is NOT a join-item: daisyUI's join rounds its
+// direct children, and the wrapper would take the rounding instead of the
+// button inside it. The negative margin and inset border replace the seam and
+// divider the join would have drawn.
 export function SplitButton({
   primary,
   caretLabel,

--- a/web/src/domain/assignments/rename.ts
+++ b/web/src/domain/assignments/rename.ts
@@ -241,7 +241,7 @@ async function commitRenameConfig(
 
   await withGitConflictRetry(async () => {
     const head = await readConfigRepoHeadAt(client, org, branch)
-    // The two parent-pinned reads are independent — fetch them together.
+    // Both reads pin to the same parent and are independent; fetch together.
     // The scores read tolerates 404 (no file — nothing was ever collected).
     const [file, scoresRaw] = await Promise.all([
       getAssignmentsFile(client, {

--- a/web/src/domain/assignments/scoreOverride.ts
+++ b/web/src/domain/assignments/scoreOverride.ts
@@ -132,11 +132,8 @@ async function readScoresFile(
   classroom: string,
   ref: string,
 ): Promise<ScoresFile> {
-  // ONLY a genuine 404 means the file is absent (never collected), so an
-  // override can seed it. Any other error (5xx / rate-limit / network) is NOT
-  // proof of absence: swallowing it would let the caller commit a scaffold over
-  // the whole gradebook. readConfigJson rethrows those and parses outside the
-  // tolerated region, so a malformed body fails the save too.
+  // Only a 404 scaffolds (never collected). readConfigJson rethrows anything
+  // else, so a blip can't make the save overwrite the gradebook with a stub.
   const parsed = await readConfigJson<ScoresFile>(client, {
     org,
     path: scoresFilePath(classroom),

--- a/web/src/domain/configRepoWrite.ts
+++ b/web/src/domain/configRepoWrite.ts
@@ -15,8 +15,7 @@ import { prefixCommit } from "@/util/commit"
 
 import { assertClassroomNotArchived } from "./classrooms"
 
-// The head of the config repo's default branch, read once per write attempt.
-// Every field a writer needs to build a tree on top of it and move the ref.
+// The config repo's head, read once per write attempt.
 export type ConfigRepoHead = {
   configBranch: string
   headSha: string
@@ -56,11 +55,10 @@ export type ConfigRepoCommitResult = {
   updatedRef: GitHubMoveBranch
 }
 
-// The write half every config-repo mutation shares: one tree on the head's
-// base tree, one commit with the head as parent, one ref move. The message is
-// prefixed here so no writer can forget it. A concurrent write to the same
-// branch surfaces as a non-fast-forward 409 from updateRef; callers wrap the
-// read + commit in withGitConflictRetry to re-read and try again.
+// The write half every config-repo mutation shares: one tree, one commit, one
+// ref move. The message is prefixed here so no writer can forget it. A losing
+// concurrent write surfaces from updateRef; callers wrap read + commit in
+// withGitConflictRetry.
 export async function commitConfigRepoFiles(
   client: GitHubClient,
   org: string,

--- a/web/src/github-core/mutations/gitObjects.test.ts
+++ b/web/src/github-core/mutations/gitObjects.test.ts
@@ -3,13 +3,16 @@ import { describe, expect, it, vi } from "vitest"
 import type { GitHubClient } from "@/github-core/client"
 
 import {
+  createClassroomMetadata,
   createGitCommit,
   createGitTree,
   createRepoCommit,
   createRepoTree,
+  createTreeForAssignment,
   updateRef,
   updateRepoRef,
 } from "./gitObjects"
+import type { StaffTeamRefs } from "./teams"
 
 const makeClient = () => {
   const request = vi.fn<(path: string, init?: unknown) => Promise<unknown>>(
@@ -93,5 +96,110 @@ describe("git-data primitives", () => {
       "/repos/acme/classroom50/git/commits",
       "/repos/acme/classroom50/git/refs/heads/main",
     ])
+  })
+})
+
+// Pins the classroom.json `teams` persistence gate in createClassroomMetadata.
+// A too-narrow gate reading only (teams.teacher || teams.ta) would silently
+// drop the teams block for an hta-only classroom on create. These assert every
+// staff-role-only block is persisted (and that an empty/absent block is still
+// omitted, matching the CLI's `omitempty`).
+describe("createClassroomMetadata teams persistence", () => {
+  const teacher = { id: 1, slug: "classroom50-cs-teacher" }
+  const ta = { id: 2, slug: "classroom50-cs-ta" }
+  const hta = { id: 3, slug: "classroom50-cs-hta" }
+
+  const build = (teams?: StaffTeamRefs) =>
+    createClassroomMetadata(
+      "org",
+      "cs",
+      undefined,
+      "fall",
+      undefined,
+      undefined,
+      teams,
+    )
+
+  it("persists a teacher-only teams block (the rename regression)", () => {
+    const meta = build({ teacher })
+    expect(meta.teams).toEqual({ teacher })
+  })
+
+  it("persists a ta-only teams block", () => {
+    const meta = build({ ta })
+    expect(meta.teams).toEqual({ ta })
+  })
+
+  it("persists an hta-only teams block", () => {
+    const meta = build({ hta })
+    expect(meta.teams).toEqual({ hta })
+  })
+
+  it("persists a full teacher+ta block", () => {
+    const meta = build({ teacher, ta })
+    expect(meta.teams).toEqual({ teacher, ta })
+  })
+
+  it("omits an empty or absent teams block (matches CLI omitempty)", () => {
+    expect(build(undefined).teams).toBeUndefined()
+    expect(build({}).teams).toBeUndefined()
+  })
+})
+
+// Pins the accept-commit tree shape: the no-shim (empty autogradeYaml) case
+// commits only the marker, and the init_shim deletePaths case posts a
+// `sha: null` deletion entry (the Trees API's "remove from base_tree") so the
+// auto_init README is removed in the same commit. Mirrors the CLI's
+// classroomcfg.DropFiles tests.
+describe("createTreeForAssignment tree entries", () => {
+  const capture = () => {
+    const request = vi.fn(async () => ({ sha: "tree-sha" }))
+    const client = { request } as unknown as GitHubClient
+    const treeOf = () => {
+      const call = request.mock.calls[0] as unknown as [
+        string,
+        { body: { tree: { path: string; content?: string; sha?: null }[] } },
+      ]
+      return call[1].body.tree
+    }
+    return { client, treeOf }
+  }
+
+  const base = {
+    owner: "org",
+    repo: "hw-alice",
+    baseTreeSha: "base",
+    metadataYaml: "classroom: cs",
+  }
+
+  it("commits marker + shim, no deletions, by default", async () => {
+    const { client, treeOf } = capture()
+    await createTreeForAssignment({ client, ...base, autogradeYaml: "name: a" })
+    const paths = treeOf().map((e) => e.path)
+    expect(paths).toEqual([
+      ".classroom50.yaml",
+      ".github/workflows/autograde.yaml",
+    ])
+    expect(treeOf().every((e) => e.sha === undefined)).toBe(true)
+  })
+
+  it("an empty shim commits only the marker", async () => {
+    const { client, treeOf } = capture()
+    await createTreeForAssignment({ client, ...base, autogradeYaml: "" })
+    expect(treeOf().map((e) => e.path)).toEqual([".classroom50.yaml"])
+  })
+
+  it("deletePaths posts sha:null deletion entries (init_shim README removal)", async () => {
+    const { client, treeOf } = capture()
+    await createTreeForAssignment({
+      client,
+      ...base,
+      autogradeYaml: "name: a",
+      deletePaths: ["README.md"],
+    })
+    const readme = treeOf().find((e) => e.path === "README.md")
+    expect(readme).toBeDefined()
+    expect(readme?.sha).toBeNull()
+    expect(readme?.content).toBeUndefined()
   })
 })

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -195,10 +195,9 @@ export const githubKeys = {
   csvFile: (owner: string, repo: string, path: string, ref?: string) =>
     [...githubKeys.all, "csv-file", owner, repo, path, ref ?? null] as const,
 
-  // The per-classroom config-repo files, as the jsonFile/csvFile keys their
-  // readers already use. Delegating (rather than minting new tuples) keeps the
-  // cache entries and every prefix invalidation identical; these exist so a
-  // writer's invalidation and the reader's key can't drift on the path string.
+  // The per-classroom config-repo files. Delegating to jsonFile/csvFile keeps
+  // every cache entry identical; the point is that a writer's invalidation and
+  // the reader's key can't drift on the path string.
   assignmentsFile: (org: string, classroom: string) =>
     githubKeys.jsonFile(org, CONFIG_REPO, assignmentsFilePath(classroom)),
   classroomFile: (org: string, classroom: string) =>

--- a/web/src/hooks/useCacheRefresh.ts
+++ b/web/src/hooks/useCacheRefresh.ts
@@ -12,7 +12,6 @@ import {
 // They live here so `useQueryClient` and `githubKeys` stay out of `pages/`
 // (AGENTS.md); each wraps the single-sourced invalidator in keys.ts.
 
-// Roster invite-status lists for every classroom team in the org.
 export function useInvalidateInviteQueries(org: string): () => void {
   const queryClient = useQueryClient()
   return useCallback(
@@ -21,13 +20,11 @@ export function useInvalidateInviteQueries(org: string): () => void {
   )
 }
 
-// Everything the viewer's org list derives from (see invalidateViewerOrgs).
 export function useInvalidateViewerOrgs(): () => void {
   const queryClient = useQueryClient()
   return useCallback(() => invalidateViewerOrgs(queryClient), [queryClient])
 }
 
-// The org policy audit, whatever plan the cached run used.
 export function useInvalidateOrgAudit(org: string): () => void {
   const queryClient = useQueryClient()
   return useCallback(

--- a/web/src/hooks/useRowSelection.ts
+++ b/web/src/hooks/useRowSelection.ts
@@ -18,7 +18,7 @@ export interface UseRowSelectionArgs<T> {
   // The full set. Selection resolves against this, so a selected row the
   // search hides is still acted on.
   rows: T[]
-  // The current filtered view: the header checkbox's target.
+  // The header checkbox's target.
   filtered: T[]
   // The ACTUAL rendered order when it differs from `filtered` (a grouped view),
   // so a shift-range spans what the user sees.

--- a/web/src/pages/assignments/TemplateField.tsx
+++ b/web/src/pages/assignments/TemplateField.tsx
@@ -492,7 +492,7 @@ function renderTemplateVerdict({
           <ExternalLink
             href={`https://github.com/${verification.owner}/${verification.repo}`}
             variant="plain"
-            className="mt-1 font-semibold underline"
+            className="mt-1 flex font-semibold underline"
           >
             {t("assignments.template.viewTemplateRepo", {
               owner: verification.owner,
@@ -575,7 +575,7 @@ function renderTemplateVerdict({
               <ExternalLink
                 href={`https://github.com/${verification.owner}/${verification.repo}`}
                 variant="plain"
-                className="mt-1 font-semibold underline"
+                className="mt-1 flex font-semibold underline"
               >
                 {t("assignments.template.viewTemplateRepo", {
                   owner: verification.owner,
@@ -666,7 +666,7 @@ const Note = ({
         <ExternalLink
           href={policy.href}
           variant="plain"
-          className="mt-1 font-semibold underline"
+          className="mt-1 flex font-semibold underline"
         >
           {t("assignments.template.policyLink", { owner: policy.owner })}
         </ExternalLink>

--- a/web/src/pages/students/PreflightSummary.test.tsx
+++ b/web/src/pages/students/PreflightSummary.test.tsx
@@ -99,6 +99,27 @@ describe("PreflightSummary", () => {
     expect(screen.queryByText(/summary_update/)).toBeNull()
   })
 
+  // The pills are solid, not soft: the soft wash reads as disabled against the
+  // bordered summary strip. Pinned because a tone-prop refactor once flipped it.
+  it("renders solid tone pills and a ghost skip pill", () => {
+    render(
+      <PreflightSummary
+        preflight={result({
+          needsInvite: [
+            { kind: "needs_invite", username: "a", role: "student" },
+          ],
+          noAction: [mk("b")],
+        })}
+        detailsOpen={false}
+        onToggleDetails={() => {}}
+      />,
+    )
+    const [add, skip] = screen.getAllByText("1").map((el) => el.className)
+    expect(add).toContain("badge-success")
+    expect(add).not.toContain("badge-soft")
+    expect(skip).toContain("badge-ghost")
+  })
+
   it("shows a no-changes message when every category is empty", () => {
     render(
       <PreflightSummary

--- a/web/src/pages/students/PreflightSummary.tsx
+++ b/web/src/pages/students/PreflightSummary.tsx
@@ -9,8 +9,9 @@ import type { BadgeTone } from "@/types/badgeTone"
 export type SummaryCategory = {
   key: "add" | "update" | "skip"
   count: number
-  // The count pill's Badge appearance.
-  pill: { tone: BadgeTone } | { ghost: true }
+  // The count pill's Badge appearance. Solid, not soft: the pill sits on a
+  // bordered summary strip where the soft wash reads as disabled.
+  pill: { tone: BadgeTone; soft: false } | { ghost: true }
 }
 
 // Collapse the five preflight buckets into the three teacher-facing categories:
@@ -38,8 +39,12 @@ export function summarizePreflight(
     preflight.metadataUpdate.length + preflight.roleChanges.length
   const skipCount = preflight.noAction.length
   const categories: SummaryCategory[] = [
-    { key: "add", count: addCount, pill: { tone: "success" } },
-    { key: "update", count: updateCount, pill: { tone: "warning" } },
+    { key: "add", count: addCount, pill: { tone: "success", soft: false } },
+    {
+      key: "update",
+      count: updateCount,
+      pill: { tone: "warning", soft: false },
+    },
     { key: "skip", count: skipCount, pill: { ghost: true } },
   ]
   return { categories, addCount, updateCount, skipCount }

--- a/web/src/test/walkSource.ts
+++ b/web/src/test/walkSource.ts
@@ -1,17 +1,11 @@
 import { readdirSync, readFileSync, statSync } from "node:fs"
 import path from "node:path"
 
-// Source-tree walk for the guard tests that scan src/** (contrast tiers, VPAT
-// architectural claims, config-repo path templates). Two things every scanner
-// needs and none should hand-roll:
-//
-// - Skip the `__*_probe_*` directories the boundary tests (eslintBoundaries,
-//   dependencyCruiser, noCycleGuard, authz/boundaryGuard) create and delete
-//   under src/ while they run. Vitest shards run in parallel, so a scanner in
-//   one shard can list a probe file that a prober in another shard removes
-//   before the read; that race was a CI-only ENOENT.
-// - Tolerate a file vanishing between the listing and the read for the same
-//   reason: a missing file is not a scan finding.
+// Source-tree walk for the guard tests that scan src/**. The boundary tests
+// create and delete `__*_probe_*` directories under src/ while they run, and
+// vitest shards run in parallel, so a scanner can list a probe file another
+// shard removes before the read (a CI-only ENOENT). Skip those directories,
+// and treat a file that vanishes mid-walk as absent, not as a finding.
 const PROBE_DIR = /^__\w+_probe_/
 
 export function walkSourceFiles(

--- a/web/src/util/orgMembers.ts
+++ b/web/src/util/orgMembers.ts
@@ -258,9 +258,8 @@ const displayName = (row: OrgMemberRow) => row.username || row.name || row.email
 // What the Name cell shows: the name when known, else the avatar's fallbacks.
 const nameFirst = (row: OrgMemberRow) => row.name || row.username || row.email
 
-// Header-driven column sort for the Members table (sortByColumn, like the
-// roster). `isOwner` backs the role column — ownership lives outside the row
-// (the admins read), so the caller supplies the predicate.
+// Column sort for the Members table. `isOwner` backs the role column: ownership
+// lives outside the row (the admins read), so the caller supplies it.
 export type OrgMembersSortColumn =
   "name" | "username" | "classrooms" | "role" | "status"
 export function sortOrgMemberRowsBy(


### PR DESCRIPTION
## Summary

A holistic review of everything merged since `web-v1.47.0` (#904 through #922, 207 files) for regressions, with fixes. Method: two independent diff-by-diff passes over `domain/` + `github-core/` + `hooks/mutations/` and over `components/` + `pages/` + `hooks/` + `util/`, each comparing the removed side against the added side per PR, plus a read of every comment those PRs introduced.

**Verdict:** no runtime regression in the data layer. Two visual regressions and one test-coverage regression in the UI layer, all fixed here. Full detail in the two review reports below; the fixes are small.

### Fixed

- **Preflight count pills went soft** (#920). `PreflightSummary` moved from `<Badge className="badge-success">` (a neutral badge with a class appended, which renders solid) to `<Badge tone="success">`, and `Badge` defaults `soft` for non-neutral tones. Restored with `soft: false`, and a test now pins that the add/update pills have no `badge-soft` while the skip pill is `badge-ghost`. No test covered this before, which is how it slipped.
- **TemplateField's follow-up links moved onto the note's text line** (#907). Three "View template repo" / "policy" links were `mt-1 flex …` (block, own line under the message) and became `ExternalLink variant="plain"` (`inline-flex`), so they flowed after the last sentence. The sweep's PR body claimed prose-adjacent sites were skipped; these were not. `ExternalLink` now yields its `inline-flex` when the caller sets `flex` (exact token, so `flex-1`/`shrink-0` do not trigger it), the three sites pass `flex`, and a test pins the yield.
- **Eight tests deleted** (#909). I replaced `gitObjects.test.ts` with a new file instead of appending, dropping `createClassroomMetadata teams persistence` (5 tests, one guarding a known rename regression) and `createTreeForAssignment tree entries` (3 tests: marker + shim, marker only, `sha: null` deletions). The PR body said "every existing test passes unchanged", which was wrong. Both suites are restored verbatim beside the four new ones; the production code they pin was never changed, so this was a coverage gap only.

### Checked and clean

The reviews specifically verified, against the pre-refactor code: `withRetry` attempt counts and the 300/600/900ms jitter sequence; every new `githubKeys` tuple byte-identical to its literal (including `undefined` org); `readConfigJson` still propagating non-404 errors and still throwing on a directory; `setAssignmentFlag`'s no-op path still calling the template reconcile with the same list; `commitRenameConfig`'s base tree from the same parent commit; `paginateAll` with `pick` stopping on the same short-page condition; `useDeleteAssignment` invalidating before the page navigates; `useRowSelection` memo triggers, the roster's none-selectable notice, and `AssignmentsPage`'s dedupe + prune; `useOrgMembersCacheSync` call order, `skipCsv` flags, and the 4s reconcile window; every `SubmissionsActionsMenu` item's `disabled`/`title`/separator position; `runBulkFanOut` under `REPO_WRITE_CONCURRENCY = 1` for the missing-scope stop; `matchesQuery` on `undefined` fields; `SplitButton`'s `tabIndex`/`disabled`; the eslint block still carrying the authz and icon patterns; `ConfirmModal` closing itself after `onConfirm`.

### Behavior changes that were disclosed and stand

- `deleteAssignment`'s commit message is now "Delete assignment:" (was a copy-pasted "Edit assignment:"); visible in the activity feed. #905.
- `orgMembers/BulkActionsBar` now holds the tab during a run; it never did before, the roster bar always did. #906.
- `updateRepoRef` URL-encodes the branch for student repos; a no-op for `main`, correct for a slashed branch. #909.
- The trailing external-link glyph is `size-3.5` on every converted link where several were `size-4`. #907.
- `createAssignment`'s template probe now overlaps the config-repo reads, so a config-read failure can surface before a template failure (previously impossible). No write happens in either case. #905.

### Comments

Every comment the refactor PRs added was read against AGENTS.md's bar (why not what, one or two lines, said once). Tightened: field comments that restated the signature (`isMounted`, `onProgress`, `ConfigRepoHead`, the three `useCacheRefresh` one-liners), the two places the "parse outside the 404 region" and `withGitConflictRetry` rationales were said twice, four over-long headers (`useBulkRun`, `walkSource`, `SplitButton`, `BulkRunModal`), and two em dashes on lines I had rewritten. Moved prose (`dashboard.ts`, `scores.ts`) is untouched.

### Further opportunities the review surfaced (not done here)

Data layer: the six roster writers and `classroomEdit.ts` still hand-roll the config-repo commit that `commitConfigRepoFiles` covers (#905 deferred them over a CSV parse-mode question, but the git half is independent); five student-repo writers share a `commitRepoFiles` shape with no helper; `fileReads.ts` has four spellings of the contents read; `status === 409/422` literals remain at ~10 sites; the `{ previousCommitSha, baseTreeSha, ...written }` result is spelled five times. UI: `displayFor` and the failed/deferred section builder are copied across the six bulk modals (~120 lines); `BulkRunModal` renders the result body itself rather than via `BulkResultBody` (left because `BulkResultBody` adds `text-sm`, a visual change); two `NotAppliedError` classes; `isSelf` duplicated in `OrgMembersPage` and `EnrolledStudents`; a `TableEmptyRow` sibling for the 7 empty rows; five text-link anchors the sweep missed; the `no-restricted-imports` rule matches `@/github-core/queries` but not `@/github-core/queries/keys`.

## Test plan

- [x] `cd web && npm run check`: tsc, eslint (0 errors, 25 warnings, unchanged), prettier, arch:validate, 5,341 node tests (was 5,331 at #922: +8 restored, +2 new pins). Browser project run separately: 18 passed.
- [x] The two new pins fail against `main` and pass here (`PreflightSummary.test.tsx` solid pills; `ExternalLink.test.tsx` flex yield).
- [ ] Manual: upload a roster and confirm the preflight count pills are solid green/amber; open the assignment form, enter a template repo, and confirm "View template repo" sits on its own line under the verification note.

## Type of change

- [x] Bug fix

## Checklist

- [x] I built, tested, and linted the module(s) I touched (web `npm run check`; no Go or Python change).
- [x] Cross-binary contract: n/a.
- [x] CLI docs: n/a.
- [x] My commits follow Conventional Commits.
