### PR TITLE
refactor(web): share bulk result section builders across the six modals

### DIFF
--- a/web/src/components/bulk/fanOut.test.ts
+++ b/web/src/components/bulk/fanOut.test.ts
@@ -182,7 +182,16 @@ describe("failedAndDeferredSections", () => {
       { owner: "bob", status: "deferred" },
     ])
     expect(
-      failedAndDeferredSections(tCount, "submissions.bulkX", groups, (l) => l),
+      failedAndDeferredSections(
+        tCount,
+        {
+          failed: "submissions.bulkX.failedSection",
+          deferred: "submissions.bulkX.deferredSection",
+          deferredDetail: "submissions.bulkX.deferredDetail",
+        },
+        groups,
+        (l) => l,
+      ),
     ).toEqual([
       {
         title: "submissions.bulkX.deferredSection:1",

--- a/web/src/components/bulk/fanOut.test.ts
+++ b/web/src/components/bulk/fanOut.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it, vi } from "vitest"
 
 import { GitHubAPIError } from "@/github-core/errors"
 
-import { partitionOutcomes, runBulkFanOut } from "./fanOut"
+import {
+  failedAndDeferredSections,
+  outcomeSection,
+  ownerDisplayName,
+  partitionOutcomes,
+  runBulkFanOut,
+} from "./fanOut"
 
 const t = ((key: string) => key) as never
 
@@ -138,5 +144,74 @@ describe("partitionOutcomes", () => {
     expect(succeeded.map((o) => o.owner)).toEqual(["a"])
     expect(deferred.map((o) => o.owner)).toEqual(["b"])
     expect(failed[0].detail).toBe("x")
+  })
+})
+
+// Mirrors t(key, { count }) closely enough to assert the count is threaded.
+const tCount = ((key: string, opts?: { count?: number }) =>
+  opts?.count === undefined ? key : `${key}:${opts.count}`) as never
+
+describe("outcomeSection", () => {
+  it("yields no section for an empty group", () => {
+    expect(outcomeSection(tCount, "x.failedSection", [], (l) => l)).toEqual([])
+  })
+
+  it("titles with the row count and prefers a row's own detail", () => {
+    const rows = [
+      { owner: "ann", status: "failed", detail: "403" },
+      { owner: "bob", status: "failed" },
+    ]
+    expect(
+      outcomeSection(tCount, "x.failedSection", rows, (l) => l, "fallback"),
+    ).toEqual([
+      {
+        title: "x.failedSection:2",
+        rows: [
+          { key: "ann", label: "ann", detail: "403" },
+          { key: "bob", label: "bob", detail: "fallback" },
+        ],
+      },
+    ])
+  })
+})
+
+describe("failedAndDeferredSections", () => {
+  it("emits failed then deferred under the prefix, skipping empty groups", () => {
+    const groups = partitionOutcomes([
+      { owner: "ann", status: "ok" },
+      { owner: "bob", status: "deferred" },
+    ])
+    expect(
+      failedAndDeferredSections(tCount, "submissions.bulkX", groups, (l) => l),
+    ).toEqual([
+      {
+        title: "submissions.bulkX.deferredSection:1",
+        rows: [
+          {
+            key: "bob",
+            label: "bob",
+            detail: "submissions.bulkX.deferredDetail",
+          },
+        ],
+      },
+    ])
+  })
+})
+
+describe("ownerDisplayName", () => {
+  it("uses the roster name when known and falls back to the login", () => {
+    const displayFor = ownerDisplayName([
+      {
+        username: "ann",
+        first_name: "Ann",
+        last_name: "Lee",
+        email: "",
+        section: "",
+        github_id: "",
+        role: "",
+      },
+    ])
+    expect(displayFor("ann")).toBe("Ann Lee")
+    expect(displayFor("zed")).toBe("zed")
   })
 })

--- a/web/src/components/bulk/fanOut.ts
+++ b/web/src/components/bulk/fanOut.ts
@@ -138,23 +138,23 @@ export function outcomeSection<O extends AnyOutcome & { detail?: string }>(
 }
 
 // The two sections every fan-out result carries, from a `partitionOutcomes`
-// result and the modal's i18n prefix: `<prefix>.failedSection` with each
-// failure's reason, then `<prefix>.deferredSection` with
-// `<prefix>.deferredDetail` on every row.
+// result: failures with their own reasons, then deferrals sharing one
+// explanation. Callers spell out all three keys so the i18n audit can see them
+// (it can't follow a key assembled from a prefix).
 export function failedAndDeferredSections<O extends AnyOutcome>(
   t: TFunction,
-  prefix: string,
+  keys: { failed: string; deferred: string; deferredDetail: string },
   groups: Pick<ReturnType<typeof partitionOutcomes<O>>, "failed" | "deferred">,
   displayFor: (login: string) => string,
 ): BulkResultView["sections"] {
   return [
-    ...outcomeSection(t, `${prefix}.failedSection`, groups.failed, displayFor),
+    ...outcomeSection(t, keys.failed, groups.failed, displayFor),
     ...outcomeSection(
       t,
-      `${prefix}.deferredSection`,
+      keys.deferred,
       groups.deferred,
       displayFor,
-      t(`${prefix}.deferredDetail`),
+      t(keys.deferredDetail),
     ),
   ]
 }

--- a/web/src/components/bulk/fanOut.ts
+++ b/web/src/components/bulk/fanOut.ts
@@ -3,7 +3,11 @@ import type { TFunction } from "i18next"
 import { describeWriteFailure } from "@/components/modals/collaboratorHelpers"
 import { GitHubAPIError } from "@/github-core/errors"
 import { REPO_READ_CONCURRENCY } from "@/github-core/queries"
+import type { Student } from "@/types/classroom"
 import { mapWithConcurrency } from "@/util/concurrency"
+import { getName } from "@/util/students"
+
+import type { BulkResultView } from "./resultView"
 
 // The three outcomes every fan-out can produce. A caller may widen the union
 // with its own statuses by returning them from `perOwner`; the widened type
@@ -102,4 +106,55 @@ export function partitionOutcomes<O extends AnyOutcome>(outcomes: O[]) {
         o.status === "failed",
     ),
   }
+}
+
+// How a bulk result names an owner: roster name when known, else the login.
+export const ownerDisplayName =
+  (students: Student[]) =>
+  (login: string): string =>
+    getName(login, students) || login
+
+// One result section from a group of outcomes, or none when the group is
+// empty. `titleKey` takes `count`; a row's own `detail` wins over the fallback
+// (a failure carries its reason, a deferral gets the shared explanation).
+export function outcomeSection<O extends AnyOutcome & { detail?: string }>(
+  t: TFunction,
+  titleKey: string,
+  rows: O[],
+  displayFor: (login: string) => string,
+  detailFallback?: string,
+): BulkResultView["sections"] {
+  if (rows.length === 0) return []
+  return [
+    {
+      title: t(titleKey, { count: rows.length }),
+      rows: rows.map((o) => ({
+        key: o.owner,
+        label: displayFor(o.owner),
+        detail: o.detail ?? detailFallback,
+      })),
+    },
+  ]
+}
+
+// The two sections every fan-out result carries, from a `partitionOutcomes`
+// result and the modal's i18n prefix: `<prefix>.failedSection` with each
+// failure's reason, then `<prefix>.deferredSection` with
+// `<prefix>.deferredDetail` on every row.
+export function failedAndDeferredSections<O extends AnyOutcome>(
+  t: TFunction,
+  prefix: string,
+  groups: Pick<ReturnType<typeof partitionOutcomes<O>>, "failed" | "deferred">,
+  displayFor: (login: string) => string,
+): BulkResultView["sections"] {
+  return [
+    ...outcomeSection(t, `${prefix}.failedSection`, groups.failed, displayFor),
+    ...outcomeSection(
+      t,
+      `${prefix}.deferredSection`,
+      groups.deferred,
+      displayFor,
+      t(`${prefix}.deferredDetail`),
+    ),
+  ]
 }

--- a/web/src/components/modals/BulkAutogradeStateModal.tsx
+++ b/web/src/components/modals/BulkAutogradeStateModal.tsx
@@ -7,12 +7,16 @@ import {
   BulkProgressBlock,
   BulkResultBody,
 } from "@/components/bulk/resultView"
-import { runBulkFanOut, type FanOutOutcome } from "@/components/bulk/fanOut"
+import {
+  outcomeSection,
+  ownerDisplayName,
+  runBulkFanOut,
+  type FanOutOutcome,
+} from "@/components/bulk/fanOut"
 import { useBulkRun } from "@/components/bulk/useBulkRun"
 import { setAutogradeState } from "@/github-core/mutations"
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { studentRepoName } from "@/util/studentRepo"
-import { getName } from "@/util/students"
 import type { Student } from "@/types/classroom"
 
 type BulkAutogradeStateModalProps = {
@@ -53,7 +57,7 @@ export function BulkAutogradeStateModal({
   const { phase, progress, result, busy } = bulk
 
   const total = owners.length
-  const displayFor = (login: string) => getName(login, students) || login
+  const displayFor = ownerDisplayName(students)
   const isPause = action === "pause"
 
   const run = async () => {
@@ -79,24 +83,8 @@ export function BulkAutogradeStateModal({
     const deferred = outcomes.filter((o) => o.status === "deferred")
     const failed = outcomes.filter((o) => o.status === "failed")
 
-    const section = (
-      titleKey: string,
-      rows: Outcome[],
-      detailFallback?: string,
-    ) =>
-      rows.length
-        ? [
-            {
-              title: t(titleKey, { count: rows.length }),
-              rows: rows.map((o) => ({
-                key: o.owner,
-                label: displayFor(o.owner),
-                detail:
-                  ("detail" in o ? o.detail : undefined) ?? detailFallback,
-              })),
-            },
-          ]
-        : []
+    const section = (titleKey: string, rows: Outcome[], detail?: string) =>
+      outcomeSection(t, titleKey, rows, displayFor, detail)
 
     bulk.complete(
       {

--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -105,7 +105,11 @@ export function BulkRepoAccessModal({
             }),
         sections: failedAndDeferredSections(
           t,
-          "submissions.bulkAccess",
+          {
+            failed: "submissions.bulkAccess.failedSection",
+            deferred: "submissions.bulkAccess.deferredSection",
+            deferredDetail: "submissions.bulkAccess.deferredDetail",
+          },
           { failed, deferred },
           displayFor,
         ),

--- a/web/src/components/modals/BulkRepoAccessModal.tsx
+++ b/web/src/components/modals/BulkRepoAccessModal.tsx
@@ -14,11 +14,14 @@ import {
   BulkProgressBlock,
   BulkResultBody,
 } from "@/components/bulk/resultView"
-import { partitionOutcomes } from "@/components/bulk/fanOut"
+import {
+  failedAndDeferredSections,
+  ownerDisplayName,
+  partitionOutcomes,
+} from "@/components/bulk/fanOut"
 import { runBulkRepoAccess } from "@/components/bulk/repoAccessFanOut"
 import { useBulkRun } from "@/components/bulk/useBulkRun"
 import useAddRepoCollaborator from "@/hooks/mutations/useAddRepoCollaborator"
-import { getName } from "@/util/students"
 import type { RepoPermission, Student } from "@/types/classroom"
 import { REPO_PERMISSIONS } from "@/types/classroom"
 
@@ -58,7 +61,7 @@ export function BulkRepoAccessModal({
   }, [open])
 
   const total = owners.length
-  const displayFor = (login: string) => getName(login, students) || login
+  const displayFor = ownerDisplayName(students)
 
   const permissionLabel = (level: RepoPermission) =>
     t(`assignments.form.studentPermission.levels.${level}`)
@@ -100,36 +103,12 @@ export function BulkRepoAccessModal({
               total,
               level: permissionLabel(permission),
             }),
-        sections: [
-          ...(failed.length
-            ? [
-                {
-                  title: t("submissions.bulkAccess.failedSection", {
-                    count: failed.length,
-                  }),
-                  rows: failed.map((o) => ({
-                    key: o.owner,
-                    label: displayFor(o.owner),
-                    detail: o.detail,
-                  })),
-                },
-              ]
-            : []),
-          ...(deferred.length
-            ? [
-                {
-                  title: t("submissions.bulkAccess.deferredSection", {
-                    count: deferred.length,
-                  }),
-                  rows: deferred.map((o) => ({
-                    key: o.owner,
-                    label: displayFor(o.owner),
-                    detail: t("submissions.bulkAccess.deferredDetail"),
-                  })),
-                },
-              ]
-            : []),
-        ],
+        sections: failedAndDeferredSections(
+          t,
+          "submissions.bulkAccess",
+          { failed, deferred },
+          displayFor,
+        ),
       },
       failed.length || deferred.length ? "error" : "complete",
     )

--- a/web/src/components/modals/BulkRepoFeaturesModal.tsx
+++ b/web/src/components/modals/BulkRepoFeaturesModal.tsx
@@ -14,12 +14,16 @@ import {
   BulkProgressBlock,
   BulkResultBody,
 } from "@/components/bulk/resultView"
-import { partitionOutcomes, runBulkFanOut } from "@/components/bulk/fanOut"
+import {
+  failedAndDeferredSections,
+  ownerDisplayName,
+  partitionOutcomes,
+  runBulkFanOut,
+} from "@/components/bulk/fanOut"
 import { useBulkRun } from "@/components/bulk/useBulkRun"
 import useSetRepoFeatures from "@/hooks/mutations/useSetRepoFeatures"
 import type { RepoFeaturePatch } from "@/github-core/mutations"
 import { studentRepoName } from "@/util/studentRepo"
-import { getName } from "@/util/students"
 import type { Student } from "@/types/classroom"
 
 type BulkRepoFeaturesModalProps = {
@@ -91,7 +95,7 @@ export function BulkRepoFeaturesModal({
   }, [open])
 
   const total = owners.length
-  const displayFor = (login: string) => getName(login, students) || login
+  const displayFor = ownerDisplayName(students)
   const patch = useMemo(() => choicesToPatch(choices), [choices])
   const nothingSelected = Object.keys(patch).length === 0
 
@@ -125,36 +129,12 @@ export function BulkRepoFeaturesModal({
               count: succeeded.length,
               total,
             }),
-        sections: [
-          ...(failed.length
-            ? [
-                {
-                  title: t("submissions.bulkFeatures.failedSection", {
-                    count: failed.length,
-                  }),
-                  rows: failed.map((o) => ({
-                    key: o.owner,
-                    label: displayFor(o.owner),
-                    detail: o.detail,
-                  })),
-                },
-              ]
-            : []),
-          ...(deferred.length
-            ? [
-                {
-                  title: t("submissions.bulkFeatures.deferredSection", {
-                    count: deferred.length,
-                  }),
-                  rows: deferred.map((o) => ({
-                    key: o.owner,
-                    label: displayFor(o.owner),
-                    detail: t("submissions.bulkFeatures.deferredDetail"),
-                  })),
-                },
-              ]
-            : []),
-        ],
+        sections: failedAndDeferredSections(
+          t,
+          "submissions.bulkFeatures",
+          { failed, deferred },
+          displayFor,
+        ),
       },
       failed.length || deferred.length ? "error" : "complete",
     )

--- a/web/src/components/modals/BulkRepoFeaturesModal.tsx
+++ b/web/src/components/modals/BulkRepoFeaturesModal.tsx
@@ -131,7 +131,11 @@ export function BulkRepoFeaturesModal({
             }),
         sections: failedAndDeferredSections(
           t,
-          "submissions.bulkFeatures",
+          {
+            failed: "submissions.bulkFeatures.failedSection",
+            deferred: "submissions.bulkFeatures.deferredSection",
+            deferredDetail: "submissions.bulkFeatures.deferredDetail",
+          },
           { failed, deferred },
           displayFor,
         ),

--- a/web/src/components/modals/BulkRepoVisibilityModal.tsx
+++ b/web/src/components/modals/BulkRepoVisibilityModal.tsx
@@ -14,11 +14,15 @@ import {
   BulkProgressBlock,
   BulkResultBody,
 } from "@/components/bulk/resultView"
-import { partitionOutcomes, runBulkFanOut } from "@/components/bulk/fanOut"
+import {
+  failedAndDeferredSections,
+  ownerDisplayName,
+  partitionOutcomes,
+  runBulkFanOut,
+} from "@/components/bulk/fanOut"
 import { useBulkRun } from "@/components/bulk/useBulkRun"
 import useSetRepoVisibility from "@/hooks/mutations/useSetRepoVisibility"
 import { studentRepoName } from "@/util/studentRepo"
-import { getName } from "@/util/students"
 import type { RepoVisibility, Student } from "@/types/classroom"
 
 type BulkRepoVisibilityModalProps = {
@@ -62,7 +66,7 @@ export function BulkRepoVisibilityModal({
   }, [open])
 
   const total = owners.length
-  const displayFor = (login: string) => getName(login, students) || login
+  const displayFor = ownerDisplayName(students)
   const nothingSelected = choice === "keep"
 
   const run = async () => {
@@ -96,36 +100,12 @@ export function BulkRepoVisibilityModal({
               count: succeeded.length,
               total,
             }),
-        sections: [
-          ...(failed.length
-            ? [
-                {
-                  title: t("submissions.bulkVisibility.failedSection", {
-                    count: failed.length,
-                  }),
-                  rows: failed.map((o) => ({
-                    key: o.owner,
-                    label: displayFor(o.owner),
-                    detail: o.detail,
-                  })),
-                },
-              ]
-            : []),
-          ...(deferred.length
-            ? [
-                {
-                  title: t("submissions.bulkVisibility.deferredSection", {
-                    count: deferred.length,
-                  }),
-                  rows: deferred.map((o) => ({
-                    key: o.owner,
-                    label: displayFor(o.owner),
-                    detail: t("submissions.bulkVisibility.deferredDetail"),
-                  })),
-                },
-              ]
-            : []),
-        ],
+        sections: failedAndDeferredSections(
+          t,
+          "submissions.bulkVisibility",
+          { failed, deferred },
+          displayFor,
+        ),
       },
       failed.length || deferred.length ? "error" : "complete",
     )

--- a/web/src/components/modals/BulkRepoVisibilityModal.tsx
+++ b/web/src/components/modals/BulkRepoVisibilityModal.tsx
@@ -102,7 +102,11 @@ export function BulkRepoVisibilityModal({
             }),
         sections: failedAndDeferredSections(
           t,
-          "submissions.bulkVisibility",
+          {
+            failed: "submissions.bulkVisibility.failedSection",
+            deferred: "submissions.bulkVisibility.deferredSection",
+            deferredDetail: "submissions.bulkVisibility.deferredDetail",
+          },
           { failed, deferred },
           displayFor,
         ),

--- a/web/src/components/modals/BulkSubmissionTriggerModal.tsx
+++ b/web/src/components/modals/BulkSubmissionTriggerModal.tsx
@@ -7,7 +7,12 @@ import {
   BulkProgressBlock,
   BulkResultBody,
 } from "@/components/bulk/resultView"
-import { runBulkFanOut, type FanOutOutcome } from "@/components/bulk/fanOut"
+import {
+  outcomeSection,
+  ownerDisplayName,
+  runBulkFanOut,
+  type FanOutOutcome,
+} from "@/components/bulk/fanOut"
 import { useBulkRun } from "@/components/bulk/useBulkRun"
 import {
   updateShimSubmissionMode,
@@ -16,7 +21,6 @@ import {
 import { useGitHubClient } from "@/context/github/GitHubProvider"
 import { REPO_WRITE_CONCURRENCY } from "@/github-core/queries"
 import { studentRepoName } from "@/util/studentRepo"
-import { getName } from "@/util/students"
 import type { Student, SubmissionMode } from "@/types/classroom"
 
 type BulkSubmissionTriggerModalProps = {
@@ -63,7 +67,7 @@ export function BulkSubmissionTriggerModal({
   const { phase, progress, result, busy } = bulk
 
   const total = owners.length
-  const displayFor = (login: string) => getName(login, students) || login
+  const displayFor = ownerDisplayName(students)
   const modeLabel = t(
     submissionMode === "tag"
       ? "assignments.form.submissionMode.choices.tag"
@@ -118,24 +122,8 @@ export function BulkSubmissionTriggerModal({
     const scope = outcomes.filter((o) => o.status === "missingWorkflowScope")
     const failed = outcomes.filter((o) => o.status === "failed")
 
-    const section = (
-      titleKey: string,
-      rows: Outcome[],
-      detailFallback?: string,
-    ) =>
-      rows.length
-        ? [
-            {
-              title: t(titleKey, { count: rows.length }),
-              rows: rows.map((o) => ({
-                key: o.owner,
-                label: displayFor(o.owner),
-                detail:
-                  ("detail" in o ? o.detail : undefined) ?? detailFallback,
-              })),
-            },
-          ]
-        : []
+    const section = (titleKey: string, rows: Outcome[], detail?: string) =>
+      outcomeSection(t, titleKey, rows, displayFor, detail)
 
     bulk.complete(
       {

--- a/web/src/components/modals/CloseSubmissionModal.tsx
+++ b/web/src/components/modals/CloseSubmissionModal.tsx
@@ -136,7 +136,11 @@ export function CloseSubmissionModal({
         headline: t(headlineKey, { count: succeeded.length, total }),
         sections: failedAndDeferredSections(
           t,
-          "submissions.closeSubmission",
+          {
+            failed: "submissions.closeSubmission.failedSection",
+            deferred: "submissions.closeSubmission.deferredSection",
+            deferredDetail: "submissions.closeSubmission.deferredDetail",
+          },
           { failed, deferred },
           displayFor,
         ),

--- a/web/src/components/modals/CloseSubmissionModal.tsx
+++ b/web/src/components/modals/CloseSubmissionModal.tsx
@@ -4,12 +4,15 @@ import { CalendarIcon } from "@/components/ui/icons"
 
 import { Alert, Button, Modal, ModalIcon } from "@/components/ui"
 import { BulkProgressBlock, BulkResultBody } from "@/components/bulk/resultView"
-import { partitionOutcomes } from "@/components/bulk/fanOut"
+import {
+  failedAndDeferredSections,
+  ownerDisplayName,
+  partitionOutcomes,
+} from "@/components/bulk/fanOut"
 import { runBulkRepoAccess } from "@/components/bulk/repoAccessFanOut"
 import { useBulkRun } from "@/components/bulk/useBulkRun"
 import useAddRepoCollaborator from "@/hooks/mutations/useAddRepoCollaborator"
 import useSetAssignmentClosed from "@/hooks/mutations/useSetAssignmentClosed"
-import { getName } from "@/util/students"
 import type { RepoPermission, Student } from "@/types/classroom"
 
 type CloseSubmissionModalProps = {
@@ -67,7 +70,7 @@ export function CloseSubmissionModal({
   }, [open])
 
   const total = owners.length
-  const displayFor = (login: string) => getName(login, students) || login
+  const displayFor = ownerDisplayName(students)
 
   // Set every accepted student's role on their own repo. `flipFlag` runs the
   // full close/reopen (flag flip first, then fan-out); `finishOnly` skips the
@@ -131,36 +134,12 @@ export function CloseSubmissionModal({
     bulk.complete(
       {
         headline: t(headlineKey, { count: succeeded.length, total }),
-        sections: [
-          ...(failed.length
-            ? [
-                {
-                  title: t("submissions.closeSubmission.failedSection", {
-                    count: failed.length,
-                  }),
-                  rows: failed.map((o) => ({
-                    key: o.owner,
-                    label: displayFor(o.owner),
-                    detail: o.detail,
-                  })),
-                },
-              ]
-            : []),
-          ...(deferred.length
-            ? [
-                {
-                  title: t("submissions.closeSubmission.deferredSection", {
-                    count: deferred.length,
-                  }),
-                  rows: deferred.map((o) => ({
-                    key: o.owner,
-                    label: displayFor(o.owner),
-                    detail: t("submissions.closeSubmission.deferredDetail"),
-                  })),
-                },
-              ]
-            : []),
-        ],
+        sections: failedAndDeferredSections(
+          t,
+          "submissions.closeSubmission",
+          { failed, deferred },
+          displayFor,
+        ),
       },
       failed.length || deferred.length ? "error" : "complete",
     )


### PR DESCRIPTION
Follow-up from the post-refactor review: the six bulk modals still each hand-rolled the same two pieces of their result view. Every modal defined `const displayFor = (login) => getName(login, students) || login`, four of them inlined the identical failed/deferred section pair, and the two with extra sections (`BulkAutogradeStateModal`, `BulkSubmissionTriggerModal`) each carried their own local `section()` helper with the same body.

`components/bulk/fanOut.ts` now owns that logic, next to `runBulkFanOut` and `partitionOutcomes` that already feed it:

- `ownerDisplayName(students)` is the one definition of how a result names an owner.
- `outcomeSection(t, titleKey, rows, displayFor, detailFallback?)` builds one section from a group of outcomes, or none when the group is empty. A row's own `detail` wins over the fallback, which is exactly the rule the two local helpers encoded.
- `failedAndDeferredSections(t, prefix, groups, displayFor)` is the failed-then-deferred pair every fan-out result carries, keyed off the modal's i18n prefix. It takes the `partitionOutcomes` result the modal already computed for its headline and status, so nothing is partitioned twice.

The four inline modals collapse their `sections` array to a single call; the two extended modals keep their `section()` name but bind it onto `outcomeSection`, so their call sites are unchanged. No copy, i18n key, or rendered output changes. Unit tests pin the empty-group, count-threading, own-detail-wins, and name-fallback rules.

Net: 7 files, roughly 120 insertions against 175 deletions once the new tests are counted.