### PR TITLE
fix(gh-teacher): stop a stalled clone or pull from hanging download

### DIFF
--- a/cli/gh-student/internal/submitcmd/submit.go
+++ b/cli/gh-student/internal/submitcmd/submit.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/foundation50/classroom50-cli-shared/contract"
 	"github.com/foundation50/classroom50-cli-shared/ghui"
 	"github.com/foundation50/classroom50-cli-shared/ghutil"
+	"github.com/foundation50/classroom50-cli-shared/gitexec"
 	"github.com/foundation50/gh-student/internal/assignments"
 	"github.com/foundation50/gh-student/internal/classroomcfg"
 	"github.com/foundation50/gh-student/internal/githubapi"
@@ -434,15 +434,9 @@ var (
 	teacherFileTimeout = 15 * time.Second
 	// Post-push ls-remote probe + tag push.
 	submitTagTimeout = 30 * time.Second
-	// git aborts an HTTPS transfer that moves under 1 byte/s for this long:
-	// catches a dead connection in seconds without failing a slow one.
-	gitStallTimeout = 30 * time.Second
-	// Ceiling on clone + push. The stall detector is HTTPS-only, so this is
-	// the SSH backstop; generous so a slow transfer never trips it.
+	// Ceiling on clone + push. gitexec's stall detector is HTTPS-only, so this
+	// is the SSH backstop; generous so a slow transfer never trips it.
 	gitNetworkTimeout = 10 * time.Minute
-	// How long Wait() may block on a killed git's pipes, which an orphaned
-	// git-remote-https still holds open.
-	cmdWaitDelay = 5 * time.Second
 )
 
 // getBounded issues a GET under its own deadline and returns the raw body.
@@ -666,18 +660,6 @@ func commitWorkTreeOnRemoteBranch(ctx context.Context, gitDir string, workTree s
 	return strings.TrimSpace(sha), nil
 }
 
-// gitCmd builds a ctx-bound git invocation with the HTTPS stall detector and
-// WaitDelay; both are no-ops for local-only subcommands.
-func gitCmd(ctx context.Context, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Env = append(os.Environ(),
-		"GIT_HTTP_LOW_SPEED_LIMIT=1",
-		"GIT_HTTP_LOW_SPEED_TIME="+strconv.Itoa(int(gitStallTimeout/time.Second)),
-	)
-	cmd.WaitDelay = cmdWaitDelay
-	return cmd
-}
-
 // gitErr wraps a failed git run. Only a deadline is reworded; Ctrl-C also
 // cancels ctx and is not a network problem.
 func gitErr(ctx context.Context, args []string, err error) error {
@@ -694,7 +676,7 @@ func gitErr(ctx context.Context, args []string, err error) error {
 // clone and returns stdout.
 func gitOutputWithGitDir(ctx context.Context, gitDir string, args ...string) (string, error) {
 	fullArgs := append([]string{"--git-dir", gitDir}, args...)
-	out, err := gitCmd(ctx, fullArgs...).Output()
+	out, err := gitexec.Command(ctx, "git", fullArgs...).Output()
 	if err != nil {
 		return "", gitErr(ctx, fullArgs, err)
 	}
@@ -703,7 +685,7 @@ func gitOutputWithGitDir(ctx context.Context, gitDir string, args ...string) (st
 
 // runGit runs git with stdout/stderr streamed to the given writers.
 func runGit(ctx context.Context, out io.Writer, errOut io.Writer, args ...string) error {
-	cmd := gitCmd(ctx, args...)
+	cmd := gitexec.Command(ctx, "git", args...)
 	cmd.Stdout = out
 	cmd.Stderr = errOut
 	if err := cmd.Run(); err != nil {

--- a/cli/gh-student/internal/submitcmd/timeout_test.go
+++ b/cli/gh-student/internal/submitcmd/timeout_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/foundation50/classroom50-cli-shared/gitexec"
 	"github.com/foundation50/gh-student/internal/githubtest"
 	identitypkg "github.com/foundation50/gh-student/internal/identity"
 )
@@ -89,8 +90,8 @@ func TestFetchRepoPath_FailsFastOnStall(t *testing.T) {
 // On a dead HTTPS remote the stall detector, not the ceiling, should fire: git
 // exits on its own and the error is git's, not a deadline.
 func TestCommitWorkTreeOnRemoteBranch_StallDetectorAbortsClone(t *testing.T) {
-	setTimeout(t, &gitStallTimeout, time.Second) // git's minimum granularity
-	setTimeout(t, &cmdWaitDelay, 50*time.Millisecond)
+	setTimeout(t, &gitexec.StallTimeout, time.Second) // git's minimum granularity
+	setTimeout(t, &gitexec.WaitDelay, 50*time.Millisecond)
 
 	start := time.Now()
 	_, err := commitWorkTreeOnRemoteBranch(
@@ -109,7 +110,7 @@ func TestCommitWorkTreeOnRemoteBranch_StallDetectorAbortsClone(t *testing.T) {
 // and say what to do next.
 func TestCommitWorkTreeOnRemoteBranch_CeilingAbortsClone(t *testing.T) {
 	setTimeout(t, &gitNetworkTimeout, 200*time.Millisecond)
-	setTimeout(t, &cmdWaitDelay, 50*time.Millisecond)
+	setTimeout(t, &gitexec.WaitDelay, 50*time.Millisecond)
 
 	start := time.Now()
 	_, err := commitWorkTreeOnRemoteBranch(
@@ -126,7 +127,7 @@ func TestCommitWorkTreeOnRemoteBranch_CeilingAbortsClone(t *testing.T) {
 
 // Ctrl-C cancels the root context; that must not read as network advice.
 func TestRunGit_CancelIsNotReportedAsStall(t *testing.T) {
-	setTimeout(t, &cmdWaitDelay, 50*time.Millisecond)
+	setTimeout(t, &gitexec.WaitDelay, 50*time.Millisecond)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -141,7 +142,7 @@ func TestRunGit_CancelIsNotReportedAsStall(t *testing.T) {
 
 func TestPushSubmitTag_FailsFastOnStall(t *testing.T) {
 	setTimeout(t, &submitTagTimeout, 200*time.Millisecond)
-	setTimeout(t, &cmdWaitDelay, 50*time.Millisecond)
+	setTimeout(t, &gitexec.WaitDelay, 50*time.Millisecond)
 
 	local, _, sha := _tagTestRepos(t)
 	if out, err := exec.Command("git", "--git-dir", local, "remote", "set-url", "origin", stalledRemoteURL(t)).CombinedOutput(); err != nil {

--- a/cli/gh-teacher/internal/download/download.go
+++ b/cli/gh-teacher/internal/download/download.go
@@ -8,6 +8,7 @@ package download
 
 import (
 	"bytes"
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/foundation50/classroom50-cli-shared/contract"
 	"github.com/foundation50/classroom50-cli-shared/ghui"
+	"github.com/foundation50/classroom50-cli-shared/gitexec"
 	"github.com/foundation50/gh-teacher/internal/assignment"
 	"github.com/foundation50/gh-teacher/internal/cliutil"
 	"github.com/foundation50/gh-teacher/internal/configrepo"
@@ -1286,8 +1288,15 @@ func cloneOrgRepo(out, errOut io.Writer, org, repo, target string, quiet, verbos
 	if quiet {
 		args = append(args, "--", "--quiet")
 	}
-	return runGitStep(exec.Command("gh", args...), out, errOut, verbose)
+	ctx, cancel := context.WithTimeout(context.Background(), repoStepTimeout)
+	defer cancel()
+	return runGitStep(ctx, gitexec.Command(ctx, "gh", args...), out, errOut, verbose)
 }
+
+// repoStepTimeout is the ceiling on one clone or pull. gitexec's stall
+// detector is HTTPS-only, so this is the SSH backstop; generous so a slow
+// transfer never trips it, but finite so one dead repo cannot hang the batch.
+const repoStepTimeout = 10 * time.Minute
 
 // pullRepo fast-forwards the clone at target with `git pull --ff-only`.
 // Fast-forward only: a teacher may have local commits (feedback, notes) and a
@@ -1313,9 +1322,11 @@ func pullRepo(out, errOut io.Writer, target string, quiet, verbose bool) error {
 	if quiet {
 		args = append(args, "--quiet")
 	}
-	cmd := exec.Command("git", args...)
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
-	if err := runGitStep(cmd, out, errOut, verbose); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), repoStepTimeout)
+	defer cancel()
+	cmd := gitexec.Command(ctx, "git", args...)
+	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
+	if err := runGitStep(ctx, cmd, out, errOut, verbose); err != nil {
 		return fmt.Errorf("%w (fix the clone with git, or delete %s and run again to clone it fresh)", err, target)
 	}
 	return nil
@@ -1323,8 +1334,9 @@ func pullRepo(out, errOut io.Writer, target string, quiet, verbose bool) error {
 
 // runGitStep runs a git-backed command. Verbose streams its output; otherwise
 // stdout is discarded and the stderr tail is captured so failures carry git's
-// diagnostic, not just "exit status 1".
-func runGitStep(cmd *exec.Cmd, out, errOut io.Writer, verbose bool) error {
+// diagnostic, not just "exit status 1". A deadline is reported as a stall,
+// since a killed git leaves no diagnostic of its own.
+func runGitStep(ctx context.Context, cmd *exec.Cmd, out, errOut io.Writer, verbose bool) error {
 	var stderrTail *tailWriter
 	if verbose {
 		cmd.Stdout = out
@@ -1336,6 +1348,9 @@ func runGitStep(cmd *exec.Cmd, out, errOut io.Writer, verbose bool) error {
 	}
 
 	if err := cmd.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("timed out after %s, the network connection appears stalled", repoStepTimeout)
+		}
 		if stderrTail != nil {
 			// Last line is git's actionable error (e.g., `fatal: ...`).
 			if msg := lastNonEmptyLine(stderrTail.String()); msg != "" {

--- a/cli/gh-teacher/internal/download/download_test.go
+++ b/cli/gh-teacher/internal/download/download_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -19,6 +20,7 @@ import (
 	"time"
 
 	"github.com/foundation50/classroom50-cli-shared/contract"
+	"github.com/foundation50/classroom50-cli-shared/gitexec"
 	"github.com/foundation50/gh-teacher/internal/assignment"
 	"github.com/foundation50/gh-teacher/internal/githubtest"
 	scoresschema "github.com/foundation50/gh-teacher/internal/scores"
@@ -1470,6 +1472,31 @@ func TestPullRepo(t *testing.T) {
 		}
 		if _, err := os.Stat(filepath.Join(target, "NOTES.md")); err != nil {
 			t.Errorf("local work lost: %v", err)
+		}
+	})
+
+	t.Run("stalled remote fails instead of hanging the batch", func(t *testing.T) {
+		restore := gitexec.StallTimeout
+		gitexec.StallTimeout = time.Second // git's minimum granularity
+		t.Cleanup(func() { gitexec.StallTimeout = restore })
+
+		origin, _ := studentRepo(t)
+		target := teacherClone(t, t.TempDir(), "clone", origin)
+		// A socket that completes the TCP handshake but never sends a byte.
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		t.Cleanup(func() { _ = ln.Close() })
+		git(t, target, "remote", "set-url", "origin", fmt.Sprintf("http://%s/o/repo.git", ln.Addr().String()))
+
+		start := time.Now()
+		err = pullRepo(io.Discard, io.Discard, target, false, false)
+		if err == nil {
+			t.Fatal("expected pullRepo against a stalled remote to fail")
+		}
+		if elapsed := time.Since(start); elapsed > 3*time.Second {
+			t.Fatalf("pullRepo took %v to fail; the stall detector should have ended it", elapsed)
 		}
 	})
 }

--- a/cli/shared/gitexec/gitexec.go
+++ b/cli/shared/gitexec/gitexec.go
@@ -1,0 +1,34 @@
+// Package gitexec builds git subprocesses that cannot hang on a stalled
+// network connection, shared by gh-teacher (download) and gh-student (submit).
+package gitexec
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+// Vars rather than consts so tests can shrink them.
+var (
+	// StallTimeout makes git abort an HTTPS transfer that moves under 1 byte/s
+	// for this long: a dead connection fails in seconds, a slow one does not.
+	StallTimeout = 30 * time.Second
+	// WaitDelay bounds Wait() on a killed git's pipes, which an orphaned
+	// git-remote-https still holds open.
+	WaitDelay = 5 * time.Second
+)
+
+// Command builds a ctx-bound git-backed subprocess (git itself, or gh wrapping
+// git) with the HTTPS stall detector and WaitDelay applied. Both are no-ops
+// for local-only subcommands, so callers need no network/local split.
+func Command(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = append(os.Environ(),
+		"GIT_HTTP_LOW_SPEED_LIMIT=1",
+		"GIT_HTTP_LOW_SPEED_TIME="+strconv.Itoa(int(StallTimeout/time.Second)),
+	)
+	cmd.WaitDelay = WaitDelay
+	return cmd
+}

--- a/cli/shared/gitexec/gitexec_test.go
+++ b/cli/shared/gitexec/gitexec_test.go
@@ -1,0 +1,69 @@
+package gitexec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+// stalledRemoteURL points at a socket that completes the TCP handshake (via
+// the listen backlog) but never sends a byte, like a dead VPN looks to git.
+func stalledRemoteURL(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	return fmt.Sprintf("http://%s/o/repo.git", ln.Addr().String())
+}
+
+func setTimeout(t *testing.T, target *time.Duration, d time.Duration) {
+	t.Helper()
+	restore := *target
+	*target = d
+	t.Cleanup(func() { *target = restore })
+}
+
+// The stall detector makes git itself give up, so the error is git's and the
+// context is untouched.
+func TestCommand_StallDetectorAbortsClone(t *testing.T) {
+	setTimeout(t, &StallTimeout, time.Second) // git's minimum granularity
+	setTimeout(t, &WaitDelay, 50*time.Millisecond)
+	ctx := context.Background()
+
+	start := time.Now()
+	err := Command(ctx, "git", "clone", "--bare", stalledRemoteURL(t), t.TempDir()).Run()
+	if err == nil {
+		t.Fatal("expected clone against a stalled remote to fail")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("clone took %v to fail; the stall detector should have ended it", elapsed)
+	}
+	if ctx.Err() != nil || errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("stall detector should fire without a deadline, got: %v", err)
+	}
+}
+
+// A ctx deadline kills git; WaitDelay keeps the orphaned transport helper
+// from holding Wait() open afterwards.
+func TestCommand_DeadlineEndsClone(t *testing.T) {
+	setTimeout(t, &WaitDelay, 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := Command(ctx, "git", "clone", "--bare", stalledRemoteURL(t), t.TempDir()).Run()
+	if err == nil {
+		t.Fatal("expected clone against a stalled remote to fail")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("clone took %v to fail; the deadline should have ended it", elapsed)
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("expected the deadline to have fired, ctx.Err() = %v", ctx.Err())
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #933. `gh teacher download` runs `gh repo clone` and `git pull --ff-only` once per student repo with no bound, so one stalled connection hangs the whole batch. It was the last unbounded network subprocess in either CLI.

The git-runner recipe from submit moves into a new `cli/shared/gitexec` package so both CLIs share one source: `gitexec.Command` builds a ctx-bound `git` (or `gh` wrapping git) subprocess with git's HTTPS stall detector (`GIT_HTTP_LOW_SPEED_LIMIT=1`, `GIT_HTTP_LOW_SPEED_TIME=30`, so a dead connection fails in about 30 seconds while a slow transfer is left alone) and `cmd.WaitDelay` (so an orphaned `git-remote-https` cannot hold `Wait()` open after git is killed). `submitcmd` now calls it instead of its local copy.

`download` uses it for both clone and pull, each under a 10-minute per-repo ceiling as the SSH backstop. A deadline is reported as "timed out after 10m0s, the network connection appears stalled" rather than a bare exit status, and the existing "delete and clone it fresh" hint still applies for pulls. The command is not context-plumbed, so the ceiling is created at the subprocess boundary, as `ignorematch` already does.

Tests: `gitexec` proves the stall detector fires on its own and that a deadline ends a clone; `download` gains a `pullRepo` case against a socket that accepts but never answers.

Independent of #940 (client-level API timeout); the two can merge in either order.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [ ] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [ ] If I added or changed a CLI command or flag, I documented it in the wiki (not in a README).
- [x] My commits follow Conventional Commits (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).