### PR TITLE
refactor(web): share the student-repo commit sequence across five writers

### DIFF
--- a/web/src/domain/assignments/accept.ts
+++ b/web/src/domain/assignments/accept.ts
@@ -3,18 +3,14 @@ import type { AssignmentMode, RepoPermission } from "@/types/classroom"
 import { getUser } from "@/github-core/queries"
 import { studentRepoName } from "@/util/studentRepo"
 import {
-  createRepoCommit,
-  createTreeForAssignment,
+  assignmentAcceptTree,
+  commitRepoFiles,
+  readRepoHead,
   getRepoTreeRecursive,
-  updateRepoRef,
 } from "@/github-core/mutations"
 import { getRepo } from "@/github-core/repoReads"
 import type { GitHubRepo } from "@/github-core/types"
-import {
-  getBranchRefRepo,
-  getCommitByRepo,
-  withFreshRepoRetry,
-} from "@/github-core/queries"
+import { withFreshRepoRetry } from "@/github-core/queries"
 import {
   ensureFeedbackPullRequest,
   resolveFeedbackBaselineSha,
@@ -130,19 +126,12 @@ async function commitAcceptFilesWithFreshRepoRetry(params: {
       // may never exist. Fall back to the caller's branch while it's still empty.
       const live = await getRepo(client, owner, repo)
       const targetBranch = live?.default_branch || branch
-      const ref = await getBranchRefRepo(client, owner, repo, targetBranch)
-      const parentSha = ref.object.sha
-      const currentCommit = await getCommitByRepo(
+      const head = await readRepoHead(
         client,
-        owner,
-        repo,
-        parentSha,
+        { owner, repo },
+        targetBranch,
+        () => freshRepoNotReadyError(owner, repo),
       )
-      const baseTreeSha = currentCommit.tree?.sha
-
-      if (!parentSha || !baseTreeSha) {
-        throw freshRepoNotReadyError(owner, repo)
-      }
 
       // Re-render the default shim's push trigger for the branch that actually
       // materialized (targetBranch), so autograde fires on the repo's real
@@ -152,50 +141,37 @@ async function commitAcceptFilesWithFreshRepoRetry(params: {
         : autogradeYaml
 
       let deletePaths: string[] = []
-      const atSeedCommit = (currentCommit.parents?.length ?? 0) === 0
+      const atSeedCommit = (head.commit.parents?.length ?? 0) === 0
       if (removeSeededReadme && atSeedCommit) {
         const baseTree = await getRepoTreeRecursive({
           client,
           owner,
           repo,
-          treeSha: baseTreeSha,
+          treeSha: head.baseTreeSha,
         })
         deletePaths = baseTree.tree.some((e) => e.path === "README.md")
           ? ["README.md"]
           : []
       }
 
-      const tree = await createTreeForAssignment({
+      // The accept commit that lands `.classroom50.yaml`, the marker the runner
+      // uses to resolve the Feedback-PR baseline (see the constant).
+      const { commitSha } = await commitRepoFiles(
         client,
-        owner,
-        repo,
-        baseTreeSha,
-        metadataYaml,
-        autogradeYaml: shim,
-        deletePaths,
-      })
-
-      const commit = await createRepoCommit(client, {
-        owner,
-        repo,
-        // The accept commit that lands `.classroom50.yaml` — the marker the
-        // runner uses to resolve the Feedback-PR baseline (see the constant).
-        message: ACCEPT_COMMIT_SUBJECT,
-        treeSha: tree.sha,
-        parentSha,
-      })
-
-      await updateRepoRef(client, {
-        owner,
-        repo,
-        branch: targetBranch,
-        commitSha: commit.sha,
-      })
+        { owner, repo },
+        head,
+        assignmentAcceptTree({
+          metadataYaml,
+          autogradeYaml: shim,
+          deletePaths,
+        }),
+        ACCEPT_COMMIT_SUBJECT,
+      )
 
       // The accept commit's SHA (the Feedback-PR base anchor) and the SETTLED
       // branch it actually landed on — the caller's pre-guessed branch may be a
       // transient `main` on a `master` template.
-      return { commitSha: commit.sha, branch: targetBranch }
+      return { commitSha, branch: targetBranch }
     },
     {
       ...ACCEPT_SETUP_RETRY,

--- a/web/src/domain/assignments/feedbackPr.ts
+++ b/web/src/domain/assignments/feedbackPr.ts
@@ -3,14 +3,13 @@ import {
   addIssueLabels,
   createBranchRef,
   createPullRequest,
-  createRepoCommit,
   ensureRepoLabel,
-  updateRepoRef,
+  commitRepoTree,
+  readRepoHead,
 } from "@/github-core/mutations"
 import { is422NoCommitsBetween } from "@/github-core/errors"
 import {
   getBranchRefRepo,
-  getCommitByRepo,
   getOldestCommitShaForPath,
   isFreshRepoLagError,
   listPullRequestsByBaseHead,
@@ -399,22 +398,14 @@ async function pushEmptyCommit(params: {
   branch: string
 }) {
   const { client, owner, repo, branch } = params
-  const ref = await getBranchRefRepo(client, owner, repo, branch)
-  const headSha = ref.object.sha
-  const head = await getCommitByRepo(client, owner, repo, headSha)
-  const commit = await createRepoCommit(client, {
-    owner,
-    repo,
-    message: FEEDBACK_OPEN_COMMIT_MESSAGE,
-    treeSha: head.tree.sha,
-    parentSha: headSha,
-  })
-  await updateRepoRef(client, {
-    owner,
-    repo,
-    branch,
-    commitSha: commit.sha,
-  })
+  const head = await readRepoHead(client, { owner, repo }, branch)
+  await commitRepoTree(
+    client,
+    { owner, repo },
+    head,
+    head.baseTreeSha,
+    FEEDBACK_OPEN_COMMIT_MESSAGE,
+  )
 }
 
 // The baseline commit to freeze `feedback` at: the OLDEST commit touching the

--- a/web/src/domain/assignments/rename.ts
+++ b/web/src/domain/assignments/rename.ts
@@ -18,20 +18,17 @@ import {
   type AssignmentsFile,
 } from "../queries/assignments"
 import {
-  createRepoCommit,
-  createRepoTree,
   getRepoTreeRecursive,
   type GitTreeEntry,
   type GitTreeFileMode,
   renameRepo,
-  updateRepoRef,
+  commitRepoFiles,
+  readRepoHead,
 } from "@/github-core/mutations"
 import {
   getOrgRepos,
   getRawFile,
   getRepoFileAtRef,
-  getBranchRefRepo,
-  getCommitByRepo,
 } from "@/github-core/queries"
 import { GitHubAPIError, tolerateGitHubError } from "@/github-core/errors"
 import { getErrorMessage } from "@/github-core/errorMessage"
@@ -431,13 +428,12 @@ async function renameOneRepo(params: {
   let step: MarkerStep
   try {
     step = await withGitConflictRetry(async (): Promise<MarkerStep> => {
-      const headRef = await getBranchRefRepo(client, org, repo, branch)
-      const headSha = headRef.object.sha
+      const head = await readRepoHead(client, { owner: org, repo }, branch)
       const raw = await getRepoFileAtRef(client, {
         owner: org,
         repo,
         path: ".classroom50.yaml",
-        ref: headSha,
+        ref: head.headSha,
       })
       if (raw === null) {
         return {
@@ -471,12 +467,13 @@ async function renameOneRepo(params: {
         return { kind: "done", rewroteMarker: false }
       }
 
-      const headCommit = await getCommitByRepo(client, org, repo, headSha)
-      const tree = await createRepoTree(client, {
-        owner: org,
-        repo,
-        baseTreeSha: headCommit.tree.sha,
-        tree: [
+      // [skip ci]: the marker touch must not burn an autograde run on every
+      // student repo.
+      await commitRepoFiles(
+        client,
+        { owner: org, repo },
+        head,
+        [
           {
             path: ".classroom50.yaml",
             mode: "100644",
@@ -484,24 +481,9 @@ async function renameOneRepo(params: {
             content: rewrite.content ?? "",
           },
         ],
-      })
-      // [skip ci]: the marker touch must not burn an autograde run on every
-      // student repo.
-      const commit = await createRepoCommit(client, {
-        owner: org,
-        repo,
-        parentSha: headSha,
-        treeSha: tree.sha,
-        message:
-          prefixCommit(`Update assignment slug to ${newSlug} (rename)`) +
+        prefixCommit(`Update assignment slug to ${newSlug} (rename)`) +
           "\n\n[skip ci]",
-      })
-      await updateRepoRef(client, {
-        owner: org,
-        repo,
-        branch,
-        commitSha: commit.sha,
-      })
+      )
       return { kind: "done", rewroteMarker: true }
     })
   } catch (err) {

--- a/web/src/domain/assignments/submissionTrigger.ts
+++ b/web/src/domain/assignments/submissionTrigger.ts
@@ -13,12 +13,11 @@
 // (cli/gh-teacher/internal/assignmentcmd/submissionmode.go shimTriggerBlock).
 import type { GitHubClient } from "@/github-core/client"
 import {
-  createRepoCommit,
+  commitRepoTree,
   createRepoTree,
-  updateRepoRef,
+  readRepoHead,
 } from "@/github-core/mutations"
 import { getRepo } from "@/github-core/repoReads"
-import { getBranchRefRepo, getCommitByRepo } from "@/github-core/queries"
 import { GitHubAPIError } from "@/github-core/errors"
 import { decodeBase64Utf8 } from "@/util/github"
 import { shimUpdateCommitMessage } from "@/util/commit"
@@ -134,18 +133,12 @@ export async function updateShimSubmissionMode(params: {
   // live 2026-08-05), which would rewrite from stale content or misreport
   // "current"; reading at the same SHA the commit builds on keeps the no-op
   // check and the write consistent.
-  const ref = await getBranchRefRepo(client, org, repo, branch)
-  const parentSha = ref.object.sha
-  const parentCommit = await getCommitByRepo(client, org, repo, parentSha)
-  const baseTreeSha = parentCommit.tree?.sha
-  if (!parentSha || !baseTreeSha) {
-    throw new Error(`${org}/${repo}: could not resolve the branch tip`)
-  }
+  const head = await readRepoHead(client, { owner: org, repo }, branch)
 
   let current: string
   try {
     const resp = await client.request<{ content?: string; encoding?: string }>(
-      `/repos/${org}/${repo}/contents/${AUTOGRADE_SHIM_PATH}?ref=${encodeURIComponent(parentSha)}`,
+      `/repos/${org}/${repo}/contents/${AUTOGRADE_SHIM_PATH}?ref=${encodeURIComponent(head.headSha)}`,
     )
     if (!resp?.content || resp.encoding !== "base64") {
       return {
@@ -172,12 +165,15 @@ export async function updateShimSubmissionMode(params: {
     return { status: "unrecognized", reason: rewrite.reason }
   }
 
+  // Only the tree POST is classified: it is the call GitHub rejects with a
+  // 404 when the token lacks the `workflow` scope needed to touch a workflow
+  // file.
   let tree: { sha: string }
   try {
     tree = await createRepoTree(client, {
       owner: org,
       repo,
-      baseTreeSha,
+      baseTreeSha: head.baseTreeSha,
       tree: [
         {
           path: AUTOGRADE_SHIM_PATH,
@@ -197,19 +193,13 @@ export async function updateShimSubmissionMode(params: {
     }
     throw err
   }
-  const commit = await createRepoCommit(client, {
-    owner: org,
-    repo,
-    message: shimUpdateCommitMessage(mode),
-    treeSha: tree.sha,
-    parentSha,
-  })
-  await updateRepoRef(client, {
-    owner: org,
-    repo,
-    branch,
-    commitSha: commit.sha,
-  })
+  await commitRepoTree(
+    client,
+    { owner: org, repo },
+    head,
+    tree.sha,
+    shimUpdateCommitMessage(mode),
+  )
   return { status: "updated" }
 }
 

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -6,7 +6,7 @@
 // matching sub-module, not here.
 export {
   classroomSeedTree,
-  createTreeForAssignment,
+  assignmentAcceptTree,
   updateRef,
   createGitTree,
   createGitCommit,
@@ -24,6 +24,13 @@ export {
   type CreateRepoCommitInput,
   type UpdateRepoRefInput,
 } from "./mutations/gitObjects"
+export {
+  readRepoHead,
+  commitRepoTree,
+  commitRepoFiles,
+  type RepoRef,
+  type RepoHead,
+} from "./mutations/repoCommit"
 export {
   isDeletableClassroomTeamRef,
   ensureClassroomTeam,

--- a/web/src/github-core/mutations/gitObjects.test.ts
+++ b/web/src/github-core/mutations/gitObjects.test.ts
@@ -8,7 +8,7 @@ import {
   createGitTree,
   createRepoCommit,
   createRepoTree,
-  createTreeForAssignment,
+  assignmentAcceptTree,
   updateRef,
   updateRepoRef,
 } from "./gitObjects"
@@ -151,55 +151,38 @@ describe("createClassroomMetadata teams persistence", () => {
 // `sha: null` deletion entry (the Trees API's "remove from base_tree") so the
 // auto_init README is removed in the same commit. Mirrors the CLI's
 // classroomcfg.DropFiles tests.
-describe("createTreeForAssignment tree entries", () => {
-  const capture = () => {
-    const request = vi.fn(async () => ({ sha: "tree-sha" }))
-    const client = { request } as unknown as GitHubClient
-    const treeOf = () => {
-      const call = request.mock.calls[0] as unknown as [
-        string,
-        { body: { tree: { path: string; content?: string; sha?: null }[] } },
-      ]
-      return call[1].body.tree
-    }
-    return { client, treeOf }
-  }
+describe("assignmentAcceptTree entries", () => {
+  const metadataYaml = "classroom: cs"
 
-  const base = {
-    owner: "org",
-    repo: "hw-alice",
-    baseTreeSha: "base",
-    metadataYaml: "classroom: cs",
-  }
-
-  it("commits marker + shim, no deletions, by default", async () => {
-    const { client, treeOf } = capture()
-    await createTreeForAssignment({ client, ...base, autogradeYaml: "name: a" })
-    const paths = treeOf().map((e) => e.path)
-    expect(paths).toEqual([
+  it("commits marker + shim, no deletions, by default", () => {
+    const tree = assignmentAcceptTree({
+      metadataYaml,
+      autogradeYaml: "name: a",
+    })
+    expect(tree.map((e) => e.path)).toEqual([
       ".classroom50.yaml",
       ".github/workflows/autograde.yaml",
     ])
-    expect(treeOf().every((e) => e.sha === undefined)).toBe(true)
+    expect(tree.every((e) => !("sha" in e))).toBe(true)
   })
 
-  it("an empty shim commits only the marker", async () => {
-    const { client, treeOf } = capture()
-    await createTreeForAssignment({ client, ...base, autogradeYaml: "" })
-    expect(treeOf().map((e) => e.path)).toEqual([".classroom50.yaml"])
+  it("an empty shim commits only the marker", () => {
+    const tree = assignmentAcceptTree({ metadataYaml, autogradeYaml: "" })
+    expect(tree.map((e) => e.path)).toEqual([".classroom50.yaml"])
   })
 
-  it("deletePaths posts sha:null deletion entries (init_shim README removal)", async () => {
-    const { client, treeOf } = capture()
-    await createTreeForAssignment({
-      client,
-      ...base,
+  it("deletePaths posts sha:null deletion entries (init_shim README removal)", () => {
+    const tree = assignmentAcceptTree({
+      metadataYaml,
       autogradeYaml: "name: a",
       deletePaths: ["README.md"],
     })
-    const readme = treeOf().find((e) => e.path === "README.md")
-    expect(readme).toBeDefined()
-    expect(readme?.sha).toBeNull()
-    expect(readme?.content).toBeUndefined()
+    const readme = tree.find((e) => e.path === "README.md")
+    expect(readme).toEqual({
+      path: "README.md",
+      mode: "100644",
+      type: "blob",
+      sha: null,
+    })
   })
 })

--- a/web/src/github-core/mutations/gitObjects.ts
+++ b/web/src/github-core/mutations/gitObjects.ts
@@ -236,28 +236,16 @@ export function updateRef(
   })
 }
 
-// The accept-time tree for a student repo: the marker, the autograde shim
-// unless the assignment has none, and any paths the accept removes.
-export function createTreeForAssignment(params: {
-  client: GitHubClient
-  owner: string
-  repo: string
-  baseTreeSha: string
+// The accept-time tree entries for a student repo: the marker, the autograde
+// shim unless the assignment has none, and any paths the accept removes.
+export function assignmentAcceptTree(params: {
   metadataYaml: string
   autogradeYaml: string
   // Paths to remove from base_tree in the same commit (the init_shim accept
   // deletes the auto_init README this way).
   deletePaths?: string[]
-}) {
-  const {
-    client,
-    owner,
-    repo,
-    baseTreeSha,
-    metadataYaml,
-    autogradeYaml,
-    deletePaths = [],
-  } = params
+}): GitTreeEntry[] {
+  const { metadataYaml, autogradeYaml, deletePaths = [] } = params
 
   const tree: GitTreeEntry[] = [
     {
@@ -282,8 +270,7 @@ export function createTreeForAssignment(params: {
   for (const path of deletePaths) {
     tree.push({ path, mode: "100644", type: "blob", sha: null })
   }
-
-  return createRepoTree(client, { owner, repo, baseTreeSha, tree })
+  return tree
 }
 
 export async function createBlob(

--- a/web/src/github-core/mutations/provisioning.ts
+++ b/web/src/github-core/mutations/provisioning.ts
@@ -1,11 +1,7 @@
 import type { GitHubClient } from "../client"
 import { type GitHubRepo, type GitHubTreeResponse } from "../types"
 import { GitHubAPIError } from "../errors"
-import {
-  getBranchRef,
-  getCommit,
-  getConfigRepoBranch,
-} from "../configRepoReads"
+import { getConfigRepoBranch } from "../configRepoReads"
 import { getRepo } from "../repoReads"
 import { getErrorMessage } from "../errorMessage"
 import { checkPages, repairOrgDefaults } from "../orgChecks"
@@ -31,12 +27,8 @@ import { buildSkeletonFiles, type SkeletonFile } from "@/skeleton/skeleton"
 import { bytesToHex } from "@/util/hex"
 import { logger } from "@/lib/logger"
 import { LOG_SCOPE_GITHUB_SETUP } from "@/lib/logScopes"
-import {
-  CONFIG_REPO_BRANCH,
-  createRepoCommit,
-  createRepoTree,
-  updateRepoRef,
-} from "./gitObjects"
+import { CONFIG_REPO_BRANCH } from "./gitObjects"
+import { commitRepoFiles, readRepoHead } from "./repoCommit"
 
 const logSetup = logger.scope(LOG_SCOPE_GITHUB_SETUP)
 
@@ -419,36 +411,22 @@ export async function ensureSkeletonFiles(
     }
     changed = stillStale.map((f) => f.path)
 
-    const branch = await getBranchRef(client, org, configBranch)
-    const commit = await getCommit(client, org, branch.object.sha)
-
-    const tree = await createRepoTree(client, {
-      owner: org,
-      repo: CONFIG_REPO,
-      baseTreeSha: commit.tree.sha,
-      tree: stillStale.map((file) => ({
-        path: file.path,
-        mode: "100644",
-        type: "blob",
-        content: file.content,
-      })),
-    })
-
-    const newCommit = await createRepoCommit(client, {
-      owner: org,
-      repo: CONFIG_REPO,
-      message: prefixCommit("Bootstrap or refresh Classroom 50 skeleton"),
-      treeSha: tree.sha,
-      parentSha: commit.sha,
-    })
+    const configRepo = { owner: org, repo: CONFIG_REPO }
+    const head = await readRepoHead(client, configRepo, configBranch)
 
     try {
-      await updateRepoRef(client, {
-        owner: org,
-        repo: CONFIG_REPO,
-        branch: configBranch,
-        commitSha: newCommit.sha,
-      })
+      await commitRepoFiles(
+        client,
+        configRepo,
+        head,
+        stillStale.map((file) => ({
+          path: file.path,
+          mode: "100644",
+          type: "blob",
+          content: file.content,
+        })),
+        prefixCommit("Bootstrap or refresh Classroom 50 skeleton"),
+      )
       break
     } catch (err) {
       // A non-fast-forward rejection means the tip moved between our read and

--- a/web/src/github-core/mutations/repoCommit.test.ts
+++ b/web/src/github-core/mutations/repoCommit.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { GitHubClient } from "../client"
+import { commitRepoFiles, commitRepoTree, readRepoHead } from "./repoCommit"
+
+// A path-routing fake: the reads return a fixed tip, the writes record their
+// bodies and hand back SHAs the next call can be checked against.
+const makeClient = (opts?: { treeless?: boolean }) => {
+  const writes: { path: string; body: unknown }[] = []
+  const request = vi.fn(
+    async (path: string, init?: { method?: string; body?: unknown }) => {
+      if (init?.method === "POST" || init?.method === "PATCH") {
+        writes.push({ path, body: init.body })
+        if (path.endsWith("/git/trees")) return { sha: "NEWTREE" }
+        if (path.endsWith("/git/commits")) return { sha: "NEWCOMMIT" }
+        return {}
+      }
+      if (path.endsWith("/git/ref/heads/main"))
+        return { object: { sha: "HEAD" } }
+      if (path.endsWith("/git/commits/HEAD")) {
+        return opts?.treeless
+          ? { sha: "HEAD", parents: [] }
+          : { sha: "HEAD", tree: { sha: "BASETREE" }, parents: [] }
+      }
+      throw new Error(`unexpected ${path}`)
+    },
+  )
+  return { client: { request } as unknown as GitHubClient, writes }
+}
+
+const repo = { owner: "org", repo: "hw-alice" }
+
+describe("readRepoHead", () => {
+  it("returns the tip SHA, its tree, and the commit itself", async () => {
+    const { client } = makeClient()
+    await expect(readRepoHead(client, repo, "main")).resolves.toEqual({
+      branch: "main",
+      headSha: "HEAD",
+      baseTreeSha: "BASETREE",
+      commit: { sha: "HEAD", tree: { sha: "BASETREE" }, parents: [] },
+    })
+  })
+
+  it("throws the caller's error when the tip has no tree yet", async () => {
+    const { client } = makeClient({ treeless: true })
+    await expect(
+      readRepoHead(client, repo, "main", () => new Error("not ready")),
+    ).rejects.toThrow("not ready")
+  })
+})
+
+describe("commitRepoFiles", () => {
+  it("builds the tree on the head, parents on it, and fast-forwards the branch", async () => {
+    const { client, writes } = makeClient()
+    const head = await readRepoHead(client, repo, "main")
+    const entry = {
+      path: "a.txt",
+      mode: "100644" as const,
+      type: "blob" as const,
+      content: "hi",
+    }
+    const result = await commitRepoFiles(client, repo, head, [entry], "Msg")
+    expect(result).toEqual({ treeSha: "NEWTREE", commitSha: "NEWCOMMIT" })
+    expect(writes).toEqual([
+      {
+        path: "/repos/org/hw-alice/git/trees",
+        body: { base_tree: "BASETREE", tree: [entry] },
+      },
+      {
+        path: "/repos/org/hw-alice/git/commits",
+        body: { message: "Msg", tree: "NEWTREE", parents: ["HEAD"] },
+      },
+      {
+        path: "/repos/org/hw-alice/git/refs/heads/main",
+        body: { sha: "NEWCOMMIT", force: false },
+      },
+    ])
+  })
+})
+
+describe("commitRepoTree", () => {
+  it("makes an empty commit when handed the head's own tree", async () => {
+    const { client, writes } = makeClient()
+    const head = await readRepoHead(client, repo, "main")
+    await commitRepoTree(client, repo, head, head.baseTreeSha, "Empty")
+    expect(writes.map((w) => w.path)).toEqual([
+      "/repos/org/hw-alice/git/commits",
+      "/repos/org/hw-alice/git/refs/heads/main",
+    ])
+    expect(writes[0].body).toEqual({
+      message: "Empty",
+      tree: "BASETREE",
+      parents: ["HEAD"],
+    })
+  })
+})

--- a/web/src/github-core/mutations/repoCommit.ts
+++ b/web/src/github-core/mutations/repoCommit.ts
@@ -1,0 +1,89 @@
+import type { GitHubClient } from "../client"
+import { getBranchRefRepo, getCommitByRepo } from "../queries/repoRefReads"
+import type { GitHubCommitRef } from "../types"
+import {
+  createRepoCommit,
+  createRepoTree,
+  updateRepoRef,
+  type GitTreeEntry,
+} from "./gitObjects"
+
+export type RepoRef = { owner: string; repo: string }
+
+// A branch tip read once per write attempt: the SHA the commit parents on and
+// the tree it builds on, plus the commit itself for callers that inspect it
+// (accept checks whether it is the auto_init seed).
+export type RepoHead = {
+  branch: string
+  headSha: string
+  baseTreeSha: string
+  commit: GitHubCommitRef
+}
+
+// A branch may exist before its commit is readable (a fresh template copy) or
+// the commit may come back without a tree; `notReady` names that as the
+// caller's own error instead of a bare undefined downstream.
+export async function readRepoHead(
+  client: GitHubClient,
+  { owner, repo }: RepoRef,
+  branch: string,
+  notReady: () => Error = () =>
+    new Error(`${owner}/${repo}: could not resolve the branch tip`),
+): Promise<RepoHead> {
+  const ref = await getBranchRefRepo(client, owner, repo, branch)
+  const headSha = ref.object.sha
+  const commit = await getCommitByRepo(client, owner, repo, headSha)
+  const baseTreeSha = commit.tree?.sha
+  if (!headSha || !baseTreeSha) throw notReady()
+  return { branch, headSha, baseTreeSha, commit }
+}
+
+// Commit an already-built tree on the head and fast-forward the branch to it.
+// Passing `head.baseTreeSha` makes an empty commit. The message is used
+// verbatim: callers own their subject and any `[skip ci]` trailer.
+export async function commitRepoTree(
+  client: GitHubClient,
+  { owner, repo }: RepoRef,
+  head: RepoHead,
+  treeSha: string,
+  message: string,
+): Promise<{ commitSha: string }> {
+  const commit = await createRepoCommit(client, {
+    owner,
+    repo,
+    message,
+    treeSha,
+    parentSha: head.headSha,
+  })
+  await updateRepoRef(client, {
+    owner,
+    repo,
+    branch: head.branch,
+    commitSha: commit.sha,
+  })
+  return { commitSha: commit.sha }
+}
+
+// The write half every student-repo file change shares: one tree on the
+// head, then commitRepoTree.
+export async function commitRepoFiles(
+  client: GitHubClient,
+  ref: RepoRef,
+  head: RepoHead,
+  tree: GitTreeEntry[],
+  message: string,
+): Promise<{ treeSha: string; commitSha: string }> {
+  const { sha: treeSha } = await createRepoTree(client, {
+    ...ref,
+    baseTreeSha: head.baseTreeSha,
+    tree,
+  })
+  const { commitSha } = await commitRepoTree(
+    client,
+    ref,
+    head,
+    treeSha,
+    message,
+  )
+  return { treeSha, commitSha }
+}


### PR DESCRIPTION
Follow-up from the post-refactor review. #905/#927/#928 centralized the config-repo write sequence; five writers still hand-rolled the same ref → commit → tree → commit → ref sequence against arbitrary repos: `accept.ts`, `feedbackPr.ts`, `submissionTrigger.ts`, `rename.ts`, and the skeleton refresh in `provisioning.ts`.

New `github-core/mutations/repoCommit.ts` (in `github-core/` so `provisioning.ts` can use it):

- `readRepoHead(client, {owner, repo}, branch, notReady?)` returns the tip SHA, its tree, and the commit itself. The commit is exposed because `accept` checks `parents.length` for the auto_init seed; the error is caller-named because `accept` throws `freshRepoNotReadyError` while the others throw a generic one.
- `commitRepoTree(client, ref, head, treeSha, message)` commits a built tree and fast-forwards the branch. Passing `head.baseTreeSha` makes an empty commit, which is what `feedbackPr.pushEmptyCommit` does.
- `commitRepoFiles(client, ref, head, tree, message)` builds the tree and calls `commitRepoTree`.

Messages pass through verbatim: unlike the config helper, these callers own their subjects (`ACCEPT_COMMIT_SUBJECT`, the `[skip ci]` trailers, `shimUpdateCommitMessage`).

The tree/commit split exists for `submissionTrigger`, which classifies a 404 on the tree POST specifically as "token lacks the `workflow` scope". Folding the tree into one call would widen that check to the commit and ref calls, so it builds the tree itself and hands the SHA to `commitRepoTree`; a comment at the call site says why.

`createTreeForAssignment` becomes the pure `assignmentAcceptTree` (no client, returns entries) so `accept` can hand them to the helper; its three tests simplify to asserting on the return value. In `provisioning.ts` the retry loop's `try` now spans all three calls, but the `catch` still rethrows anything that isn't a non-fast-forward rejection, which only the ref PATCH can produce, so the retry semantics are unchanged.

One deliberate trade-off: `rename.ts` used to fetch the commit lazily, only once the marker needed rewriting. `readRepoHead` reads it up front, so the skip paths (no marker, foreign marker, already current) cost one extra GET per repo. Those are the rare paths in a rename sweep, so uniformity won; easy to revert to a lazy read if preferred.

No commit messages, tree contents, or result shapes change. The `accept`, `feedbackPr`, `rename`, and `submissionTrigger` suites all drive path-routing fakes on the real git endpoints, so they exercise the helper end to end; a small new test pins the three call bodies and the empty-commit path. Verified with `npm run check` (types, lint, prettier, arch, 5371 tests incl. browser mode) and the strict i18n audit. Net about −105 lines.