### PR TITLE
fix(cli): bound every GitHub API request with a client-level timeout

### DIFF
--- a/cli/gh-student/internal/githubapi/constructors.go
+++ b/cli/gh-student/internal/githubapi/constructors.go
@@ -1,13 +1,17 @@
 package githubapi
 
-import "github.com/cli/go-gh/v2/pkg/api"
+import (
+	"github.com/cli/go-gh/v2/pkg/api"
+
+	"github.com/foundation50/classroom50-cli-shared/ghauth"
+)
 
 // ClientOptions aliases go-gh's api.ClientOptions for callers that build
 // a non-default client (e.g., the test client in internal/githubtest).
 type ClientOptions = api.ClientOptions
 
-// NewClient builds a REST client from opts, as a Client. Wraps
-// api.NewRESTClient so callers don't import go-gh.
+// NewClient builds a REST client from opts, as a Client, so callers don't
+// import go-gh.
 func NewClient(opts ClientOptions) (Client, error) {
-	return api.NewRESTClient(opts)
+	return ghauth.NewRESTClient(opts)
 }

--- a/cli/gh-teacher/internal/githubapi/constructors.go
+++ b/cli/gh-teacher/internal/githubapi/constructors.go
@@ -1,6 +1,10 @@
 package githubapi
 
-import "github.com/cli/go-gh/v2/pkg/api"
+import (
+	"github.com/cli/go-gh/v2/pkg/api"
+
+	"github.com/foundation50/classroom50-cli-shared/ghauth"
+)
 
 // ClientOptions aliases go-gh's api.ClientOptions for the few call sites
 // that build a non-default client (e.g., a client authenticated as a
@@ -8,13 +12,13 @@ import "github.com/cli/go-gh/v2/pkg/api"
 type ClientOptions = api.ClientOptions
 
 // DefaultClient returns the default REST client for the configured host,
-// as a Client. Wraps api.DefaultRESTClient so callers don't import go-gh.
+// as a Client, so callers don't import go-gh.
 func DefaultClient() (Client, error) {
-	return api.DefaultRESTClient()
+	return ghauth.NewRESTClient(ClientOptions{})
 }
 
-// NewClient builds a REST client from opts, as a Client. Wraps
-// api.NewRESTClient so callers don't import go-gh.
+// NewClient builds a REST client from opts, as a Client, so callers don't
+// import go-gh.
 func NewClient(opts ClientOptions) (Client, error) {
-	return api.NewRESTClient(opts)
+	return ghauth.NewRESTClient(opts)
 }

--- a/cli/shared/ghauth/client_test.go
+++ b/cli/shared/ghauth/client_test.go
@@ -1,0 +1,53 @@
+package ghauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+)
+
+func TestWithRequestTimeout(t *testing.T) {
+	if got := withRequestTimeout(api.ClientOptions{}).Timeout; got != RequestTimeout {
+		t.Fatalf("default Timeout = %v, want %v", got, RequestTimeout)
+	}
+	if got := withRequestTimeout(api.ClientOptions{Timeout: time.Second}).Timeout; got != time.Second {
+		t.Fatalf("explicit Timeout = %v, want 1s to be preserved", got)
+	}
+}
+
+// A server that accepts but never answers must fail the request at the
+// configured timeout rather than hanging.
+func TestNewRESTClient_TimeoutEndsStalledRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+
+	client, err := NewRESTClient(api.ClientOptions{
+		Host:         "github.com",
+		AuthToken:    "test-token",
+		Transport:    &hostRewriteTransport{target: u},
+		LogIgnoreEnv: true,
+		Timeout:      50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewRESTClient: %v", err)
+	}
+
+	start := time.Now()
+	err = client.Get("user", nil)
+	if err == nil {
+		t.Fatal("expected a timeout error against a stalled server, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("request took %v to fail; the timeout should have ended it", elapsed)
+	}
+}

--- a/cli/shared/ghauth/ghauth.go
+++ b/cli/shared/ghauth/ghauth.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/cli/go-gh/v2/pkg/auth"
@@ -107,11 +108,30 @@ func RequireClient(out, errOut writer, opts Options) (*api.RESTClient, error) {
 // newDefaultClient builds go-gh's default REST client (reads the ambient gh
 // auth/host config), wrapping the error for callers.
 func newDefaultClient() (*api.RESTClient, error) {
-	client, err := api.DefaultRESTClient()
+	client, err := NewRESTClient(api.ClientOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("REST client: %w", err)
 	}
 	return client, nil
+}
+
+// RequestTimeout bounds every REST request either CLI makes. go-gh sets no
+// HTTP timeout, so without this a stalled connection hangs the command until
+// Ctrl-C. Generous because it also covers the largest single request, a
+// base64 blob upload; callers that want a tighter bound layer a context on top.
+const RequestTimeout = 60 * time.Second
+
+// NewRESTClient is the single constructor for go-gh REST clients in both CLIs,
+// applying RequestTimeout unless opts already sets one.
+func NewRESTClient(opts api.ClientOptions) (*api.RESTClient, error) {
+	return api.NewRESTClient(withRequestTimeout(opts))
+}
+
+func withRequestTimeout(opts api.ClientOptions) api.ClientOptions {
+	if opts.Timeout == 0 {
+		opts.Timeout = RequestTimeout
+	}
+	return opts
 }
 
 // isGhManagedToken reports whether TokenForHost's source string denotes a token


### PR DESCRIPTION
## Summary

Follow-up to #933, which bounded the network steps of `gh student submit`. Every other REST call in both CLIs (85 sites in gh-teacher, 24 in gh-student, 15 in cli/shared) was still unbounded: go-gh's client sets no HTTP timeout, so a stalled connection hangs any command until Ctrl-C.

Rather than threading a context through 124 call sites, this sets `api.ClientOptions.Timeout` (which becomes `http.Client.Timeout`, covering connect, headers and body) in one place. `ghauth.NewRESTClient` is now the single constructor for go-gh clients in both CLIs; `ghauth.RequireClient`, gh-teacher's `githubapi.DefaultClient`/`NewClient`, and gh-student's `githubapi.NewClient` all route through it. An explicit `Timeout` in the options is preserved, and per-call context deadlines (like submit's) still apply on top, the shorter one winning.

The bound is 60 seconds per request: generous because it also covers the largest single request the CLIs make, a base64 blob upload in `gittree.UploadBlobs`, while still ending a stall well before a user gives up. Tests cover the defaulting and prove the timeout reaches the HTTP client against a server that accepts but never answers.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [ ] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [ ] If I added or changed a CLI command or flag, I documented it in the wiki (not in a README).
- [x] My commits follow Conventional Commits (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).