### PR TITLE
refactor(web): route the seven roster.csv writers through commitConfigRepoFiles

### DIFF
--- a/web/src/domain/students/bulkEnrollment.ts
+++ b/web/src/domain/students/bulkEnrollment.ts
@@ -1,23 +1,12 @@
 import type { GitHubClient } from "@/github-core/client"
-import {
-  createGitCommit,
-  createGitTree,
-  isActiveMember,
-  updateRef,
-} from "@/github-core/mutations"
+import { isActiveMember } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import {
   withGitConflictRetry,
   assertClassroomNotArchived,
   type CreateClassroomResult,
 } from "../classrooms"
-import { getRawFile, getUser } from "@/github-core/queries"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
-import { prefixCommit } from "@/util/commit"
+import { getUser } from "@/github-core/queries"
 import {
   normalizeStudentRow,
   splitName,
@@ -25,17 +14,16 @@ import {
   stringifyStudentsCsv,
   type StudentCsvRow,
 } from "@/util/rosterCsv"
-import { rosterPath } from "@/util/configRepoPaths"
 import { type ClassroomRole } from "@/util/teamRoster"
 import {
   log,
-  rosterWriteTree,
   resolveClassroomTeamSlug,
   tryAddUserToTeam,
   normalizeGithubUsername,
   isLikelyGithubUsername,
   NoNewStudentsError,
 } from "./rosterPrimitives"
+import { commitRoster, readRosterForWrite } from "./rosterWrite"
 
 type BulkImportProgress = {
   processed: number
@@ -114,27 +102,14 @@ export async function addStudentsToClassroom(
     total: normalizedRows.length,
   })
 
-  await assertClassroomNotArchived(client, input.org, input.classroom)
-
   input.onProgress?.({
     processed: 0,
     total: normalizedRows.length,
     message: "Reading current roster.csv...",
   })
 
-  const configBranch = await getConfigRepoBranch(client, input.org)
-  const ref = await getBranchRef(client, input.org, configBranch)
-  const commit = await getCommit(client, input.org, ref.object.sha)
-
-  const studentsFilePath = rosterPath(input.classroom)
-
-  const currentCsv = await getRawFile(client, {
-    org: input.org,
-    path: studentsFilePath,
-    ref: ref.object.sha,
-  })
-
-  const currentStudents = parseStudentsCsv(currentCsv)
+  const ctx = await readRosterForWrite(client, input.org, input.classroom)
+  const currentStudents = parseStudentsCsv(ctx.currentCsv)
 
   const existingUsernameKeys = new Set(
     currentStudents.map((student) => student.username.toLowerCase()),
@@ -248,28 +223,14 @@ export async function addStudentsToClassroom(
   const nextStudents = [...currentStudents, ...addedStudents]
   const nextCsv = stringifyStudentsCsv(nextStudents)
 
-  const tree = await createGitTree(client, {
-    org: input.org,
-    base_tree: commit.tree.sha,
-    tree: rosterWriteTree(input.classroom, nextCsv),
-  })
-
-  const newCommit = await createGitCommit(client, {
-    org: input.org,
-    message: prefixCommit(
-      `Add ${addedStudents.length} student ${
-        addedStudents.length === 1 ? "" : "s"
-      }: ${input.classroom}`,
-    ),
-    tree_sha: tree.sha,
-    parents: [ref.object.sha],
-  })
-
-  const updatedRef = await updateRef(
+  const written = await commitRoster(
     client,
     input.org,
-    newCommit.sha,
-    configBranch,
+    ctx,
+    nextCsv,
+    `Add ${addedStudents.length} student ${
+      addedStudents.length === 1 ? "" : "s"
+    }: ${input.classroom}`,
   )
 
   input.onProgress?.({
@@ -286,11 +247,9 @@ export async function addStudentsToClassroom(
   })
 
   return {
-    previousCommitSha: ref.object.sha,
-    baseTreeSha: commit.tree.sha,
-    newTreeSha: tree.sha,
-    newCommitSha: newCommit.sha,
-    updatedRef,
+    previousCommitSha: ctx.headSha,
+    baseTreeSha: ctx.baseTreeSha,
+    ...written,
     addedStudents,
     skippedStudents,
   }

--- a/web/src/domain/students/bulkEnrollment.ts
+++ b/web/src/domain/students/bulkEnrollment.ts
@@ -23,7 +23,8 @@ import {
   isLikelyGithubUsername,
   NoNewStudentsError,
 } from "./rosterPrimitives"
-import { commitRoster, readRosterForWrite } from "./rosterWrite"
+import { getConfigRepoBranch } from "@/github-core/configRepoReads"
+import { commitRoster, readRosterForWriteAt } from "./rosterWrite"
 
 type BulkImportProgress = {
   processed: number
@@ -102,13 +103,21 @@ export async function addStudentsToClassroom(
     total: normalizedRows.length,
   })
 
+  await assertClassroomNotArchived(client, input.org, input.classroom)
+
   input.onProgress?.({
     processed: 0,
     total: normalizedRows.length,
     message: "Reading current roster.csv...",
   })
 
-  const ctx = await readRosterForWrite(client, input.org, input.classroom)
+  const configBranch = await getConfigRepoBranch(client, input.org)
+  const ctx = await readRosterForWriteAt(
+    client,
+    input.org,
+    input.classroom,
+    configBranch,
+  )
   const currentStudents = parseStudentsCsv(ctx.currentCsv)
 
   const existingUsernameKeys = new Set(

--- a/web/src/domain/students/enrollment.ts
+++ b/web/src/domain/students/enrollment.ts
@@ -1,13 +1,10 @@
 import type { GitHubClient } from "@/github-core/client"
 import {
-  createGitCommit,
-  createGitTree,
   createOrgInvitation,
   deleteInviteTeam,
   ensureInviteTeam,
   ensureOrgMembership,
   isActiveMember,
-  updateRef,
   type InviteTeamRef,
 } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
@@ -16,15 +13,9 @@ import {
   assertClassroomNotArchived,
   type CreateClassroomResult,
 } from "../classrooms"
-import { getRawFile, getUser } from "@/github-core/queries"
+import { getUser } from "@/github-core/queries"
 import { getAuthenticatedUser } from "../queries/users"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
 import { GitHubAPIError } from "@/github-core/errors"
-import { prefixCommit } from "@/util/commit"
 import {
   normalizeStudentRow,
   splitName,
@@ -32,18 +23,17 @@ import {
   stringifyStudentsCsv,
   type StudentCsvRow,
 } from "@/util/rosterCsv"
-import { rosterPath } from "@/util/configRepoPaths"
 import { resolveGitHubId } from "@/util/students"
 import {
   appendEmailInviteRows,
   log,
-  rosterWriteTree,
   resolveClassroomTeam,
   resolveClassroomTeamWithRetry,
   tryAddUserToTeam,
   StudentAlreadyEnrolledError,
 } from "./rosterPrimitives"
 import i18n from "@/i18n"
+import { commitRoster, readRosterForWrite } from "./rosterWrite"
 
 export type AddStudentToClassroomResult = CreateClassroomResult & {
   student: StudentCsvRow
@@ -61,22 +51,10 @@ export async function addStudentToClassroom(
     throw new Error("GitHub username is required")
   }
 
-  await assertClassroomNotArchived(client, input.org, input.classroom)
-
-  const configBranch = await getConfigRepoBranch(client, input.org)
-  const ref = await getBranchRef(client, input.org, configBranch)
-  const commit = await getCommit(client, input.org, ref.object.sha)
-
-  const studentsFilePath = rosterPath(input.classroom)
-
-  const currentCsv = await getRawFile(client, {
-    org: input.org,
-    path: studentsFilePath,
-    ref: ref.object.sha,
-  })
+  const ctx = await readRosterForWrite(client, input.org, input.classroom)
 
   const githubUser = await getUser(client, normalizedUsername)
-  const currentStudents = parseStudentsCsv(currentCsv)
+  const currentStudents = parseStudentsCsv(ctx.currentCsv)
 
   const alreadyExists = currentStudents.some(
     (student) =>
@@ -128,34 +106,18 @@ export async function addStudentToClassroom(
   const nextStudents = [...currentStudents, student]
   const nextCsv = stringifyStudentsCsv(nextStudents)
 
-  const tree = await createGitTree(client, {
-    org: input.org,
-    base_tree: commit.tree.sha,
-    tree: rosterWriteTree(input.classroom, nextCsv),
-  })
-
-  const newCommit = await createGitCommit(client, {
-    org: input.org,
-    message: prefixCommit(
-      `Add student: ${input.classroom}/${student.username}`,
-    ),
-    tree_sha: tree.sha,
-    parents: [ref.object.sha],
-  })
-
-  const updatedRef = await updateRef(
+  const written = await commitRoster(
     client,
     input.org,
-    newCommit.sha,
-    configBranch,
+    ctx,
+    nextCsv,
+    `Add student: ${input.classroom}/${student.username}`,
   )
 
   return {
-    previousCommitSha: ref.object.sha,
-    baseTreeSha: commit.tree.sha,
-    newTreeSha: tree.sha,
-    newCommitSha: newCommit.sha,
-    updatedRef,
+    previousCommitSha: ctx.headSha,
+    baseTreeSha: ctx.baseTreeSha,
+    ...written,
     student,
   }
 }

--- a/web/src/domain/students/rosterPrimitives.ts
+++ b/web/src/domain/students/rosterPrimitives.ts
@@ -2,13 +2,9 @@ import type { GitHubClient } from "@/github-core/client"
 import {
   addUserToTeam,
   cancelOrgInvitation,
-  createGitCommit,
-  createGitTree,
   ensureClassroomRoleTeam,
   grantTeamConfigRepoAccess,
   resendOrgInvitation,
-  updateRef,
-  type GitTreeEntry,
 } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import {
@@ -18,9 +14,7 @@ import {
   sleep,
 } from "@/github-core/queries"
 import {
-  getBranchRef,
   getClassroomJson,
-  getCommit,
   getConfigRepoBranch,
 } from "@/github-core/configRepoReads"
 import {
@@ -28,8 +22,6 @@ import {
   isDefinitiveGitHubStatus,
   tolerateGitHubError,
 } from "@/github-core/errors"
-import { rosterPath } from "@/util/configRepoPaths"
-import { prefixCommit } from "@/util/commit"
 import {
   formatRosterProblems,
   normalizeStudentRow,
@@ -49,28 +41,18 @@ import { isTeacherRole } from "@/authz"
 import { classroomTeamSlug, resolveClassroomRoleSlug } from "@/util/teamSlug"
 import { STAFF_ROLES, type StaffRole, type Student } from "@/types/classroom"
 import { logger } from "@/lib/logger"
+import { commitRoster, readRosterForWriteAt } from "./rosterWrite"
 
 export const log = logger.scope("mutations:students")
 
-// Git-tree entries for a roster write: the roster.csv blob.
-export function rosterWriteTree(
-  classroom: string,
-  csv: string,
-): GitTreeEntry[] {
-  return [
-    { path: rosterPath(classroom), mode: "100644", type: "blob", content: csv },
-  ]
-}
-
 // The conflict-safe roster.csv read-modify-write shared by every roster writer
 // (the role/metadata/username writers in roleWrites, plus the email-invite row
-// append/remove below). Runs inside withGitConflictRetry:
-// reads the config branch/ref/commit, reads roster.csv,
-// parses it tolerantly and REFUSES a malformed file with a typed
-// RosterCsvMalformedError (a positional re-serialize would corrupt the bad row),
-// then hands the parsed rows to `mutate`. `mutate` returns the next rows plus how
-// many changed and the commit message; when `changed === 0` no commit is made.
-// The formula-injection guard + canonical column order come from
+// append/remove below). Runs inside withGitConflictRetry: reads roster.csv at
+// the config-repo head, parses it tolerantly and REFUSES a malformed file with
+// a typed RosterCsvMalformedError (a positional re-serialize would corrupt the
+// bad row), then hands the parsed rows to `mutate`, which returns the next rows
+// plus how many changed and the commit message; when `changed === 0` no commit
+// is made. The formula-injection guard + canonical column order come from
 // stringifyStudentsCsv. Callers own their own identity/field-diff logic and the
 // archived-classroom guard.
 export async function withRosterRewrite(
@@ -85,17 +67,8 @@ export async function withRosterRewrite(
   const { org, classroom } = input
   return withGitConflictRetry(async () => {
     const configBranch = await getConfigRepoBranch(client, org)
-    const ref = await getBranchRef(client, org, configBranch)
-    const commit = await getCommit(client, org, ref.object.sha)
-    // Read at the freshly-fetched branch HEAD (not a commit we just wrote), so
-    // a 404 here means roster.csv is genuinely absent, not read-your-own-write
-    // lag — surface it rather than masking a missing file.
-    const currentCsv = await getRawFile(client, {
-      org,
-      path: rosterPath(classroom),
-      ref: ref.object.sha,
-    })
-    const { rows: currentStudents, problems } = parseRosterCsv(currentCsv)
+    const ctx = await readRosterForWriteAt(client, org, classroom, configBranch)
+    const { rows: currentStudents, problems } = parseRosterCsv(ctx.currentCsv)
     if (problems.length > 0) {
       throw new RosterCsvMalformedError(formatRosterProblems(problems))
     }
@@ -103,19 +76,13 @@ export async function withRosterRewrite(
     const { nextStudents, changed, message } = mutate(currentStudents)
     if (changed === 0) return { changed: 0 }
 
-    const nextCsv = stringifyStudentsCsv(nextStudents)
-    const tree = await createGitTree(client, {
+    await commitRoster(
+      client,
       org,
-      base_tree: commit.tree.sha,
-      tree: rosterWriteTree(classroom, nextCsv),
-    })
-    const newCommit = await createGitCommit(client, {
-      org,
-      message: prefixCommit(message),
-      tree_sha: tree.sha,
-      parents: [ref.object.sha],
-    })
-    await updateRef(client, org, newCommit.sha, configBranch)
+      ctx,
+      stringifyStudentsCsv(nextStudents),
+      message,
+    )
     return { changed }
   })
 }

--- a/web/src/domain/students/rosterSync.test.ts
+++ b/web/src/domain/students/rosterSync.test.ts
@@ -32,16 +32,6 @@ vi.mock("../classrooms", () => ({
 }))
 vi.mock("./rosterPrimitives", () => ({
   log: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
-  // Mirrors the real helper (one blob at the roster path); hand-rolled because
-  // importing the actual module would drag in the unmocked github-core surface.
-  rosterWriteTree: (classroom: string, csv: string) => [
-    {
-      path: `${classroom}/roster.csv`,
-      mode: "100644",
-      type: "blob",
-      content: csv,
-    },
-  ],
   resolveClassroomTeamSlugs: (...a: unknown[]) =>
     resolveClassroomTeamSlugs(...a),
   listClassroomMembersWithRoles: (...a: unknown[]) =>

--- a/web/src/domain/students/rosterSync.ts
+++ b/web/src/domain/students/rosterSync.ts
@@ -1,35 +1,23 @@
 import type { GitHubClient } from "@/github-core/client"
-import {
-  createGitCommit,
-  createGitTree,
-  updateRef,
-} from "@/github-core/mutations"
 import { withGitConflictRetry, assertClassroomNotArchived } from "../classrooms"
-import { getRawFile } from "@/github-core/queries"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
+import { getConfigRepoBranch } from "@/github-core/configRepoReads"
 import { rosterClaimSet } from "@/util/identity"
 import { parseGitHubId, resolveGitHubId } from "@/util/students"
 import { normalizeInviteEmail } from "@/util/inviteTeam"
-import { prefixCommit } from "@/util/commit"
 import {
   normalizeStudentRow,
   parseStudentsCsv,
   stringifyStudentsCsv,
   type StudentCsvRow,
 } from "@/util/rosterCsv"
-import { rosterPath } from "@/util/configRepoPaths"
 import {
   log,
-  rosterWriteTree,
   resolveClassroomTeamSlugs,
   listClassroomMembersWithRoles,
 } from "./rosterPrimitives"
 import type { InviteReconcileState, RecoveredInvite } from "./inviteRecoveries"
 import { collectInviteRecoveries } from "./inviteRecoveries"
+import { commitRoster, readRosterForWriteAt } from "./rosterWrite"
 
 export type SyncRosterFromTeamResult = {
   // Team members newly appended to roster.csv as metadata rows.
@@ -100,16 +88,8 @@ export async function syncRosterFromTeam(
         listClassroomMembersWithRoles(client, org, slugs),
         getConfigRepoBranch(client, org),
       ])
-    const ref = await getBranchRef(client, org, configBranch)
-    const commit = await getCommit(client, org, ref.object.sha)
-
-    const studentsFilePath = rosterPath(classroom)
-    const currentCsv = await getRawFile(client, {
-      org,
-      path: studentsFilePath,
-      ref: ref.object.sha,
-    })
-    const currentStudents = parseStudentsCsv(currentCsv)
+    const ctx = await readRosterForWriteAt(client, org, classroom, configBranch)
+    const currentStudents = parseStudentsCsv(ctx.currentCsv)
 
     // --- Invite fold: claim each recovered mapping onto its row -------------
     // Match by the invited email first (the row written at invite time), then
@@ -376,20 +356,13 @@ export async function syncRosterFromTeam(
 
     const nextCsv = stringifyStudentsCsv([...reconciledStudents, ...addedRows])
 
-    const tree = await createGitTree(client, {
+    await commitRoster(
+      client,
       org,
-      base_tree: commit.tree.sha,
-      tree: rosterWriteTree(classroom, nextCsv),
-    })
-
-    const newCommit = await createGitCommit(client, {
-      org,
-      message: prefixCommit(`Sync roster from teams: ${classroom}`),
-      tree_sha: tree.sha,
-      parents: [ref.object.sha],
-    })
-
-    await updateRef(client, org, newCommit.sha, configBranch)
+      ctx,
+      nextCsv,
+      `Sync roster from teams: ${classroom}`,
+    )
 
     log.info("sync roster from team: completed", {
       org,

--- a/web/src/domain/students/rosterWrite.test.ts
+++ b/web/src/domain/students/rosterWrite.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { GitHubClient } from "@/github-core/client"
+
+const readConfigRepoHead = vi.fn(async () => ({
+  configBranch: "main",
+  headSha: "HEAD",
+  baseTreeSha: "BASETREE",
+}))
+const readConfigRepoHeadAt = vi.fn(async (_c, _o, configBranch: string) => ({
+  configBranch,
+  headSha: "HEAD",
+  baseTreeSha: "BASETREE",
+}))
+const commitConfigRepoFiles = vi.fn(async () => ({
+  newTreeSha: "NEWTREE",
+  newCommitSha: "NEWCOMMIT",
+  updatedRef: { ref: "refs/heads/main" },
+}))
+vi.mock("../configRepoWrite", () => ({
+  readConfigRepoHead: (...a: unknown[]) => readConfigRepoHead(...(a as [])),
+  readConfigRepoHeadAt: (...a: unknown[]) =>
+    readConfigRepoHeadAt(...(a as [GitHubClient, string, string])),
+  commitConfigRepoFiles: (...a: unknown[]) =>
+    commitConfigRepoFiles(...(a as [])),
+}))
+const getRawFile = vi.fn(async () => "username,first_name\nann,Ann\n")
+vi.mock("@/github-core/queries", () => ({
+  getRawFile: (...a: unknown[]) => getRawFile(...(a as [])),
+}))
+
+import {
+  commitRoster,
+  readRosterForWrite,
+  readRosterForWriteAt,
+} from "./rosterWrite"
+
+const client = {} as GitHubClient
+
+beforeEach(() => {
+  readConfigRepoHead.mockClear()
+  readConfigRepoHeadAt.mockClear()
+  commitConfigRepoFiles.mockClear()
+  getRawFile.mockClear()
+})
+
+describe("readRosterForWrite", () => {
+  it("reads roster.csv at the head it will commit against", async () => {
+    const ctx = await readRosterForWrite(client, "org", "cs50")
+    expect(readConfigRepoHead).toHaveBeenCalledWith(client, "org", "cs50")
+    expect(getRawFile).toHaveBeenCalledWith(client, {
+      org: "org",
+      path: "cs50/roster.csv",
+      ref: "HEAD",
+    })
+    expect(ctx).toEqual({
+      configBranch: "main",
+      headSha: "HEAD",
+      baseTreeSha: "BASETREE",
+      path: "cs50/roster.csv",
+      currentCsv: "username,first_name\nann,Ann\n",
+    })
+  })
+
+  it("the At variant uses the caller's branch and skips the guarded read", async () => {
+    const ctx = await readRosterForWriteAt(client, "org", "cs50", "config")
+    expect(readConfigRepoHead).not.toHaveBeenCalled()
+    expect(readConfigRepoHeadAt).toHaveBeenCalledWith(client, "org", "config")
+    expect(ctx.configBranch).toBe("config")
+  })
+})
+
+describe("commitRoster", () => {
+  it("commits the CSV as the single blob at the context's path", async () => {
+    const ctx = await readRosterForWrite(client, "org", "cs50")
+    const result = await commitRoster(client, "org", ctx, "next,csv\n", "Edit")
+    expect(commitConfigRepoFiles).toHaveBeenCalledWith(
+      client,
+      "org",
+      ctx,
+      [
+        {
+          path: "cs50/roster.csv",
+          mode: "100644",
+          type: "blob",
+          content: "next,csv\n",
+        },
+      ],
+      "Edit",
+    )
+    expect(result.newCommitSha).toBe("NEWCOMMIT")
+  })
+})

--- a/web/src/domain/students/rosterWrite.ts
+++ b/web/src/domain/students/rosterWrite.ts
@@ -1,0 +1,71 @@
+import type { GitHubClient } from "@/github-core/client"
+import { getRawFile } from "@/github-core/queries"
+import { rosterPath } from "@/util/configRepoPaths"
+
+import {
+  commitConfigRepoFiles,
+  readConfigRepoHead,
+  readConfigRepoHeadAt,
+  type ConfigRepoCommitResult,
+  type ConfigRepoHead,
+} from "../configRepoWrite"
+
+// The read half of every roster.csv write: the config-repo head plus the file
+// as it stands at that head, so no writer reads at one ref and commits
+// against another. The CSV is returned raw because the writers split on how
+// to parse it (lenient parseStudentsCsv vs strict parseRosterCsv).
+export type RosterWriteContext = ConfigRepoHead & {
+  path: string
+  currentCsv: string
+}
+
+export async function readRosterForWrite(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+): Promise<RosterWriteContext> {
+  const head = await readConfigRepoHead(client, org, classroom)
+  return readRosterAtHead(client, org, classroom, head)
+}
+
+// For writers that ran the archive guard themselves (outside a retry loop) or
+// resolved the branch to overlap it with other reads.
+export async function readRosterForWriteAt(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+  configBranch: string,
+): Promise<RosterWriteContext> {
+  const head = await readConfigRepoHeadAt(client, org, configBranch)
+  return readRosterAtHead(client, org, classroom, head)
+}
+
+async function readRosterAtHead(
+  client: GitHubClient,
+  org: string,
+  classroom: string,
+  head: ConfigRepoHead,
+): Promise<RosterWriteContext> {
+  const path = rosterPath(classroom)
+  // Read at the freshly fetched head, never a commit we just wrote, so a 404
+  // means roster.csv is genuinely absent rather than read-your-own-write lag.
+  const currentCsv = await getRawFile(client, { org, path, ref: head.headSha })
+  return { ...head, path, currentCsv }
+}
+
+// The write half: roster.csv is the only file in the tree.
+export function commitRoster(
+  client: GitHubClient,
+  org: string,
+  ctx: RosterWriteContext,
+  nextCsv: string,
+  message: string,
+): Promise<ConfigRepoCommitResult> {
+  return commitConfigRepoFiles(
+    client,
+    org,
+    ctx,
+    [{ path: ctx.path, mode: "100644", type: "blob", content: nextCsv }],
+    message,
+  )
+}

--- a/web/src/domain/students/unenroll.ts
+++ b/web/src/domain/students/unenroll.ts
@@ -1,36 +1,26 @@
 import type { GitHubClient } from "@/github-core/client"
 import {
-  createGitCommit,
-  createGitTree,
   getOrgMembershipState,
   removeUserFromTeam,
-  updateRef,
 } from "@/github-core/mutations"
 import { getErrorMessage } from "@/github-core/errorMessage"
 import { withGitConflictRetry, assertClassroomNotArchived } from "../classrooms"
-import { getRawFile } from "@/github-core/queries"
 import { getAuthenticatedUser } from "@/domain/queries/users"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
+import { getConfigRepoBranch } from "@/github-core/configRepoReads"
 import { isSameGitHubUser } from "@/util/students"
-import { prefixCommit } from "@/util/commit"
 import {
   parseStudentsCsv,
   stringifyStudentsCsv,
   type StudentCsvRow,
 } from "@/util/rosterCsv"
-import { rosterPath } from "@/util/configRepoPaths"
 import { type Student } from "@/types/classroom"
 import {
   log,
-  rosterWriteTree,
   resolveClassroomTeamSlug,
   cancelSoleClassroomInviteOnUnenroll,
   matchesRosterRow,
 } from "./rosterPrimitives"
+import { commitRoster, readRosterForWriteAt } from "./rosterWrite"
 
 export type UnenrollStudentInput = {
   org: string
@@ -75,18 +65,8 @@ export async function unenrollStudent(
   viewerPromise.catch(() => {})
 
   const configBranch = await getConfigRepoBranch(client, org)
-  const ref = await getBranchRef(client, org, configBranch)
-  const commit = await getCommit(client, org, ref.object.sha)
-
-  const studentsFilePath = rosterPath(classroom)
-
-  const currentCsv = await getRawFile(client, {
-    org,
-    path: studentsFilePath,
-    ref: ref.object.sha,
-  })
-
-  const currentStudents = parseStudentsCsv(currentCsv)
+  const ctx = await readRosterForWriteAt(client, org, classroom, configBranch)
+  const currentStudents = parseStudentsCsv(ctx.currentCsv)
 
   // Match the target row via the shared roster-row matcher (username/github_id).
   const sameRow = (student: StudentCsvRow) =>
@@ -103,22 +83,13 @@ export async function unenrollStudent(
   const nextStudents = currentStudents.filter((student) => !sameRow(student))
   const nextCsv = stringifyStudentsCsv(nextStudents)
 
-  const tree = await createGitTree(client, {
+  const written = await commitRoster(
+    client,
     org,
-    base_tree: commit.tree.sha,
-    tree: rosterWriteTree(classroom, nextCsv),
-  })
-
-  const newCommit = await createGitCommit(client, {
-    org,
-    message: prefixCommit(
-      `Remove student: ${classroom}/${normalizedUsername || normalizedGithubId}`,
-    ),
-    tree_sha: tree.sha,
-    parents: [ref.object.sha],
-  })
-
-  const updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
+    ctx,
+    nextCsv,
+    `Remove student: ${classroom}/${normalizedUsername || normalizedGithubId}`,
+  )
 
   // Commit landed, so every org-side step below is a non-fatal warning.
   const warnings: string[] = []
@@ -184,11 +155,9 @@ export async function unenrollStudent(
     warnings: warnings.length,
   })
   return {
-    previousCommitSha: ref.object.sha,
-    baseTreeSha: commit.tree.sha,
-    newTreeSha: tree.sha,
-    newCommitSha: newCommit.sha,
-    updatedRef,
+    previousCommitSha: ctx.headSha,
+    baseTreeSha: ctx.baseTreeSha,
+    ...written,
     teamWarning: warnings.length > 0 ? warnings.join(" ") : undefined,
   }
 }
@@ -267,21 +236,14 @@ export async function bulkUnenrollStudents(
   // One conflict-retried CSV commit dropping every matched row. Re-reads the CSV
   // each attempt so a concurrent edit is preserved. Reports which targets were
   // actually present (removed) vs. missing (notFound).
-  const studentsFilePath = rosterPath(classroom)
   let removed: Student[] = []
   let notFound: Student[] = []
   let newCommitSha: string | undefined
 
   await withGitConflictRetry(async () => {
     const configBranch = await getConfigRepoBranch(client, org)
-    const ref = await getBranchRef(client, org, configBranch)
-    const commit = await getCommit(client, org, ref.object.sha)
-    const currentCsv = await getRawFile(client, {
-      org,
-      path: studentsFilePath,
-      ref: ref.object.sha,
-    })
-    const currentStudents = parseStudentsCsv(currentCsv)
+    const ctx = await readRosterForWriteAt(client, org, classroom, configBranch)
+    const currentStudents = parseStudentsCsv(ctx.currentCsv)
 
     removed = targets.filter((target) =>
       currentStudents.some((row) => matchesTarget(row, target)),
@@ -299,21 +261,14 @@ export async function bulkUnenrollStudents(
     )
     const nextCsv = stringifyStudentsCsv(nextStudents)
 
-    const tree = await createGitTree(client, {
+    const written = await commitRoster(
+      client,
       org,
-      base_tree: commit.tree.sha,
-      tree: rosterWriteTree(classroom, nextCsv),
-    })
-    const newCommit = await createGitCommit(client, {
-      org,
-      message: prefixCommit(
-        `Remove ${removed.length} student${removed.length === 1 ? "" : "s"}: ${classroom}`,
-      ),
-      tree_sha: tree.sha,
-      parents: [ref.object.sha],
-    })
-    await updateRef(client, org, newCommit.sha, configBranch)
-    newCommitSha = newCommit.sha
+      ctx,
+      nextCsv,
+      `Remove ${removed.length} student${removed.length === 1 ? "" : "s"}: ${classroom}`,
+    )
+    newCommitSha = written.newCommitSha
   })
 
   // Roster commit landed; every org-side step below is a non-fatal warning.

--- a/web/src/domain/students/updateStudent.ts
+++ b/web/src/domain/students/updateStudent.ts
@@ -1,30 +1,13 @@
 import type { GitHubClient } from "@/github-core/client"
-import {
-  createGitCommit,
-  createGitTree,
-  updateRef,
-} from "@/github-core/mutations"
-import {
-  withGitConflictRetry,
-  assertClassroomNotArchived,
-  type CreateClassroomResult,
-} from "../classrooms"
-import { getRawFile } from "@/github-core/queries"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "@/github-core/configRepoReads"
+import { withGitConflictRetry, type CreateClassroomResult } from "../classrooms"
 import { studentKey } from "@/util/identity"
-import { prefixCommit } from "@/util/commit"
 import {
   normalizeStudentRow,
   parseStudentsCsv,
   stringifyStudentsCsv,
   type StudentCsvRow,
 } from "@/util/rosterCsv"
-import { rosterPath } from "@/util/configRepoPaths"
-import { rosterWriteTree } from "./rosterPrimitives"
+import { commitRoster, readRosterForWrite } from "./rosterWrite"
 
 // The teacher-editable subset of a roster row. Identity columns (username,
 // github_id) are deliberately excluded — they are bound at enrollment and by
@@ -69,21 +52,8 @@ export async function updateStudent(
     throw new Error("A student row identity is required")
   }
 
-  await assertClassroomNotArchived(client, org, classroom)
-
-  const configBranch = await getConfigRepoBranch(client, org)
-  const ref = await getBranchRef(client, org, configBranch)
-  const commit = await getCommit(client, org, ref.object.sha)
-
-  const studentsFilePath = rosterPath(classroom)
-
-  const currentCsv = await getRawFile(client, {
-    org,
-    path: studentsFilePath,
-    ref: ref.object.sha,
-  })
-
-  const currentStudents = parseStudentsCsv(currentCsv)
+  const ctx = await readRosterForWrite(client, org, classroom)
+  const currentStudents = parseStudentsCsv(ctx.currentCsv)
 
   // Stable per-row identity via the shared studentKey (github_id -> username ->
   // email), the same precedence the UI and reconcile use.
@@ -151,29 +121,18 @@ export async function updateStudent(
       )
   const nextCsv = stringifyStudentsCsv(nextStudents)
 
-  const tree = await createGitTree(client, {
+  const written = await commitRoster(
+    client,
     org,
-    base_tree: commit.tree.sha,
-    tree: rosterWriteTree(classroom, nextCsv),
-  })
-
-  const newCommit = await createGitCommit(client, {
-    org,
-    message: prefixCommit(
-      `Edit student: ${classroom}/${updatedStudent.username || updatedStudent.email || targetKey}`,
-    ),
-    tree_sha: tree.sha,
-    parents: [ref.object.sha],
-  })
-
-  const updatedRef = await updateRef(client, org, newCommit.sha, configBranch)
+    ctx,
+    nextCsv,
+    `Edit student: ${classroom}/${updatedStudent.username || updatedStudent.email || targetKey}`,
+  )
 
   return {
-    previousCommitSha: ref.object.sha,
-    baseTreeSha: commit.tree.sha,
-    newTreeSha: tree.sha,
-    newCommitSha: newCommit.sha,
-    updatedRef,
+    previousCommitSha: ctx.headSha,
+    baseTreeSha: ctx.baseTreeSha,
+    ...written,
     student: updatedStudent,
   }
 }


### PR DESCRIPTION
Follow-up from the post-refactor review. #905 centralized the config-repo ref → commit → tree → commit → ref sequence in `domain/configRepoWrite.ts` and moved the assignment writers onto it, but the roster writers still hand-rolled it: `enrollment.ts`, `bulkEnrollment.ts`, `updateStudent.ts`, both writers in `unenroll.ts`, `rosterSync.ts`, and `withRosterRewrite` in `rosterPrimitives.ts`.

New `domain/students/rosterWrite.ts` mirrors `assignmentsWrite.ts`:

- `readRosterForWrite(client, org, classroom)` runs the archive guard and returns the head plus `roster.csv` read at that head, so no writer can read at one ref and commit against another. `readRosterForWriteAt(..., configBranch)` is the guard-free form for writers that already ran the guard outside a retry loop or resolved the branch to overlap it with other reads.
- `commitRoster(client, org, ctx, nextCsv, message)` commits the CSV as the single blob at the context's path and prefixes the message via `commitConfigRepoFiles`.

The context carries the raw CSV rather than parsed rows because the writers still split on how to parse it (lenient `parseStudentsCsv` vs strict `parseRosterCsv`). That question is untouched here; only the git half is shared. Result shapes are unchanged: writers that returned `previousCommitSha` and friends now build them from `ctx.headSha` / `ctx.baseTreeSha` plus the commit result, exactly as the assignment writers do.

`rosterWriteTree` is gone (its only job was feeding `createGitTree`), along with the stale mock of it in `rosterSync.test.ts`. A small test pins that the CSV is read at the resolved head and committed at the roster path.

Left for separate changes: `editClassroom` still hand-rolls the sequence but lives in `github-core/`, which cannot import `domain/`, so it needs to move first. `createClassroom` and `deleteClassroom` in `domain/classrooms.ts` also hand-roll it but through metadata-carrying wrappers and a recursive tree read, which don't fit the helper as is.

Verified with `npm run check` (types, lint, prettier, arch, 5367 tests incl. browser mode) and the strict i18n audit. Net around −230 lines.