### PR TITLE
fix(gh-student): add timeouts to submit's network calls

### DIFF
--- a/cli/gh-student/internal/submitcmd/orchestration_test.go
+++ b/cli/gh-student/internal/submitcmd/orchestration_test.go
@@ -1,6 +1,7 @@
 package submitcmd
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -48,7 +49,7 @@ func TestFetchRepoPath(t *testing.T) {
 	client := githubtest.NewTestClient(t, server)
 
 	dst := t.TempDir()
-	if err := fetchRepoPath(client, dst, "o", "r", "main", ".github"); err != nil {
+	if err := fetchRepoPath(context.Background(), client, dst, "o", "r", "main", ".github"); err != nil {
 		t.Fatalf("fetchRepoPath: %v", err)
 	}
 
@@ -78,7 +79,7 @@ func TestFetchRepoPath_RejectsNonBase64(t *testing.T) {
 	t.Cleanup(server.Close)
 	client := githubtest.NewTestClient(t, server)
 
-	err := fetchRepoPath(client, t.TempDir(), "o", "r", "main", "file.txt")
+	err := fetchRepoPath(context.Background(), client, t.TempDir(), "o", "r", "main", "file.txt")
 	if err == nil || !strings.Contains(err.Error(), "unsupported encoding") {
 		t.Fatalf("err = %v, want an 'unsupported encoding' error", err)
 	}

--- a/cli/gh-student/internal/submitcmd/submit.go
+++ b/cli/gh-student/internal/submitcmd/submit.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -136,7 +137,7 @@ func submitAssignment(ctx context.Context, client githubapi.Client, verbose bool
 	// Classroom 50, may have named `master`) so the autograde shim — which
 	// triggers on that branch — fires. A failed lookup is fatal: silently
 	// falling back to `main` would push to the wrong branch and skip grading.
-	branch, err := resolveRepoDefaultBranch(client, repoOwner, repoName)
+	branch, err := resolveRepoDefaultBranch(ctx, client, repoOwner, repoName)
 	if err != nil {
 		return err
 	}
@@ -185,12 +186,20 @@ func submitAssignment(ctx context.Context, client githubapi.Client, verbose bool
 			)
 		}
 
-		if err := fetchRepoPath(client, workTree, config.Source.Owner, config.Source.Repo, config.Source.Branch, ".gitignore"); err != nil {
+		// One deadline covers both refreshes (and every recursive call inside
+		// fetchRepoPath for .github/'s subtree): go-gh's client has no HTTP
+		// timeout of its own, and each recursive fetchRepoPath call is a
+		// fresh, unbounded request, so without an outer deadline a stalled
+		// connection partway through a deep .github/ tree hangs forever.
+		refreshCtx, cancel := context.WithTimeout(ctx, teacherFileRefreshTimeout)
+		defer cancel()
+
+		if err := fetchRepoPath(refreshCtx, client, workTree, config.Source.Owner, config.Source.Repo, config.Source.Branch, ".gitignore"); err != nil {
 			if !classroomcfg.IsHTTPNotFound(err) {
 				return fmt.Errorf("fetch teacher .gitignore: %w", err)
 			}
 		}
-		if err := fetchRepoPath(client, workTree, config.Source.Owner, config.Source.Repo, config.Source.Branch, ".github"); err != nil {
+		if err := fetchRepoPath(refreshCtx, client, workTree, config.Source.Owner, config.Source.Repo, config.Source.Branch, ".github"); err != nil {
 			if !classroomcfg.IsHTTPNotFound(err) {
 				return fmt.Errorf("fetch teacher .github: %w", err)
 			}
@@ -219,7 +228,16 @@ func submitAssignment(ctx context.Context, client githubapi.Client, verbose bool
 		u.Detail("Pushing submission to %s %s", remote, branch)
 	}
 
+	// git has no notion of a request timeout, and a stalled TCP connection
+	// (dead wifi, VPN drop, silent firewall) can otherwise leave this step
+	// hanging far longer than any reasonable wait — OS-level TCP keepalive
+	// is the only backstop, which can take many minutes. Bind an explicit
+	// deadline instead of relying on that.
+	pushCtx, cancel := context.WithTimeout(ctx, gitNetworkTimeout)
+	defer cancel()
+
 	sha, err := commitWorkTreeOnRemoteBranch(
+		pushCtx,
 		gitDir,
 		workTree,
 		remoteURL,
@@ -297,7 +315,7 @@ func finishSubmission(
 	}
 
 	if entry != nil && entry.IsTagSubmissionMode() {
-		tag, err := pushSubmitTag(gitDir, sha)
+		tag, err := pushSubmitTag(ctx, gitDir, sha)
 		if err != nil {
 			return fmt.Errorf(
 				"submission pushed (%s/commit/%s) but the submit tag failed: %w\n"+
@@ -352,8 +370,17 @@ func fetchSubmitEntry(ctx context.Context, org string, config *classroomcfg.Conf
 // submit/* tag already points at sha (a retry after a tag-push failure, or a
 // hand-pushed tag), it is reused — mirroring the runner's ls-remote
 // idempotency check — so the same commit never grades twice.
-func pushSubmitTag(gitDir, sha string) (string, error) {
-	existing, err := existingSubmitTagAt(gitDir, sha)
+//
+// Bounded by submitTagTimeout, covering both the ls-remote probe and the tag
+// push: like the clone/push in commitWorkTreeOnRemoteBranch, these are git
+// subprocesses talking to the real remote over the network, with no timeout
+// of their own — a stalled connection here must not hang the process after
+// the branch push has already succeeded.
+func pushSubmitTag(ctx context.Context, gitDir, sha string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, submitTagTimeout)
+	defer cancel()
+
+	existing, err := existingSubmitTagAt(ctx, gitDir, sha)
 	if err == nil && existing != "" {
 		return existing, nil
 	}
@@ -361,17 +388,23 @@ func pushSubmitTag(gitDir, sha string) (string, error) {
 	// submit/* tag at the same SHA (one extra identical graded run), preferred
 	// over failing a submission whose push would succeed.
 	tag := contract.BuildSubmitTag(timeNow(), sha)
-	if _, err := gitOutputWithGitDir(gitDir, "push", "origin", sha+":refs/tags/"+tag); err != nil {
+	if _, err := gitOutputWithGitDir(ctx, gitDir, "push", "origin", sha+":refs/tags/"+tag); err != nil {
 		return "", err
 	}
 	return tag, nil
 }
 
+// submitTagTimeout bounds pushSubmitTag's ls-remote probe + tag push.
+// Smaller than gitNetworkTimeout: by this point the full clone/push already
+// succeeded, so only a single small ref update remains. A var so tests can
+// shrink it.
+var submitTagTimeout = 30 * time.Second
+
 // existingSubmitTagAt returns the first submit/* tag pointing at sha on
 // origin, or "" when none. `--refs` filters the peeled-ref (^{}) rows
 // annotated tags emit, mirroring the runner's awk pipeline.
-func existingSubmitTagAt(gitDir, sha string) (string, error) {
-	out, err := gitOutputWithGitDir(gitDir, "ls-remote", "--refs", "--tags", "origin")
+func existingSubmitTagAt(ctx context.Context, gitDir, sha string) (string, error) {
+	out, err := gitOutputWithGitDir(ctx, gitDir, "ls-remote", "--refs", "--tags", "origin")
 	if err != nil {
 		return "", err
 	}
@@ -416,22 +449,65 @@ const assignmentNameTimeout = 3 * time.Second
 // clone/push, so the extra allowance never stalls a completed submission.
 const submitEntryTimeout = 15 * time.Second
 
+// teacherFileRefreshTimeout bounds the whole pre-push .gitignore/.github
+// refresh from the template source repo, including every recursive
+// fetchRepoPath call inside a deep .github/ tree. Generous relative to the
+// single-object timeouts above: a large .github/workflows tree is several
+// sequential requests, but it still must not be able to hang forever.
+// A var so tests can shrink it.
+var teacherFileRefreshTimeout = 30 * time.Second
+
+// gitNetworkTimeout bounds the clone + push step. Generous — it covers the
+// slowest part of submit (full history clone plus push) — but finite, so a
+// stalled connection fails with a clear timeout error instead of hanging
+// indefinitely with no OS-level backstop the user can rely on. A var so
+// tests can shrink it.
+var gitNetworkTimeout = 5 * time.Minute
+
+// cmdWaitDelay bounds how long runCmd/runGitWithDirAndTree wait for a
+// subprocess's I/O pipes to close after its context is canceled. Needed
+// because a killed git process can leave a grandchild transport helper
+// (e.g. git-remote-http) running on a stalled connection, which would
+// otherwise hold Wait() open indefinitely even though git itself is dead.
+// A var so tests can shrink it.
+var cmdWaitDelay = 5 * time.Second
+
 // resolveRepoDefaultBranch reads the assignment repo's default branch. A GET
 // failure is returned as an error (submitting to the wrong branch would skip
 // grading); an empty value falls back to "main" (matches an auto_init repo).
-func resolveRepoDefaultBranch(client githubapi.Client, owner, repo string) (string, error) {
+// Bounded by defaultBranchTimeout: go-gh's default client has no HTTP
+// timeout, and this call runs before anything else in submit, so a stalled
+// network here must not hang the process silently before the spinner even
+// starts.
+func resolveRepoDefaultBranch(ctx context.Context, client githubapi.Client, owner, repo string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, defaultBranchTimeout)
+	defer cancel()
+
+	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
+	httpResp, err := client.RequestWithContext(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return "", fmt.Errorf("resolve default branch for %s/%s: %w", owner, repo, err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
 	var resp struct {
 		DefaultBranch string `json:"default_branch"`
 	}
-	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
-	if err := client.Get(path, &resp); err != nil {
-		return "", fmt.Errorf("resolve default branch for %s/%s: %w", owner, repo, err)
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return "", fmt.Errorf("decode default branch response for %s/%s: %w", owner, repo, err)
 	}
 	if resp.DefaultBranch == "" {
 		return "main", nil
 	}
 	return resp.DefaultBranch, nil
 }
+
+// defaultBranchTimeout bounds the pre-everything-else default-branch lookup.
+// Short: it's a single-object GET, and a stall here should fail fast rather
+// than eat into the user's patience before the actual submission starts.
+// A var (not const), like timeNow above, so tests can shrink it temporarily
+// to exercise the timeout path without a real 10s wait.
+var defaultBranchTimeout = 10 * time.Second
 
 func gitOutput(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
@@ -462,6 +538,7 @@ type contentsFile struct {
 }
 
 func fetchRepoPath(
+	ctx context.Context,
 	client githubapi.Client,
 	dstRoot string,
 	owner string,
@@ -476,9 +553,15 @@ func fetchRepoPath(
 		url.QueryEscape(ref),
 	)
 
-	var raw json.RawMessage
-	if err := client.Get(apiPath, &raw); err != nil {
+	httpResp, err := client.RequestWithContext(ctx, http.MethodGet, apiPath, nil)
+	if err != nil {
 		return fmt.Errorf("GET %s: %w", apiPath, err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	raw, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return fmt.Errorf("GET %s: read body: %w", apiPath, err)
 	}
 
 	trimmed := bytes.TrimSpace(raw)
@@ -496,7 +579,7 @@ func fetchRepoPath(
 
 		for _, entry := range entries {
 			if entry.Type == "dir" || entry.Type == "file" {
-				if err := fetchRepoPath(client, dstRoot, owner, repo, ref, entry.Path); err != nil {
+				if err := fetchRepoPath(ctx, client, dstRoot, owner, repo, ref, entry.Path); err != nil {
 					return err
 				}
 			}
@@ -574,13 +657,13 @@ func splitOwnerRepo(s string) (owner, repo string) {
 // commitWorkTreeOnRemoteBranch clones origin into a temporary bare repo,
 // stages workTree onto `branch`, commits with `identity`, and pushes. Returns
 // the new commit SHA (informational; the runner workflow auto-tags on its end).
-func commitWorkTreeOnRemoteBranch(gitDir string, workTree string, remoteURL string, branch string, message string, identity identitypkg.GitIdentity, out io.Writer, errOut io.Writer) (string, error) {
-	if err := runCmd(out, errOut, "", "git", "clone", "--bare", remoteURL, gitDir); err != nil {
+func commitWorkTreeOnRemoteBranch(ctx context.Context, gitDir string, workTree string, remoteURL string, branch string, message string, identity identitypkg.GitIdentity, out io.Writer, errOut io.Writer) (string, error) {
+	if err := runCmd(ctx, out, errOut, "", "git", "clone", "--bare", remoteURL, gitDir); err != nil {
 		return "", fmt.Errorf("clone remote history: %w", err)
 	}
 
 	git := func(args ...string) error {
-		return runGitWithDirAndTree(gitDir, workTree, out, errOut, args...)
+		return runGitWithDirAndTree(ctx, gitDir, workTree, out, errOut, args...)
 	}
 
 	ref := "refs/heads/" + branch
@@ -608,7 +691,7 @@ func commitWorkTreeOnRemoteBranch(gitDir string, workTree string, remoteURL stri
 	}
 
 	// Resolve HEAD post-push so callers can log the SHA the runner will tag.
-	sha, err := gitOutputWithGitDir(gitDir, "rev-parse", "HEAD")
+	sha, err := gitOutputWithGitDir(ctx, gitDir, "rev-parse", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("resolve submission SHA: %w", err)
 	}
@@ -617,12 +700,18 @@ func commitWorkTreeOnRemoteBranch(gitDir string, workTree string, remoteURL stri
 
 // gitOutputWithGitDir runs `git --git-dir=<gitDir> <args>`. Separate from
 // gitOutput because rev-parsing the submitted commit runs against the bare
-// clone (no work tree).
-func gitOutputWithGitDir(gitDir string, args ...string) (string, error) {
+// clone (no work tree). Some callers (rev-parse) are local-only, others
+// (push, ls-remote) hit the network — ctx is threaded through uniformly so
+// every caller gets the same stalled-connection backstop via cmdWaitDelay.
+func gitOutputWithGitDir(ctx context.Context, gitDir string, args ...string) (string, error) {
 	fullArgs := append([]string{"--git-dir", gitDir}, args...)
-	cmd := exec.Command("git", fullArgs...)
+	cmd := exec.CommandContext(ctx, "git", fullArgs...)
+	cmd.WaitDelay = cmdWaitDelay
 	out, err := cmd.Output()
 	if err != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("git %v: %w (network stalled?)", fullArgs, ctx.Err())
+		}
 		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			return "", fmt.Errorf("git %v: %s", fullArgs, strings.TrimSpace(string(exitErr.Stderr)))
 		}
@@ -632,6 +721,7 @@ func gitOutputWithGitDir(gitDir string, args ...string) (string, error) {
 }
 
 func runGitWithDirAndTree(
+	ctx context.Context,
 	gitDir string,
 	workTree string,
 	out io.Writer,
@@ -644,26 +734,39 @@ func runGitWithDirAndTree(
 	}
 	fullArgs = append(fullArgs, args...)
 
-	cmd := exec.Command("git", fullArgs...)
+	cmd := exec.CommandContext(ctx, "git", fullArgs...)
 	cmd.Stdout = out
 	cmd.Stderr = errOut
+	// Bounds Wait() when ctx is canceled: CommandContext's default Cancel
+	// only kills the direct git process, not a grandchild transport helper
+	// (e.g. git-remote-http) stuck reading a stalled connection. Without
+	// WaitDelay, Wait() blocks forever on that grandchild's inherited
+	// stdout/stderr pipes even after git itself is dead.
+	cmd.WaitDelay = cmdWaitDelay
 
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("git %v: %w (network stalled?)", fullArgs, ctx.Err())
+		}
 		return fmt.Errorf("git %v: %w", fullArgs, err)
 	}
 
 	return nil
 }
 
-func runCmd(out io.Writer, errOut io.Writer, dir string, name string, args ...string) error {
-	cmd := exec.Command(name, args...)
+func runCmd(ctx context.Context, out io.Writer, errOut io.Writer, dir string, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
 	cmd.Stdout = out
 	cmd.Stderr = errOut
+	cmd.WaitDelay = cmdWaitDelay
 
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("%s %v: %w (network stalled?)", name, args, ctx.Err())
+		}
 		return fmt.Errorf("%s %v: %w", name, args, err)
 	}
 

--- a/cli/gh-student/internal/submitcmd/submit.go
+++ b/cli/gh-student/internal/submitcmd/submit.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -186,20 +187,12 @@ func submitAssignment(ctx context.Context, client githubapi.Client, verbose bool
 			)
 		}
 
-		// One deadline covers both refreshes (and every recursive call inside
-		// fetchRepoPath for .github/'s subtree): go-gh's client has no HTTP
-		// timeout of its own, and each recursive fetchRepoPath call is a
-		// fresh, unbounded request, so without an outer deadline a stalled
-		// connection partway through a deep .github/ tree hangs forever.
-		refreshCtx, cancel := context.WithTimeout(ctx, teacherFileRefreshTimeout)
-		defer cancel()
-
-		if err := fetchRepoPath(refreshCtx, client, workTree, config.Source.Owner, config.Source.Repo, config.Source.Branch, ".gitignore"); err != nil {
+		if err := fetchRepoPath(ctx, client, workTree, config.Source.Owner, config.Source.Repo, config.Source.Branch, ".gitignore"); err != nil {
 			if !classroomcfg.IsHTTPNotFound(err) {
 				return fmt.Errorf("fetch teacher .gitignore: %w", err)
 			}
 		}
-		if err := fetchRepoPath(refreshCtx, client, workTree, config.Source.Owner, config.Source.Repo, config.Source.Branch, ".github"); err != nil {
+		if err := fetchRepoPath(ctx, client, workTree, config.Source.Owner, config.Source.Repo, config.Source.Branch, ".github"); err != nil {
 			if !classroomcfg.IsHTTPNotFound(err) {
 				return fmt.Errorf("fetch teacher .github: %w", err)
 			}
@@ -228,16 +221,8 @@ func submitAssignment(ctx context.Context, client githubapi.Client, verbose bool
 		u.Detail("Pushing submission to %s %s", remote, branch)
 	}
 
-	// git has no notion of a request timeout, and a stalled TCP connection
-	// (dead wifi, VPN drop, silent firewall) can otherwise leave this step
-	// hanging far longer than any reasonable wait — OS-level TCP keepalive
-	// is the only backstop, which can take many minutes. Bind an explicit
-	// deadline instead of relying on that.
-	pushCtx, cancel := context.WithTimeout(ctx, gitNetworkTimeout)
-	defer cancel()
-
 	sha, err := commitWorkTreeOnRemoteBranch(
-		pushCtx,
+		ctx,
 		gitDir,
 		workTree,
 		remoteURL,
@@ -369,13 +354,9 @@ func fetchSubmitEntry(ctx context.Context, org string, config *classroomcfg.Conf
 // it from the temp bare clone left by commitWorkTreeOnRemoteBranch. If a
 // submit/* tag already points at sha (a retry after a tag-push failure, or a
 // hand-pushed tag), it is reused — mirroring the runner's ls-remote
-// idempotency check — so the same commit never grades twice.
-//
-// Bounded by submitTagTimeout, covering both the ls-remote probe and the tag
-// push: like the clone/push in commitWorkTreeOnRemoteBranch, these are git
-// subprocesses talking to the real remote over the network, with no timeout
-// of their own — a stalled connection here must not hang the process after
-// the branch push has already succeeded.
+// idempotency check — so the same commit never grades twice. Bounded by
+// submitTagTimeout: the branch push already landed, so a stall here must not
+// hang the terminal.
 func pushSubmitTag(ctx context.Context, gitDir, sha string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, submitTagTimeout)
 	defer cancel()
@@ -393,12 +374,6 @@ func pushSubmitTag(ctx context.Context, gitDir, sha string) (string, error) {
 	}
 	return tag, nil
 }
-
-// submitTagTimeout bounds pushSubmitTag's ls-remote probe + tag push.
-// Smaller than gitNetworkTimeout: by this point the full clone/push already
-// succeeded, so only a single small ref update remains. A var so tests can
-// shrink it.
-var submitTagTimeout = 30 * time.Second
 
 // existingSubmitTagAt returns the first submit/* tag pointing at sha on
 // origin, or "" when none. `--refs` filters the peeled-ref (^{}) rows
@@ -449,65 +424,63 @@ const assignmentNameTimeout = 3 * time.Second
 // clone/push, so the extra allowance never stalls a completed submission.
 const submitEntryTimeout = 15 * time.Second
 
-// teacherFileRefreshTimeout bounds the whole pre-push .gitignore/.github
-// refresh from the template source repo, including every recursive
-// fetchRepoPath call inside a deep .github/ tree. Generous relative to the
-// single-object timeouts above: a large .github/workflows tree is several
-// sequential requests, but it still must not be able to hang forever.
-// A var so tests can shrink it.
-var teacherFileRefreshTimeout = 30 * time.Second
+// The remaining bounds cover the calls that could otherwise hang forever on a
+// stalled connection: go-gh's client has no HTTP timeout, and git has no
+// request timeout of its own. Vars rather than consts so tests can shrink them.
+var (
+	// One GET, before anything else runs: fail fast.
+	defaultBranchTimeout = 10 * time.Second
+	// Per request inside fetchRepoPath (not one budget for the whole .github/
+	// tree), so a large tree is never penalized for being large.
+	teacherFileTimeout = 15 * time.Second
+	// Post-push ls-remote probe + tag push, both small ref updates.
+	submitTagTimeout = 30 * time.Second
+	// git's stall detector: abort a transfer that moves under 1 byte/s for
+	// this long. Catches the dead-connection case in seconds while leaving a
+	// slow but progressing clone or push alone.
+	gitStallTimeout = 30 * time.Second
+	// Hard ceiling on clone + push. The stall detector only covers HTTPS, so
+	// this is the backstop for SSH remotes; deliberately generous so it never
+	// trips on a legitimately slow transfer.
+	gitNetworkTimeout = 10 * time.Minute
+	// How long Wait() may block on a killed git's pipes. git-remote-https
+	// outlives its parent and inherits stdout/stderr, so without this a stall
+	// would survive the kill.
+	cmdWaitDelay = 5 * time.Second
+)
 
-// gitNetworkTimeout bounds the clone + push step. Generous — it covers the
-// slowest part of submit (full history clone plus push) — but finite, so a
-// stalled connection fails with a clear timeout error instead of hanging
-// indefinitely with no OS-level backstop the user can rely on. A var so
-// tests can shrink it.
-var gitNetworkTimeout = 5 * time.Minute
-
-// cmdWaitDelay bounds how long runCmd/runGitWithDirAndTree wait for a
-// subprocess's I/O pipes to close after its context is canceled. Needed
-// because a killed git process can leave a grandchild transport helper
-// (e.g. git-remote-http) running on a stalled connection, which would
-// otherwise hold Wait() open indefinitely even though git itself is dead.
-// A var so tests can shrink it.
-var cmdWaitDelay = 5 * time.Second
+// getBounded issues a GET under its own deadline and returns the raw body.
+func getBounded(ctx context.Context, client githubapi.Client, path string, timeout time.Duration) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	httpResp, err := client.RequestWithContext(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+	return io.ReadAll(httpResp.Body)
+}
 
 // resolveRepoDefaultBranch reads the assignment repo's default branch. A GET
 // failure is returned as an error (submitting to the wrong branch would skip
 // grading); an empty value falls back to "main" (matches an auto_init repo).
-// Bounded by defaultBranchTimeout: go-gh's default client has no HTTP
-// timeout, and this call runs before anything else in submit, so a stalled
-// network here must not hang the process silently before the spinner even
-// starts.
 func resolveRepoDefaultBranch(ctx context.Context, client githubapi.Client, owner, repo string) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, defaultBranchTimeout)
-	defer cancel()
-
 	path := fmt.Sprintf("repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))
-	httpResp, err := client.RequestWithContext(ctx, http.MethodGet, path, nil)
+	raw, err := getBounded(ctx, client, path, defaultBranchTimeout)
 	if err != nil {
 		return "", fmt.Errorf("resolve default branch for %s/%s: %w", owner, repo, err)
 	}
-	defer func() { _ = httpResp.Body.Close() }()
-
 	var resp struct {
 		DefaultBranch string `json:"default_branch"`
 	}
-	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
-		return "", fmt.Errorf("decode default branch response for %s/%s: %w", owner, repo, err)
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return "", fmt.Errorf("resolve default branch for %s/%s: %w", owner, repo, err)
 	}
 	if resp.DefaultBranch == "" {
 		return "main", nil
 	}
 	return resp.DefaultBranch, nil
 }
-
-// defaultBranchTimeout bounds the pre-everything-else default-branch lookup.
-// Short: it's a single-object GET, and a stall here should fail fast rather
-// than eat into the user's patience before the actual submission starts.
-// A var (not const), like timeNow above, so tests can shrink it temporarily
-// to exercise the timeout path without a real 10s wait.
-var defaultBranchTimeout = 10 * time.Second
 
 func gitOutput(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
@@ -553,15 +526,9 @@ func fetchRepoPath(
 		url.QueryEscape(ref),
 	)
 
-	httpResp, err := client.RequestWithContext(ctx, http.MethodGet, apiPath, nil)
+	raw, err := getBounded(ctx, client, apiPath, teacherFileTimeout)
 	if err != nil {
 		return fmt.Errorf("GET %s: %w", apiPath, err)
-	}
-	defer func() { _ = httpResp.Body.Close() }()
-
-	raw, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return fmt.Errorf("GET %s: read body: %w", apiPath, err)
 	}
 
 	trimmed := bytes.TrimSpace(raw)
@@ -657,13 +624,18 @@ func splitOwnerRepo(s string) (owner, repo string) {
 // commitWorkTreeOnRemoteBranch clones origin into a temporary bare repo,
 // stages workTree onto `branch`, commits with `identity`, and pushes. Returns
 // the new commit SHA (informational; the runner workflow auto-tags on its end).
+// Bounded by gitNetworkTimeout on top of the per-transfer stall detector.
 func commitWorkTreeOnRemoteBranch(ctx context.Context, gitDir string, workTree string, remoteURL string, branch string, message string, identity identitypkg.GitIdentity, out io.Writer, errOut io.Writer) (string, error) {
-	if err := runCmd(ctx, out, errOut, "", "git", "clone", "--bare", remoteURL, gitDir); err != nil {
+	ctx, cancel := context.WithTimeout(ctx, gitNetworkTimeout)
+	defer cancel()
+
+	if err := runGit(ctx, out, errOut, "clone", "--bare", remoteURL, gitDir); err != nil {
 		return "", fmt.Errorf("clone remote history: %w", err)
 	}
 
 	git := func(args ...string) error {
-		return runGitWithDirAndTree(ctx, gitDir, workTree, out, errOut, args...)
+		fullArgs := []string{"--git-dir", gitDir, "--work-tree", workTree}
+		return runGit(ctx, out, errOut, append(fullArgs, args...)...)
 	}
 
 	ref := "refs/heads/" + branch
@@ -698,78 +670,51 @@ func commitWorkTreeOnRemoteBranch(ctx context.Context, gitDir string, workTree s
 	return strings.TrimSpace(sha), nil
 }
 
-// gitOutputWithGitDir runs `git --git-dir=<gitDir> <args>`. Separate from
-// gitOutput because rev-parsing the submitted commit runs against the bare
-// clone (no work tree). Some callers (rev-parse) are local-only, others
-// (push, ls-remote) hit the network — ctx is threaded through uniformly so
-// every caller gets the same stalled-connection backstop via cmdWaitDelay.
+// gitCmd builds a ctx-bound git invocation for the temp clone. Every call
+// gets the HTTPS stall detector and WaitDelay (see the timeout vars); both
+// are no-ops for local-only subcommands, so there is no network/local split.
+func gitCmd(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = append(os.Environ(),
+		"GIT_HTTP_LOW_SPEED_LIMIT=1",
+		"GIT_HTTP_LOW_SPEED_TIME="+strconv.Itoa(int(gitStallTimeout/time.Second)),
+	)
+	cmd.WaitDelay = cmdWaitDelay
+	return cmd
+}
+
+// gitErr wraps a failed git run. Only a deadline hit is reworded: Ctrl-C also
+// cancels ctx, and that must not be reported as a network problem.
+func gitErr(ctx context.Context, args []string, err error) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("git timed out, the network connection appears stalled; check your connection and run `gh student submit` again")
+	}
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && len(exitErr.Stderr) > 0 {
+		return fmt.Errorf("git %v: %s", args, strings.TrimSpace(string(exitErr.Stderr)))
+	}
+	return fmt.Errorf("git %v: %w", args, err)
+}
+
+// gitOutputWithGitDir runs `git --git-dir=<gitDir> <args>` and returns stdout.
+// Separate from gitOutput because it runs against the bare clone (no work
+// tree) and is ctx-bound.
 func gitOutputWithGitDir(ctx context.Context, gitDir string, args ...string) (string, error) {
 	fullArgs := append([]string{"--git-dir", gitDir}, args...)
-	cmd := exec.CommandContext(ctx, "git", fullArgs...)
-	cmd.WaitDelay = cmdWaitDelay
-	out, err := cmd.Output()
+	out, err := gitCmd(ctx, fullArgs...).Output()
 	if err != nil {
-		if ctx.Err() != nil {
-			return "", fmt.Errorf("git %v: %w (network stalled?)", fullArgs, ctx.Err())
-		}
-		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
-			return "", fmt.Errorf("git %v: %s", fullArgs, strings.TrimSpace(string(exitErr.Stderr)))
-		}
-		return "", fmt.Errorf("git %v: %w", fullArgs, err)
+		return "", gitErr(ctx, fullArgs, err)
 	}
 	return string(out), nil
 }
 
-func runGitWithDirAndTree(
-	ctx context.Context,
-	gitDir string,
-	workTree string,
-	out io.Writer,
-	errOut io.Writer,
-	args ...string,
-) error {
-	fullArgs := []string{"--git-dir", gitDir}
-	if workTree != "" {
-		fullArgs = append(fullArgs, "--work-tree", workTree)
-	}
-	fullArgs = append(fullArgs, args...)
-
-	cmd := exec.CommandContext(ctx, "git", fullArgs...)
+// runGit runs git with stdout/stderr streamed to the given writers.
+func runGit(ctx context.Context, out io.Writer, errOut io.Writer, args ...string) error {
+	cmd := gitCmd(ctx, args...)
 	cmd.Stdout = out
 	cmd.Stderr = errOut
-	// Bounds Wait() when ctx is canceled: CommandContext's default Cancel
-	// only kills the direct git process, not a grandchild transport helper
-	// (e.g. git-remote-http) stuck reading a stalled connection. Without
-	// WaitDelay, Wait() blocks forever on that grandchild's inherited
-	// stdout/stderr pipes even after git itself is dead.
-	cmd.WaitDelay = cmdWaitDelay
-
 	if err := cmd.Run(); err != nil {
-		if ctx.Err() != nil {
-			return fmt.Errorf("git %v: %w (network stalled?)", fullArgs, ctx.Err())
-		}
-		return fmt.Errorf("git %v: %w", fullArgs, err)
+		return gitErr(ctx, args, err)
 	}
-
-	return nil
-}
-
-func runCmd(ctx context.Context, out io.Writer, errOut io.Writer, dir string, name string, args ...string) error {
-	cmd := exec.CommandContext(ctx, name, args...)
-	if dir != "" {
-		cmd.Dir = dir
-	}
-	cmd.Stdout = out
-	cmd.Stderr = errOut
-	cmd.WaitDelay = cmdWaitDelay
-
-	if err := cmd.Run(); err != nil {
-		if ctx.Err() != nil {
-			return fmt.Errorf("%s %v: %w (network stalled?)", name, args, ctx.Err())
-		}
-		return fmt.Errorf("%s %v: %w", name, args, err)
-	}
-
 	return nil
 }
 

--- a/cli/gh-student/internal/submitcmd/submit.go
+++ b/cli/gh-student/internal/submitcmd/submit.go
@@ -355,8 +355,7 @@ func fetchSubmitEntry(ctx context.Context, org string, config *classroomcfg.Conf
 // submit/* tag already points at sha (a retry after a tag-push failure, or a
 // hand-pushed tag), it is reused — mirroring the runner's ls-remote
 // idempotency check — so the same commit never grades twice. Bounded by
-// submitTagTimeout: the branch push already landed, so a stall here must not
-// hang the terminal.
+// submitTagTimeout so a stall after the branch push cannot hang the terminal.
 func pushSubmitTag(ctx context.Context, gitDir, sha string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, submitTagTimeout)
 	defer cancel()
@@ -424,28 +423,25 @@ const assignmentNameTimeout = 3 * time.Second
 // clone/push, so the extra allowance never stalls a completed submission.
 const submitEntryTimeout = 15 * time.Second
 
-// The remaining bounds cover the calls that could otherwise hang forever on a
-// stalled connection: go-gh's client has no HTTP timeout, and git has no
-// request timeout of its own. Vars rather than consts so tests can shrink them.
+// Bounds for the calls that could otherwise hang forever on a stalled
+// connection: go-gh's client has no HTTP timeout and git has no request
+// timeout. Vars so tests can shrink them.
 var (
-	// One GET, before anything else runs: fail fast.
+	// Single GET before anything else runs.
 	defaultBranchTimeout = 10 * time.Second
-	// Per request inside fetchRepoPath (not one budget for the whole .github/
-	// tree), so a large tree is never penalized for being large.
+	// Per request inside fetchRepoPath, so a large .github/ tree is not
+	// penalized for its size.
 	teacherFileTimeout = 15 * time.Second
-	// Post-push ls-remote probe + tag push, both small ref updates.
+	// Post-push ls-remote probe + tag push.
 	submitTagTimeout = 30 * time.Second
-	// git's stall detector: abort a transfer that moves under 1 byte/s for
-	// this long. Catches the dead-connection case in seconds while leaving a
-	// slow but progressing clone or push alone.
+	// git aborts an HTTPS transfer that moves under 1 byte/s for this long:
+	// catches a dead connection in seconds without failing a slow one.
 	gitStallTimeout = 30 * time.Second
-	// Hard ceiling on clone + push. The stall detector only covers HTTPS, so
-	// this is the backstop for SSH remotes; deliberately generous so it never
-	// trips on a legitimately slow transfer.
+	// Ceiling on clone + push. The stall detector is HTTPS-only, so this is
+	// the SSH backstop; generous so a slow transfer never trips it.
 	gitNetworkTimeout = 10 * time.Minute
-	// How long Wait() may block on a killed git's pipes. git-remote-https
-	// outlives its parent and inherits stdout/stderr, so without this a stall
-	// would survive the kill.
+	// How long Wait() may block on a killed git's pipes, which an orphaned
+	// git-remote-https still holds open.
 	cmdWaitDelay = 5 * time.Second
 )
 
@@ -670,9 +666,8 @@ func commitWorkTreeOnRemoteBranch(ctx context.Context, gitDir string, workTree s
 	return strings.TrimSpace(sha), nil
 }
 
-// gitCmd builds a ctx-bound git invocation for the temp clone. Every call
-// gets the HTTPS stall detector and WaitDelay (see the timeout vars); both
-// are no-ops for local-only subcommands, so there is no network/local split.
+// gitCmd builds a ctx-bound git invocation with the HTTPS stall detector and
+// WaitDelay; both are no-ops for local-only subcommands.
 func gitCmd(ctx context.Context, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = append(os.Environ(),
@@ -683,8 +678,8 @@ func gitCmd(ctx context.Context, args ...string) *exec.Cmd {
 	return cmd
 }
 
-// gitErr wraps a failed git run. Only a deadline hit is reworded: Ctrl-C also
-// cancels ctx, and that must not be reported as a network problem.
+// gitErr wraps a failed git run. Only a deadline is reworded; Ctrl-C also
+// cancels ctx and is not a network problem.
 func gitErr(ctx context.Context, args []string, err error) error {
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return fmt.Errorf("git timed out, the network connection appears stalled; check your connection and run `gh student submit` again")
@@ -695,9 +690,8 @@ func gitErr(ctx context.Context, args []string, err error) error {
 	return fmt.Errorf("git %v: %w", args, err)
 }
 
-// gitOutputWithGitDir runs `git --git-dir=<gitDir> <args>` and returns stdout.
-// Separate from gitOutput because it runs against the bare clone (no work
-// tree) and is ctx-bound.
+// gitOutputWithGitDir runs `git --git-dir=<gitDir> <args>` against the bare
+// clone and returns stdout.
 func gitOutputWithGitDir(ctx context.Context, gitDir string, args ...string) (string, error) {
 	fullArgs := append([]string{"--git-dir", gitDir}, args...)
 	out, err := gitCmd(ctx, fullArgs...).Output()

--- a/cli/gh-student/internal/submitcmd/submit_tag_test.go
+++ b/cli/gh-student/internal/submitcmd/submit_tag_test.go
@@ -1,6 +1,7 @@
 package submitcmd
 
 import (
+	"context"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -67,7 +68,7 @@ func TestPushSubmitTag_PushesCanonicalTag(t *testing.T) {
 		return time.Date(2026, 8, 3, 14, 30, 5, 0, time.UTC)
 	}
 
-	tag, err := pushSubmitTag(local, sha)
+	tag, err := pushSubmitTag(context.Background(), local, sha)
 	if err != nil {
 		t.Fatalf("pushSubmitTag: %v", err)
 	}
@@ -93,7 +94,7 @@ func TestPushSubmitTag_ReusesExistingTagAtSHA(t *testing.T) {
 		t.Fatalf("seed existing tag: %v\n%s", err, out)
 	}
 
-	tag, err := pushSubmitTag(local, sha)
+	tag, err := pushSubmitTag(context.Background(), local, sha)
 	if err != nil {
 		t.Fatalf("pushSubmitTag: %v", err)
 	}
@@ -116,7 +117,7 @@ func TestPushSubmitTag_NonSubmitTagAtSHAIsIgnored(t *testing.T) {
 		t.Fatalf("seed unrelated tag: %v\n%s", err, out)
 	}
 
-	tag, err := pushSubmitTag(local, sha)
+	tag, err := pushSubmitTag(context.Background(), local, sha)
 	if err != nil {
 		t.Fatalf("pushSubmitTag: %v", err)
 	}
@@ -137,7 +138,7 @@ func TestPushSubmitTag_PushFailureSurfacesError(t *testing.T) {
 	).CombinedOutput(); err != nil {
 		t.Fatalf("set-url: %v\n%s", err, out)
 	}
-	if _, err := pushSubmitTag(local, sha); err == nil {
+	if _, err := pushSubmitTag(context.Background(), local, sha); err == nil {
 		t.Fatal("pushSubmitTag against a dead remote must error (submit surfaces the re-run guidance)")
 	}
 }

--- a/cli/gh-student/internal/submitcmd/submit_test.go
+++ b/cli/gh-student/internal/submitcmd/submit_test.go
@@ -1,6 +1,7 @@
 package submitcmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -110,7 +111,7 @@ func TestResolveRepoDefaultBranch(t *testing.T) {
 			}
 			_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": "master"})
 		})
-		got, err := resolveRepoDefaultBranch(githubtest.NewTestClient(t, server), "o", "repo")
+		got, err := resolveRepoDefaultBranch(context.Background(), githubtest.NewTestClient(t, server), "o", "repo")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -123,7 +124,7 @@ func TestResolveRepoDefaultBranch(t *testing.T) {
 		server := newClient(t, func(w http.ResponseWriter, r *http.Request) {
 			_ = json.NewEncoder(w).Encode(map[string]string{"default_branch": ""})
 		})
-		got, err := resolveRepoDefaultBranch(githubtest.NewTestClient(t, server), "o", "repo")
+		got, err := resolveRepoDefaultBranch(context.Background(), githubtest.NewTestClient(t, server), "o", "repo")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -136,7 +137,7 @@ func TestResolveRepoDefaultBranch(t *testing.T) {
 		server := newClient(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 		})
-		_, err := resolveRepoDefaultBranch(githubtest.NewTestClient(t, server), "o", "repo")
+		_, err := resolveRepoDefaultBranch(context.Background(), githubtest.NewTestClient(t, server), "o", "repo")
 		if err == nil {
 			t.Fatal("expected an error on a failed default-branch lookup")
 		}

--- a/cli/gh-student/internal/submitcmd/timeout_test.go
+++ b/cli/gh-student/internal/submitcmd/timeout_test.go
@@ -1,0 +1,183 @@
+package submitcmd
+
+// These tests exist to prove a regression fix, not just exercise the happy
+// path: before this fix, resolveRepoDefaultBranch, fetchRepoPath,
+// commitWorkTreeOnRemoteBranch, and pushSubmitTag could all hang
+// indefinitely against a connection that accepts but never responds (a
+// stalled network, dead VPN, silent firewall drop). Each test below sets up
+// exactly that — a server that never answers — and asserts the call still
+// returns, with an error, close to its configured timeout rather than
+// blocking the test (and, in production, the user's terminal) forever.
+//
+// slowTestTimeout is deliberately generous headroom above each shrunk
+// timeout: it's the ceiling that would fail the test if the fix regressed
+// back to "hangs forever", not a tight bound on exact timing.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/foundation50/gh-student/internal/githubtest"
+	identitypkg "github.com/foundation50/gh-student/internal/identity"
+)
+
+const slowTestTimeout = 2 * time.Second
+
+// neverRespondHandler accepts the request but writes nothing back until the
+// test itself unblocks it (on cleanup) or a generous safety net fires. It
+// simulates a stalled connection, not a slow-but-completing one.
+func neverRespondHandler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	unblock := make(chan struct{})
+	t.Cleanup(func() { close(unblock) })
+	return func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-unblock:
+		case <-time.After(slowTestTimeout):
+		}
+	}
+}
+
+func TestResolveRepoDefaultBranch_FailsFastOnStalledConnection(t *testing.T) {
+	restore := defaultBranchTimeout
+	defaultBranchTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { defaultBranchTimeout = restore })
+
+	server := httptest.NewServer(neverRespondHandler(t))
+	defer server.Close()
+
+	start := time.Now()
+	_, err := resolveRepoDefaultBranch(context.Background(), githubtest.NewTestClient(t, server), "o", "repo")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error against a stalled connection, got nil")
+	}
+	if elapsed > slowTestTimeout {
+		t.Fatalf("resolveRepoDefaultBranch took %v to fail (timeout was 50ms); "+
+			"it should fail near the timeout, not hang", elapsed)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected error to wrap context.DeadlineExceeded, got: %v", err)
+	}
+}
+
+func TestFetchRepoPath_FailsFastOnStalledConnection(t *testing.T) {
+	restore := teacherFileRefreshTimeout
+	teacherFileRefreshTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { teacherFileRefreshTimeout = restore })
+
+	server := httptest.NewServer(neverRespondHandler(t))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), teacherFileRefreshTimeout)
+	defer cancel()
+
+	start := time.Now()
+	err := fetchRepoPath(ctx, githubtest.NewTestClient(t, server), t.TempDir(), "o", "repo", "main", ".github")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error against a stalled connection, got nil")
+	}
+	if elapsed > slowTestTimeout {
+		t.Fatalf("fetchRepoPath took %v to fail (timeout was 50ms); "+
+			"it should fail near the timeout, not hang", elapsed)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected error to wrap context.DeadlineExceeded, got: %v", err)
+	}
+}
+
+func TestCommitWorkTreeOnRemoteBranch_FailsFastOnStalledClone(t *testing.T) {
+	restoreDelay := cmdWaitDelay
+	cmdWaitDelay = 50 * time.Millisecond
+	t.Cleanup(func() { cmdWaitDelay = restoreDelay })
+
+	// A TCP listener that never calls Accept() still completes the TCP
+	// handshake (the kernel does that via the listen backlog), but no
+	// application data ever flows — exactly what a stalled connection looks
+	// like to the git subprocess trying to clone it. The git process itself
+	// gets killed at the context deadline, but a grandchild transport
+	// helper (git-remote-http) can outlive it, still blocked on that same
+	// stalled socket — which is exactly what cmdWaitDelay bounds.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	remoteURL := fmt.Sprintf("http://%s/o/repo.git", ln.Addr().String())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err = commitWorkTreeOnRemoteBranch(
+		ctx,
+		t.TempDir(),
+		t.TempDir(),
+		remoteURL,
+		"main",
+		"Submit test",
+		identitypkg.GitIdentity{Name: "Test Student", Email: "test@example.com"},
+		io.Discard,
+		io.Discard,
+	)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected clone to fail against a stalled server, got nil")
+	}
+	if elapsed > slowTestTimeout {
+		t.Fatalf("commitWorkTreeOnRemoteBranch took %v to fail (timeout was 200ms); "+
+			"it should fail near the timeout, not hang", elapsed)
+	}
+}
+
+func TestPushSubmitTag_FailsFastOnStalledRemote(t *testing.T) {
+	restoreDelay := cmdWaitDelay
+	cmdWaitDelay = 50 * time.Millisecond
+	t.Cleanup(func() { cmdWaitDelay = restoreDelay })
+
+	restoreTimeout := submitTagTimeout
+	submitTagTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { submitTagTimeout = restoreTimeout })
+
+	local, _, sha := _tagTestRepos(t)
+
+	// Same stalled-listener mechanism as
+	// TestCommitWorkTreeOnRemoteBranch_FailsFastOnStalledClone: point origin
+	// at a socket that completes the TCP handshake but never answers, then
+	// repoint the fixture's already-working origin at it.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	stalledURL := fmt.Sprintf("http://%s/o/repo.git", ln.Addr().String())
+	if out, err := exec.Command("git", "--git-dir", local, "remote", "set-url", "origin", stalledURL).CombinedOutput(); err != nil {
+		t.Fatalf("remote set-url: %v\n%s", err, out)
+	}
+
+	start := time.Now()
+	_, err = pushSubmitTag(context.Background(), local, sha)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected pushSubmitTag to fail against a stalled remote, got nil")
+	}
+	if elapsed > slowTestTimeout {
+		t.Fatalf("pushSubmitTag took %v to fail (timeout was 200ms); "+
+			"it should fail near the timeout, not hang", elapsed)
+	}
+}

--- a/cli/gh-student/internal/submitcmd/timeout_test.go
+++ b/cli/gh-student/internal/submitcmd/timeout_test.go
@@ -1,9 +1,7 @@
 package submitcmd
 
-// Regression guards for #932: each network step in submit must return (with
-// an error) against a connection that accepts but never answers, instead of
-// blocking until Ctrl-C. Timeouts are shrunk so the tests run in well under
-// the 2s ceiling that would flag a return to "hangs forever".
+// Regression guards for #932: every network step in submit must return an
+// error against a connection that accepts but never answers.
 
 import (
 	"context"
@@ -24,8 +22,8 @@ import (
 
 const stallCeiling = 2 * time.Second
 
-// stalledServer accepts requests and holds them open until the client gives
-// up, so its Close() never blocks on a handler.
+// stalledServer holds every request open until the client gives up, so
+// Close() never blocks on a handler.
 func stalledServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -35,9 +33,8 @@ func stalledServer(t *testing.T) *httptest.Server {
 	return server
 }
 
-// stalledRemoteURL returns an http:// git URL to a socket that completes the
-// TCP handshake (the kernel's listen backlog does that) but never sends a
-// byte, which is what a dead VPN or silent firewall looks like to git.
+// stalledRemoteURL points at a socket that completes the TCP handshake (via
+// the listen backlog) but never sends a byte, like a dead VPN looks to git.
 func stalledRemoteURL(t *testing.T) string {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -89,8 +86,8 @@ func TestFetchRepoPath_FailsFastOnStall(t *testing.T) {
 	}
 }
 
-// The stall detector, not the overall ceiling, is what should fire on a dead
-// HTTPS remote: git exits on its own, so the error is git's, not a deadline.
+// On a dead HTTPS remote the stall detector, not the ceiling, should fire: git
+// exits on its own and the error is git's, not a deadline.
 func TestCommitWorkTreeOnRemoteBranch_StallDetectorAbortsClone(t *testing.T) {
 	setTimeout(t, &gitStallTimeout, time.Second) // git's minimum granularity
 	setTimeout(t, &cmdWaitDelay, 50*time.Millisecond)
@@ -108,8 +105,8 @@ func TestCommitWorkTreeOnRemoteBranch_StallDetectorAbortsClone(t *testing.T) {
 	}
 }
 
-// The ceiling is the SSH backstop (the stall detector is HTTPS-only), so it
-// must also end a stalled clone on its own and say what to do next.
+// The ceiling is the SSH backstop, so it must end a stalled clone on its own
+// and say what to do next.
 func TestCommitWorkTreeOnRemoteBranch_CeilingAbortsClone(t *testing.T) {
 	setTimeout(t, &gitNetworkTimeout, 200*time.Millisecond)
 	setTimeout(t, &cmdWaitDelay, 50*time.Millisecond)
@@ -127,8 +124,7 @@ func TestCommitWorkTreeOnRemoteBranch_CeilingAbortsClone(t *testing.T) {
 	}
 }
 
-// Ctrl-C cancels the root context; that must surface as a plain cancellation,
-// not as network advice.
+// Ctrl-C cancels the root context; that must not read as network advice.
 func TestRunGit_CancelIsNotReportedAsStall(t *testing.T) {
 	setTimeout(t, &cmdWaitDelay, 50*time.Millisecond)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cli/gh-student/internal/submitcmd/timeout_test.go
+++ b/cli/gh-student/internal/submitcmd/timeout_test.go
@@ -1,17 +1,9 @@
 package submitcmd
 
-// These tests exist to prove a regression fix, not just exercise the happy
-// path: before this fix, resolveRepoDefaultBranch, fetchRepoPath,
-// commitWorkTreeOnRemoteBranch, and pushSubmitTag could all hang
-// indefinitely against a connection that accepts but never responds (a
-// stalled network, dead VPN, silent firewall drop). Each test below sets up
-// exactly that — a server that never answers — and asserts the call still
-// returns, with an error, close to its configured timeout rather than
-// blocking the test (and, in production, the user's terminal) forever.
-//
-// slowTestTimeout is deliberately generous headroom above each shrunk
-// timeout: it's the ceiling that would fail the test if the fix regressed
-// back to "hangs forever", not a tight bound on exact timing.
+// Regression guards for #932: each network step in submit must return (with
+// an error) against a connection that accepts but never answers, instead of
+// blocking until Ctrl-C. Timeouts are shrunk so the tests run in well under
+// the 2s ceiling that would flag a return to "hangs forever".
 
 import (
 	"context"
@@ -22,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,155 +22,137 @@ import (
 	identitypkg "github.com/foundation50/gh-student/internal/identity"
 )
 
-const slowTestTimeout = 2 * time.Second
+const stallCeiling = 2 * time.Second
 
-// neverRespondHandler accepts the request but writes nothing back until the
-// test itself unblocks it (on cleanup) or a generous safety net fires. It
-// simulates a stalled connection, not a slow-but-completing one.
-func neverRespondHandler(t *testing.T) http.HandlerFunc {
+// stalledServer accepts requests and holds them open until the client gives
+// up, so its Close() never blocks on a handler.
+func stalledServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	unblock := make(chan struct{})
-	t.Cleanup(func() { close(unblock) })
-	return func(w http.ResponseWriter, r *http.Request) {
-		select {
-		case <-unblock:
-		case <-time.After(slowTestTimeout):
-		}
-	}
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+	return server
 }
 
-func TestResolveRepoDefaultBranch_FailsFastOnStalledConnection(t *testing.T) {
-	restore := defaultBranchTimeout
-	defaultBranchTimeout = 50 * time.Millisecond
-	t.Cleanup(func() { defaultBranchTimeout = restore })
-
-	server := httptest.NewServer(neverRespondHandler(t))
-	defer server.Close()
-
-	start := time.Now()
-	_, err := resolveRepoDefaultBranch(context.Background(), githubtest.NewTestClient(t, server), "o", "repo")
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("expected an error against a stalled connection, got nil")
-	}
-	if elapsed > slowTestTimeout {
-		t.Fatalf("resolveRepoDefaultBranch took %v to fail (timeout was 50ms); "+
-			"it should fail near the timeout, not hang", elapsed)
-	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected error to wrap context.DeadlineExceeded, got: %v", err)
-	}
-}
-
-func TestFetchRepoPath_FailsFastOnStalledConnection(t *testing.T) {
-	restore := teacherFileRefreshTimeout
-	teacherFileRefreshTimeout = 50 * time.Millisecond
-	t.Cleanup(func() { teacherFileRefreshTimeout = restore })
-
-	server := httptest.NewServer(neverRespondHandler(t))
-	defer server.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), teacherFileRefreshTimeout)
-	defer cancel()
-
-	start := time.Now()
-	err := fetchRepoPath(ctx, githubtest.NewTestClient(t, server), t.TempDir(), "o", "repo", "main", ".github")
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("expected an error against a stalled connection, got nil")
-	}
-	if elapsed > slowTestTimeout {
-		t.Fatalf("fetchRepoPath took %v to fail (timeout was 50ms); "+
-			"it should fail near the timeout, not hang", elapsed)
-	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected error to wrap context.DeadlineExceeded, got: %v", err)
-	}
-}
-
-func TestCommitWorkTreeOnRemoteBranch_FailsFastOnStalledClone(t *testing.T) {
-	restoreDelay := cmdWaitDelay
-	cmdWaitDelay = 50 * time.Millisecond
-	t.Cleanup(func() { cmdWaitDelay = restoreDelay })
-
-	// A TCP listener that never calls Accept() still completes the TCP
-	// handshake (the kernel does that via the listen backlog), but no
-	// application data ever flows — exactly what a stalled connection looks
-	// like to the git subprocess trying to clone it. The git process itself
-	// gets killed at the context deadline, but a grandchild transport
-	// helper (git-remote-http) can outlive it, still blocked on that same
-	// stalled socket — which is exactly what cmdWaitDelay bounds.
+// stalledRemoteURL returns an http:// git URL to a socket that completes the
+// TCP handshake (the kernel's listen backlog does that) but never sends a
+// byte, which is what a dead VPN or silent firewall looks like to git.
+func stalledRemoteURL(t *testing.T) string {
+	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer func() { _ = ln.Close() }()
+	t.Cleanup(func() { _ = ln.Close() })
+	return fmt.Sprintf("http://%s/o/repo.git", ln.Addr().String())
+}
 
-	remoteURL := fmt.Sprintf("http://%s/o/repo.git", ln.Addr().String())
+func setTimeout(t *testing.T, target *time.Duration, d time.Duration) {
+	t.Helper()
+	restore := *target
+	*target = d
+	t.Cleanup(func() { *target = restore })
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-
-	start := time.Now()
-	_, err = commitWorkTreeOnRemoteBranch(
-		ctx,
-		t.TempDir(),
-		t.TempDir(),
-		remoteURL,
-		"main",
-		"Submit test",
-		identitypkg.GitIdentity{Name: "Test Student", Email: "test@example.com"},
-		io.Discard,
-		io.Discard,
-	)
-	elapsed := time.Since(start)
-
+func assertStalledFailure(t *testing.T, what string, elapsed time.Duration, err error) {
+	t.Helper()
 	if err == nil {
-		t.Fatal("expected clone to fail against a stalled server, got nil")
+		t.Fatalf("%s: expected an error against a stalled connection, got nil", what)
 	}
-	if elapsed > slowTestTimeout {
-		t.Fatalf("commitWorkTreeOnRemoteBranch took %v to fail (timeout was 200ms); "+
-			"it should fail near the timeout, not hang", elapsed)
+	if elapsed > stallCeiling {
+		t.Fatalf("%s took %v to fail; it should fail near its timeout, not hang", what, elapsed)
 	}
 }
 
-func TestPushSubmitTag_FailsFastOnStalledRemote(t *testing.T) {
-	restoreDelay := cmdWaitDelay
-	cmdWaitDelay = 50 * time.Millisecond
-	t.Cleanup(func() { cmdWaitDelay = restoreDelay })
+func TestResolveRepoDefaultBranch_FailsFastOnStall(t *testing.T) {
+	setTimeout(t, &defaultBranchTimeout, 50*time.Millisecond)
+	client := githubtest.NewTestClient(t, stalledServer(t))
 
-	restoreTimeout := submitTagTimeout
-	submitTagTimeout = 200 * time.Millisecond
-	t.Cleanup(func() { submitTagTimeout = restoreTimeout })
+	start := time.Now()
+	_, err := resolveRepoDefaultBranch(context.Background(), client, "o", "repo")
+	assertStalledFailure(t, "resolveRepoDefaultBranch", time.Since(start), err)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	}
+}
+
+func TestFetchRepoPath_FailsFastOnStall(t *testing.T) {
+	setTimeout(t, &teacherFileTimeout, 50*time.Millisecond)
+	client := githubtest.NewTestClient(t, stalledServer(t))
+
+	start := time.Now()
+	err := fetchRepoPath(context.Background(), client, t.TempDir(), "o", "repo", "main", ".github")
+	assertStalledFailure(t, "fetchRepoPath", time.Since(start), err)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	}
+}
+
+// The stall detector, not the overall ceiling, is what should fire on a dead
+// HTTPS remote: git exits on its own, so the error is git's, not a deadline.
+func TestCommitWorkTreeOnRemoteBranch_StallDetectorAbortsClone(t *testing.T) {
+	setTimeout(t, &gitStallTimeout, time.Second) // git's minimum granularity
+	setTimeout(t, &cmdWaitDelay, 50*time.Millisecond)
+
+	start := time.Now()
+	_, err := commitWorkTreeOnRemoteBranch(
+		context.Background(), t.TempDir(), t.TempDir(), stalledRemoteURL(t),
+		"main", "Submit test",
+		identitypkg.GitIdentity{Name: "Test Student", Email: "test@example.com"},
+		io.Discard, io.Discard,
+	)
+	assertStalledFailure(t, "commitWorkTreeOnRemoteBranch", time.Since(start), err)
+	if errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("stall detector should abort before the ceiling, got a deadline error: %v", err)
+	}
+}
+
+// The ceiling is the SSH backstop (the stall detector is HTTPS-only), so it
+// must also end a stalled clone on its own and say what to do next.
+func TestCommitWorkTreeOnRemoteBranch_CeilingAbortsClone(t *testing.T) {
+	setTimeout(t, &gitNetworkTimeout, 200*time.Millisecond)
+	setTimeout(t, &cmdWaitDelay, 50*time.Millisecond)
+
+	start := time.Now()
+	_, err := commitWorkTreeOnRemoteBranch(
+		context.Background(), t.TempDir(), t.TempDir(), stalledRemoteURL(t),
+		"main", "Submit test",
+		identitypkg.GitIdentity{Name: "Test Student", Email: "test@example.com"},
+		io.Discard, io.Discard,
+	)
+	assertStalledFailure(t, "commitWorkTreeOnRemoteBranch", time.Since(start), err)
+	if !strings.Contains(err.Error(), "run `gh student submit` again") {
+		t.Fatalf("deadline error must tell the student what to do next, got: %v", err)
+	}
+}
+
+// Ctrl-C cancels the root context; that must surface as a plain cancellation,
+// not as network advice.
+func TestRunGit_CancelIsNotReportedAsStall(t *testing.T) {
+	setTimeout(t, &cmdWaitDelay, 50*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runGit(ctx, io.Discard, io.Discard, "clone", "--bare", stalledRemoteURL(t), t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error from a canceled context")
+	}
+	if strings.Contains(err.Error(), "network") {
+		t.Fatalf("a canceled context must not be reported as a network stall, got: %v", err)
+	}
+}
+
+func TestPushSubmitTag_FailsFastOnStall(t *testing.T) {
+	setTimeout(t, &submitTagTimeout, 200*time.Millisecond)
+	setTimeout(t, &cmdWaitDelay, 50*time.Millisecond)
 
 	local, _, sha := _tagTestRepos(t)
-
-	// Same stalled-listener mechanism as
-	// TestCommitWorkTreeOnRemoteBranch_FailsFastOnStalledClone: point origin
-	// at a socket that completes the TCP handshake but never answers, then
-	// repoint the fixture's already-working origin at it.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	defer func() { _ = ln.Close() }()
-
-	stalledURL := fmt.Sprintf("http://%s/o/repo.git", ln.Addr().String())
-	if out, err := exec.Command("git", "--git-dir", local, "remote", "set-url", "origin", stalledURL).CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "--git-dir", local, "remote", "set-url", "origin", stalledRemoteURL(t)).CombinedOutput(); err != nil {
 		t.Fatalf("remote set-url: %v\n%s", err, out)
 	}
 
 	start := time.Now()
-	_, err = pushSubmitTag(context.Background(), local, sha)
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("expected pushSubmitTag to fail against a stalled remote, got nil")
-	}
-	if elapsed > slowTestTimeout {
-		t.Fatalf("pushSubmitTag took %v to fail (timeout was 200ms); "+
-			"it should fail near the timeout, not hang", elapsed)
-	}
+	_, err := pushSubmitTag(context.Background(), local, sha)
+	assertStalledFailure(t, "pushSubmitTag", time.Since(start), err)
 }


### PR DESCRIPTION
## Summary

`gh student submit` could hang indefinitely on a stalled network connection (dead VPN, silent firewall drop): the default-branch lookup, the recursive teacher `.gitignore`/`.github` refresh, the bare clone + push, and the tag-mode `ls-remote` + tag push all ran with no deadline. Every one of them is now bounded.

- REST calls (`resolveRepoDefaultBranch`, `fetchRepoPath`) go through one `getBounded` helper using `RequestWithContext` with a per-request deadline, so a large `.github/` tree is never penalized for its size.
- Git network calls use git's own stall detector (`GIT_HTTP_LOW_SPEED_LIMIT=1`, `GIT_HTTP_LOW_SPEED_TIME=30`): a dead HTTPS connection fails in about 30 seconds while a slow but progressing clone or push is left alone. A generous 10-minute ceiling remains as the backstop for SSH remotes, and `pushSubmitTag` has its own 30-second bound.
- All git invocations share one `gitCmd` constructor (`exec.CommandContext` + `cmd.WaitDelay`, so an orphaned `git-remote-https` can't hold `Wait()` open after git is killed) and one `gitErr` wrapper. A deadline surfaces as a student-readable error that says what to do next; Ctrl-C (which cancels the root context) is not reported as a network problem.
- Timeouts live in a single `var` block; the ones tests shrink are vars, the existing ones stay consts.

Tests cover each stalled path with a server that accepts but never answers, including separate proofs that the stall detector fires before the ceiling and that the ceiling fires with the guidance message.

Closes #932

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [ ] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [ ] If I added or changed a CLI command or flag, I documented it in the wiki (not in a README).
- [x] My commits follow Conventional Commits (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).