### PR TITLE
docs(wiki): describe completing a roster row that already names the account

### DIFF
--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -302,6 +302,9 @@ gh teacher roster add cs50-fall-2026 cs-principles alice --first-name Alice --em
 Resolves the student's numeric `github_id`, upserts the row (case-insensitive by
 username), sends an organization invite if needed, and adds the student to the
 classroom team (so they can read in-org private templates). Re-running is safe.
+A row that already carries the student's `github_id` but a blank or outdated
+username is completed in place rather than duplicated; a row that carries the
+username for a different account blocks the add until you correct or remove it.
 If the student was invited by email, pass `--email` with that same address:
 `add` then fills in the pending row instead of adding a second one for the same
 person. Without it, the pending row stays put and the student is listed twice. See
@@ -478,7 +481,8 @@ gh teacher roster sync <org> <classroom> --write    # apply it
 
 It records the students who accepted an email invitation (username and
 `github_id`, onto their own pending row), fills in a missing `github_id` from the
-classroom team's membership, and deletes the invite teams that are done. If no
+classroom team's membership (and a blank or outdated username from the member's
+`github_id`), and deletes the invite teams that are done. If no
 row claims an accepted invitation (the pending row was deleted, or the invite's
 roster commit never landed), it appends one so the address isn't lost; that row
 records the role of the classroom team the account was found on, so a staff

--- a/wiki/Web-Teacher-Guide.md
+++ b/wiki/Web-Teacher-Guide.md
@@ -537,6 +537,12 @@ dialog, choose a **Role** (**Student** is preselected), then enter the student's
 **GitHub username**. **First name**, **Last name**, **Email**, and **Section**
 are optional. Click **Add member**.
 
+If the roster already has a row for that account with only its `github_id` or
+only its username filled in (for example, after a hand edit to `roster.csv`), the
+add completes that row instead of adding a second one, and the confirmation names
+the row it linked. Fields you type replace the stored ones; fields you leave blank
+keep them.
+
 To invite a student who hasn't given you a GitHub username yet, enter their
 **Email** and leave **GitHub username** empty. The address goes onto the roster
 as a pending row and is matched to the student's account when they accept. For

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -302,7 +302,12 @@ gh teacher roster add <org> <classroom> <username> [--first-name <n>] [--last-na
 ```
 
 Upserts one row by username (case-insensitive), then invites the student to the
-organization if needed and adds them to the classroom team. Safe to re-run. When
+organization if needed and adds them to the classroom team. Safe to re-run. A
+row that already carries the account's `github_id` but a blank or outdated
+username is completed in place: the username is set to the current login and
+any name, email, or section you don't pass keeps the stored value. If a row
+carries that username for a different account, nothing is written; correct or
+remove that row first. When
 no row matches the username and `--email` matches a pending row's address, that
 row is filled in rather than duplicated; the pending row's `role` is deliberately
 not inherited, since the team is the authority for role.
@@ -405,7 +410,8 @@ gh teacher roster sync <org> <classroom> --write    # apply
 
 Catches `roster.csv` up with GitHub: records the students who accepted an email
 invitation (username and `github_id`, onto their own pending row), fills in a
-missing `github_id` from the classroom team's membership, and deletes the
+missing `github_id` from the classroom team's membership (and a blank or
+outdated username from the member's `github_id`), and deletes the
 invite teams that are done. If no row claims a recovered invitation (the
 pending row was deleted, or `roster invite`'s commit never landed), it appends
 a row so the address isn't lost. The web app runs this same sync when a teacher


### PR DESCRIPTION
## Summary

Follow-up to #946. The `roster add`, `roster sync`, and web **Add member** pages now describe what happens when the account already has a partial roster row: the row is completed in place (id-first, blank cells keep their stored value), the sync fills a blank or outdated username from the member's `github_id`, and a username that belongs to a different account blocks the add until the row is fixed. Three pages, a sentence or two each; nothing removed.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched: not applicable, `wiki/` only.
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass. (No contract change.)
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README). (This PR is that documentation.)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
