### PR TITLE
refactor(web): classify ensure* ladder errors through one rung table

### DIFF
--- a/web/src/github-core/__snapshots__/mutations.ensureLadders.test.ts.snap
+++ b/web/src/github-core/__snapshots__/mutations.ensureLadders.test.ts.snap
@@ -1,0 +1,530 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ensureBranchProtection > succeeds 1`] = `
+{
+  "branch": "main",
+  "message": "acme/classroom50: branch protection applied to main; force-pushes and deletions are disabled.",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/branches",
+  "status": "complete",
+}
+`;
+
+exports[`ensureBranchProtection > warns on 403 1`] = `
+{
+  "branch": "main",
+  "message": "acme/classroom50: branch protection could not be applied because the authenticated user lacks permission. Review branch protection manually at https://github.com/acme/classroom50/settings/branches.",
+  "reason": "permission_denied",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/branches",
+  "status": "warning",
+}
+`;
+
+exports[`ensureBranchProtection > warns on 403 rate limited 1`] = `
+{
+  "branch": "main",
+  "message": "acme/classroom50: branch protection could not be applied because the authenticated user lacks permission. Review branch protection manually at https://github.com/acme/classroom50/settings/branches.",
+  "reason": "permission_denied",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/branches",
+  "status": "warning",
+}
+`;
+
+exports[`ensureBranchProtection > warns on 404 1`] = `
+{
+  "branch": "main",
+  "message": "acme/classroom50: branch protection could not be applied because the target branch was not found. The repository may still be initializing. Retry setup or review https://github.com/acme/classroom50/settings/branches.",
+  "reason": "branch_not_found",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/branches",
+  "status": "warning",
+}
+`;
+
+exports[`ensureBranchProtection > warns on 409 1`] = `
+{
+  "branch": "main",
+  "message": "acme/classroom50: branch protection could not be applied: http 409. Review https://github.com/acme/classroom50/settings/branches.",
+  "reason": "unexpected",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/branches",
+  "status": "warning",
+}
+`;
+
+exports[`ensureBranchProtection > warns on 422 1`] = `
+{
+  "branch": "main",
+  "message": "acme/classroom50: GitHub rejected the branch protection request. This may be due to repository plan, ruleset, or policy constraints. Review https://github.com/acme/classroom50/settings/branches.",
+  "reason": "unsupported",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/branches",
+  "status": "warning",
+}
+`;
+
+exports[`ensureBranchProtection > warns on 500 1`] = `
+{
+  "branch": "main",
+  "message": "acme/classroom50: branch protection could not be applied: http 500. Review https://github.com/acme/classroom50/settings/branches.",
+  "reason": "unexpected",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/branches",
+  "status": "warning",
+}
+`;
+
+exports[`ensureBranchProtection > warns on non-API error 1`] = `
+{
+  "branch": "main",
+  "message": "acme/classroom50: branch protection could not be applied: boom. Review https://github.com/acme/classroom50/settings/branches.",
+  "reason": "unexpected",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/branches",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsBudgetCap > creates the cap 1`] = `
+{
+  "budgetCreated": true,
+  "message": "acme: created a $0 GitHub Actions budget cap (blocks paid Actions minutes).",
+  "org": "acme",
+  "settingsUrl": "https://github.com/organizations/acme/settings/billing/budgets",
+  "status": "complete",
+}
+`;
+
+exports[`ensureOrgActionsBudgetCap > warns on 403 1`] = `
+{
+  "message": "acme: couldn't create the $0 Actions budget cap — add Organization Administration: Read and write to your token, or create it by hand at https://github.com/organizations/acme/settings/billing/budgets.",
+  "org": "acme",
+  "reason": "permission_denied",
+  "settingsUrl": "https://github.com/organizations/acme/settings/billing/budgets",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsBudgetCap > warns on 403 rate limited 1`] = `
+{
+  "message": "acme: couldn't create the $0 Actions budget cap — add Organization Administration: Read and write to your token, or create it by hand at https://github.com/organizations/acme/settings/billing/budgets.",
+  "org": "acme",
+  "reason": "permission_denied",
+  "settingsUrl": "https://github.com/organizations/acme/settings/billing/budgets",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsBudgetCap > warns on 404 1`] = `
+{
+  "message": "acme: couldn't create the $0 Actions budget cap (http 404); create it by hand at https://github.com/organizations/acme/settings/billing/budgets.",
+  "org": "acme",
+  "reason": "create_failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/billing/budgets",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsBudgetCap > warns on 409 1`] = `
+{
+  "message": "acme: couldn't create the $0 Actions budget cap (http 409); create it by hand at https://github.com/organizations/acme/settings/billing/budgets.",
+  "org": "acme",
+  "reason": "create_failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/billing/budgets",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsBudgetCap > warns on 422 1`] = `
+{
+  "message": "acme: couldn't create the $0 Actions budget cap (http 422); create it by hand at https://github.com/organizations/acme/settings/billing/budgets.",
+  "org": "acme",
+  "reason": "create_failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/billing/budgets",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsBudgetCap > warns on 500 1`] = `
+{
+  "message": "acme: couldn't create the $0 Actions budget cap (http 500); create it by hand at https://github.com/organizations/acme/settings/billing/budgets.",
+  "org": "acme",
+  "reason": "create_failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/billing/budgets",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsBudgetCap > warns on non-API error 1`] = `
+{
+  "message": "acme: couldn't create the $0 Actions budget cap (boom); create it by hand at https://github.com/organizations/acme/settings/billing/budgets.",
+  "org": "acme",
+  "reason": "create_failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/billing/budgets",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsBudgetCap > warns when the readback fails 1`] = `
+{
+  "message": "acme: couldn't read org billing budgets (boom). Your token may lack Organization Administration: Read, or the plan may not expose budgets. Set a $0 GitHub Actions budget by hand at https://github.com/organizations/acme/settings/billing/budgets to hard-stop paid Actions minutes.",
+  "org": "acme",
+  "reason": "readback_failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/billing/budgets",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsEnabled > succeeds 1`] = `
+{
+  "allowedActions": "all",
+  "enabledRepositories": "all",
+  "message": "acme: GitHub Actions enabled for all repositories.",
+  "org": "acme",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "complete",
+}
+`;
+
+exports[`ensureOrgActionsEnabled > warns on 403 1`] = `
+{
+  "allowedActions": "local_only",
+  "enabledRepositories": "none",
+  "message": "acme: couldn't enable GitHub Actions at the organization level. The authenticated user may lack org-owner/admin permissions, or an enterprise policy may block this change. Open https://github.com/organizations/acme/settings/actions and set Actions permissions to allow repositories in this organization to run workflows.",
+  "org": "acme",
+  "reason": "permission_denied",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsEnabled > warns on 403 rate limited 1`] = `
+{
+  "allowedActions": "local_only",
+  "enabledRepositories": "none",
+  "message": "acme: hit a rate limit enabling GitHub Actions; retry shortly.",
+  "org": "acme",
+  "reason": "rate_limited",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsEnabled > warns on 404 1`] = `
+{
+  "allowedActions": "local_only",
+  "enabledRepositories": "none",
+  "message": "acme: couldn't enable GitHub Actions. Current setting: enabled_repositories="none", allowed_actions="local_only". Review https://github.com/organizations/acme/settings/actions. Original error: http 404",
+  "org": "acme",
+  "reason": "unknown",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsEnabled > warns on 409 1`] = `
+{
+  "allowedActions": "local_only",
+  "enabledRepositories": "none",
+  "message": "acme: GitHub Actions permissions appear to be controlled by an organization or enterprise policy. Current setting: enabled_repositories="none", allowed_actions="local_only". Classroom50 workflows may not run until Actions are enabled. Review https://github.com/organizations/acme/settings/actions.",
+  "org": "acme",
+  "reason": "enterprise_policy",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsEnabled > warns on 422 1`] = `
+{
+  "allowedActions": "local_only",
+  "enabledRepositories": "none",
+  "message": "acme: GitHub rejected the Actions permissions update. Current setting: enabled_repositories="none", allowed_actions="local_only". Review https://github.com/organizations/acme/settings/actions. Original error: http 422",
+  "org": "acme",
+  "reason": "validation_failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsEnabled > warns on 500 1`] = `
+{
+  "allowedActions": "local_only",
+  "enabledRepositories": "none",
+  "message": "acme: couldn't enable GitHub Actions. Current setting: enabled_repositories="none", allowed_actions="local_only". Review https://github.com/organizations/acme/settings/actions. Original error: http 500",
+  "org": "acme",
+  "reason": "unknown",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsEnabled > warns on 500 when the readback also fails 1`] = `
+{
+  "allowedActions": "unknown",
+  "enabledRepositories": "unknown",
+  "message": "acme: couldn't enable GitHub Actions. Current setting: enabled_repositories="unknown", allowed_actions="unknown". Review https://github.com/organizations/acme/settings/actions. Original error: http 500",
+  "org": "acme",
+  "reason": "readback_failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgActionsEnabled > warns on non-API error 1`] = `
+{
+  "allowedActions": "local_only",
+  "enabledRepositories": "none",
+  "message": "acme: couldn't enable GitHub Actions. Current setting: enabled_repositories="none", allowed_actions="local_only". Review https://github.com/organizations/acme/settings/actions. Original error: boom",
+  "org": "acme",
+  "reason": "unknown",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureOrgCanCreatePullRequests > handles 403 1`] = `
+{
+  "resolved": {
+    "message": "acme: couldn't enable Actions-created pull requests (http 403); the opt-in Feedback PR won't open until an org admin turns on "Allow GitHub Actions to create and approve pull requests" at https://github.com/organizations/acme/settings/actions.",
+    "org": "acme",
+    "reason": "permission_denied",
+    "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+    "status": "warning",
+  },
+}
+`;
+
+exports[`ensureOrgCanCreatePullRequests > handles 403 rate limited 1`] = `
+{
+  "resolved": {
+    "message": "acme: couldn't enable Actions-created pull requests (http 403); the opt-in Feedback PR won't open until an org admin turns on "Allow GitHub Actions to create and approve pull requests" at https://github.com/organizations/acme/settings/actions.",
+    "org": "acme",
+    "reason": "permission_denied",
+    "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+    "status": "warning",
+  },
+}
+`;
+
+exports[`ensureOrgCanCreatePullRequests > handles 404 1`] = `
+{
+  "rejected": "GitHubAPIError: http 404",
+}
+`;
+
+exports[`ensureOrgCanCreatePullRequests > handles 409 1`] = `
+{
+  "resolved": {
+    "message": "acme: couldn't enable Actions-created pull requests (http 409); the opt-in Feedback PR won't open until an org admin turns on "Allow GitHub Actions to create and approve pull requests" at https://github.com/organizations/acme/settings/actions.",
+    "org": "acme",
+    "reason": "policy_conflict",
+    "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+    "status": "warning",
+  },
+}
+`;
+
+exports[`ensureOrgCanCreatePullRequests > handles 422 1`] = `
+{
+  "rejected": "GitHubAPIError: http 422",
+}
+`;
+
+exports[`ensureOrgCanCreatePullRequests > handles 500 1`] = `
+{
+  "rejected": "GitHubAPIError: http 500",
+}
+`;
+
+exports[`ensureOrgCanCreatePullRequests > handles non-API error 1`] = `
+{
+  "rejected": "Error: boom",
+}
+`;
+
+exports[`ensureOrgCanCreatePullRequests > is already complete 1`] = `
+{
+  "message": "acme: GitHub Actions is already allowed to create pull requests (Feedback PRs can open).",
+  "org": "acme",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "complete",
+}
+`;
+
+exports[`ensureOrgCanCreatePullRequests > succeeds 1`] = `
+{
+  "message": "acme: enabled GitHub Actions to create pull requests (required for opt-in Feedback PRs).",
+  "org": "acme",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "complete",
+}
+`;
+
+exports[`ensureOrgCanCreatePullRequests > warns when the readback fails 1`] = `
+{
+  "message": "acme: couldn't read organization workflow permissions (boom); GitHub Actions may be blocked from opening Feedback PRs. Enable "Allow GitHub Actions to create and approve pull requests" at https://github.com/organizations/acme/settings/actions.",
+  "org": "acme",
+  "reason": "readback_failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureReusableWorkflowAccess > succeeds 1`] = `
+{
+  "accessLevel": "organization",
+  "message": "acme/classroom50: reusable-workflow access enabled for the organization.",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/actions",
+  "status": "complete",
+}
+`;
+
+exports[`ensureReusableWorkflowAccess > warns on 403 1`] = `
+{
+  "accessLevel": "unknown",
+  "message": "acme/classroom50: couldn't enable reusable-workflow access for the organization. Student autograde workflows may fail with a 403 when resolving the reusable workflow. Retry with an org-admin token or toggle it manually at https://github.com/acme/classroom50/settings/actions → Access.",
+  "reason": "permission_denied",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureReusableWorkflowAccess > warns on 403 rate limited 1`] = `
+{
+  "accessLevel": "unknown",
+  "message": "acme/classroom50: couldn't enable reusable-workflow access for the organization. Student autograde workflows may fail with a 403 when resolving the reusable workflow. Retry with an org-admin token or toggle it manually at https://github.com/acme/classroom50/settings/actions → Access.",
+  "reason": "permission_denied",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureReusableWorkflowAccess > warns on 404 1`] = `
+{
+  "accessLevel": "unknown",
+  "message": "acme/classroom50: couldn't enable reusable-workflow access: http 404. Student autograde workflows may fail resolving the reusable workflow. Review https://github.com/acme/classroom50/settings/actions → Access.",
+  "reason": "unknown",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureReusableWorkflowAccess > warns on 409 1`] = `
+{
+  "accessLevel": "unknown",
+  "message": "acme/classroom50: reusable-workflow access appears to be controlled by an organization or enterprise policy. Student autograde workflows may fail resolving the reusable workflow unless org-level access allows it. Review https://github.com/acme/classroom50/settings/actions → Access.",
+  "reason": "policy_conflict",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureReusableWorkflowAccess > warns on 422 1`] = `
+{
+  "accessLevel": "unknown",
+  "message": "acme/classroom50: couldn't enable reusable-workflow access: http 422. Student autograde workflows may fail resolving the reusable workflow. Review https://github.com/acme/classroom50/settings/actions → Access.",
+  "reason": "unknown",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureReusableWorkflowAccess > warns on 500 1`] = `
+{
+  "accessLevel": "unknown",
+  "message": "acme/classroom50: couldn't enable reusable-workflow access: http 500. Student autograde workflows may fail resolving the reusable workflow. Review https://github.com/acme/classroom50/settings/actions → Access.",
+  "reason": "unknown",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`ensureReusableWorkflowAccess > warns on non-API error 1`] = `
+{
+  "accessLevel": "unknown",
+  "message": "acme/classroom50: couldn't enable reusable-workflow access: boom. Student autograde workflows may fail resolving the reusable workflow. Review https://github.com/acme/classroom50/settings/actions → Access.",
+  "reason": "unknown",
+  "repo": "acme/classroom50",
+  "settingsUrl": "https://github.com/acme/classroom50/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`setOrgActionsMode > warns on 403 rate limited when resuming 1`] = `
+{
+  "message": "acme: couldn't change GitHub Actions permissions — the token may lack org-owner rights. Review https://github.com/organizations/acme/settings/actions.",
+  "org": "acme",
+  "reason": "permission_denied",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`setOrgActionsMode > warns on 403 when resuming 1`] = `
+{
+  "message": "acme: couldn't change GitHub Actions permissions — the token may lack org-owner rights. Review https://github.com/organizations/acme/settings/actions.",
+  "org": "acme",
+  "reason": "permission_denied",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`setOrgActionsMode > warns on 404 when resuming 1`] = `
+{
+  "message": "acme: couldn't change GitHub Actions permissions (http 404). Review https://github.com/organizations/acme/settings/actions.",
+  "org": "acme",
+  "reason": "failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`setOrgActionsMode > warns on 409 when resuming 1`] = `
+{
+  "message": "acme: GitHub Actions permissions appear controlled by an org or enterprise policy. Review https://github.com/organizations/acme/settings/actions.",
+  "org": "acme",
+  "reason": "enterprise_policy",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`setOrgActionsMode > warns on 422 when resuming 1`] = `
+{
+  "message": "acme: GitHub rejected the Actions permissions update (http 422). Review https://github.com/organizations/acme/settings/actions.",
+  "org": "acme",
+  "reason": "validation_failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`setOrgActionsMode > warns on 500 when resuming 1`] = `
+{
+  "message": "acme: couldn't change GitHub Actions permissions (http 500). Review https://github.com/organizations/acme/settings/actions.",
+  "org": "acme",
+  "reason": "failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;
+
+exports[`setOrgActionsMode > warns on non-API error when resuming 1`] = `
+{
+  "message": "acme: couldn't change GitHub Actions permissions (boom). Review https://github.com/organizations/acme/settings/actions.",
+  "org": "acme",
+  "reason": "failed",
+  "settingsUrl": "https://github.com/organizations/acme/settings/actions",
+  "status": "warning",
+}
+`;

--- a/web/src/github-core/mutations.ensureLadders.test.ts
+++ b/web/src/github-core/mutations.ensureLadders.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest"
+
+import type { GitHubClient } from "./client"
+import { GitHubAPIError } from "./errors"
+import {
+  ensureBranchProtection,
+  ensureOrgActionsBudgetCap,
+  ensureOrgActionsEnabled,
+  ensureOrgCanCreatePullRequests,
+  ensureReusableWorkflowAccess,
+  setOrgActionsMode,
+} from "./mutations"
+
+// Every ensure* ladder's warning branch, one status at a time, snapshotted in
+// full. The `reason` values are a contract (orgPolicy/repair keys on them and
+// the setup board renders the messages), so a refactor of the ladders must
+// reproduce each result byte for byte.
+
+const org = "acme"
+const rateLimit = {
+  limit: null,
+  remaining: null,
+  used: null,
+  reset: null,
+  resource: null,
+  retryAfter: null,
+}
+const apiError = (status: number, overrides?: Partial<typeof rateLimit>) =>
+  new GitHubAPIError({
+    status,
+    url: "/x",
+    message: `http ${status}`,
+    body: {},
+    rateLimit: { ...rateLimit, ...overrides },
+  })
+const plainError = new Error("boom")
+
+// A fake client: GETs answer from `reads` (a value or an Error to throw),
+// writes throw `writeError` when set.
+function makeClient(opts: {
+  reads?: Record<string, unknown>
+  writeError?: unknown
+}) {
+  const request = async (
+    path: string,
+    init?: { method?: string; body?: unknown },
+  ) => {
+    const method = init?.method ?? "GET"
+    if (method !== "GET") {
+      if (opts.writeError) throw opts.writeError
+      return {}
+    }
+    const key = Object.keys(opts.reads ?? {}).find((k) => path.startsWith(k))
+    const value = key ? opts.reads![key] : undefined
+    if (value instanceof Error) throw value
+    if (value === undefined) throw new Error(`unexpected GET ${path}`)
+    return value
+  }
+  return { request } as unknown as GitHubClient
+}
+
+const failures: [string, unknown][] = [
+  ["403", apiError(403)],
+  ["403 rate limited", apiError(403, { remaining: 0 })],
+  ["404", apiError(404)],
+  ["409", apiError(409)],
+  ["422", apiError(422)],
+  ["500", apiError(500)],
+  ["non-API error", plainError],
+]
+
+describe("ensureReusableWorkflowAccess", () => {
+  it("succeeds", async () => {
+    expect(
+      await ensureReusableWorkflowAccess(makeClient({}), org),
+    ).toMatchSnapshot()
+  })
+  for (const [label, err] of failures) {
+    it(`warns on ${label}`, async () => {
+      expect(
+        await ensureReusableWorkflowAccess(
+          makeClient({ writeError: err }),
+          org,
+        ),
+      ).toMatchSnapshot()
+    })
+  }
+})
+
+describe("ensureBranchProtection", () => {
+  const reads = { [`/repos/${org}/classroom50`]: { default_branch: "main" } }
+  it("succeeds", async () => {
+    expect(
+      await ensureBranchProtection(makeClient({ reads }), org),
+    ).toMatchSnapshot()
+  })
+  for (const [label, err] of failures) {
+    it(`warns on ${label}`, async () => {
+      expect(
+        await ensureBranchProtection(
+          makeClient({ reads, writeError: err }),
+          org,
+        ),
+      ).toMatchSnapshot()
+    })
+  }
+})
+
+describe("ensureOrgActionsEnabled", () => {
+  const perms = `/orgs/${org}/actions/permissions`
+  const reads = {
+    [perms]: { enabled_repositories: "none", allowed_actions: "local_only" },
+  }
+  it("succeeds", async () => {
+    expect(
+      await ensureOrgActionsEnabled(makeClient({ reads }), org),
+    ).toMatchSnapshot()
+  })
+  for (const [label, err] of failures) {
+    it(`warns on ${label}`, async () => {
+      expect(
+        await ensureOrgActionsEnabled(
+          makeClient({ reads, writeError: err }),
+          org,
+        ),
+      ).toMatchSnapshot()
+    })
+  }
+  it("warns on 500 when the readback also fails", async () => {
+    expect(
+      await ensureOrgActionsEnabled(
+        makeClient({
+          reads: { [perms]: plainError },
+          writeError: apiError(500),
+        }),
+        org,
+      ),
+    ).toMatchSnapshot()
+  })
+})
+
+describe("ensureOrgCanCreatePullRequests", () => {
+  const path = `/orgs/${org}/actions/permissions/workflow`
+  const reads = {
+    [path]: {
+      default_workflow_permissions: "read",
+      can_approve_pull_request_reviews: false,
+    },
+  }
+  it("succeeds", async () => {
+    expect(
+      await ensureOrgCanCreatePullRequests(makeClient({ reads }), org),
+    ).toMatchSnapshot()
+  })
+  it("is already complete", async () => {
+    expect(
+      await ensureOrgCanCreatePullRequests(
+        makeClient({
+          reads: {
+            [path]: {
+              default_workflow_permissions: "read",
+              can_approve_pull_request_reviews: true,
+            },
+          },
+        }),
+        org,
+      ),
+    ).toMatchSnapshot()
+  })
+  it("warns when the readback fails", async () => {
+    expect(
+      await ensureOrgCanCreatePullRequests(
+        makeClient({ reads: { [path]: plainError } }),
+        org,
+      ),
+    ).toMatchSnapshot()
+  })
+  for (const [label, err] of failures) {
+    it(`handles ${label}`, async () => {
+      await expect(
+        ensureOrgCanCreatePullRequests(
+          makeClient({ reads, writeError: err }),
+          org,
+        ).then(
+          (r) => ({ resolved: r }),
+          (e) => ({ rejected: String(e) }),
+        ),
+      ).resolves.toMatchSnapshot()
+    })
+  }
+})
+
+describe("ensureOrgActionsBudgetCap", () => {
+  const path = `/organizations/${org}/settings/billing/budgets`
+  const reads = { [path]: { budgets: [] } }
+  it("creates the cap", async () => {
+    expect(
+      await ensureOrgActionsBudgetCap(makeClient({ reads }), org),
+    ).toMatchSnapshot()
+  })
+  it("warns when the readback fails", async () => {
+    expect(
+      await ensureOrgActionsBudgetCap(
+        makeClient({ reads: { [path]: plainError } }),
+        org,
+      ),
+    ).toMatchSnapshot()
+  })
+  for (const [label, err] of failures) {
+    it(`warns on ${label}`, async () => {
+      expect(
+        await ensureOrgActionsBudgetCap(
+          makeClient({ reads, writeError: err }),
+          org,
+        ),
+      ).toMatchSnapshot()
+    })
+  }
+})
+
+describe("setOrgActionsMode", () => {
+  // A fully disabled org, so resume reaches the write instead of no-op'ing.
+  const reads = {
+    [`/orgs/${org}/actions/permissions`]: { enabled_repositories: "none" },
+  }
+  for (const [label, err] of failures) {
+    it(`warns on ${label} when resuming`, async () => {
+      expect(
+        await setOrgActionsMode(
+          makeClient({ reads, writeError: err }),
+          org,
+          "active",
+        ),
+      ).toMatchSnapshot()
+    })
+  }
+})

--- a/web/src/github-core/mutations.ensureLadders.test.ts
+++ b/web/src/github-core/mutations.ensureLadders.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import type { GitHubClient } from "./client"
-import { GitHubAPIError } from "./errors"
+import { GitHubAPIError, type GitHubRateLimit } from "./errors"
 import {
   ensureBranchProtection,
   ensureOrgActionsBudgetCap,
@@ -17,7 +17,7 @@ import {
 // reproduce each result byte for byte.
 
 const org = "acme"
-const rateLimit = {
+const rateLimit: GitHubRateLimit = {
   limit: null,
   remaining: null,
   used: null,
@@ -25,7 +25,7 @@ const rateLimit = {
   resource: null,
   retryAfter: null,
 }
-const apiError = (status: number, overrides?: Partial<typeof rateLimit>) =>
+const apiError = (status: number, overrides?: Partial<GitHubRateLimit>) =>
   new GitHubAPIError({
     status,
     url: "/x",

--- a/web/src/github-core/mutations/classifyApiError.ts
+++ b/web/src/github-core/mutations/classifyApiError.ts
@@ -1,0 +1,27 @@
+import { GitHubAPIError } from "../errors"
+
+// One rung of an ensure* status ladder: the first predicate the API error
+// satisfies names the warning `reason`.
+export type ErrorRung<R extends string> = [
+  matches: (err: GitHubAPIError) => boolean,
+  reason: R,
+]
+
+// Anything that is not a GitHubAPIError, or matches no rung, gets `fallback`
+// (a reason, or null for callers that rethrow instead).
+export function classifyApiError<R extends string, F>(
+  err: unknown,
+  rungs: ErrorRung<R>[],
+  fallback: F,
+): R | F {
+  if (err instanceof GitHubAPIError) {
+    for (const [matches, reason] of rungs) if (matches(err)) return reason
+  }
+  return fallback
+}
+
+export const forbidden = (err: GitHubAPIError) => err.isForbidden
+export const notFound = (err: GitHubAPIError) => err.isNotFound
+export const rateLimited = (err: GitHubAPIError) => err.isRateLimited
+export const status = (code: number) => (err: GitHubAPIError) =>
+  err.status === code

--- a/web/src/github-core/mutations/provisioning.ts
+++ b/web/src/github-core/mutations/provisioning.ts
@@ -29,6 +29,13 @@ import { logger } from "@/lib/logger"
 import { LOG_SCOPE_GITHUB_SETUP } from "@/lib/logScopes"
 import { CONFIG_REPO_BRANCH } from "./gitObjects"
 import { commitRepoFiles, readRepoHead } from "./repoCommit"
+import {
+  classifyApiError,
+  forbidden,
+  notFound,
+  rateLimited,
+  status,
+} from "./classifyApiError"
 
 const logSetup = logger.scope(LOG_SCOPE_GITHUB_SETUP)
 
@@ -755,37 +762,26 @@ export async function ensureReusableWorkflowAccess(
       message: `${owner}/${repo}: reusable-workflow access enabled for the organization.`,
     }
   } catch (err) {
-    const message = getErrorMessage(err)
-    if (err instanceof GitHubAPIError) {
-      if (err.isForbidden) {
-        return {
-          status: "warning",
-          repo: `${owner}/${repo}`,
-          accessLevel: "unknown",
-          reason: "permission_denied",
-          settingsUrl,
-          message: `${owner}/${repo}: couldn't enable reusable-workflow access for the organization. Student autograde workflows may fail with a 403 when resolving the reusable workflow. Retry with an org-admin token or toggle it manually at ${settingsUrl} → Access.`,
-        }
-      }
-
-      if (err.status === 409) {
-        return {
-          status: "warning",
-          repo: `${owner}/${repo}`,
-          accessLevel: "unknown",
-          reason: "policy_conflict",
-          settingsUrl,
-          message: `${owner}/${repo}: reusable-workflow access appears to be controlled by an organization or enterprise policy. Student autograde workflows may fail resolving the reusable workflow unless org-level access allows it. Review ${settingsUrl} → Access.`,
-        }
-      }
+    const reason = classifyApiError(
+      err,
+      [
+        [forbidden, "permission_denied"],
+        [status(409), "policy_conflict"],
+      ],
+      "unknown",
+    )
+    const messages: Record<typeof reason, string> = {
+      permission_denied: `${owner}/${repo}: couldn't enable reusable-workflow access for the organization. Student autograde workflows may fail with a 403 when resolving the reusable workflow. Retry with an org-admin token or toggle it manually at ${settingsUrl} → Access.`,
+      policy_conflict: `${owner}/${repo}: reusable-workflow access appears to be controlled by an organization or enterprise policy. Student autograde workflows may fail resolving the reusable workflow unless org-level access allows it. Review ${settingsUrl} → Access.`,
+      unknown: `${owner}/${repo}: couldn't enable reusable-workflow access: ${getErrorMessage(err)}. Student autograde workflows may fail resolving the reusable workflow. Review ${settingsUrl} → Access.`,
     }
     return {
       status: "warning",
       repo: `${owner}/${repo}`,
       accessLevel: "unknown",
-      reason: "unknown",
+      reason,
       settingsUrl,
-      message: `${owner}/${repo}: couldn't enable reusable-workflow access: ${message}. Student autograde workflows may fail resolving the reusable workflow. Review ${settingsUrl} → Access.`,
+      message: messages[reason],
     }
   }
 }
@@ -871,50 +867,28 @@ export async function ensureBranchProtection(
       message: `${owner}/${repo}: branch protection applied to ${targetBranch}; force-pushes and deletions are disabled.`,
     }
   } catch (err) {
-    const message = getErrorMessage(err)
-
-    if (err instanceof GitHubAPIError) {
-      if (err.isForbidden) {
-        return {
-          status: "warning",
-          repo: `${owner}/${repo}`,
-          branch: targetBranch,
-          reason: "permission_denied",
-          settingsUrl,
-          message: `${owner}/${repo}: branch protection could not be applied because the authenticated user lacks permission. Review branch protection manually at ${settingsUrl}.`,
-        }
-      }
-
-      if (err.isNotFound) {
-        return {
-          status: "warning",
-          repo: `${owner}/${repo}`,
-          branch: targetBranch,
-          reason: "branch_not_found",
-          settingsUrl,
-          message: `${owner}/${repo}: branch protection could not be applied because the target branch was not found. The repository may still be initializing. Retry setup or review ${settingsUrl}.`,
-        }
-      }
-
-      if (err.status === 422) {
-        return {
-          status: "warning",
-          repo: `${owner}/${repo}`,
-          branch: targetBranch,
-          reason: "unsupported",
-          settingsUrl,
-          message: `${owner}/${repo}: GitHub rejected the branch protection request. This may be due to repository plan, ruleset, or policy constraints. Review ${settingsUrl}.`,
-        }
-      }
+    const reason = classifyApiError(
+      err,
+      [
+        [forbidden, "permission_denied"],
+        [notFound, "branch_not_found"],
+        [status(422), "unsupported"],
+      ],
+      "unexpected",
+    )
+    const messages: Record<typeof reason, string> = {
+      permission_denied: `${owner}/${repo}: branch protection could not be applied because the authenticated user lacks permission. Review branch protection manually at ${settingsUrl}.`,
+      branch_not_found: `${owner}/${repo}: branch protection could not be applied because the target branch was not found. The repository may still be initializing. Retry setup or review ${settingsUrl}.`,
+      unsupported: `${owner}/${repo}: GitHub rejected the branch protection request. This may be due to repository plan, ruleset, or policy constraints. Review ${settingsUrl}.`,
+      unexpected: `${owner}/${repo}: branch protection could not be applied: ${getErrorMessage(err)}. Review ${settingsUrl}.`,
     }
-
     return {
       status: "warning",
       repo: `${owner}/${repo}`,
       branch: targetBranch,
-      reason: "unexpected",
+      reason,
       settingsUrl,
-      message: `${owner}/${repo}: branch protection could not be applied: ${message}. Review ${settingsUrl}.`,
+      message: messages[reason],
     }
   }
 }
@@ -1032,92 +1006,60 @@ export async function ensureOrgActionsEnabled(
       message: `${org}: GitHub Actions enabled for all repositories.`,
     }
   } catch (err) {
-    const message = getErrorMessage(err)
-
+    // Re-read so the warning can quote the effective policy; an unreadable
+    // policy is itself the fallback reason.
     let current: OrgActionsPermissions | null = null
-
     try {
       current = await getOrgActionsPermissions(client, org)
     } catch {
       // nothing for now, still want good warning info
     }
-
     const enabledRepositories = current?.enabled_repositories ?? "unknown"
     const allowedActions = current?.allowed_actions ?? "unknown"
+    const currentSetting = `Current setting: enabled_repositories="${enabledRepositories}", allowed_actions="${allowedActions}". `
 
-    if (err instanceof GitHubAPIError) {
-      // A secondary rate limit also surfaces as 403, so classify it before the
-      // permission wall — it's retryable, and callers key their retry-vs-manual
-      // messaging off the reason.
-      if (err.isRateLimited) {
-        return {
-          status: "warning",
-          org,
-          enabledRepositories,
-          allowedActions,
-          reason: "rate_limited",
-          settingsUrl,
-          message: `${org}: hit a rate limit enabling GitHub Actions; retry shortly.`,
-        }
-      }
-
-      if (err.isForbidden) {
-        return {
-          status: "warning",
-          org,
-          enabledRepositories,
-          allowedActions,
-          reason: "permission_denied",
-          settingsUrl,
-          message:
-            `${org}: couldn't enable GitHub Actions at the organization level. ` +
-            `The authenticated user may lack org-owner/admin permissions, or an enterprise policy may block this change. ` +
-            `Open ${settingsUrl} and set Actions permissions to allow repositories in this organization to run workflows.`,
-        }
-      }
-
-      if (err.status === 409) {
-        return {
-          status: "warning",
-          org,
-          enabledRepositories,
-          allowedActions,
-          reason: "enterprise_policy",
-          settingsUrl,
-          message:
-            `${org}: GitHub Actions permissions appear to be controlled by an organization or enterprise policy. ` +
-            `Current setting: enabled_repositories="${enabledRepositories}", allowed_actions="${allowedActions}". ` +
-            `Classroom50 workflows may not run until Actions are enabled. Review ${settingsUrl}.`,
-        }
-      }
-
-      if (err.status === 422) {
-        return {
-          status: "warning",
-          org,
-          enabledRepositories,
-          allowedActions,
-          reason: "validation_failed",
-          settingsUrl,
-          message:
-            `${org}: GitHub rejected the Actions permissions update. ` +
-            `Current setting: enabled_repositories="${enabledRepositories}", allowed_actions="${allowedActions}". ` +
-            `Review ${settingsUrl}. Original error: ${message}`,
-        }
-      }
+    // A secondary rate limit also surfaces as 403, so it precedes the
+    // permission wall: it's retryable, and callers key their retry-vs-manual
+    // messaging off the reason.
+    const reason = classifyApiError(
+      err,
+      [
+        [rateLimited, "rate_limited"],
+        [forbidden, "permission_denied"],
+        [status(409), "enterprise_policy"],
+        [status(422), "validation_failed"],
+      ],
+      current ? ("unknown" as const) : ("readback_failed" as const),
+    )
+    const couldNotEnable =
+      `${org}: couldn't enable GitHub Actions. ` +
+      currentSetting +
+      `Review ${settingsUrl}. Original error: ${getErrorMessage(err)}`
+    const messages: Record<typeof reason, string> = {
+      rate_limited: `${org}: hit a rate limit enabling GitHub Actions; retry shortly.`,
+      permission_denied:
+        `${org}: couldn't enable GitHub Actions at the organization level. ` +
+        `The authenticated user may lack org-owner/admin permissions, or an enterprise policy may block this change. ` +
+        `Open ${settingsUrl} and set Actions permissions to allow repositories in this organization to run workflows.`,
+      enterprise_policy:
+        `${org}: GitHub Actions permissions appear to be controlled by an organization or enterprise policy. ` +
+        currentSetting +
+        `Classroom50 workflows may not run until Actions are enabled. Review ${settingsUrl}.`,
+      validation_failed:
+        `${org}: GitHub rejected the Actions permissions update. ` +
+        currentSetting +
+        `Review ${settingsUrl}. Original error: ${getErrorMessage(err)}`,
+      unknown: couldNotEnable,
+      readback_failed: couldNotEnable,
     }
-
     return {
       status: "warning",
       org,
       enabledRepositories,
       allowedActions,
-      reason: current ? "unknown" : "readback_failed",
+      reason,
       settingsUrl,
-      message:
-        `${org}: couldn't enable GitHub Actions. ` +
-        `Current setting: enabled_repositories="${enabledRepositories}", allowed_actions="${allowedActions}". ` +
-        `Review ${settingsUrl}. Original error: ${message}`,
+      message: messages[reason],
     }
   }
 }
@@ -1178,39 +1120,27 @@ function setOrgActionsModeWarning(
   err: unknown,
 ): SetOrgActionsModeResult {
   const settingsUrl = githubOrgActionsSettingsUrl(org)
-  const message = getErrorMessage(err)
-  if (err instanceof GitHubAPIError) {
-    if (err.isForbidden)
-      return {
-        status: "warning",
-        org,
-        reason: "permission_denied",
-        settingsUrl,
-        message: `${org}: couldn't change GitHub Actions permissions — the token may lack org-owner rights. Review ${settingsUrl}.`,
-      }
-    if (err.status === 409)
-      return {
-        status: "warning",
-        org,
-        reason: "enterprise_policy",
-        settingsUrl,
-        message: `${org}: GitHub Actions permissions appear controlled by an org or enterprise policy. Review ${settingsUrl}.`,
-      }
-    if (err.status === 422)
-      return {
-        status: "warning",
-        org,
-        reason: "validation_failed",
-        settingsUrl,
-        message: `${org}: GitHub rejected the Actions permissions update (${message}). Review ${settingsUrl}.`,
-      }
+  const reason = classifyApiError(
+    err,
+    [
+      [forbidden, "permission_denied"],
+      [status(409), "enterprise_policy"],
+      [status(422), "validation_failed"],
+    ],
+    "failed",
+  )
+  const messages: Record<typeof reason, string> = {
+    permission_denied: `${org}: couldn't change GitHub Actions permissions — the token may lack org-owner rights. Review ${settingsUrl}.`,
+    enterprise_policy: `${org}: GitHub Actions permissions appear controlled by an org or enterprise policy. Review ${settingsUrl}.`,
+    validation_failed: `${org}: GitHub rejected the Actions permissions update (${getErrorMessage(err)}). Review ${settingsUrl}.`,
+    failed: `${org}: couldn't change GitHub Actions permissions (${getErrorMessage(err)}). Review ${settingsUrl}.`,
   }
   return {
     status: "warning",
     org,
-    reason: "failed",
+    reason,
     settingsUrl,
-    message: `${org}: couldn't change GitHub Actions permissions (${message}). Review ${settingsUrl}.`,
+    message: messages[reason],
   }
 }
 
@@ -1451,15 +1381,21 @@ export async function ensureOrgActionsBudgetCap(
       },
     })
   } catch (err) {
-    const permission = err instanceof GitHubAPIError && err.isForbidden
+    const reason = classifyApiError(
+      err,
+      [[forbidden, "permission_denied"]],
+      "create_failed",
+    )
+    const messages: Record<typeof reason, string> = {
+      permission_denied: `${org}: couldn't create the $0 Actions budget cap — add Organization Administration: Read and write to your token, or create it by hand at ${settingsUrl}.`,
+      create_failed: `${org}: couldn't create the $0 Actions budget cap (${getErrorMessage(err)}); create it by hand at ${settingsUrl}.`,
+    }
     return {
       status: "warning",
       org,
-      reason: permission ? "permission_denied" : "create_failed",
+      reason,
       settingsUrl,
-      message: permission
-        ? `${org}: couldn't create the $0 Actions budget cap — add Organization Administration: Read and write to your token, or create it by hand at ${settingsUrl}.`
-        : `${org}: couldn't create the $0 Actions budget cap (${getErrorMessage(err)}); create it by hand at ${settingsUrl}.`,
+      message: messages[reason],
     }
   }
 
@@ -1543,22 +1479,26 @@ export async function ensureOrgCanCreatePullRequests(
       message: `${org}: enabled GitHub Actions to create pull requests (required for opt-in Feedback PRs).`,
     }
   } catch (err) {
-    if (
-      err instanceof GitHubAPIError &&
-      (err.isForbidden || err.status === 409)
-    ) {
-      return {
-        status: "warning",
-        org,
-        reason: err.isForbidden ? "permission_denied" : "policy_conflict",
-        settingsUrl,
-        message: `${org}: couldn't enable Actions-created pull requests (${getErrorMessage(
-          err,
-        )}); the opt-in Feedback PR won't open until an org admin turns on "Allow GitHub Actions to create and approve pull requests" at ${settingsUrl}.`,
-      }
+    // Only the two policy-shaped refusals degrade to a warning; anything else
+    // is a real failure and propagates.
+    const reason = classifyApiError(
+      err,
+      [
+        [forbidden, "permission_denied"],
+        [status(409), "policy_conflict"],
+      ],
+      null,
+    )
+    if (reason === null) throw err
+    return {
+      status: "warning",
+      org,
+      reason,
+      settingsUrl,
+      message: `${org}: couldn't enable Actions-created pull requests (${getErrorMessage(
+        err,
+      )}); the opt-in Feedback PR won't open until an org admin turns on "Allow GitHub Actions to create and approve pull requests" at ${settingsUrl}.`,
     }
-
-    throw err
   }
 }
 


### PR DESCRIPTION
Follow-up from the post-refactor review (D2). Six write paths in `github-core/mutations/provisioning.ts` each ended in the same hand-rolled ladder: catch, check `instanceof GitHubAPIError`, walk `isForbidden` / `status === 409` / `status === 422` / ... in order, and return a warning that restates the same scope fields on every branch with a per-reason message. About 180 lines of that across `ensureReusableWorkflowAccess`, `ensureBranchProtection`, `ensureOrgActionsEnabled`, `ensureOrgCanCreatePullRequests`, `ensureOrgActionsBudgetCap`, and `setOrgActionsModeWarning`.

**Oracle first.** The `reason` values are a contract (`orgPolicy/repair` keys on `autograding_paused` and `branch_not_found`; the setup board renders the messages) and only three of the six had tests, so the first commit adds `mutations.ensureLadders.test.ts`: each ladder driven through 403, 403-rate-limited, 404, 409, 422, 500, and a non-API error against a scripted fake client, with the full result snapshotted (51 snapshots). Recorded against the unchanged code, then held fixed through the refactor, so every reason, message, and extra field is proven byte-identical.

**The refactor.** New `mutations/classifyApiError.ts`: `classifyApiError(err, rungs, fallback)` returns the reason of the first rung whose predicate the `GitHubAPIError` satisfies, else the fallback; `forbidden`, `notFound`, `rateLimited`, and `status(n)` are the predicates. Each ladder becomes two declarations, the rung table and a `Record<typeof reason, string>` of messages, followed by one return. The `Record` keyed on the inferred reason union means a rung without a message (or vice versa) is a compile error.

Per-ladder notes: `ensureOrgActionsEnabled` keeps rate-limited ahead of forbidden (a secondary rate limit is also a 403) and its fallback still depends on whether the post-failure readback succeeded; `unknown` and `readback_failed` share one message, bound once. `ensureOrgCanCreatePullRequests` uses a `null` fallback and rethrows, matching its old "only 403/409 degrade to a warning" behavior. `ensurePages`'s single 409 check and `tryStep`'s warning-code list are not ladders and are untouched.

Verified with `npm run check` (types, lint, prettier, arch, 5422 tests incl. browser mode) and the strict i18n audit. Net about −60 lines in `provisioning.ts` after the classifier is counted, with the readability gain being the point: each ladder now states its rungs in one place.