### PR TITLE
docs(wiki): cover the 1.48.0 release changes

### DIFF
--- a/wiki/CLI-Student-Guide.md
+++ b/wiki/CLI-Student-Guide.md
@@ -49,7 +49,9 @@ your teacher configured the assignment to create public repositories; in that
 case accept warns you first that your work will be visible to anyone on the
 internet. If the organization doesn't let you create public repositories,
 accept creates a private one instead and says your teacher can make it public
-later.
+later. If the assignment publishes a website with GitHub Pages, accept turns
+the site on for your repository and prints its address; anyone on the internet
+can view the site even when the repository is private.
 
 <details>
 <summary>What accept does, step by step</summary>
@@ -60,13 +62,16 @@ later.
 4. Creates your repository (a copy of the starter code, or a new
    README-initialized repository), private unless the assignment opts into
    public repositories, in which case you're warned first.
-5. Commits the setup files (`.classroom50.yaml` and the autograding workflow)
+5. Turns on GitHub Pages, when the assignment publishes a website. If GitHub
+   refuses (for example, the plan doesn't allow Pages on a private
+   repository), accept warns and carries on; your teacher can enable it later.
+6. Commits the setup files (`.classroom50.yaml` and the autograding workflow)
    and verifies they're in place.
-6. Opens the feedback pull request, when the assignment enables it.
-7. Sets your repository role: `push` for an individual assignment, or `admin`
+7. Opens the feedback pull request, when the assignment enables it.
+8. Sets your repository role: `push` for an individual assignment, or `admin`
    for a legacy group assignment (so its founder can invite teammates). On a
    team assignment your access comes through the group's GitHub team instead.
-8. Prints the `git clone` command.
+9. Prints the `git clone` command.
 
 </details>
 

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -486,9 +486,10 @@ member who accepted an email invitation is recorded with their staff role rather
 than as a student. A role already recorded is never rewritten.
 
 The sync **never removes a row**. A pending row whose invitation expired or was
-canceled stays on the roster for you to link or delete by hand (the web app
-shows it as unlinked); drop it from the web app's roster or by editing
-`roster.csv`.
+canceled stays on the roster for you to re-invite, link, or delete by hand: the
+web app shows it as unlinked with an **Invitation expired** badge and offers
+**Re-invite**, **Link account**, and **Remove row**; from the CLI, drop it by
+editing `roster.csv`.
 
 The web app runs this same sync when a teacher opens the roster, and
 additionally refreshes each row's recorded `role` from live team membership; this

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -98,8 +98,8 @@ accepted yet. It holds the invited address and role, with no username or
 `github_id`, because GitHub offers no way to look up an account from an email
 address. A sync fills in the account once they accept; cancelling the
 invitation removes the row immediately. A sync never removes a row, so a row
-whose invitation expired stays on the roster as an unlinked row until you link
-or delete it.
+whose invitation expired stays on the roster as an unlinked row, flagged
+**Invitation expired** in the web app, until you re-invite, link, or delete it.
 
 #### Invite team
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -25,6 +25,35 @@ GH_DEBUG=api gh teacher invite cs50-fall-2026 alice
 
 Commands with informational output also accept `--quiet` / `-q`.
 
+### A command reports "the network connection appears stalled"
+
+Both CLIs put a limit on every network step, so a dead connection (a VPN that
+dropped, a firewall silently discarding packets) ends with an error instead of
+a command that hangs until you press Ctrl-C:
+
+- Every GitHub API request has a 60-second limit.
+- The git transfers (`gh student submit`'s clone and push, `gh teacher
+  download`'s clone and pull) use git's own stall detector: a transfer that
+  moves no data for about 30 seconds fails, while a slow but progressing one
+  is left alone. A 10-minute limit per repository is the backstop, mainly for
+  SSH remotes, where the detector doesn't apply.
+
+What to do:
+
+- **`gh student submit`**: check your connection, then run `gh student submit`
+  again. Submit is safe to repeat.
+- **`gh teacher download`**: the batch skips the stalled repository and
+  continues; the summary line and the error at the end list every repository
+  that failed. Run the same command again to retry them. Existing clones are
+  skipped (or fast-forwarded with `--pull`); if a pull keeps failing, delete
+  that clone and run again to clone it fresh, as the error suggests.
+- Any other command: check the connection and re-run. The commands that write
+  (`init`, `roster add`, `assignment add`, `accept`) check what already exists
+  first, so a re-run picks up where the stalled one stopped.
+
+If the same step times out on a healthy connection, run it with `-v` to see
+which request stalls, and include that output when you file an issue.
+
 ## Reaching classroom50.org and signing in
 
 ### classroom50.org won't load, or is flagged as unsafe
@@ -243,6 +272,39 @@ The desired state already exists, but the commands react differently:
   a non-zero exit: GitHub rejects re-invites to a pending or existing member.
   Use `roster add` when you need a re-runnable enrollment path.
 
+### A student's invitation expired before they accepted
+
+GitHub organization invitations last 7 days. When one lapses, GitHub moves it
+to the organization's failed invitations list, and the student can no longer
+accept it. In Classroom 50 the row stays on the roster (nothing removes a row
+automatically) with an **Invitation expired** badge next to its state
+(**Unlinked** for an email row, **Not in organization** for an account row),
+and the **Members** page shows the same badge. To recover:
+
+- **One student.** On the classroom's **Roster** page, click the row, then
+  **Re-invite**. A fresh invitation is sent and GitHub's failed record is
+  cleared once the send is confirmed.
+- **Several students.** Select their rows, open **Actions**, then click **Send
+  invitations (N)**; or filter by **Invitation expired** first and select all.
+  The count shows how many of the selected rows can be invited.
+- **A whole class.** Upload the roster file again. Each expired address is
+  marked **Resend invitation (expired)** in the preview and re-sent on import;
+  addresses with a live invitation are skipped.
+
+A failed invitation whose roster row was already removed shows up on the
+**Members** page as a **failed invitation that isn't on any roster**. Nothing
+can re-invite it from there: add the student to a roster again (upload or
+**Add to classroom**), and **Dismiss** the leftover record to clear GitHub's
+list.
+
+If **Re-invite** reports that nothing was sent because GitHub already has a
+live invitation or a member for the address, the student was invited from
+another classroom in the organization or has already joined. Check the
+organization's **People** page on GitHub, then link the row to that member
+once they accept. If it reports GitHub's daily invitation limit (50 a day for
+organizations under a month old or on the free plan, otherwise 500), wait
+until the next day and try again.
+
 ### Already an org member, but not on the roster
 
 Adding a student who is **already in your organization** (commonly someone from
@@ -275,17 +337,21 @@ only a **name** (an SIS export before students have GitHub accounts).
 
 To link or remove unlinked rows yourself, open the roster's **Unlinked** filter, then:
 
-- Click a row and use **Link to organization member** to attach the right
+- Click a row and use **Link account** to open the **Link to organization
+  member** picker and attach the right
   account, which also enrolls them on the classroom team. The picker suggests
   members of your classrooms first. To search every member of the organization,
   such as a student who joined the organization directly on GitHub, select
   **Include organization members not in any classroom**.
+- Click a row and use **Re-invite** if the row has an email address and the
+  student isn't in the organization yet (for example, the invitation expired).
 - Select rows, open **Actions**, then click **Remove rows** to delete the ones
   you don't need.
 
 Unlinked rows are never removed automatically: Classroom 50's roster sync never
 deletes a row, so a row whose invitation expired (or was never sendable) waits
-visibly under **Unlinked** instead of disappearing; only linking or an explicit
+visibly under **Unlinked** with an **Invitation expired** badge instead of
+disappearing; only linking or an explicit
 delete ends it. From the CLI, `gh teacher roster add cs50-fall-2026
 cs-principles alice` (or `roster import`) enrolls an existing member the same
 way. **Keep `gh teacher` up to date** if you use both tools: releases older than

--- a/wiki/Web-Student-Guide.md
+++ b/wiki/Web-Student-Guide.md
@@ -51,10 +51,24 @@ After signing in, the home page lists your **Classroom 50 organizations**.
    **View assignments**.
 
 The **Assignments** page lists every assignment your teacher has released, with
-its type (**Individual**, **Group**, or **Group (legacy)**), due date, and
-status (**Accepted** or **Not accepted**). Click **Accept assignment** to accept
-one. Once you have, the button reads **View my submission** (or **View group
-submission** on a group assignment).
+its type (**Individual**, **Group**, or **Group (legacy)**), due date, when you
+last submitted, and status:
+
+- **Not accepted**: you haven't accepted it yet. Click **Accept assignment**
+  to accept one.
+- **Accepted**: you have a repository but nothing submitted in it yet. The
+  button reads **View my submission** (or **View group submission** on a group
+  assignment).
+- **Submitted**: your repository has at least one submission. **Last
+  submitted** shows when.
+
+A past due date is red only while nothing has been submitted; once you've
+submitted, it's shown as plain text. The status and last-submitted cells of
+each row fill in as the page checks your repositories, so a row may shimmer
+for a moment. If a check fails, the row keeps its **Accepted** badge and says
+**Couldn't check submissions**; refresh the page to try again. Filter the list
+by status (**To do**, **Accepted**, **Submitted**), type, or due date, and
+sort by due date or name.
 
 Some assignments open only from the invite link your teacher shares. After you
 accept one, it appears in the list too.
@@ -83,6 +97,16 @@ repository.
 > accept: **This repository will be public**, so anyone on the internet can see
 > your work, including your code, commits, and name. If your organization
 > doesn't let you create public repositories, a private one is created instead.
+
+If the accept page says **GitHub Pages is enabled for this assignment**, your
+teacher set the assignment up to publish each repository as a website, and
+accepting turns the site on for you. The site's address is shown in the
+notice's tooltip, and anyone on the internet can view it even when the
+repository itself is private, so keep anything you don't want published out of
+the branch or folder your teacher told you to publish from. If the site
+couldn't be turned on (for example, the organization's GitHub plan doesn't
+allow it on a private repository), the setup checklist says so; your
+assignment still works, and your teacher can enable the site later.
 
 You can't accept when the page reports one of these:
 

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -583,6 +583,32 @@ The upload checks every row before it changes anything:
   you can link or remove later.
 - Only a row with nothing usable at all is skipped; everyone else is imported.
 
+Re-uploading a roster is also how you recover invitations in bulk. The preview
+marks each email row with what will happen to it:
+
+- **Resend invitation (expired)** or **Resend invitation (not delivered)**:
+  the previous invitation expired or couldn't be delivered, so a fresh one is
+  sent. GitHub's record of the failed invitation is cleared only after the new
+  one is confirmed.
+- **Invitation already pending**: the address has a live invitation, so
+  nothing is re-sent. An upload where every row is already pending imports
+  nothing and says so.
+- An address that matches a student who already has a GitHub account is
+  **linked to that account** by default, since GitHub skips an email
+  invitation to an existing member. Clear **Link these addresses to the
+  matched GitHub accounts** to opt out; the row then gets an email invitation
+  and stays **Unlinked** until you link it by hand.
+
+If the **Import** button is unavailable, hover over it: the tooltip says which
+check hasn't passed yet (nothing to process, a change waiting for your
+confirmation, and so on).
+
+GitHub caps how many invitations an organization can send per day (50 for
+organizations under a month old or on the free plan, otherwise 500). When an
+upload hits the cap, the batch stops there, the rows it didn't reach are
+reported, and any invitation it had cancelled to re-send is restored; upload
+the same file again the next day to finish.
+
 ### Roster CSV fields
 
 Each row needs at least one column that identifies a student: `github_id`,
@@ -669,8 +695,9 @@ email, and the address is recorded as a pending roster row:
   identifies the invitation: to use a different one, cancel and invite the new
   address.
 - If you cancel the invitation, the row is removed with it. An expired
-  invitation's row is not removed: it stays on the roster as **Unlinked** for
-  you to link or remove, and the next roster refresh only retires the
+  invitation's row is not removed: it stays on the roster with an
+  **Invitation expired** badge (GitHub invitations last 7 days) for you to
+  **Re-invite**, link, or remove, and the next roster refresh only retires the
   invitation's bookkeeping.
 
 A pending row is why the stored `roster.csv` can hold a row with no `username`
@@ -711,33 +738,52 @@ first, then share a link so they can accept and sign in.
 The table lists everyone in this classroom, one row per member, with
 **Member**, **Username**, **Role**, **Section**, and **Status** columns; click
 a column header to sort by it, and click a row to open the member's detail.
-**Section** appears only when at least one member carries a section label, and
-**Status** only while a row has something to report: a pending invitation, a
-member who needs a role, someone not in the organization, or an **unlinked**
-row (one with no GitHub account attached: a name-only upload, or an address
-that couldn't be invited). Click an unlinked row to link it to an organization
-member or remove it.
+**Section** appears only when at least one member carries a section label.
+**Status** shows one badge per row:
+
+- **Enrolled.** In the organization and on the classroom team.
+- **Invitation pending.** An email invitation hasn't been accepted yet.
+- **Not enrolled.** In the organization but missing from the classroom team,
+  so score collection would miss them.
+- **Not in organization.** On the roster but not an organization member (for
+  example, they left or were removed).
+- **Unlinked.** No GitHub account attached: a name-only upload, an address
+  that couldn't be invited, or an address whose invitation is no longer live.
+
+A row whose invitation expired before it was accepted (GitHub invitations last
+7 days) or couldn't be delivered carries an extra **Invitation expired** or
+**Invitation failed** badge next to its state. Click an unlinked or expired row
+to fix it: the detail explains the case and offers **Re-invite** (sends a fresh
+invitation), **Link account** (attach the row to an organization member), and
+**Remove row**. Link and Remove open their own panel, so one workflow is on
+screen at a time.
 
 The toolbar narrows and groups the table:
 
 - **Search**: match members by name, username, or email.
-- **Show**: one filter covering both status (**Enrolled**, **Pending**,
-  **Needs a role**, **Not in organization**, **Unlinked** while such rows
-  exist) and role (**Student**, **Teacher**, **Head TA**, **TA**).
+- **Show**: one filter covering both status (**Enrolled**, **Invitation
+  pending**, **Not enrolled**, **Not in organization**, **Unlinked**, and
+  **Invitation expired**, each shown while such rows exist) and role
+  (**Student**, **Teacher**, **Head TA**, **TA**).
 - A **section filter**, shown when members have sections.
 - **Group by**: group the rows by role or by section.
 
 Selecting rows (with the row checkboxes, or the select-all in the header)
 replaces the toolbar's left side with a selection bar carrying one
-**Actions** menu:
+**Actions** menu. Each action shows how many of the selected rows it can act
+on and applies only to those, so a mixed selection is safe:
 
-- **Invite** re-sends the selected students' organization invitations.
-- **Cancel** cancels their pending invitations.
-- **Unenroll** removes them from the classroom.
-- **Remove rows** (when the selection includes unlinked rows) deletes those
-  rows from `roster.csv`.
+- **Send invitations (N)** invites the selected students to the organization:
+  a pending invitation is cancelled and sent again, an expired one is
+  replaced, and a student who isn't in the organization is invited. A row
+  with no email address or GitHub username can't be invited.
+- **Cancel invitations (N)** cancels their pending invitations.
+- **Unenroll (N)** removes them from the classroom.
+- **Remove rows (N)** (when the selection includes unlinked rows) deletes
+  those rows from `roster.csv`.
 
-Each action asks you to confirm, then reports its results. Bulk actions apply
+Each action asks you to confirm, then reports its results, with a next step
+for every row it skipped or couldn't process. Bulk actions apply
 to students only; staff are managed in the classroom's **Settings**.
 
 **Edit** (owners only) switches the table into an editing surface:
@@ -834,30 +880,59 @@ classrooms they belong to. Open your organization in Classroom 50, then select
 The table shows **Name**, **Username**, **Classrooms**, **Roles**, and
 **Status** columns; click a column header to sort by it. **Roles** is the
 organization role (**Owner** or **Member**), and **Status** reports only
-problems:
+problems, using the same vocabulary as the roster:
 
-- **Not an org member.** On a classroom roster but not in the organization
+- **Not in organization.** On a classroom roster but not in the organization
   (for example, they left or were removed). Click **Invite** on the row to
   restore their access.
-- **Invitation pending.** An email invitation hasn't been accepted yet.
+- **Invitation pending.** GitHub has a live invitation for this person that
+  hasn't been accepted yet.
+- **Unlinked.** A roster row with no GitHub account and no live invitation
+  (a name-only row, or an address whose invitation lapsed).
 - **Not enrolled.** On a roster but missing from the classroom team, so
   score collection would miss them.
 
+A row whose invitation expired (GitHub invitations last 7 days) or couldn't be
+delivered also carries an **Invitation expired** or **Invitation failed**
+badge, as on the roster. Its detail panel says
+exactly what happened and links to the person's row on each classroom roster,
+where **Re-invite**, **Link account**, and **Remove row** live; the Members
+page itself doesn't act on pending or unlinked rows, since an invitation
+belongs to a classroom. If the organization's invitation list can't be read,
+the page says so: pending and expired invitations aren't shown, rows may read
+as unlinked or not in the organization, and you should retry before inviting
+anyone.
+
+A notice reading **N failed invitations aren't on any roster** appears when
+GitHub still records expired or undeliverable invitations that no roster row
+or member matches (usually the row was removed after the invitation expired).
+Nothing here can re-invite them. Click **View details** to list them, then
+**Dismiss** one or **Dismiss all** to clear them from GitHub's failed
+invitations list, or leave any you sent for another purpose.
+
 The toolbar narrows the table: **Search** matches members by name, username,
-or email; a **Show** filter covers both status and organization role
-(**Owners**, **Members**); and a classroom filter shows one classroom's
-members, or members on **No classroom**.
+or email; a **Show** filter covers both status (**Not in organization**,
+**Invitation pending**, **Unlinked**, **Invitation expired**, **Not
+enrolled**) and organization role (**Owners**, **Members**); and a classroom
+filter shows one classroom's members, or members on **No classroom**.
 
 Click a row to open the member's details: their name, GitHub username and ID,
 every email address the rosters record for them, and their classroom access
 with a link to each classroom. From here you can also invite an on-roster
-non-member back to the organization, or remove a member from the organization.
+non-member back to the organization (the invitation attaches their classroom
+teams, and an existing pending or active state is reported rather than
+re-sent), or remove a member from the organization.
 
 ### Bulk member actions
 
 Select rows with the checkboxes (or the select-all in the header), then open
-the **Actions** menu:
+the **Actions** menu. Each action shows how many of the selected rows it can
+act on and applies only to those:
 
+- **Send invitations (N)** invites the selected people who are on a roster
+  but not in the organization, attaching their classroom teams. Rows invited
+  by email and still pending, and unlinked rows, are skipped with a pointer to
+  the classroom's **Roster** page, where those cases are handled.
 - **Add to classroom** enrolls the selected members on a classroom you pick in
   the dialog. Members already on that classroom, and people who aren't
   organization members yet, are skipped.

--- a/wiki/gh-student.md
+++ b/wiki/gh-student.md
@@ -40,7 +40,9 @@ repositories; then accept warns you before creating it that your work (code,
 commits, and name) will be visible to anyone on the internet. If the
 organization doesn't let you create public repositories, accept creates a
 private repository instead and notes that your teacher can make it public
-later.
+later. When the assignment publishes a website with GitHub Pages, accept
+prints a note before creating the repository: the site's address, and that
+anyone on the internet can view it even when the repository is private.
 
 Flags:
 
@@ -69,7 +71,7 @@ Flags:
    repository).
 4. Creates the repository: a copy of the starter code, a new
    README-initialized repository, or (when the teacher chose an empty
-   repository) a bare one with steps 3, 6, and 7 skipped. Private by default;
+   repository) a bare one with steps 3, 6, 7, and 8 skipped. Private by default;
    public when the assignment opts in, with the warning printed before
    creation and a fallback to private when the organization denies the public
    create.
@@ -80,22 +82,32 @@ Flags:
    on or off per assignment. With no starter code, GitHub's own defaults apply
    unless the teacher forced a feature. Best-effort: a rejected feature update
    never fails accept.
-6. Writes the classroom marker file (`.classroom50.yaml`) and the autograding
+6. Turns on GitHub Pages when the assignment publishes a website, before the
+   setup commit so that commit's push is the site's first deploy (and a
+   deploy workflow succeeds on its first run). Best-effort: a refusal (the
+   organization's plan doesn't allow Pages on a private repository, the
+   organization doesn't let members publish sites, or the branch to publish
+   doesn't exist yet) is printed with what to do next and never fails accept;
+   your teacher can enable the site later from the submissions page. A site
+   that already exists is left alone, and this step runs on a fresh create
+   only, never on a re-run. An older `gh-student` that doesn't recognize the
+   assignment's Pages setting warns and skips the step rather than guess.
+7. Writes the classroom marker file (`.classroom50.yaml`) and the autograding
    workflow (`.github/workflows/autograde.yaml`) in a single commit, then
    verifies both are in place before reporting success. The workflow only
    points at the grading logic your teacher manages, so grading updates apply
    on your next submission without changing your repository. When the teacher
    turned the README off for an assignment with no starter code, this commit
    also removes the seeded README.
-7. Opens the feedback pull request when the assignment enables it.
+8. Opens the feedback pull request when the assignment enables it.
    Best-effort: if this fails, the autograding run creates the pull request on
    your first submission instead.
-8. Sets your repository role, last so a failed role change never leaves a
+9. Sets your repository role, last so a failed role change never leaves a
    half-set-up repository: `push` for an individual assignment, or `admin`
    for a legacy group assignment (so its founder can invite teammates). On a
    team assignment access flows through the group's GitHub team, so no
    special role is kept. The teacher can override the role per assignment.
-9. Prints the `git clone` command.
+10. Prints the `git clone` command.
 
 </details>
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -415,8 +415,9 @@ membership, and it adds a row for a classroom-team member the roster is
 missing.
 
 The sync **never removes a roster row**. An email-only row nothing backs (an
-expired or canceled invitation) stays on the roster for you to link or delete
-by hand; the web app shows it as unlinked. Its scope is the email-invite
+expired or canceled invitation) stays on the roster for you to re-invite, link,
+or delete by hand; the web app shows it as unlinked with an **Invitation
+expired** badge and offers **Re-invite**. Its scope is the email-invite
 lifecycle and `github_id`. It never rewrites a `role` already recorded on a
 row, and it doesn't add rows for organization members who were never invited
 through Classroom 50; see


### PR DESCRIPTION
Brings the wiki up to date with the features and fixes in release 1.48.0 (#924). Every UI label was checked against `en.json` and the CLI sources.

## What changed

- **Web Teacher Guide**: roster upload re-sends expired invitations and links matched accounts by default (#938); roster and Members pages get the new status vocabulary, **Invitation expired** badge, **Re-invite** / **Link account** / **Remove row**, counted bulk actions, and the orphaned failed-invitations notice (#931).
- **Web Student Guide**: the assignments list's **Not accepted** / **Accepted** / **Submitted** states, **Last submitted** column, and due-date colouring (#939); the GitHub Pages notice on the accept page (#934).
- **CLI Student Guide and `gh-student`**: the GitHub Pages step in `gh student accept` (#934).
- **Troubleshooting**: new entries for an expired student invitation (#931) and for the CLI's "the network connection appears stalled" timeouts (#933, #940, #941); unlinked-row actions updated.
- **Glossary, CLI Teacher Guide, `gh-teacher`**: expired rows can now be re-invited, not only linked or deleted.

The teacher-side Pages docs already landed with #934; #923 was internal and needs no wiki change.

## Type of change

- [x] Documentation

## Checklist

- [x] No code, schema, or CLI flag changes.
- [x] My commits follow Conventional Commits.