### PR TITLE
refactor(web): add TableEmptyRow for the seven bare empty-state table rows

### DIFF
--- a/web/src/components/list/emptyState.test.tsx
+++ b/web/src/components/list/emptyState.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, afterEach, vi } from "vitest"
 import { render, screen, cleanup } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
-import { EmptyState, NoSearchResults } from "./index"
+import { EmptyState, NoSearchResults, TableEmptyRow } from "./index"
 
 afterEach(cleanup)
 
@@ -58,6 +58,33 @@ describe("EmptyState", () => {
     render(<EmptyState body="Nothing matched" />)
     expect(screen.queryByRole("heading")).toBeNull()
     expect(screen.getByText("Nothing matched")).toBeDefined()
+  })
+})
+
+describe("TableEmptyRow", () => {
+  it("spans the table with a bare EmptyState and forwards its props", () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <TableEmptyRow
+            colSpan={4}
+            className="py-6"
+            title="No rows"
+            titleAs="h3"
+            body="Add one to begin"
+          />
+        </tbody>
+      </table>,
+    )
+    const cell = container.querySelector("tr > td")
+    expect(cell?.getAttribute("colspan")).toBe("4")
+    const state = cell?.firstElementChild
+    expect(state?.className).not.toContain("border-dashed")
+    expect(state?.className).toContain("py-6")
+    expect(screen.getByRole("heading", { level: 3 }).textContent).toBe(
+      "No rows",
+    )
+    expect(screen.getByText("Add one to begin")).toBeDefined()
   })
 })
 

--- a/web/src/components/list/index.tsx
+++ b/web/src/components/list/index.tsx
@@ -60,6 +60,16 @@ export function ViewToggle({
 // one action slot. `variant="card"` is the dashed-border shell for page-level
 // blankslates; `variant="bare"` is shell-less for table rows and quiet
 // blocks. `className` merges onto the shell (layout-only additions like mt-4).
+export type EmptyStateProps = {
+  icon?: EmptyStateIcon
+  title?: ReactNode
+  titleAs?: "h1" | "h2" | "h3" | "h4"
+  body?: ReactNode
+  action?: ReactNode
+  variant?: "card" | "bare"
+  className?: string
+}
+
 export function EmptyState({
   icon: Icon,
   title,
@@ -68,15 +78,7 @@ export function EmptyState({
   action,
   variant = "card",
   className,
-}: {
-  icon?: EmptyStateIcon
-  title?: ReactNode
-  titleAs?: "h1" | "h2" | "h3" | "h4"
-  body?: ReactNode
-  action?: ReactNode
-  variant?: "card" | "bare"
-  className?: string
-}) {
+}: EmptyStateProps) {
   return (
     <div
       className={cx(
@@ -105,6 +107,21 @@ export function EmptyState({
       )}
       {action && <div className="mt-4">{action}</div>}
     </div>
+  )
+}
+
+// The one "nothing to list" table row: a bare EmptyState spanning the table.
+// Sibling of TableErrorRow, which owns the "failed to load" row.
+export function TableEmptyRow({
+  colSpan,
+  ...emptyState
+}: { colSpan: number } & Omit<EmptyStateProps, "variant">) {
+  return (
+    <tr>
+      <td colSpan={colSpan}>
+        <EmptyState variant="bare" {...emptyState} />
+      </td>
+    </tr>
   )
 }
 

--- a/web/src/pages/OrgMembersPage.tsx
+++ b/web/src/pages/OrgMembersPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react"
-import { EmptyState } from "@/components/list"
+import { TableEmptyRow } from "@/components/list"
 import { Trans, useTranslation } from "react-i18next"
 import { useParams } from "@tanstack/react-router"
 import {
@@ -525,25 +525,21 @@ const OrgMembersPage = () => {
                   />
                 )}
                 {!isLoading && !isError && filtered.length === 0 && (
-                  <tr>
-                    <td colSpan={MEMBERS_COL_COUNT}>
-                      <EmptyState
-                        variant="bare"
-                        body={
-                          classroomFilter === NO_CLASSROOM_FILTER
-                            ? t("orgMembers.noMembersNoClassroom")
-                            : classroomFilter
-                              ? t("orgMembers.noMembersInClassroom", {
-                                  classroom:
-                                    classroomOptions.find(
-                                      (c) => c.path === classroomFilter,
-                                    )?.name ?? classroomFilter,
-                                })
-                              : t("orgMembers.noMatch")
-                        }
-                      />
-                    </td>
-                  </tr>
+                  <TableEmptyRow
+                    colSpan={MEMBERS_COL_COUNT}
+                    body={
+                      classroomFilter === NO_CLASSROOM_FILTER
+                        ? t("orgMembers.noMembersNoClassroom")
+                        : classroomFilter
+                          ? t("orgMembers.noMembersInClassroom", {
+                              classroom:
+                                classroomOptions.find(
+                                  (c) => c.path === classroomFilter,
+                                )?.name ?? classroomFilter,
+                            })
+                          : t("orgMembers.noMatch")
+                    }
+                  />
                 )}
                 {!isLoading &&
                   !isError &&

--- a/web/src/pages/assignments/AssignmentsTable.tsx
+++ b/web/src/pages/assignments/AssignmentsTable.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, type ReactNode } from "react"
 import { selectAllState } from "@/util/rowSelection"
 import { useNavigate } from "@tanstack/react-router"
-import { EmptyState } from "@/components/list"
+import { TableEmptyRow } from "@/components/list"
 import { useTranslation } from "react-i18next"
 import {
   AlertIcon,
@@ -263,6 +263,7 @@ const AssignmentsTable = ({
   // Mutating row actions require both an unarchived classroom and author rights.
   const canMutate = !archived && canAuthor
   const selectable = Boolean(selectedSlugs && onToggleRow && onToggleSelectAll)
+  const colSpan = selectable ? DATA_COLUMNS + 1 : DATA_COLUMNS
   // The header box describes the view: "is everything I can see ticked".
   const { allSelected, someSelected } = selectAllState(
     selectable ? (assignments ?? []) : [],
@@ -342,39 +343,36 @@ const AssignmentsTable = ({
           {loading && <SkeletonRows bars={SKELETON_BARS} />}
           {!loading && loadError && (
             <TableErrorRow
-              colSpan={selectable ? DATA_COLUMNS + 1 : DATA_COLUMNS}
+              colSpan={colSpan}
               message={t("assignments.table.loadError")}
               retryLabel={t("assignments.table.retry")}
               onRetry={onRetryLoad}
             />
           )}
-          {!loading && !loadError && !assignments?.length && (
-            <tr>
-              <td colSpan={selectable ? DATA_COLUMNS + 1 : DATA_COLUMNS}>
-                {emptyAction ? (
-                  // First-use blankslate (Primer): the resolving action lives
-                  // here, and the page hides its toolbar so the view carries
-                  // a single primary action.
-                  <EmptyState
-                    variant="bare"
-                    className="py-12"
-                    icon={PlusIcon}
-                    titleAs="h3"
-                    title={t("assignments.table.emptyTitle")}
-                    body={t("assignments.table.emptyBody")}
-                    action={emptyAction}
-                  />
-                ) : (
-                  // Read-only viewers (TA, archived classroom) get the plain
-                  // statement — there is no action they could take.
-                  <EmptyState
-                    variant="bare"
-                    body={t("assignments.table.empty")}
-                  />
-                )}
-              </td>
-            </tr>
-          )}
+          {!loading &&
+            !loadError &&
+            !assignments?.length &&
+            (emptyAction ? (
+              // First-use blankslate (Primer): the resolving action lives
+              // here, and the page hides its toolbar so the view carries
+              // a single primary action.
+              <TableEmptyRow
+                colSpan={colSpan}
+                className="py-12"
+                icon={PlusIcon}
+                titleAs="h3"
+                title={t("assignments.table.emptyTitle")}
+                body={t("assignments.table.emptyBody")}
+                action={emptyAction}
+              />
+            ) : (
+              // Read-only viewers (TA, archived classroom) get the plain
+              // statement: there is no action they could take.
+              <TableEmptyRow
+                colSpan={colSpan}
+                body={t("assignments.table.empty")}
+              />
+            ))}
           {!loading &&
             !loadError &&
             assignments?.map((assignment) => (

--- a/web/src/pages/assignments/AutogradingTestsPane.tsx
+++ b/web/src/pages/assignments/AutogradingTestsPane.tsx
@@ -7,7 +7,7 @@ import {
   TrashIcon,
   UploadIcon,
 } from "@/components/ui/icons"
-import { EmptyState } from "@/components/list"
+import { TableEmptyRow } from "@/components/list"
 import { useRevealOnExpand } from "@/hooks/useRevealOnExpand"
 import { assignmentBundleUploadUrl } from "@/util/orgUrl"
 import type { AssignmentForm } from "./assignmentFormModel"
@@ -688,15 +688,11 @@ const AutogradingTestsPane = ({
                 </thead>
                 <tbody>
                   {field.state.value.length === 0 ? (
-                    <tr>
-                      <td colSpan={5}>
-                        <EmptyState
-                          variant="bare"
-                          className="py-6"
-                          body={t("assignments.autograder.empty")}
-                        />
-                      </td>
-                    </tr>
+                    <TableEmptyRow
+                      colSpan={5}
+                      className="py-6"
+                      body={t("assignments.autograder.empty")}
+                    />
                   ) : (
                     field.state.value.map(
                       (test: AssignmentTestDraft, index: number) => (

--- a/web/src/pages/students/CsvRosterView.tsx
+++ b/web/src/pages/students/CsvRosterView.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react"
-import { EmptyState } from "@/components/list"
+import { TableEmptyRow } from "@/components/list"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -89,14 +89,7 @@ const CsvRosterView = ({
               onRetry={onRetryLoad}
             />
           ) : rows.length === 0 ? (
-            <tr>
-              <td colSpan={3}>
-                <EmptyState
-                  variant="bare"
-                  body={t("students.csvRoster.empty")}
-                />
-              </td>
-            </tr>
+            <TableEmptyRow colSpan={3} body={t("students.csvRoster.empty")} />
           ) : (
             rows.map((student) => (
               // studentKey falls back to the email, so two pending invites

--- a/web/src/pages/students/EnrolledStudents.tsx
+++ b/web/src/pages/students/EnrolledStudents.tsx
@@ -17,7 +17,7 @@ import {
   TableErrorRow,
   TableShell,
 } from "@/components/ui"
-import { EmptyState } from "@/components/list"
+import { TableEmptyRow } from "@/components/list"
 import type { Student } from "@/types/classroom"
 import type { RosterCsvProblem } from "@/domain/students"
 import { useDismissFailedInvite } from "@/hooks/mutations/useDismissFailedInvite"
@@ -1058,68 +1058,60 @@ const EnrolledStudents = ({
               </tbody>
             ) : isEmpty ? (
               <tbody>
-                <tr>
-                  <td colSpan={colCount}>
-                    <EmptyState
-                      variant="bare"
-                      className="py-12"
-                      icon={PeopleIcon}
-                      titleAs="h3"
-                      title={t("students.emptyTitle")}
-                      body={t("students.emptyBody")}
-                      action={
-                        addActions ? (
-                          <div className="flex flex-col items-center gap-3">
-                            {/* The toolbar (and its syncing indicator) is hidden
-                              on an empty roster, so say it here too. */}
-                            {syncing ? (
-                              <span
-                                className="flex items-center gap-2 text-sm text-base-content/70"
-                                aria-live="polite"
-                              >
-                                <SyncIcon
-                                  aria-hidden="true"
-                                  className="size-4 animate-spin"
-                                />
-                                {t("students.syncActive")}
-                              </span>
-                            ) : null}
-                            <div className="flex justify-center gap-2">
-                              <AddStudentButtons addActions={addActions} />
-                            </div>
-                          </div>
-                        ) : null
-                      }
-                    />
-                  </td>
-                </tr>
+                <TableEmptyRow
+                  colSpan={colCount}
+                  className="py-12"
+                  icon={PeopleIcon}
+                  titleAs="h3"
+                  title={t("students.emptyTitle")}
+                  body={t("students.emptyBody")}
+                  action={
+                    addActions ? (
+                      <div className="flex flex-col items-center gap-3">
+                        {/* The toolbar (and its syncing indicator) is hidden
+                          on an empty roster, so say it here too. */}
+                        {syncing ? (
+                          <span
+                            className="flex items-center gap-2 text-sm text-base-content/70"
+                            aria-live="polite"
+                          >
+                            <SyncIcon
+                              aria-hidden="true"
+                              className="size-4 animate-spin"
+                            />
+                            {t("students.syncActive")}
+                          </span>
+                        ) : null}
+                        <div className="flex justify-center gap-2">
+                          <AddStudentButtons addActions={addActions} />
+                        </div>
+                      </div>
+                    ) : null
+                  }
+                />
               </tbody>
             ) : filtered.length === 0 ? (
               <tbody>
-                <tr>
-                  <td colSpan={colCount}>
-                    <EmptyState
-                      variant="bare"
-                      body={
-                        query.trim()
-                          ? t("students.noMatch")
-                          : effectiveSection !== "all" && statusFilter === "all"
-                            ? t("students.noneInSection", {
-                                section:
-                                  effectiveSection === NO_SECTION
-                                    ? t("students.noSection")
-                                    : effectiveSection,
-                              })
-                            : t("students.noneWithStatus", {
-                                status:
-                                  statusOptions.find(
-                                    (o) => o.value === statusFilter,
-                                  )?.label ?? statusFilter,
-                              })
-                      }
-                    />
-                  </td>
-                </tr>
+                <TableEmptyRow
+                  colSpan={colCount}
+                  body={
+                    query.trim()
+                      ? t("students.noMatch")
+                      : effectiveSection !== "all" && statusFilter === "all"
+                        ? t("students.noneInSection", {
+                            section:
+                              effectiveSection === NO_SECTION
+                                ? t("students.noSection")
+                                : effectiveSection,
+                          })
+                        : t("students.noneWithStatus", {
+                            status:
+                              statusOptions.find(
+                                (o) => o.value === statusFilter,
+                              )?.label ?? statusFilter,
+                          })
+                  }
+                />
               </tbody>
             ) : groupedRows ? (
               // One <tbody> per group (role or section), opened by a full-width

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -1,5 +1,5 @@
 import { FilterRemoveIcon, InboxIcon } from "@/components/ui/icons"
-import { EmptyState } from "@/components/list"
+import { TableEmptyRow } from "@/components/list"
 import { motion } from "motion/react"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -953,48 +953,39 @@ const SubmissionsTable = ({
             (isGroup || !nonSubmitters.length) &&
             !unsubmittedGroupRepos.length &&
             !teamsWithoutRepos.length &&
-            !nonSubmittersLoading && (
-              <tr>
-                <td colSpan={isTeam ? 6 : 5}>
-                  {filtered ? (
-                    <EmptyState
-                      variant="bare"
-                      icon={FilterRemoveIcon}
-                      titleAs="h3"
-                      title={t("submissions.table.emptyFilteredTitle")}
-                      body={t("submissions.table.emptyFilteredBody")}
-                      action={
-                        onClearFilters && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={onClearFilters}
-                          >
-                            {t("submissions.table.emptyClearFilters")}
-                          </Button>
-                        )
-                      }
-                    />
-                  ) : (
-                    <EmptyState
-                      variant="bare"
-                      icon={InboxIcon}
-                      titleAs="h3"
-                      title={
-                        isGroup
-                          ? t("submissions.table.emptyNoGroupsTitle")
-                          : t("submissions.table.emptyNoDataTitle")
-                      }
-                      body={
-                        isGroup
-                          ? t("submissions.table.emptyNoGroupsBody")
-                          : t("submissions.table.emptyNoDataBody")
-                      }
-                    />
-                  )}
-                </td>
-              </tr>
-            )}
+            !nonSubmittersLoading &&
+            (filtered ? (
+              <TableEmptyRow
+                colSpan={isTeam ? 6 : 5}
+                icon={FilterRemoveIcon}
+                titleAs="h3"
+                title={t("submissions.table.emptyFilteredTitle")}
+                body={t("submissions.table.emptyFilteredBody")}
+                action={
+                  onClearFilters && (
+                    <Button variant="ghost" size="sm" onClick={onClearFilters}>
+                      {t("submissions.table.emptyClearFilters")}
+                    </Button>
+                  )
+                }
+              />
+            ) : (
+              <TableEmptyRow
+                colSpan={isTeam ? 6 : 5}
+                icon={InboxIcon}
+                titleAs="h3"
+                title={
+                  isGroup
+                    ? t("submissions.table.emptyNoGroupsTitle")
+                    : t("submissions.table.emptyNoDataTitle")
+                }
+                body={
+                  isGroup
+                    ? t("submissions.table.emptyNoGroupsBody")
+                    : t("submissions.table.emptyNoDataBody")
+                }
+              />
+            ))}
           {/* The whole row sequence waits for initialLoading: parts of it
               (e.g. team-mode group-repo rows from the org repo list) can be
               derivable before the queries the ROW CONTENT needs (team display


### PR DESCRIPTION
Follow-up from the post-refactor review. Seven table bodies rendered the same `<tr><td colSpan={n}><EmptyState variant="bare" … /></td></tr>` by hand: `AutogradingTestsPane`, `OrgMembersPage`, `CsvRosterView`, both empty branches in `EnrolledStudents`, and the two-way ternaries in `AssignmentsTable` and `SubmissionsTable`.

`TableEmptyRow` in `components/list/` (next to `EmptyState`, whose props it forwards minus `variant`) now owns that row, as the sibling of `TableErrorRow` for the "failed to load" case. It lives in `list/` rather than `ui/TableShell` because `list/` already imports `Heading`/`cx` from `ui/`, and putting it in `ui/` would invert that edge.

Call sites shrink to a single element each; the two ternary sites choose between two `TableEmptyRow`s so each branch keeps its comment. `AssignmentsTable` also hoists its repeated `selectable ? DATA_COLUMNS + 1 : DATA_COLUMNS` into one `colSpan` shared with the error row. `EmptyStateProps` is exported so the row type can derive from it. No copy or rendered markup changes; a test pins the `tr > td[colspan]` shape, the bare variant, and prop forwarding.

Verified with `npm run check` (types, lint, prettier, arch, 5364 tests incl. browser mode) and the strict i18n audit.