### PR TITLE
fix(web): explain failed publishes and recover a stuck student site

### DIFF
--- a/.github/workflows/lint-ci.yaml
+++ b/.github/workflows/lint-ci.yaml
@@ -80,9 +80,13 @@ jobs:
         # `classroom50/autograde` (literal Markdown, not a shell variable);
         # shellcheck's "expressions don't expand in single quotes" info is a
         # false positive there. It is the only finding across all workflows.
+        # `concurrency.queue` is newer than actionlint 1.7.12's schema, so its
+        # syntax check rejects the key publish-pages.yaml needs. Ignored by
+        # exact message; drop the ignore once a release accepts the key.
         run: |
           set -euo pipefail
           actionlint -shellcheck "shellcheck --exclude=SC2016" \
+            -ignore 'unexpected key "queue" for "concurrency" section' \
             .github/workflows/*.yaml \
             cli/gh-teacher/skeleton/dotgithub/workflows/*.yaml \
             cli/gh-student/embed/autograde-shim.yaml

--- a/cli/gh-teacher/init_skeleton_test.go
+++ b/cli/gh-teacher/init_skeleton_test.go
@@ -96,6 +96,21 @@ func TestSkeletonFiles_Manifest(t *testing.T) {
 	if !strings.Contains(pubBody, `"active"`) {
 		t.Error("publish-pages.yaml classrooms index must include the \"active\" key so the student accept page can refuse archived classrooms")
 	}
+
+	// Publishes must queue, not cancel: with the default single-slot queue,
+	// three quick saves cancel the middle run, and the web banner reports
+	// that change as failed. A cancelled deploy can also leave its Pages
+	// deployment in progress and block the next one, so no cancel-in-progress.
+	var pubDoc any
+	if err := yaml.Unmarshal([]byte(pubBody), &pubDoc); err != nil {
+		t.Fatalf("publish-pages.yaml: %v", err)
+	}
+	if got, ok := nested(pubDoc, "concurrency", "queue"); !ok || got != "max" {
+		t.Errorf("publish-pages.yaml concurrency.queue = %v, want \"max\"", got)
+	}
+	if got, ok := nested(pubDoc, "concurrency", "cancel-in-progress"); !ok || got != false {
+		t.Errorf("publish-pages.yaml concurrency.cancel-in-progress = %v, want false", got)
+	}
 }
 
 // TestSkeletonFiles_AutogradeRunner pins the runner workflow's

--- a/cli/gh-teacher/init_skeleton_test.go
+++ b/cli/gh-teacher/init_skeleton_test.go
@@ -97,10 +97,8 @@ func TestSkeletonFiles_Manifest(t *testing.T) {
 		t.Error("publish-pages.yaml classrooms index must include the \"active\" key so the student accept page can refuse archived classrooms")
 	}
 
-	// Publishes must queue, not cancel: with the default single-slot queue,
-	// three quick saves cancel the middle run, and the web banner reports
-	// that change as failed. A cancelled deploy can also leave its Pages
-	// deployment in progress and block the next one, so no cancel-in-progress.
+	// Publishes queue rather than cancel each other; see the comment in the
+	// workflow for why cancel-in-progress must stay false.
 	var pubDoc any
 	if err := yaml.Unmarshal([]byte(pubBody), &pubDoc); err != nil {
 		t.Fatalf("publish-pages.yaml: %v", err)

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/publish-pages.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/publish-pages.yaml
@@ -21,9 +21,16 @@ permissions:
   pages: write
   id-token: write
 
+# queue: max lets every publish wait its turn. The default (one pending run)
+# cancels the middle run when a teacher saves three changes in a minute, and
+# the banner then reports that change as failed even though the newest run
+# publishes the whole site. GitHub Pages also allows one deployment at a time,
+# so cancel-in-progress must stay false: a cancelled deploy can leave its
+# Pages deployment in progress and block the next one for up to 10 minutes.
 concurrency:
   group: pages
   cancel-in-progress: false
+  queue: max
 
 jobs:
   build:

--- a/cli/gh-teacher/skeleton/dotgithub/workflows/publish-pages.yaml
+++ b/cli/gh-teacher/skeleton/dotgithub/workflows/publish-pages.yaml
@@ -21,12 +21,10 @@ permissions:
   pages: write
   id-token: write
 
-# queue: max lets every publish wait its turn. The default (one pending run)
-# cancels the middle run when a teacher saves three changes in a minute, and
-# the banner then reports that change as failed even though the newest run
-# publishes the whole site. GitHub Pages also allows one deployment at a time,
-# so cancel-in-progress must stay false: a cancelled deploy can leave its
-# Pages deployment in progress and block the next one for up to 10 minutes.
+# queue: max lets every publish wait its turn; the default single-slot queue
+# cancels the middle run when three saves land close together. Keep
+# cancel-in-progress false: a cancelled deploy can leave its Pages deployment
+# in progress, which blocks the next one for up to 10 minutes.
 concurrency:
   group: pages
   cancel-in-progress: false

--- a/web/src/components/status/ActionsBanner.test.tsx
+++ b/web/src/components/status/ActionsBanner.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+
+import type { ActionActivity, Tracker } from "@/hooks/useActionActivity"
+import type { PublishFailureDetail } from "@/hooks/usePublishFailureDetail"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  }
+})
+
+// The banner is a projection of the hook: the test sets what the hook returns.
+let activity: ActionActivity
+vi.mock("@/hooks/useActionActivity", () => ({
+  useActionActivity: () => activity,
+}))
+
+let detail: PublishFailureDetail
+vi.mock("@/hooks/usePublishFailureDetail", () => ({
+  usePublishFailureDetail: () => detail,
+}))
+
+import { ActionsBanner } from "./ActionsBanner"
+
+const failedPublish: Tracker = {
+  id: "op-a",
+  displayLabel: "Publishing hw1: failed",
+  phase: "failed",
+  htmlUrl: "https://github.com/acme/classroom50/actions/runs/10",
+  runId: 10,
+  workflow: "publish-pages.yaml",
+  dismissible: true,
+  retriable: true,
+  startedAtMs: 1,
+  endedAtMs: 2,
+}
+
+const baseActivity = (): ActionActivity => ({
+  org: "acme",
+  trackers: [failedPublish],
+  anyFailed: true,
+  pollError: false,
+  dismiss: vi.fn(),
+  retry: vi.fn(),
+  unstick: vi.fn(),
+  busy: new Set(),
+  unsticking: new Set(),
+})
+
+const locked: PublishFailureDetail = {
+  state: "known",
+  failure: { kind: "deployLocked", blockerSha: "656e8d" },
+  blockerInProgress: true,
+}
+
+// The banner reveals itself 150ms after load, so every assertion waits. In
+// happy-dom the measured height stays 0, so only the aria-hidden measuring
+// probe renders; role queries therefore opt in to hidden elements. The probe
+// renders the same body as the visible bar, which is the invariant the
+// shared-state design keeps.
+const role = (name: string) =>
+  screen.findAllByRole("button", { name, hidden: true })
+const queryRole = (name: string) =>
+  screen.queryByRole("button", { name, hidden: true })
+
+describe("ActionsBanner publish failure detail", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    )
+    activity = baseActivity()
+    detail = locked
+  })
+  afterEach(() => cleanup())
+
+  it("offers to cancel the blocking deployment and hands the sha to unstick", async () => {
+    render(<ActionsBanner />)
+    const [button] = await role("actionsBanner.publishFailure.unstick")
+    expect(
+      screen.getAllByText("actionsBanner.publishFailure.deployLocked").length,
+    ).toBeGreaterThan(0)
+    fireEvent.click(button)
+    expect(activity.unstick).toHaveBeenCalledWith("op-a", "656e8d")
+  })
+
+  it("drops the cancel action once the blocker has cleared", async () => {
+    detail = { ...locked, blockerInProgress: false }
+    render(<ActionsBanner />)
+    await waitFor(() =>
+      expect(
+        screen.getAllByText("actionsBanner.publishFailure.deployLockCleared")
+          .length,
+      ).toBeGreaterThan(0),
+    )
+    expect(queryRole("actionsBanner.publishFailure.unstick")).toBeNull()
+  })
+
+  it("disables both Retry and the cancel action while a cancel is in flight", async () => {
+    activity = {
+      ...baseActivity(),
+      busy: new Set(["op-a"]),
+      unsticking: new Set(["op-a"]),
+    }
+    render(<ActionsBanner />)
+    const cancelButtons = await role("actionsBanner.publishFailure.unsticking")
+    for (const b of cancelButtons)
+      expect((b as HTMLButtonElement).disabled).toBe(true)
+    for (const b of await role("actionsBanner.retry")) {
+      expect((b as HTMLButtonElement).disabled).toBe(true)
+    }
+  })
+
+  it("explains a non-lock cause without offering a cancel", async () => {
+    detail = { state: "known", failure: { kind: "timeout" } }
+    render(<ActionsBanner />)
+    await waitFor(() =>
+      expect(
+        screen.getAllByText("actionsBanner.publishFailure.timeout").length,
+      ).toBeGreaterThan(0),
+    )
+    expect(queryRole("actionsBanner.publishFailure.unstick")).toBeNull()
+  })
+
+  it("shows only the run link when the cause is unknown", async () => {
+    detail = { state: "unknown" }
+    render(<ActionsBanner />)
+    await screen.findAllByText("actionsBanner.viewRun")
+    expect(screen.queryByText(/actionsBanner\.publishFailure\./)).toBeNull()
+  })
+})

--- a/web/src/components/status/ActionsBanner.tsx
+++ b/web/src/components/status/ActionsBanner.tsx
@@ -6,12 +6,16 @@ import {
   AlertIcon,
   CheckCircleIcon,
   ChevronDownIcon,
+  SkipIcon,
   SyncIcon,
   XIcon,
 } from "@/components/ui/icons"
 import { useTranslation } from "react-i18next"
 
 import { useActionActivity, type Tracker } from "@/hooks/useActionActivity"
+import { usePublishFailureDetail } from "@/hooks/usePublishFailureDetail"
+import { useCancelPagesDeployment } from "@/hooks/mutations/useCancelPagesDeployment"
+import { PUBLISH_PAGES_WORKFLOW } from "@/github-core/workflows"
 import { collapseVariants, DURATION, EASE_OUT } from "@/lib/motion"
 import type { BadgeTone } from "@/types/badgeTone"
 
@@ -68,6 +72,13 @@ const StatusIcon = ({
         className={`size-4 shrink-0 ${tinted ? "text-success" : ""}`}
       />
     )
+  if (phase === "superseded")
+    return (
+      <SkipIcon
+        aria-hidden="true"
+        className={`size-4 shrink-0 ${tinted ? "text-base-content/60" : ""}`}
+      />
+    )
   return <InlineSpinner className={`shrink-0 ${tinted ? "text-info" : ""}`} />
 }
 
@@ -76,12 +87,105 @@ const StatusIcon = ({
 const ROW_TONE: Record<Tracker["phase"], BadgeTone> = {
   failed: "error",
   success: "success",
+  superseded: "neutral",
   running: "info",
   pending: "info",
 }
 
+// Why a publish failed and what to do next, under a failed publish row. Reads
+// the run's annotations once it has failed; a cause it can't name falls back to
+// the run link alone. The deploy-lock case also offers to cancel the blocking
+// Pages deployment and re-run, since waiting out GitHub's lock is otherwise
+// the teacher's only option and nothing tells them so.
+const PublishFailureDetail = ({
+  org,
+  tracker,
+  onRetry,
+  retrying,
+}: {
+  org: string | undefined
+  tracker: Tracker
+  onRetry: (id: string) => void
+  retrying: boolean
+}) => {
+  const { t } = useTranslation()
+  const detail = usePublishFailureDetail(org, tracker.runId)
+  const cancelDeployment = useCancelPagesDeployment()
+  const [unsticking, setUnsticking] = useState(false)
+
+  if (detail.state !== "known") return null
+  const { failure } = detail
+
+  if (failure.kind !== "deployLocked") {
+    return (
+      <p className="text-xs opacity-90">
+        {t(`actionsBanner.publishFailure.${failure.kind}`)}
+      </p>
+    )
+  }
+
+  const cleared = detail.blockerInProgress === false
+  const busy = unsticking || retrying
+  const unstick = async () => {
+    if (!org || busy) return
+    setUnsticking(true)
+    try {
+      await cancelDeployment.mutateAsync({
+        org,
+        deploymentId: failure.blockerSha,
+      })
+      onRetry(tracker.id)
+    } catch {
+      // The row keeps showing the lock; the retry mutation's own toast covers a
+      // failed re-run, and a failed cancel is reported inline below.
+    } finally {
+      setUnsticking(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+      <span className="opacity-90">
+        {t(
+          cleared
+            ? "actionsBanner.publishFailure.deployLockCleared"
+            : "actionsBanner.publishFailure.deployLocked",
+        )}
+      </span>
+      {!cleared && (
+        // Same link-shaped affordance as the row's Retry, so the two read as
+        // one set of actions.
+        <button
+          type="button"
+          onClick={() => void unstick()}
+          disabled={busy}
+          className="flex shrink-0 cursor-pointer items-center gap-1 font-semibold underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {unsticking && <InlineSpinner />}
+          {t(
+            unsticking
+              ? "actionsBanner.publishFailure.unsticking"
+              : "actionsBanner.publishFailure.unstick",
+          )}
+        </button>
+      )}
+      {cancelDeployment.isError && (
+        <span role="alert" className="opacity-90">
+          {t("actionsBanner.publishFailure.unstickFailed", {
+            detail:
+              cancelDeployment.error instanceof Error
+                ? cancelDeployment.error.message
+                : String(cancelDeployment.error),
+          })}
+        </span>
+      )}
+    </div>
+  )
+}
+
 const TrackerRow = ({
   tracker,
+  org,
   onDismiss,
   onRetry,
   retrying,
@@ -89,6 +193,7 @@ const TrackerRow = ({
   compact,
 }: {
   tracker: Tracker
+  org: string | undefined
   onDismiss: (id: string) => void
   onRetry: (id: string) => void
   retrying: boolean
@@ -98,53 +203,72 @@ const TrackerRow = ({
   compact?: boolean
 }) => {
   const { t } = useTranslation()
+  // Only a failed publish gets a second line: its deploy annotations name a
+  // cause with a distinct fix, which the other workflows' failures don't.
+  const showPublishDetail =
+    tracker.phase === "failed" &&
+    tracker.workflow === PUBLISH_PAGES_WORKFLOW &&
+    tracker.runId !== undefined
   return (
     <div
-      className={`flex items-center gap-2 ${
+      className={`flex flex-col gap-1 ${
         compact
           ? ""
           : `rounded-selector px-2 py-1.5 ${chipToneClass[ROW_TONE[tracker.phase]]}`
       }`}
     >
-      <StatusIcon phase={tracker.phase} tinted={!compact} />
-      <span className="min-w-0 flex-1 truncate text-sm">
-        {tracker.displayLabel}
-      </span>
-      <ElapsedLabel tracker={tracker} now={now} />
-      {tracker.htmlUrl && (
-        <ExternalLink
-          href={tracker.htmlUrl}
-          variant="plain"
-          className="shrink-0 cursor-pointer text-xs font-medium opacity-80 hover:opacity-100"
-        >
-          {t("actionsBanner.viewRun")}
-        </ExternalLink>
-      )}
-      {tracker.retriable && (
-        <button
-          type="button"
-          onClick={() => onRetry(tracker.id)}
-          disabled={retrying}
-          aria-label={t("actionsBanner.retry")}
-          className="flex shrink-0 cursor-pointer items-center gap-1 text-xs font-semibold underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {retrying ? (
-            <InlineSpinner />
-          ) : (
-            <SyncIcon aria-hidden="true" className="size-4" />
-          )}
-          {t("actionsBanner.retry")}
-        </button>
-      )}
-      {tracker.dismissible && (
-        <button
-          type="button"
-          onClick={() => onDismiss(tracker.id)}
-          aria-label={t("actionsBanner.dismiss")}
-          className="flex shrink-0 cursor-pointer items-center opacity-70 hover:opacity-100"
-        >
-          <XIcon aria-hidden="true" className="size-4" />
-        </button>
+      <div className="flex items-center gap-2">
+        <StatusIcon phase={tracker.phase} tinted={!compact} />
+        <span className="min-w-0 flex-1 truncate text-sm">
+          {tracker.displayLabel}
+        </span>
+        <ElapsedLabel tracker={tracker} now={now} />
+        {tracker.htmlUrl && (
+          <ExternalLink
+            href={tracker.htmlUrl}
+            variant="plain"
+            className="shrink-0 cursor-pointer text-xs font-medium opacity-80 hover:opacity-100"
+          >
+            {t("actionsBanner.viewRun")}
+          </ExternalLink>
+        )}
+        {tracker.retriable && (
+          <button
+            type="button"
+            onClick={() => onRetry(tracker.id)}
+            disabled={retrying}
+            aria-label={t("actionsBanner.retry")}
+            className="flex shrink-0 cursor-pointer items-center gap-1 text-xs font-semibold underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {retrying ? (
+              <InlineSpinner />
+            ) : (
+              <SyncIcon aria-hidden="true" className="size-4" />
+            )}
+            {t("actionsBanner.retry")}
+          </button>
+        )}
+        {tracker.dismissible && (
+          <button
+            type="button"
+            onClick={() => onDismiss(tracker.id)}
+            aria-label={t("actionsBanner.dismiss")}
+            className="flex shrink-0 cursor-pointer items-center opacity-70 hover:opacity-100"
+          >
+            <XIcon aria-hidden="true" className="size-4" />
+          </button>
+        )}
+      </div>
+      {showPublishDetail && (
+        // Indented past the status icon so the detail reads as the row's own.
+        <div className="ps-6">
+          <PublishFailureDetail
+            org={org}
+            tracker={tracker}
+            onRetry={onRetry}
+            retrying={retrying}
+          />
+        </div>
       )}
     </div>
   )
@@ -153,6 +277,7 @@ const TrackerRow = ({
 // Inner banner content (one row, or the expandable header + list). Extracted so
 // it renders in both the hidden measuring probe and the visible bar.
 const BannerBody = ({
+  org,
   trackers,
   primary,
   primaryPhase,
@@ -165,6 +290,7 @@ const BannerBody = ({
   retrying,
   now,
 }: {
+  org: string | undefined
   trackers: Tracker[]
   primary: Tracker | undefined
   primaryPhase: Tracker["phase"]
@@ -185,6 +311,7 @@ const BannerBody = ({
       <div className="px-4 py-2.5">
         <TrackerRow
           tracker={trackers[0]}
+          org={org}
           onDismiss={dismiss}
           onRetry={retry}
           retrying={retrying.has(trackers[0].id)}
@@ -253,6 +380,7 @@ const BannerBody = ({
               <li key={tracker.id}>
                 <TrackerRow
                   tracker={tracker}
+                  org={org}
                   onDismiss={dismiss}
                   onRetry={retry}
                   retrying={retrying.has(tracker.id)}
@@ -268,7 +396,7 @@ const BannerBody = ({
 }
 
 export function ActionsBanner() {
-  const { trackers, anyFailed, pollError, dismiss, retry, retrying } =
+  const { org, trackers, anyFailed, pollError, dismiss, retry, retrying } =
     useActionActivity()
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
@@ -316,7 +444,9 @@ export function ActionsBanner() {
   const failedCount = trackers.filter((tr) => tr.phase === "failed").length
 
   // Tone follows the LATEST action's phase — an older failure does NOT repaint
-  // the whole bar; it surfaces as the attention badge below. Solid fill.
+  // the whole bar; it surfaces as the attention badge below. Solid fill. A
+  // superseded publish is neither a failure nor a success of its own, so it
+  // takes the neutral in-progress tone.
   const tone =
     primaryPhase === "failed"
       ? "border-error bg-error text-error-content"
@@ -379,6 +509,7 @@ export function ActionsBanner() {
   const body = (
     <>
       <BannerBody
+        org={org}
         trackers={trackers}
         primary={primary}
         primaryPhase={primaryPhase}

--- a/web/src/components/status/ActionsBanner.tsx
+++ b/web/src/components/status/ActionsBanner.tsx
@@ -14,7 +14,6 @@ import { useTranslation } from "react-i18next"
 
 import { useActionActivity, type Tracker } from "@/hooks/useActionActivity"
 import { usePublishFailureDetail } from "@/hooks/usePublishFailureDetail"
-import { useCancelPagesDeployment } from "@/hooks/mutations/useCancelPagesDeployment"
 import { PUBLISH_PAGES_WORKFLOW } from "@/github-core/workflows"
 import { collapseVariants, DURATION, EASE_OUT } from "@/lib/motion"
 import type { BadgeTone } from "@/types/badgeTone"
@@ -92,24 +91,31 @@ const ROW_TONE: Record<Tracker["phase"], BadgeTone> = {
   pending: "info",
 }
 
+// The one recipe for a row's link-shaped actions (Retry, unstick), so the two
+// read as one set and can't drift.
+const ROW_ACTION_CLASS =
+  "flex shrink-0 cursor-pointer items-center gap-1 text-xs font-semibold underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+
 // Why a publish failed and what to do next, under a failed publish row. A cause
 // the annotations don't name shows nothing (the run link remains). The deploy-
-// lock case also offers to cancel the blocking deployment and re-run.
+// lock case also offers to cancel the blocking deployment and re-run. No local
+// state: the banner body renders twice (height probe + visible bar), so every
+// copy must render identically from the shared hook state.
 const PublishFailureDetail = ({
   org,
   tracker,
-  onRetry,
-  retrying,
+  onUnstick,
+  busy,
+  unsticking,
 }: {
   org: string | undefined
   tracker: Tracker
-  onRetry: (id: string) => void
-  retrying: boolean
+  onUnstick: (id: string, blockerSha: string) => void
+  busy: boolean
+  unsticking: boolean
 }) => {
   const { t } = useTranslation()
   const detail = usePublishFailureDetail(org, tracker.runId)
-  const cancelDeployment = useCancelPagesDeployment()
-  const [unsticking, setUnsticking] = useState(false)
 
   if (detail.state !== "known") return null
   const { failure } = detail
@@ -123,24 +129,6 @@ const PublishFailureDetail = ({
   }
 
   const cleared = detail.blockerInProgress === false
-  const busy = unsticking || retrying
-  const unstick = async () => {
-    if (!org || busy) return
-    setUnsticking(true)
-    try {
-      await cancelDeployment.mutateAsync({
-        org,
-        deploymentId: failure.blockerSha,
-      })
-      onRetry(tracker.id)
-    } catch {
-      // A failed cancel is reported inline below; a failed re-run by the retry
-      // mutation's toast.
-    } finally {
-      setUnsticking(false)
-    }
-  }
-
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
       <span className="opacity-90">
@@ -151,12 +139,11 @@ const PublishFailureDetail = ({
         )}
       </span>
       {!cleared && (
-        // Styled like the row's Retry so the two read as one set of actions.
         <button
           type="button"
-          onClick={() => void unstick()}
+          onClick={() => onUnstick(tracker.id, failure.blockerSha)}
           disabled={busy}
-          className="flex shrink-0 cursor-pointer items-center gap-1 font-semibold underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+          className={ROW_ACTION_CLASS}
         >
           {unsticking && <InlineSpinner />}
           {t(
@@ -165,16 +152,6 @@ const PublishFailureDetail = ({
               : "actionsBanner.publishFailure.unstick",
           )}
         </button>
-      )}
-      {cancelDeployment.isError && (
-        <span role="alert" className="opacity-90">
-          {t("actionsBanner.publishFailure.unstickFailed", {
-            detail:
-              cancelDeployment.error instanceof Error
-                ? cancelDeployment.error.message
-                : String(cancelDeployment.error),
-          })}
-        </span>
       )}
     </div>
   )
@@ -185,7 +162,9 @@ const TrackerRow = ({
   org,
   onDismiss,
   onRetry,
-  retrying,
+  onUnstick,
+  busy,
+  unsticking,
   now,
   compact,
 }: {
@@ -193,7 +172,10 @@ const TrackerRow = ({
   org: string | undefined
   onDismiss: (id: string) => void
   onRetry: (id: string) => void
-  retrying: boolean
+  onUnstick: (id: string, blockerSha: string) => void
+  // A retry or unstick is in flight for this row: both actions disable.
+  busy: boolean
+  unsticking: boolean
   now: number
   // compact = inline in the collapsed single-tracker bar (inherits header
   // tone); otherwise the row carries its own per-phase tone.
@@ -205,6 +187,9 @@ const TrackerRow = ({
     tracker.phase === "failed" &&
     tracker.workflow === PUBLISH_PAGES_WORKFLOW &&
     tracker.runId !== undefined
+  // The retry spinner belongs to the retry step only; the unstick button shows
+  // its own while the cancel runs.
+  const retrying = busy && !unsticking
   return (
     <div
       className={`flex flex-col gap-1 ${
@@ -232,9 +217,9 @@ const TrackerRow = ({
           <button
             type="button"
             onClick={() => onRetry(tracker.id)}
-            disabled={retrying}
+            disabled={busy}
             aria-label={t("actionsBanner.retry")}
-            className="flex shrink-0 cursor-pointer items-center gap-1 text-xs font-semibold underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+            className={ROW_ACTION_CLASS}
           >
             {retrying ? (
               <InlineSpinner />
@@ -260,8 +245,9 @@ const TrackerRow = ({
           <PublishFailureDetail
             org={org}
             tracker={tracker}
-            onRetry={onRetry}
-            retrying={retrying}
+            onUnstick={onUnstick}
+            busy={busy}
+            unsticking={unsticking}
           />
         </div>
       )}
@@ -282,7 +268,9 @@ const BannerBody = ({
   setExpanded,
   dismiss,
   retry,
-  retrying,
+  unstick,
+  busy,
+  unsticking,
   now,
 }: {
   org: string | undefined
@@ -297,7 +285,9 @@ const BannerBody = ({
   setExpanded: (fn: (v: boolean) => boolean) => void
   dismiss: (id: string) => void
   retry: (id: string) => void
-  retrying: ReadonlySet<string>
+  unstick: (id: string, blockerSha: string) => void
+  busy: ReadonlySet<string>
+  unsticking: ReadonlySet<string>
   now: number
 }) => {
   const { t } = useTranslation()
@@ -309,7 +299,9 @@ const BannerBody = ({
           org={org}
           onDismiss={dismiss}
           onRetry={retry}
-          retrying={retrying.has(trackers[0].id)}
+          onUnstick={unstick}
+          busy={busy.has(trackers[0].id)}
+          unsticking={unsticking.has(trackers[0].id)}
           now={now}
           compact
         />
@@ -378,7 +370,9 @@ const BannerBody = ({
                   org={org}
                   onDismiss={dismiss}
                   onRetry={retry}
-                  retrying={retrying.has(tracker.id)}
+                  onUnstick={unstick}
+                  busy={busy.has(tracker.id)}
+                  unsticking={unsticking.has(tracker.id)}
                   now={now}
                 />
               </li>
@@ -391,8 +385,17 @@ const BannerBody = ({
 }
 
 export function ActionsBanner() {
-  const { org, trackers, anyFailed, pollError, dismiss, retry, retrying } =
-    useActionActivity()
+  const {
+    org,
+    trackers,
+    anyFailed,
+    pollError,
+    dismiss,
+    retry,
+    unstick,
+    busy,
+    unsticking,
+  } = useActionActivity()
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
 
@@ -513,7 +516,9 @@ export function ActionsBanner() {
         setExpanded={setExpanded}
         dismiss={dismiss}
         retry={retry}
-        retrying={retrying}
+        unstick={unstick}
+        busy={busy}
+        unsticking={unsticking}
         now={now}
       />
       {pollError && (

--- a/web/src/components/status/ActionsBanner.tsx
+++ b/web/src/components/status/ActionsBanner.tsx
@@ -92,11 +92,9 @@ const ROW_TONE: Record<Tracker["phase"], BadgeTone> = {
   pending: "info",
 }
 
-// Why a publish failed and what to do next, under a failed publish row. Reads
-// the run's annotations once it has failed; a cause it can't name falls back to
-// the run link alone. The deploy-lock case also offers to cancel the blocking
-// Pages deployment and re-run, since waiting out GitHub's lock is otherwise
-// the teacher's only option and nothing tells them so.
+// Why a publish failed and what to do next, under a failed publish row. A cause
+// the annotations don't name shows nothing (the run link remains). The deploy-
+// lock case also offers to cancel the blocking deployment and re-run.
 const PublishFailureDetail = ({
   org,
   tracker,
@@ -136,8 +134,8 @@ const PublishFailureDetail = ({
       })
       onRetry(tracker.id)
     } catch {
-      // The row keeps showing the lock; the retry mutation's own toast covers a
-      // failed re-run, and a failed cancel is reported inline below.
+      // A failed cancel is reported inline below; a failed re-run by the retry
+      // mutation's toast.
     } finally {
       setUnsticking(false)
     }
@@ -153,8 +151,7 @@ const PublishFailureDetail = ({
         )}
       </span>
       {!cleared && (
-        // Same link-shaped affordance as the row's Retry, so the two read as
-        // one set of actions.
+        // Styled like the row's Retry so the two read as one set of actions.
         <button
           type="button"
           onClick={() => void unstick()}
@@ -203,8 +200,7 @@ const TrackerRow = ({
   compact?: boolean
 }) => {
   const { t } = useTranslation()
-  // Only a failed publish gets a second line: its deploy annotations name a
-  // cause with a distinct fix, which the other workflows' failures don't.
+  // Only a failed publish has annotations that name a cause with its own fix.
   const showPublishDetail =
     tracker.phase === "failed" &&
     tracker.workflow === PUBLISH_PAGES_WORKFLOW &&
@@ -260,7 +256,6 @@ const TrackerRow = ({
         )}
       </div>
       {showPublishDetail && (
-        // Indented past the status icon so the detail reads as the row's own.
         <div className="ps-6">
           <PublishFailureDetail
             org={org}
@@ -445,8 +440,7 @@ export function ActionsBanner() {
 
   // Tone follows the LATEST action's phase — an older failure does NOT repaint
   // the whole bar; it surfaces as the attention badge below. Solid fill. A
-  // superseded publish is neither a failure nor a success of its own, so it
-  // takes the neutral in-progress tone.
+  // superseded publish takes the neutral in-progress tone.
   const tone =
     primaryPhase === "failed"
       ? "border-error bg-error text-error-content"

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -113,6 +113,7 @@ export {
   triggerRegrade,
   triggerProbeToken,
   rerunFailedRun,
+  cancelPagesDeployment,
   CollectInputsUnsupportedError,
   ProbeWorkflowMissingError,
 } from "./mutations/workflowDispatch"

--- a/web/src/github-core/mutations.ts
+++ b/web/src/github-core/mutations.ts
@@ -112,6 +112,7 @@ export {
   triggerScoreCollection,
   triggerRegrade,
   triggerProbeToken,
+  triggerPublishPages,
   rerunFailedRun,
   cancelPagesDeployment,
   CollectInputsUnsupportedError,

--- a/web/src/github-core/mutations/workflowDispatch.test.ts
+++ b/web/src/github-core/mutations/workflowDispatch.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { GitHubAPIError, type GitHubRateLimit } from "@/github-core/errors"
 import {
+  cancelPagesDeployment,
   CollectInputsUnsupportedError,
   ProbeWorkflowMissingError,
   triggerProbeToken,
@@ -365,5 +366,55 @@ describe("triggerProbeToken", () => {
   it("requires an org", async () => {
     const { client } = makeClient(() => ({}))
     await expect(triggerProbeToken(client, undefined)).rejects.toThrow(/org/)
+  })
+})
+
+describe("cancelPagesDeployment", () => {
+  const SHA = "656e8d140b36230c9ccfe14584b9a81fa8c9c8d0"
+
+  it("POSTs the cancel for the sha GitHub named as blocking", async () => {
+    const request = vi.fn(() => Promise.resolve(undefined))
+    const client = { request } as unknown as GitHubClient
+    await cancelPagesDeployment(client, "acme", SHA)
+    expect(request).toHaveBeenCalledWith(
+      `/repos/acme/classroom50/pages/deployments/${SHA}/cancel`,
+      { method: "POST" },
+    )
+  })
+
+  it("treats a 404 as already cleared", async () => {
+    const request = vi.fn(() =>
+      Promise.reject(
+        new GitHubAPIError({
+          status: 404,
+          url: "https://api.github.com/x",
+          message: "Not Found",
+          body: null,
+          rateLimit: noRateLimit,
+        }),
+      ),
+    )
+    const client = { request } as unknown as GitHubClient
+    await expect(
+      cancelPagesDeployment(client, "acme", SHA),
+    ).resolves.toBeUndefined()
+  })
+
+  it("rethrows a refusal (no Pages write)", async () => {
+    const request = vi.fn(() =>
+      Promise.reject(
+        new GitHubAPIError({
+          status: 403,
+          url: "https://api.github.com/x",
+          message: "Forbidden",
+          body: null,
+          rateLimit: noRateLimit,
+        }),
+      ),
+    )
+    const client = { request } as unknown as GitHubClient
+    await expect(cancelPagesDeployment(client, "acme", SHA)).rejects.toThrow(
+      /Forbidden/,
+    )
   })
 })

--- a/web/src/github-core/mutations/workflowDispatch.test.ts
+++ b/web/src/github-core/mutations/workflowDispatch.test.ts
@@ -6,6 +6,7 @@ import {
   CollectInputsUnsupportedError,
   ProbeWorkflowMissingError,
   triggerProbeToken,
+  triggerPublishPages,
   triggerScoreCollection,
 } from "./workflowDispatch"
 import type { GitHubClient } from "../client"
@@ -366,6 +367,29 @@ describe("triggerProbeToken", () => {
   it("requires an org", async () => {
     const { client } = makeClient(() => ({}))
     await expect(triggerProbeToken(client, undefined)).rejects.toThrow(/org/)
+  })
+})
+
+describe("triggerPublishPages", () => {
+  it("dispatches publish-pages.yaml with no inputs and returns the baseline", async () => {
+    const { client, request } = makeClient(() => ({}))
+    const result = await triggerPublishPages(client, "acme")
+    expect(result.sinceRunId).toBe(41)
+    const dispatchCall = request.mock.calls.find(([url]) =>
+      (url as string).endsWith("/dispatches"),
+    )
+    expect(dispatchCall?.[0]).toBe(
+      "/repos/acme/classroom50/actions/workflows/publish-pages.yaml/dispatches",
+    )
+    expect(dispatchCall?.[1]).toEqual({
+      method: "POST",
+      body: { ref: "main" },
+    })
+  })
+
+  it("requires an org", async () => {
+    const { client } = makeClient(() => ({}))
+    await expect(triggerPublishPages(client, undefined)).rejects.toThrow(/org/)
   })
 })
 

--- a/web/src/github-core/mutations/workflowDispatch.ts
+++ b/web/src/github-core/mutations/workflowDispatch.ts
@@ -255,10 +255,9 @@ export async function triggerProbeToken(
 
 /**
  * Dispatches the classroom50 repo's `publish-pages.yaml` workflow, redeploying
- * the whole student site from the config repo's current default branch. No
- * inputs. Nothing is committed, so this is the recovery for a site that
- * drifted from the repo (a failed or stuck deploy, a manual edit on GitHub, a
- * Pages site that was re-enabled). Returns `sinceRunId` (see openDispatch).
+ * the student site from the default branch without a commit: the recovery for
+ * a site that drifted from the repo. No inputs. Returns `sinceRunId` (see
+ * openDispatch).
  */
 export async function triggerPublishPages(
   client: GitHubClient,
@@ -293,9 +292,8 @@ export async function rerunFailedRun(
 }
 
 // Cancel a Pages deployment in <org>/classroom50 that GitHub still holds as in
-// progress, so the next deploy can go ahead. `deploymentId` is the commit SHA
-// GitHub names in its "please cancel <sha> first" refusal. A 404 means the
-// lock already cleared, which is the outcome the caller wanted.
+// progress. `deploymentId` is the commit SHA from GitHub's 400 refusal. A 404
+// means it already cleared, which is what the caller wanted.
 // https://docs.github.com/en/rest/pages/pages#cancel-a-github-pages-deployment
 export async function cancelPagesDeployment(
   client: GitHubClient,

--- a/web/src/github-core/mutations/workflowDispatch.ts
+++ b/web/src/github-core/mutations/workflowDispatch.ts
@@ -266,3 +266,25 @@ export async function rerunFailedRun(
     { method: "POST" },
   )
 }
+
+// Cancel a Pages deployment in <org>/classroom50 that GitHub still holds as in
+// progress, so the next deploy can go ahead. `deploymentId` is the commit SHA
+// GitHub names in its "please cancel <sha> first" refusal. A 404 means the
+// lock already cleared, which is the outcome the caller wanted.
+// https://docs.github.com/en/rest/pages/pages#cancel-a-github-pages-deployment
+export async function cancelPagesDeployment(
+  client: GitHubClient,
+  org: string,
+  deploymentId: string,
+): Promise<void> {
+  logWorkflows.info("cancelling stuck Pages deployment", { org, deploymentId })
+  try {
+    await client.request(
+      `/repos/${org}/${CONFIG_REPO}/pages/deployments/${encodeURIComponent(deploymentId)}/cancel`,
+      { method: "POST" },
+    )
+  } catch (err) {
+    if (err instanceof GitHubAPIError && err.isNotFound) return
+    throw err
+  }
+}

--- a/web/src/github-core/mutations/workflowDispatch.ts
+++ b/web/src/github-core/mutations/workflowDispatch.ts
@@ -5,6 +5,7 @@ import { getRepo } from "../repoReads"
 import {
   COLLECT_SCORES_WORKFLOW,
   PROBE_TOKEN_WORKFLOW,
+  PUBLISH_PAGES_WORKFLOW,
   REGRADE_WORKFLOW,
 } from "../workflows"
 import { CONFIG_REPO, DEFAULT_BRANCH } from "@/util/configRepo"
@@ -249,6 +250,30 @@ export async function triggerProbeToken(
   await post()
 
   logWorkflows.info("dispatched probe-token", { org, sinceRunId })
+  return { sinceRunId }
+}
+
+/**
+ * Dispatches the classroom50 repo's `publish-pages.yaml` workflow, redeploying
+ * the whole student site from the config repo's current default branch. No
+ * inputs. Nothing is committed, so this is the recovery for a site that
+ * drifted from the repo (a failed or stuck deploy, a manual edit on GitHub, a
+ * Pages site that was re-enabled). Returns `sinceRunId` (see openDispatch).
+ */
+export async function triggerPublishPages(
+  client: GitHubClient,
+  org: string | undefined,
+): Promise<{ sinceRunId: number | null }> {
+  if (!org) throw new Error("org must be specified to publish the site")
+
+  const { sinceRunId, post } = await openDispatch(
+    client,
+    org,
+    PUBLISH_PAGES_WORKFLOW,
+  )
+  await post()
+
+  logWorkflows.info("dispatched publish-pages", { org, sinceRunId })
   return { sinceRunId }
 }
 

--- a/web/src/github-core/queries.ts
+++ b/web/src/github-core/queries.ts
@@ -147,3 +147,8 @@ export {
   type RunAnnotation,
 } from "./queries/releaseRunReads"
 export { getRepoPages, type RepoPagesInfo } from "./queries/repoPagesReads"
+export {
+  getPagesDeploymentStatus,
+  isPagesDeploymentInProgress,
+  type PagesDeploymentStatus,
+} from "./queries/pagesDeploymentReads"

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -244,8 +244,7 @@ export const githubKeys = {
   runAnnotations: (owner: string, runId: number) =>
     [...githubKeys.all, "run-annotations", owner, runId] as const,
 
-  // One Pages deployment's status in the config repo, keyed by the commit SHA
-  // GitHub named as blocking a later deploy.
+  // One Pages deployment's status, keyed by the sha GitHub named as blocking.
   pagesDeployment: (owner: string, deploymentId: string) =>
     [...githubKeys.all, "pages-deployment", owner, deploymentId] as const,
 

--- a/web/src/github-core/queries/keys.ts
+++ b/web/src/github-core/queries/keys.ts
@@ -244,6 +244,11 @@ export const githubKeys = {
   runAnnotations: (owner: string, runId: number) =>
     [...githubKeys.all, "run-annotations", owner, runId] as const,
 
+  // One Pages deployment's status in the config repo, keyed by the commit SHA
+  // GitHub named as blocking a later deploy.
+  pagesDeployment: (owner: string, deploymentId: string) =>
+    [...githubKeys.all, "pages-deployment", owner, deploymentId] as const,
+
   skeletonDrift: (owner: string) =>
     [...githubKeys.all, "skeletonDrift", owner] as const,
 

--- a/web/src/github-core/queries/pagesDeploymentReads.test.ts
+++ b/web/src/github-core/queries/pagesDeploymentReads.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  getPagesDeploymentStatus,
+  isPagesDeploymentInProgress,
+} from "./pagesDeploymentReads"
+import { GitHubAPIError } from "../errors"
+import type { GitHubClient } from "../client"
+
+const SHA = "656e8d140b36230c9ccfe14584b9a81fa8c9c8d0"
+
+function apiError(status: number): GitHubAPIError {
+  return new GitHubAPIError({
+    status,
+    url: `/repos/acme/classroom50/pages/deployments/${SHA}`,
+    message: `HTTP ${status}`,
+    body: null,
+    rateLimit: {
+      limit: null,
+      remaining: null,
+      used: null,
+      reset: null,
+      resource: null,
+      retryAfter: null,
+    },
+  })
+}
+
+function makeClient(outcome: unknown) {
+  const request = vi.fn<(url: string) => Promise<unknown>>(async () => {
+    if (outcome instanceof GitHubAPIError) throw outcome
+    return outcome
+  })
+  return { client: { request } as unknown as GitHubClient, request }
+}
+
+describe("getPagesDeploymentStatus", () => {
+  it("reads the deployment by the sha GitHub named in its refusal", async () => {
+    const { client, request } = makeClient({ status: "updating_pages" })
+    expect(await getPagesDeploymentStatus(client, "acme", SHA)).toBe(
+      "updating_pages",
+    )
+    expect(request.mock.calls[0][0]).toBe(
+      `/repos/acme/classroom50/pages/deployments/${SHA}`,
+    )
+  })
+
+  it("reads a 404 as gone (the lock has cleared)", async () => {
+    const { client } = makeClient(apiError(404))
+    expect(await getPagesDeploymentStatus(client, "acme", SHA)).toBeNull()
+  })
+
+  it("rethrows other failures", async () => {
+    const { client } = makeClient(apiError(500))
+    await expect(
+      getPagesDeploymentStatus(client, "acme", SHA),
+    ).rejects.toThrow()
+  })
+})
+
+describe("isPagesDeploymentInProgress", () => {
+  it("treats every pre-final status, including a scheduled retry, as holding the lock", () => {
+    for (const status of [
+      "deployment_in_progress",
+      "syncing_files",
+      "finished_file_sync",
+      "updating_pages",
+      "purging_cdn",
+      "deployment_attempt_error",
+    ]) {
+      expect(isPagesDeploymentInProgress(status)).toBe(true)
+    }
+  })
+
+  it("treats final statuses as released", () => {
+    for (const status of [
+      "succeed",
+      "deployment_cancelled",
+      "deployment_failed",
+      "deployment_content_failed",
+      "deployment_lost",
+    ]) {
+      expect(isPagesDeploymentInProgress(status)).toBe(false)
+    }
+  })
+})

--- a/web/src/github-core/queries/pagesDeploymentReads.test.ts
+++ b/web/src/github-core/queries/pagesDeploymentReads.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   getPagesDeploymentStatus,
   isPagesDeploymentInProgress,
+  type PagesDeploymentStatus,
 } from "./pagesDeploymentReads"
 import { GitHubAPIError } from "../errors"
 import type { GitHubClient } from "../client"
@@ -60,26 +61,28 @@ describe("getPagesDeploymentStatus", () => {
 
 describe("isPagesDeploymentInProgress", () => {
   it("treats every pre-final status, including a scheduled retry, as holding the lock", () => {
-    for (const status of [
+    const held: PagesDeploymentStatus[] = [
       "deployment_in_progress",
       "syncing_files",
       "finished_file_sync",
       "updating_pages",
       "purging_cdn",
       "deployment_attempt_error",
-    ]) {
+    ]
+    for (const status of held) {
       expect(isPagesDeploymentInProgress(status)).toBe(true)
     }
   })
 
   it("treats final statuses as released", () => {
-    for (const status of [
+    const released: PagesDeploymentStatus[] = [
       "succeed",
       "deployment_cancelled",
       "deployment_failed",
       "deployment_content_failed",
       "deployment_lost",
-    ]) {
+    ]
+    for (const status of released) {
       expect(isPagesDeploymentInProgress(status)).toBe(false)
     }
   })

--- a/web/src/github-core/queries/pagesDeploymentReads.ts
+++ b/web/src/github-core/queries/pagesDeploymentReads.ts
@@ -2,9 +2,8 @@ import type { GitHubClient } from "../client"
 import { GitHubAPIError } from "../errors"
 import { CONFIG_REPO } from "@/util/configRepo"
 
-// GET /repos/{owner}/{repo}/pages/deployments/{id}. The id may be the commit
-// SHA the deployment was built from, which is what GitHub names in its
-// "in progress deployment, please cancel <sha>" refusal.
+// GET /repos/{owner}/{repo}/pages/deployments/{id}. The id can be the commit
+// SHA, which is how GitHub names a blocking deployment in its 400 refusal.
 // https://docs.github.com/en/rest/pages/pages#get-the-status-of-a-github-pages-deployment
 export type PagesDeploymentStatus =
   | "deployment_in_progress"
@@ -35,9 +34,8 @@ export function isPagesDeploymentInProgress(
   return IN_PROGRESS_STATUSES.has(status)
 }
 
-// The status of one Pages deployment in <org>/classroom50, or `null` when
-// GitHub no longer has it (404): an expired lock reads the same as a cleared
-// one, and both mean the next deploy can go ahead.
+// `null` when GitHub no longer has the deployment (404): the lock is gone
+// either way.
 export async function getPagesDeploymentStatus(
   client: GitHubClient,
   org: string,

--- a/web/src/github-core/queries/pagesDeploymentReads.ts
+++ b/web/src/github-core/queries/pagesDeploymentReads.ts
@@ -18,18 +18,19 @@ export type PagesDeploymentStatus =
   | "deployment_lost"
   | "succeed"
 
-const IN_PROGRESS_STATUSES: ReadonlySet<string> = new Set([
-  "deployment_in_progress",
-  "syncing_files",
-  "finished_file_sync",
-  "updating_pages",
-  "purging_cdn",
-  // GitHub schedules a retry, so the lock is still held.
-  "deployment_attempt_error",
-])
+const IN_PROGRESS_STATUSES: ReadonlySet<PagesDeploymentStatus> =
+  new Set<PagesDeploymentStatus>([
+    "deployment_in_progress",
+    "syncing_files",
+    "finished_file_sync",
+    "updating_pages",
+    "purging_cdn",
+    // GitHub schedules a retry, so the lock is still held.
+    "deployment_attempt_error",
+  ])
 
 export function isPagesDeploymentInProgress(
-  status: PagesDeploymentStatus | string,
+  status: PagesDeploymentStatus,
 ): boolean {
   return IN_PROGRESS_STATUSES.has(status)
 }

--- a/web/src/github-core/queries/pagesDeploymentReads.ts
+++ b/web/src/github-core/queries/pagesDeploymentReads.ts
@@ -1,0 +1,57 @@
+import type { GitHubClient } from "../client"
+import { GitHubAPIError } from "../errors"
+import { CONFIG_REPO } from "@/util/configRepo"
+
+// GET /repos/{owner}/{repo}/pages/deployments/{id}. The id may be the commit
+// SHA the deployment was built from, which is what GitHub names in its
+// "in progress deployment, please cancel <sha>" refusal.
+// https://docs.github.com/en/rest/pages/pages#get-the-status-of-a-github-pages-deployment
+export type PagesDeploymentStatus =
+  | "deployment_in_progress"
+  | "syncing_files"
+  | "finished_file_sync"
+  | "updating_pages"
+  | "purging_cdn"
+  | "deployment_cancelled"
+  | "deployment_failed"
+  | "deployment_content_failed"
+  | "deployment_attempt_error"
+  | "deployment_lost"
+  | "succeed"
+
+const IN_PROGRESS_STATUSES: ReadonlySet<string> = new Set([
+  "deployment_in_progress",
+  "syncing_files",
+  "finished_file_sync",
+  "updating_pages",
+  "purging_cdn",
+  // GitHub schedules a retry, so the lock is still held.
+  "deployment_attempt_error",
+])
+
+export function isPagesDeploymentInProgress(
+  status: PagesDeploymentStatus | string,
+): boolean {
+  return IN_PROGRESS_STATUSES.has(status)
+}
+
+// The status of one Pages deployment in <org>/classroom50, or `null` when
+// GitHub no longer has it (404): an expired lock reads the same as a cleared
+// one, and both mean the next deploy can go ahead.
+export async function getPagesDeploymentStatus(
+  client: GitHubClient,
+  org: string,
+  deploymentId: string,
+  signal?: AbortSignal,
+): Promise<PagesDeploymentStatus | null> {
+  try {
+    const res = await client.request<{ status?: PagesDeploymentStatus }>(
+      `/repos/${encodeURIComponent(org)}/${CONFIG_REPO}/pages/deployments/${encodeURIComponent(deploymentId)}`,
+      { method: "GET", signal },
+    )
+    return res.status ?? null
+  } catch (err) {
+    if (err instanceof GitHubAPIError && err.isNotFound) return null
+    throw err
+  }
+}

--- a/web/src/github-core/workflows.ts
+++ b/web/src/github-core/workflows.ts
@@ -6,6 +6,11 @@ export const COLLECT_SCORES_WORKFLOW = "collect-scores.yaml"
 // follow-up collect-scores run refreshes the gradebook.
 export const REGRADE_WORKFLOW = "regrade.yaml"
 
+// The push-triggered student-site publisher in <org>/classroom50. Every config
+// commit (assignment, classroom, skeleton) triggers it; the artifact is the
+// whole site, so the newest successful run publishes every earlier change too.
+export const PUBLISH_PAGES_WORKFLOW = "publish-pages.yaml"
+
 // The read-only service-token health check in <org>/classroom50. Dispatched
 // with no inputs; it exercises every scope the token needs and reports each as
 // a workflow annotation, which is how the settings page shows the result.

--- a/web/src/github-core/workflows.ts
+++ b/web/src/github-core/workflows.ts
@@ -6,9 +6,8 @@ export const COLLECT_SCORES_WORKFLOW = "collect-scores.yaml"
 // follow-up collect-scores run refreshes the gradebook.
 export const REGRADE_WORKFLOW = "regrade.yaml"
 
-// The push-triggered student-site publisher in <org>/classroom50. Every config
-// commit (assignment, classroom, skeleton) triggers it; the artifact is the
-// whole site, so the newest successful run publishes every earlier change too.
+// The push-triggered student-site publisher in <org>/classroom50. Its artifact
+// is the whole site, so the newest successful run carries every earlier change.
 export const PUBLISH_PAGES_WORKFLOW = "publish-pages.yaml"
 
 // The read-only service-token health check in <org>/classroom50. Dispatched

--- a/web/src/hooks/mutations/useCancelPagesDeployment.ts
+++ b/web/src/hooks/mutations/useCancelPagesDeployment.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
+import { cancelPagesDeployment } from "@/github-core/mutations"
+import { githubKeys } from "@/github-core/queries"
+
+// Cancel the Pages deployment GitHub named as blocking a later publish, so the
+// failed deploy job can be re-run at once instead of waiting out GitHub's
+// ~10-minute lock. Cancelling only frees the lock; the caller re-runs the
+// failed job (rerunFailedRun) as its own step so a cancel that succeeds but a
+// retry that fails is reported as such. Optional client because the banner
+// mounts above auth, like useActionActivity.
+export function useCancelPagesDeployment() {
+  const client = useOptionalGitHubClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      org,
+      deploymentId,
+    }: {
+      org: string
+      deploymentId: string
+    }) => {
+      if (!client) throw new Error("GitHub client is not ready")
+      return cancelPagesDeployment(client, org, deploymentId)
+    },
+    onSettled: (_data, _err, { org, deploymentId }) => {
+      // Re-read the blocker so the failure row reflects the cleared (or still
+      // held) lock, whichever way the cancel went.
+      void queryClient.invalidateQueries({
+        queryKey: githubKeys.pagesDeployment(org, deploymentId),
+      })
+    },
+  })
+}
+
+export default useCancelPagesDeployment

--- a/web/src/hooks/mutations/useCancelPagesDeployment.ts
+++ b/web/src/hooks/mutations/useCancelPagesDeployment.ts
@@ -4,12 +4,10 @@ import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
 import { cancelPagesDeployment } from "@/github-core/mutations"
 import { githubKeys } from "@/github-core/queries"
 
-// Cancel the Pages deployment GitHub named as blocking a later publish, so the
-// failed deploy job can be re-run at once instead of waiting out GitHub's
-// ~10-minute lock. Cancelling only frees the lock; the caller re-runs the
-// failed job (rerunFailedRun) as its own step so a cancel that succeeds but a
-// retry that fails is reported as such. Optional client because the banner
-// mounts above auth, like useActionActivity.
+// Cancel the Pages deployment blocking a later publish, so the failed deploy can
+// be re-run now instead of after GitHub's ~10-minute release. Only frees the
+// lock; the caller re-runs the failed job as its own step so each outcome is
+// reported separately. Optional client because the banner mounts above auth.
 export function useCancelPagesDeployment() {
   const client = useOptionalGitHubClient()
   const queryClient = useQueryClient()
@@ -26,8 +24,7 @@ export function useCancelPagesDeployment() {
       return cancelPagesDeployment(client, org, deploymentId)
     },
     onSettled: (_data, _err, { org, deploymentId }) => {
-      // Re-read the blocker so the failure row reflects the cleared (or still
-      // held) lock, whichever way the cancel went.
+      // Re-read the blocker so the failure row reflects whichever way it went.
       void queryClient.invalidateQueries({
         queryKey: githubKeys.pagesDeployment(org, deploymentId),
       })

--- a/web/src/hooks/mutations/useRepublishSite.test.tsx
+++ b/web/src/hooks/mutations/useRepublishSite.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { createElement, type PropsWithChildren } from "react"
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useGitHubClient: () => ({}),
+}))
+
+const register = vi.fn()
+vi.mock("@/context/actions/ActionActivityProvider", () => ({
+  useActionActivityRegistry: () => ({ register }),
+}))
+
+const triggerPublishPages = vi.fn()
+vi.mock("@/github-core/mutations", () => ({
+  triggerPublishPages: (...args: unknown[]) => triggerPublishPages(...args),
+}))
+
+import { useRepublishSite } from "./useRepublishSite"
+
+const wrapper = ({ children }: PropsWithChildren) =>
+  createElement(QueryClientProvider, { client: new QueryClient() }, children)
+
+describe("useRepublishSite", () => {
+  it("registers the dispatched run with the banner as a publish-pages dispatch tracker", async () => {
+    triggerPublishPages.mockResolvedValue({ sinceRunId: 41 })
+    const { result } = renderHook(() => useRepublishSite(), { wrapper })
+    result.current.mutate({ org: "acme", label: "Publishing to student site" })
+    await waitFor(() => expect(register).toHaveBeenCalledTimes(1))
+    expect(triggerPublishPages.mock.calls[0][1]).toBe("acme")
+    expect(register).toHaveBeenCalledWith({
+      org: "acme",
+      label: "Publishing to student site",
+      anchor: {
+        kind: "sinceRunId",
+        workflow: "publish-pages.yaml",
+        sinceRunId: 41,
+      },
+    })
+  })
+
+  it("registers nothing when the dispatch is refused", async () => {
+    register.mockClear()
+    triggerPublishPages.mockRejectedValue(new Error("403"))
+    const { result } = renderHook(() => useRepublishSite(), { wrapper })
+    result.current.mutate({ org: "acme", label: "x" })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(register).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/hooks/mutations/useRepublishSite.ts
+++ b/web/src/hooks/mutations/useRepublishSite.ts
@@ -1,0 +1,35 @@
+import { useMutation } from "@tanstack/react-query"
+
+import { useGitHubClient } from "@/context/github/GitHubProvider"
+import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
+import { triggerPublishPages } from "@/github-core/mutations"
+import { PUBLISH_PAGES_WORKFLOW } from "@/github-core/workflows"
+
+// Redeploy the student site from the config repo as it stands, with no commit.
+// The teacher's way to bring the site back in line with the repo after a
+// failed or stuck deploy, or after re-enabling Pages. Registers the run with
+// the Actions banner here (not at the call site) so the tracker appears even if
+// the teacher navigates away the instant the dispatch resolves. `label` is
+// pre-translated by the caller (hooks stay t()-free).
+export function useRepublishSite() {
+  const client = useGitHubClient()
+  const { register } = useActionActivityRegistry()
+
+  return useMutation({
+    mutationFn: ({ org }: { org: string; label: string }) =>
+      triggerPublishPages(client, org),
+    onSuccess: ({ sinceRunId }, { org, label }) => {
+      register({
+        org,
+        label,
+        anchor: {
+          kind: "sinceRunId",
+          workflow: PUBLISH_PAGES_WORKFLOW,
+          sinceRunId,
+        },
+      })
+    },
+  })
+}
+
+export default useRepublishSite

--- a/web/src/hooks/mutations/useRepublishSite.ts
+++ b/web/src/hooks/mutations/useRepublishSite.ts
@@ -5,11 +5,9 @@ import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvi
 import { triggerPublishPages } from "@/github-core/mutations"
 import { PUBLISH_PAGES_WORKFLOW } from "@/github-core/workflows"
 
-// Redeploy the student site from the config repo as it stands, with no commit.
-// The teacher's way to bring the site back in line with the repo after a
-// failed or stuck deploy, or after re-enabling Pages. Registers the run with
-// the Actions banner here (not at the call site) so the tracker appears even if
-// the teacher navigates away the instant the dispatch resolves. `label` is
+// Redeploy the student site from the config repo without a commit. Registers
+// the run with the Actions banner here, not at the call site, so the tracker
+// appears even if the teacher navigates away at once. `label` is
 // pre-translated by the caller (hooks stay t()-free).
 export function useRepublishSite() {
   const client = useGitHubClient()

--- a/web/src/hooks/useActionActivity.test.tsx
+++ b/web/src/hooks/useActionActivity.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { createElement, type PropsWithChildren } from "react"
+
+import type { GitHubWorkflowRun } from "@/github-core/types"
+import type { ActionOperation } from "@/util/actionActivity"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, params?: Record<string, unknown>) =>
+        params ? `${key}:${JSON.stringify(params)}` : key,
+    }),
+  }
+})
+vi.mock("@/hooks/useActiveOrg", () => ({ useActiveOrg: () => "acme" }))
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useOptionalGitHubClient: () => ({}),
+}))
+
+const notify = vi.fn()
+vi.mock("@/context/notifications/NotificationProvider", () => ({
+  useOptionalToast: () => ({ notify }),
+}))
+
+// The registry is driven by the test: `ops` is what operationsForOrg returns.
+let ops: ActionOperation[] = []
+const clearOp = vi.fn()
+const dismiss = vi.fn()
+vi.mock("@/context/actions/ActionActivityProvider", () => ({
+  useActionActivityRegistry: () => ({
+    operationsForOrg: () => ops,
+    lastRegisteredAt: () => 0,
+    isDismissed: () => false,
+    dismiss,
+    clearOp,
+  }),
+}))
+
+let runs: GitHubWorkflowRun[] = []
+vi.mock("@/github-core/activityRuns", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/github-core/activityRuns")>()
+  return { ...actual, listActiveAndRecentRuns: async () => runs }
+})
+
+const rerunFailedRun = vi.fn<(...args: unknown[]) => Promise<void>>(
+  async () => undefined,
+)
+vi.mock("@/github-core/mutations", () => ({
+  rerunFailedRun: (...args: unknown[]) => rerunFailedRun(...args),
+}))
+
+// The cancel mutation is a stub whose call-site callbacks the test fires by
+// hand, so the cancel -> retry sequence can be stepped through.
+type CancelCallbacks = {
+  onSuccess?: () => void
+  onError?: (err: unknown) => void
+  onSettled?: () => void
+}
+const cancelMutate =
+  vi.fn<
+    (vars: { org: string; deploymentId: string }, cb: CancelCallbacks) => void
+  >()
+vi.mock("@/hooks/mutations/useCancelPagesDeployment", () => ({
+  useCancelPagesDeployment: () => ({ mutate: cancelMutate }),
+}))
+
+import { useActionActivity } from "./useActionActivity"
+
+const run = (over: Partial<GitHubWorkflowRun>): GitHubWorkflowRun =>
+  ({
+    id: 1,
+    status: "completed",
+    conclusion: "success",
+    event: "push",
+    path: ".github/workflows/publish-pages.yaml",
+    created_at: "2026-09-11T10:00:00Z",
+    run_started_at: "2026-09-11T10:00:00Z",
+    updated_at: "2026-09-11T10:01:00Z",
+    html_url: "https://github.com/acme/classroom50/actions/runs/1",
+    ...over,
+  }) as GitHubWorkflowRun
+
+const publishOp = (id: string, sha: string): ActionOperation => ({
+  id,
+  org: "acme",
+  label: `Publishing ${id}`,
+  anchor: { kind: "sha", sha },
+  startedAt: Date.now(),
+})
+
+let queryClient: QueryClient
+const wrapper = ({ children }: PropsWithChildren) =>
+  createElement(QueryClientProvider, { client: queryClient }, children)
+
+const renderActivity = () => renderHook(() => useActionActivity(), { wrapper })
+
+describe("useActionActivity", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    ops = []
+    runs = []
+    notify.mockReset()
+    clearOp.mockReset()
+    rerunFailedRun.mockClear()
+    cancelMutate.mockReset()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("reads a cancelled publish as superseded when a newer publish succeeded", async () => {
+    ops = [publishOp("op-a", "aaa")]
+    runs = [
+      run({ id: 11, head_sha: "bbb" }),
+      run({ id: 10, head_sha: "aaa", conclusion: "cancelled" }),
+    ]
+    const { result } = renderActivity()
+    await waitFor(() =>
+      expect(result.current.trackers[0]?.phase).toBe("superseded"),
+    )
+    const tracker = result.current.trackers[0]
+    expect(tracker.workflow).toBe("publish-pages.yaml")
+    expect(tracker.dismissible).toBe(true)
+    expect(tracker.retriable).toBe(false)
+    expect(tracker.displayLabel).toBe(
+      'actionsBanner.state.superseded:{"label":"Publishing op-a"}',
+    )
+  })
+
+  it("keeps a cancelled publish failed (and retriable) when the newer publish failed", async () => {
+    ops = [publishOp("op-a", "aaa")]
+    runs = [
+      run({ id: 11, head_sha: "bbb", conclusion: "failure" }),
+      run({ id: 10, head_sha: "aaa", conclusion: "cancelled" }),
+    ]
+    const { result } = renderActivity()
+    await waitFor(() =>
+      expect(result.current.trackers[0]?.phase).toBe("failed"),
+    )
+    expect(result.current.trackers[0].retriable).toBe(true)
+    expect(result.current.anyFailed).toBe(true)
+  })
+
+  it("auto-dismisses once every tracker has succeeded or been superseded", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    ops = [publishOp("op-a", "aaa"), publishOp("op-b", "bbb")]
+    runs = [
+      run({ id: 11, head_sha: "bbb" }),
+      run({ id: 10, head_sha: "aaa", conclusion: "cancelled" }),
+    ]
+    const { result } = renderActivity()
+    await waitFor(() =>
+      expect(result.current.trackers.map((tr) => tr.phase).sort()).toEqual([
+        "success",
+        "superseded",
+      ]),
+    )
+    expect(clearOp).not.toHaveBeenCalled()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8_100)
+    })
+    expect(clearOp.mock.calls.map((c) => c[0]).sort()).toEqual(["op-a", "op-b"])
+  })
+
+  it("unstick cancels the blocker, disables Retry meanwhile, then re-runs once", async () => {
+    ops = [publishOp("op-a", "aaa")]
+    runs = [run({ id: 10, head_sha: "aaa", conclusion: "failure" })]
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderActivity()
+    await waitFor(() =>
+      expect(result.current.trackers[0]?.retriable).toBe(true),
+    )
+
+    act(() => result.current.unstick("op-a", "656e8d"))
+    expect(cancelMutate).toHaveBeenCalledTimes(1)
+    expect(cancelMutate.mock.calls[0][0]).toEqual({
+      org: "acme",
+      deploymentId: "656e8d",
+    })
+    expect(result.current.busy.has("op-a")).toBe(true)
+    expect(result.current.unsticking.has("op-a")).toBe(true)
+
+    // Retry (and a second unstick) are no-ops while the cancel is in flight.
+    act(() => result.current.retry("op-a"))
+    act(() => result.current.unstick("op-a", "656e8d"))
+    expect(rerunFailedRun).not.toHaveBeenCalled()
+    expect(cancelMutate).toHaveBeenCalledTimes(1)
+
+    const callbacks = cancelMutate.mock.calls[0][1]
+    act(() => {
+      callbacks.onSuccess?.()
+      callbacks.onSettled?.()
+    })
+    await waitFor(() => expect(rerunFailedRun).toHaveBeenCalledTimes(1))
+    expect(rerunFailedRun.mock.calls[0].slice(1)).toEqual(["acme", 10])
+    await waitFor(() => expect(result.current.busy.has("op-a")).toBe(false))
+    // A retry re-reads the run's annotations (same run id after
+    // rerun-failed-jobs) as well as the run list.
+    expect(
+      invalidate.mock.calls.some(
+        (c) =>
+          JSON.stringify(c[0]?.queryKey) ===
+          JSON.stringify(["github", "run-annotations", "acme", 10]),
+      ),
+    ).toBe(true)
+  })
+
+  it("reports a failed cancel through the toast and does not re-run", async () => {
+    ops = [publishOp("op-a", "aaa")]
+    runs = [run({ id: 10, head_sha: "aaa", conclusion: "failure" })]
+    const { result } = renderActivity()
+    await waitFor(() =>
+      expect(result.current.trackers[0]?.retriable).toBe(true),
+    )
+    act(() => result.current.unstick("op-a", "656e8d"))
+    const callbacks = cancelMutate.mock.calls[0][1]
+    act(() => {
+      callbacks.onError?.(new Error("Forbidden"))
+      callbacks.onSettled?.()
+    })
+    expect(rerunFailedRun).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(notify.mock.calls[0][0]).toMatchObject({
+      tone: "error",
+      message: expect.stringContaining(
+        "actionsBanner.publishFailure.unstickFailed",
+      ),
+    })
+    expect(result.current.busy.has("op-a")).toBe(false)
+  })
+})

--- a/web/src/hooks/useActionActivity.ts
+++ b/web/src/hooks/useActionActivity.ts
@@ -64,8 +64,8 @@ export type Tracker = {
   htmlUrl?: string
   // Resolved run id, when known — enables retry.
   runId?: number
-  // Workflow file of the bound run (e.g., "publish-pages.yaml"); lets the banner
-  // offer workflow-specific failure detail. Absent while pending.
+  // Workflow file of the run (e.g., "publish-pages.yaml"), so the banner can
+  // show workflow-specific failure detail.
   workflow?: string
   // Terminal session-op trackers can be dismissed; discovered/non-terminal can't.
   dismissible: boolean
@@ -360,7 +360,7 @@ export function useActionActivity(): ActionActivity {
             ? workflowFile(run)
             : op.anchor.kind === "sinceRunId"
               ? op.anchor.workflow
-              : // A sha anchor is always a config-repo push, i.e. a publish.
+              : // A sha anchor is a config-repo push, i.e. a publish.
                 PUBLISH_PAGES_WORKFLOW,
         // Terminal ops persist as history and can be dismissed; running/pending can't.
         dismissible: isTerminalPhase(phase),

--- a/web/src/hooks/useActionActivity.ts
+++ b/web/src/hooks/useActionActivity.ts
@@ -8,11 +8,14 @@ import {
   listActiveAndRecentRuns,
 } from "@/github-core/activityRuns"
 import { rerunFailedRun } from "@/github-core/mutations"
+import { githubKeys } from "@/github-core/queries"
 import type { GitHubWorkflowRun } from "@/github-core/types"
 import { PUBLISH_PAGES_WORKFLOW } from "@/github-core/workflows"
 import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
 import { useOptionalToast } from "@/context/notifications/NotificationProvider"
 import { useActiveOrg } from "@/hooks/useActiveOrg"
+import { useCancelPagesDeployment } from "@/hooks/mutations/useCancelPagesDeployment"
+import { errorText } from "@/types/localizedMessage"
 import {
   isRunning,
   isTerminalPhase,
@@ -87,8 +90,13 @@ export type ActionActivity = {
   pollError: boolean
   dismiss: (id: string) => void
   retry: (id: string) => void
-  // Tracker ids with a retry in flight (spinner / disabled X).
-  retrying: ReadonlySet<string>
+  // Cancel the Pages deployment blocking a failed publish, then retry it.
+  unstick: (id: string, blockerSha: string) => void
+  // Tracker ids with a retry or an unstick in flight (spinner / disabled
+  // actions). One set so the row's Retry and unstick disable together.
+  busy: ReadonlySet<string>
+  // The subset of `busy` whose unstick (the cancel step) is in flight.
+  unsticking: ReadonlySet<string>
 }
 
 // Drives the global activity banner: one repo-wide poll advances a collection of
@@ -124,9 +132,12 @@ export function useActionActivity(): ActionActivity {
     [],
   )
 
-  // `retrying`: in-flight retry requests (spinner + double-submit guard).
-  // `optimisticRunning`: ids shown "running" right after a retry.
+  // `retrying` / `unsticking`: in-flight retry and cancel requests (spinner +
+  // double-submit guard). `optimisticRunning`: ids shown "running" right after
+  // a retry.
   const [retrying, setRetrying] = useState<Set<string>>(new Set())
+  const [unsticking, setUnsticking] = useState<Set<string>>(new Set())
+  const cancelDeployment = useCancelPagesDeployment()
   const [optimisticRunning, setOptimisticRunning] = useState<Set<string>>(
     new Set(),
   )
@@ -188,7 +199,7 @@ export function useActionActivity(): ActionActivity {
         durationMs: 8000,
       })
     },
-    onSettled: (_data, _err, { trackerId }) => {
+    onSettled: (_data, _err, { trackerId, runId }) => {
       setRetrying((prev) => {
         const next = new Set(prev)
         next.delete(trackerId)
@@ -197,6 +208,11 @@ export function useActionActivity(): ActionActivity {
       if (org) {
         void queryClient.invalidateQueries({
           queryKey: activityRunsKey(org),
+        })
+        // rerun-failed-jobs keeps the run id, so the failure detail's cached
+        // annotations would otherwise describe the previous attempt.
+        void queryClient.invalidateQueries({
+          queryKey: githubKeys.runAnnotations(org, runId),
         })
       }
     },
@@ -460,8 +476,10 @@ export function useActionActivity(): ActionActivity {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [optimisticSignature, phaseSignature])
 
-  const retry = (id: string) => {
-    if (retrying.has(id)) return
+  // The retry proper, past the busy guards. Shared by `retry` and by `unstick`
+  // once its cancel has resolved; read through a ref there so the post-await
+  // call sees the current trackers, not the click-time closure.
+  const startRetry = (id: string) => {
     const tracker = trackers.find((tr) => tr.id === id)
     if (!tracker?.retriable || tracker.runId === undefined || !org || !client) {
       return
@@ -484,6 +502,53 @@ export function useActionActivity(): ActionActivity {
     bumpExpecting()
     retryMutation.mutate({ trackerId: id, runId: tracker.runId })
   }
+  const startRetryRef = useRef(startRetry)
+  useEffect(() => {
+    startRetryRef.current = startRetry
+  })
+
+  const isBusy = (id: string) => retrying.has(id) || unsticking.has(id)
+
+  const retry = (id: string) => {
+    if (isBusy(id)) return
+    startRetry(id)
+  }
+
+  // Cancel the Pages deployment GitHub named as blocking this publish, then
+  // retry. Both steps share the busy set so the row's Retry can't fire a second
+  // re-run mid-cancel. A failed cancel is reported like a failed retry; the row
+  // keeps its lock wording and the blocker probe keeps polling.
+  const unstick = (id: string, blockerSha: string) => {
+    if (isBusy(id) || !org) return
+    const tracker = trackers.find((tr) => tr.id === id)
+    if (!tracker?.retriable) return
+    setUnsticking((prev) => new Set(prev).add(id))
+    cancelDeployment.mutate(
+      { org, deploymentId: blockerSha },
+      {
+        onSuccess: () => startRetryRef.current(id),
+        onError: (err) => {
+          toast?.notify({
+            tone: "error",
+            message: t("actionsBanner.publishFailure.unstickFailed", {
+              detail: errorText(t, err),
+            }),
+            key: `actionsBanner.unstickFailed.${id}`,
+            durationMs: 8000,
+          })
+        },
+        onSettled: () => {
+          setUnsticking((prev) => {
+            const next = new Set(prev)
+            next.delete(id)
+            return next
+          })
+        },
+      },
+    )
+  }
+
+  const busy = new Set([...retrying, ...unsticking])
 
   const anyFailed = trackers.some((tr) => tr.phase === "failed")
 
@@ -523,6 +588,8 @@ export function useActionActivity(): ActionActivity {
     pollError,
     dismiss,
     retry,
-    retrying,
+    unstick,
+    busy,
+    unsticking,
   }
 }

--- a/web/src/hooks/useActionActivity.ts
+++ b/web/src/hooks/useActionActivity.ts
@@ -9,11 +9,13 @@ import {
 } from "@/github-core/activityRuns"
 import { rerunFailedRun } from "@/github-core/mutations"
 import type { GitHubWorkflowRun } from "@/github-core/types"
+import { PUBLISH_PAGES_WORKFLOW } from "@/github-core/workflows"
 import { useActionActivityRegistry } from "@/context/actions/ActionActivityProvider"
 import { useOptionalToast } from "@/context/notifications/NotificationProvider"
 import { useActiveOrg } from "@/hooks/useActiveOrg"
 import {
   isRunning,
+  isTerminalPhase,
   nowMs,
   PHASE_LABEL_KEY,
   resolveOpRun,
@@ -62,6 +64,9 @@ export type Tracker = {
   htmlUrl?: string
   // Resolved run id, when known — enables retry.
   runId?: number
+  // Workflow file of the bound run (e.g., "publish-pages.yaml"); lets the banner
+  // offer workflow-specific failure detail. Absent while pending.
+  workflow?: string
   // Terminal session-op trackers can be dismissed; discovered/non-terminal can't.
   dismissible: boolean
   // A failed run with a known runId can be retried.
@@ -236,7 +241,7 @@ export function useActionActivity(): ActionActivity {
       run = resolveOpRun(op, allRuns, claimed)
       if (run) claimed.add(run.id)
     }
-    const realPhase = trackerPhase(run)
+    const realPhase = trackerPhase(run, allRuns)
     // Show "running" optimistically until the poll sees the re-run in flight.
     let phase =
       optimisticRunning.has(op.id) && realPhase !== "running"
@@ -245,10 +250,7 @@ export function useActionActivity(): ActionActivity {
     // Latch a terminal phase so a finished tracker survives its run scrolling
     // out of the window (which would otherwise revert it to pending and GC it).
     const latched = latchedPhase[op.id]
-    if (
-      phase === "pending" &&
-      (latched === "failed" || latched === "success")
-    ) {
+    if (phase === "pending" && latched && isTerminalPhase(latched)) {
       phase = latched
     }
     return { op, run, phase, realPhase }
@@ -288,9 +290,9 @@ export function useActionActivity(): ActionActivity {
         const carried = prev[op.id]
         // Keep an existing terminal latch; else adopt a newly-terminal phase.
         const value =
-          carried === "failed" || carried === "success"
+          carried && isTerminalPhase(carried)
             ? carried
-            : phase === "failed" || phase === "success"
+            : isTerminalPhase(phase)
               ? phase
               : undefined
         if (value !== undefined) next[op.id] = value
@@ -353,8 +355,15 @@ export function useActionActivity(): ActionActivity {
             ? runUrl(org, stableRunId)
             : undefined),
         runId: stableRunId,
+        workflow:
+          run !== null
+            ? workflowFile(run)
+            : op.anchor.kind === "sinceRunId"
+              ? op.anchor.workflow
+              : // A sha anchor is always a config-repo push, i.e. a publish.
+                PUBLISH_PAGES_WORKFLOW,
         // Terminal ops persist as history and can be dismissed; running/pending can't.
-        dismissible: phase === "success" || phase === "failed",
+        dismissible: isTerminalPhase(phase),
         retriable: phase === "failed" && stableRunId !== undefined,
         startedAtMs: times.startedAtMs,
         endedAtMs: times.endedAtMs,
@@ -379,6 +388,7 @@ export function useActionActivity(): ActionActivity {
         phase: "running" as TrackerPhase,
         htmlUrl: r.html_url,
         runId: r.id,
+        workflow: file,
         dismissible: false,
         retriable: false,
         startedAtMs: times.startedAtMs,
@@ -429,7 +439,12 @@ export function useActionActivity(): ActionActivity {
           realPhase === "failed" &&
           run !== null &&
           (runTimes(run).endedAtMs ?? 0) >= (retriedAt[id] ?? 0)
-        if (realPhase === "running" || realPhase === "success" || reFailed) {
+        if (
+          realPhase === "running" ||
+          realPhase === "success" ||
+          realPhase === "superseded" ||
+          reFailed
+        ) {
           next.delete(id)
           changed = true
         }
@@ -472,16 +487,17 @@ export function useActionActivity(): ActionActivity {
 
   const anyFailed = trackers.some((tr) => tr.phase === "failed")
 
-  // All-green auto-dismiss: when every tracker has succeeded (no failed,
-  // running, or pending — discovered runs are always "running", so they gate
-  // this too, and every id here is a session op), flash the green state
-  // briefly, then clearOp each so the banner clears itself. clearOp (not
+  // All-green auto-dismiss: when every tracker has succeeded or been superseded
+  // (no failed, running, or pending — discovered runs are always "running", so
+  // they gate this too, and every id here is a session op), flash the green
+  // state briefly, then clearOp each so the banner clears itself. clearOp (not
   // dismiss) forgets the op entirely — it's terminal history the teacher never
   // needs again — which also drops it from operationsForOrg so the idle poll
   // can stop instead of ticking until the op's TTL. Keyed off the phase
   // signature so a new/failed action cancels the pending timer.
   const allSucceeded =
-    trackers.length > 0 && trackers.every((tr) => tr.phase === "success")
+    trackers.length > 0 &&
+    trackers.every((tr) => tr.phase === "success" || tr.phase === "superseded")
   const successIds = allSucceeded ? trackers.map((tr) => tr.id) : []
   const successSignature = successIds.join(",")
   useEffect(() => {

--- a/web/src/hooks/usePublishFailureDetail.test.tsx
+++ b/web/src/hooks/usePublishFailureDetail.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { createElement, type PropsWithChildren } from "react"
+
+vi.mock("@/context/github/GitHubProvider", () => ({
+  useOptionalGitHubClient: () => ({}),
+}))
+
+const getRunAnnotations = vi.fn()
+const getPagesDeploymentStatus = vi.fn()
+vi.mock("@/github-core/queries", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/github-core/queries")>()
+  return {
+    ...actual,
+    getRunAnnotations: (...args: unknown[]) => getRunAnnotations(...args),
+    getPagesDeploymentStatus: (...args: unknown[]) =>
+      getPagesDeploymentStatus(...args),
+  }
+})
+
+import { usePublishFailureDetail } from "./usePublishFailureDetail"
+
+const wrapper = ({ children }: PropsWithChildren) =>
+  createElement(
+    QueryClientProvider,
+    {
+      client: new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      }),
+    },
+    children,
+  )
+
+const BLOCKER = "656e8d140b36230c9ccfe14584b9a81fa8c9c8d0"
+const lockAnnotation = {
+  level: "failure",
+  message: `Failed to create deployment (status: 400) with build version 8f00. Responded with: Deployment request failed for 8f00 due to in progress deployment. Please cancel ${BLOCKER} first or wait for it to complete.`,
+}
+
+describe("usePublishFailureDetail", () => {
+  beforeEach(() => {
+    getRunAnnotations.mockReset()
+    getPagesDeploymentStatus.mockReset()
+  })
+
+  it("reads nothing without a run id", () => {
+    const { result } = renderHook(
+      () => usePublishFailureDetail("acme", undefined),
+      { wrapper },
+    )
+    expect(result.current).toEqual({ state: "unknown" })
+    expect(getRunAnnotations).not.toHaveBeenCalled()
+  })
+
+  it("names the deploy lock and probes the blocking deployment", async () => {
+    getRunAnnotations.mockResolvedValue([lockAnnotation])
+    getPagesDeploymentStatus.mockResolvedValue("updating_pages")
+
+    const { result } = renderHook(() => usePublishFailureDetail("acme", 77), {
+      wrapper,
+    })
+    expect(result.current).toEqual({ state: "loading" })
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        state: "known",
+        failure: { kind: "deployLocked", blockerSha: BLOCKER },
+        blockerInProgress: true,
+      }),
+    )
+    expect(getPagesDeploymentStatus.mock.calls[0].slice(1, 3)).toEqual([
+      "acme",
+      BLOCKER,
+    ])
+  })
+
+  it("reports the lock as cleared once GitHub no longer holds the blocker", async () => {
+    getRunAnnotations.mockResolvedValue([lockAnnotation])
+    // 404 -> null: the deployment expired or was cancelled.
+    getPagesDeploymentStatus.mockResolvedValue(null)
+
+    const { result } = renderHook(() => usePublishFailureDetail("acme", 77), {
+      wrapper,
+    })
+    await waitFor(() =>
+      expect(result.current).toMatchObject({
+        state: "known",
+        blockerInProgress: false,
+      }),
+    )
+  })
+
+  it("does not probe for a cause other than the lock", async () => {
+    getRunAnnotations.mockResolvedValue([
+      { level: "failure", message: "Timeout reached, aborting!" },
+    ])
+    const { result } = renderHook(() => usePublishFailureDetail("acme", 77), {
+      wrapper,
+    })
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        state: "known",
+        failure: { kind: "timeout" },
+      }),
+    )
+    expect(getPagesDeploymentStatus).not.toHaveBeenCalled()
+  })
+
+  it("falls back to unknown when the annotations name no known cause or can't be read", async () => {
+    getRunAnnotations.mockResolvedValue([
+      { level: "failure", message: "Process completed with exit code 1." },
+    ])
+    const first = renderHook(() => usePublishFailureDetail("acme", 77), {
+      wrapper,
+    })
+    await waitFor(() =>
+      expect(first.result.current).toEqual({ state: "unknown" }),
+    )
+
+    getRunAnnotations.mockRejectedValue(new Error("403"))
+    const second = renderHook(() => usePublishFailureDetail("acme", 78), {
+      wrapper,
+    })
+    await waitFor(() =>
+      expect(second.result.current).toEqual({ state: "unknown" }),
+    )
+  })
+})

--- a/web/src/hooks/usePublishFailureDetail.ts
+++ b/web/src/hooks/usePublishFailureDetail.ts
@@ -1,0 +1,90 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { useOptionalGitHubClient } from "@/context/github/GitHubProvider"
+import {
+  getPagesDeploymentStatus,
+  getRunAnnotations,
+  githubKeys,
+  isPagesDeploymentInProgress,
+} from "@/github-core/queries"
+import {
+  classifyPublishFailure,
+  type PublishFailure,
+} from "@/util/actionActivity"
+
+// While a blocking Pages deployment is still in progress, re-read its status on
+// this cadence so the row flips to "cleared, retry now" on its own. GitHub
+// releases a stuck deployment within about 10 minutes.
+const BLOCKER_POLL_MS = 15_000
+
+export type PublishFailureDetail =
+  | { state: "loading" }
+  // The annotations named no known cause (or could not be read): the run link
+  // is the only detail on offer.
+  | { state: "unknown" }
+  | {
+      state: "known"
+      failure: PublishFailure
+      // Only for deployLocked: whether the blocking deployment still holds the
+      // lock. `undefined` while the probe is in flight or unreadable, in which
+      // case the row keeps the cautious "still finishing" wording.
+      blockerInProgress?: boolean
+    }
+
+// Why a failed publish run failed, from the deploy job's annotations, plus a
+// live probe of the blocking deployment when the cause is GitHub's one-at-a-
+// time Pages lock. Reads only once a run has failed; `runId` undefined
+// disables everything.
+export function usePublishFailureDetail(
+  org: string | undefined,
+  runId: number | undefined,
+): PublishFailureDetail {
+  const client = useOptionalGitHubClient()
+  const enabled = Boolean(client && org && runId !== undefined)
+
+  const annotations = useQuery({
+    queryKey: githubKeys.runAnnotations(org ?? "", runId ?? 0),
+    queryFn: ({ signal }) =>
+      getRunAnnotations(client!, org ?? "", runId ?? 0, signal),
+    enabled,
+    // A completed run's annotations never change.
+    staleTime: Infinity,
+    retry: false,
+  })
+
+  const failure = annotations.data
+    ? classifyPublishFailure(annotations.data)
+    : undefined
+  const blockerSha =
+    failure?.kind === "deployLocked" ? failure.blockerSha : undefined
+
+  const blocker = useQuery({
+    queryKey: githubKeys.pagesDeployment(org ?? "", blockerSha ?? ""),
+    queryFn: ({ signal }) =>
+      getPagesDeploymentStatus(client!, org ?? "", blockerSha ?? "", signal),
+    enabled: enabled && blockerSha !== undefined,
+    staleTime: 0,
+    refetchInterval: (query) => {
+      const status = query.state.data
+      // null = GitHub no longer has it, so the lock is gone.
+      if (status === undefined) return BLOCKER_POLL_MS
+      return status !== null && isPagesDeploymentInProgress(status)
+        ? BLOCKER_POLL_MS
+        : false
+    },
+    retry: false,
+  })
+
+  if (!enabled) return { state: "unknown" }
+  if (annotations.isPending) return { state: "loading" }
+  if (!failure) return { state: "unknown" }
+  if (failure.kind !== "deployLocked") return { state: "known", failure }
+
+  const blockerInProgress =
+    blocker.data === undefined
+      ? undefined
+      : blocker.data !== null && isPagesDeploymentInProgress(blocker.data)
+  return { state: "known", failure, blockerInProgress }
+}
+
+export default usePublishFailureDetail

--- a/web/src/hooks/usePublishFailureDetail.ts
+++ b/web/src/hooks/usePublishFailureDetail.ts
@@ -12,29 +12,24 @@ import {
   type PublishFailure,
 } from "@/util/actionActivity"
 
-// While a blocking Pages deployment is still in progress, re-read its status on
-// this cadence so the row flips to "cleared, retry now" on its own. GitHub
-// releases a stuck deployment within about 10 minutes.
+// Re-read a blocking deployment on this cadence so the row flips to "cleared"
+// on its own once GitHub releases it.
 const BLOCKER_POLL_MS = 15_000
 
 export type PublishFailureDetail =
   | { state: "loading" }
-  // The annotations named no known cause (or could not be read): the run link
-  // is the only detail on offer.
+  // No known cause in the annotations (or they couldn't be read).
   | { state: "unknown" }
   | {
       state: "known"
       failure: PublishFailure
-      // Only for deployLocked: whether the blocking deployment still holds the
-      // lock. `undefined` while the probe is in flight or unreadable, in which
-      // case the row keeps the cautious "still finishing" wording.
+      // deployLocked only. `undefined` while the probe is in flight or
+      // unreadable, which keeps the cautious "still finishing" wording.
       blockerInProgress?: boolean
     }
 
-// Why a failed publish run failed, from the deploy job's annotations, plus a
-// live probe of the blocking deployment when the cause is GitHub's one-at-a-
-// time Pages lock. Reads only once a run has failed; `runId` undefined
-// disables everything.
+// Why a failed publish run failed, plus a live probe of the blocking deployment
+// when the cause is the Pages lock. `runId` undefined disables both reads.
 export function usePublishFailureDetail(
   org: string | undefined,
   runId: number | undefined,
@@ -66,7 +61,6 @@ export function usePublishFailureDetail(
     staleTime: 0,
     refetchInterval: (query) => {
       const status = query.state.data
-      // null = GitHub no longer has it, so the lock is gone.
       if (status === undefined) return BLOCKER_POLL_MS
       return status !== null && isPagesDeploymentInProgress(status)
         ? BLOCKER_POLL_MS

--- a/web/src/lib/activity/timeline.ts
+++ b/web/src/lib/activity/timeline.ts
@@ -107,6 +107,9 @@ const runStatusMap = {
   running: "running",
   success: "ok",
   failed: "error",
+  // A publish GitHub cancelled in favor of a newer one: neither an error nor
+  // a success of its own.
+  superseded: "info",
 } as const
 
 export function runToItem(
@@ -115,10 +118,13 @@ export function runToItem(
     file: string | undefined,
     fallback: string | undefined,
   ) => string,
+  // The listed window; lets a publish GitHub cancelled for a newer one read as
+  // superseded rather than as an error.
+  allRuns?: readonly GitHubWorkflowRun[],
 ): TimelineItem {
   const { startedAtMs } = runTimes(run)
   const createdMs = Date.parse(run.created_at)
-  const phase = trackerPhase(run)
+  const phase = trackerPhase(run, allRuns)
   return {
     id: `run-${run.id}`,
     source: "run",

--- a/web/src/lib/activity/timeline.ts
+++ b/web/src/lib/activity/timeline.ts
@@ -107,8 +107,6 @@ const runStatusMap = {
   running: "running",
   success: "ok",
   failed: "error",
-  // A publish GitHub cancelled in favor of a newer one: neither an error nor
-  // a success of its own.
   superseded: "info",
 } as const
 
@@ -118,8 +116,7 @@ export function runToItem(
     file: string | undefined,
     fallback: string | undefined,
   ) => string,
-  // The listed window; lets a publish GitHub cancelled for a newer one read as
-  // superseded rather than as an error.
+  // The listed window, so a cancelled publish can read as superseded.
   allRuns?: readonly GitHubWorkflowRun[],
 ): TimelineItem {
   const { startedAtMs } = runTimes(run)

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -155,7 +155,19 @@
       "pending": "{{label}}: starting…",
       "running": "{{label}}…",
       "success": "{{label}}: done",
-      "failed": "{{label}}: failed"
+      "failed": "{{label}}: failed",
+      "superseded": "{{label}}: included in a newer publish"
+    },
+    "publishFailure": {
+      "deployLocked": "GitHub Pages is still finishing an earlier publish, so this one couldn't start. Your change is saved. The earlier publish usually clears within 10 minutes: retry then, or cancel it now.",
+      "deployLockCleared": "The earlier publish that blocked this one has finished. Your change is saved. Retry to publish it now.",
+      "unstick": "Cancel the stuck publish and retry",
+      "unsticking": "Cancelling…",
+      "unstickFailed": "Couldn't cancel the earlier publish: {{detail}}",
+      "pagesDisabled": "GitHub Pages is turned off for the classroom50 repository, so nothing can reach the student site. Your change is saved. Re-run setup in the organization's settings to turn Pages back on, then retry.",
+      "permission": "The publish workflow isn't allowed to write to GitHub Pages. Your change is saved. Update the organization's workflow files (a banner appears when an update is available), then retry.",
+      "timeout": "GitHub Pages didn't finish deploying within 10 minutes. Your change is saved. This is usually a GitHub slowdown: retry, and check githubstatus.com if it keeps happening.",
+      "outage": "GitHub Pages returned a server error. Your change is saved. Check githubstatus.com, then retry."
     },
     "workflow": {
       "publishPages": "Publishing to student site",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -163,7 +163,7 @@
       "deployLockCleared": "The earlier publish that blocked this one has finished. Your change is saved. Retry to publish it now.",
       "unstick": "Cancel the stuck publish and retry",
       "unsticking": "Cancelling…",
-      "unstickFailed": "Couldn't cancel the earlier publish: {{detail}}",
+      "unstickFailed": "Couldn't cancel the earlier publish: {{detail}}. It clears on its own within about 10 minutes. Retry then.",
       "pagesDisabled": "GitHub Pages is turned off for the classroom50 repository, so nothing can reach the student site. Your change is saved. Re-run setup in the organization's settings to turn Pages back on, then retry.",
       "permission": "The publish workflow isn't allowed to write to GitHub Pages. Your change is saved. Update the organization's workflow files (a banner appears when an update is available), then retry.",
       "timeout": "GitHub Pages didn't finish deploying within 10 minutes. Your change is saved. This is usually a GitHub slowdown: retry, and check githubstatus.com if it keeps happening.",
@@ -1879,7 +1879,7 @@
       "button": "Publish again",
       "help": "Redeploys the site from the classroom50 repository as it stands, without changing anything in it. Use it when a file below shows Not published or Unreachable after a failed publish.",
       "started": "Publishing to the student site now. The banner above tracks progress.",
-      "failed": "Couldn't start the publish: {{detail}}"
+      "failed": "Couldn't start the publish: {{detail}}. Check that you can run workflows in the classroom50 repository, then try again."
     },
     "customBase": "This classroom publishes to <path>{{base}}/</path> instead of the site above.",
     "noClassrooms": "No classrooms yet. Files appear here after a classroom publishes.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1875,6 +1875,12 @@
     "fileCount_one": "{{count}} file",
     "fileCount_other": "{{count}} files",
     "siteTitle": "Your public site",
+    "republish": {
+      "button": "Publish again",
+      "help": "Redeploys the site from the classroom50 repository as it stands, without changing anything in it. Use it when a file below shows Not published or Unreachable after a failed publish.",
+      "started": "Publishing to the student site now. The banner above tracks progress.",
+      "failed": "Couldn't start the publish: {{detail}}"
+    },
     "customBase": "This classroom publishes to <path>{{base}}/</path> instead of the site above.",
     "noClassrooms": "No classrooms yet. Files appear here after a classroom publishes.",
     "status": {

--- a/web/src/pages/OrgActivityPage.tsx
+++ b/web/src/pages/OrgActivityPage.tsx
@@ -91,7 +91,9 @@ const OrgActivityPage = () => {
   const items = useMemo(() => {
     const sessionItems = sessionToItems(entries)
     const commitItems = (commits.data ?? []).map(commitToItem)
-    const runItems = (runs.data ?? []).map((r) => runToItem(r, runLabel))
+    const runItems = (runs.data ?? []).map((r) =>
+      runToItem(r, runLabel, runs.data),
+    )
     const merged = mergeTimeline(
       [...sessionItems, ...commitItems, ...runItems],
       {

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -415,10 +415,8 @@ function ClassroomFolder({
   )
 }
 
-// Owner-only "Publish again": dispatches publish-pages.yaml so the site is
-// redeployed from the repo as it stands. The only way to refresh the site
-// without committing something, which is what a teacher needs after a failed
-// or stuck deploy. The Actions banner tracks the run (registered by the hook).
+// Owner-only: redeploys the site from the repo as it stands, the only way to
+// refresh it without a commit. The hook registers the run with the banner.
 function RepublishButton({ org }: { org: string }) {
   const { t } = useTranslation()
   const { notify } = useToast()

--- a/web/src/pages/PublishedResourcesPage.tsx
+++ b/web/src/pages/PublishedResourcesPage.tsx
@@ -11,6 +11,7 @@ import {
   GlobeIcon,
   LinkExternalIcon,
   ShieldXIcon,
+  SyncIcon,
   rtlFlip,
 } from "@/components/ui/icons"
 import { Trans, useTranslation } from "react-i18next"
@@ -33,6 +34,10 @@ import useGetClasses from "@/hooks/useGetClasses"
 import useGetClassroom from "@/hooks/useGetClassroom"
 import usePagesAssignments from "@/hooks/usePagesAssignments"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
+import { useRepublishSite } from "@/hooks/mutations/useRepublishSite"
+import { useIsOrgOwner } from "@/context/githubOrgRole/useIsOrgOwner"
+import { useToast } from "@/context/notifications/NotificationProvider"
+import { errorText } from "@/types/localizedMessage"
 import { classroomPagesSegment } from "@/util/secret"
 import { githubOrgUrl } from "@/util/orgUrl"
 import { defaultPagesBaseUrl } from "@/github-core/queries"
@@ -410,10 +415,56 @@ function ClassroomFolder({
   )
 }
 
+// Owner-only "Publish again": dispatches publish-pages.yaml so the site is
+// redeployed from the repo as it stands. The only way to refresh the site
+// without committing something, which is what a teacher needs after a failed
+// or stuck deploy. The Actions banner tracks the run (registered by the hook).
+function RepublishButton({ org }: { org: string }) {
+  const { t } = useTranslation()
+  const { notify } = useToast()
+  const republish = useRepublishSite()
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        variant="outline"
+        size="sm"
+        loading={republish.isPending}
+        busyLabel={t("published.republish.button")}
+        onClick={() =>
+          republish.mutate(
+            { org, label: t("actionsBanner.workflow.publishPages") },
+            {
+              onSuccess: () =>
+                notify({
+                  tone: "success",
+                  durationMs: 6000,
+                  message: t("published.republish.started"),
+                }),
+              onError: (err) =>
+                notify({
+                  tone: "error",
+                  durationMs: 8000,
+                  message: t("published.republish.failed", {
+                    detail: errorText(t, err),
+                  }),
+                }),
+            },
+          )
+        }
+      >
+        <SyncIcon aria-hidden="true" className="size-4" />
+        {t("published.republish.button")}
+      </Button>
+      <HelpTooltip help={t("published.republish.help")} />
+    </div>
+  )
+}
+
 export const PublishedResourcesPane = ({ org }: { org: string }) => {
   const { t } = useTranslation()
   const base = defaultPagesBaseUrl(org)
   const { classes, isLoading: classesLoading } = useGetClasses(org)
+  const { isOwner } = useIsOrgOwner()
 
   // Site-root files are classroom-independent: the public index and the two
   // generic engine scripts served at the Pages site root.
@@ -468,6 +519,11 @@ export const PublishedResourcesPane = ({ org }: { org: string }) => {
         <p className="mt-2 text-sm text-base-content/70">
           {t("published.publicNote")}
         </p>
+        {isOwner && (
+          <div className="mt-3">
+            <RepublishButton org={org} />
+          </div>
+        )}
       </section>
 
       <section className="divide-y divide-base-300 rounded-box border border-base-300 bg-base-100">

--- a/web/src/util/actionActivity.test.ts
+++ b/web/src/util/actionActivity.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  classifyPublishFailure,
   isFailureConclusion,
   isRunning,
+  isSupersededPublish,
+  isTerminalPhase,
   orgFromPathname,
   PHASE_LABEL_KEY,
   resolveOpRun,
@@ -257,6 +260,131 @@ describe("trackerPhase", () => {
       trackerPhase(run({ status: "completed", conclusion: "skipped" })),
     ).toBe("success")
   })
+
+  it("is superseded for a cancelled publish when a newer publish run exists", () => {
+    const cancelled = publishRun(10, { conclusion: "cancelled" })
+    const newer = publishRun(11, { conclusion: "success" })
+    expect(trackerPhase(cancelled, [newer, cancelled])).toBe("superseded")
+  })
+
+  it("stays failed for a cancelled publish without the run window", () => {
+    const cancelled = publishRun(10, { conclusion: "cancelled" })
+    expect(trackerPhase(cancelled)).toBe("failed")
+  })
+})
+
+// A completed publish-pages run (push-triggered), by id.
+const publishRun = (
+  id: number,
+  over: Partial<GitHubWorkflowRun> = {},
+): GitHubWorkflowRun =>
+  run({
+    id,
+    status: "completed",
+    path: ".github/workflows/publish-pages.yaml",
+    ...over,
+  })
+
+describe("isSupersededPublish", () => {
+  it("is true only for a cancelled publish with a newer publish run in the window", () => {
+    const cancelled = publishRun(10, { conclusion: "cancelled" })
+    expect(
+      isSupersededPublish(cancelled, [
+        publishRun(11, { conclusion: "success" }),
+      ]),
+    ).toBe(true)
+    // A newer run of ANOTHER workflow doesn't carry the publish.
+    expect(
+      isSupersededPublish(cancelled, [
+        dispatchRun(11, "collect-scores.yaml", {
+          status: "completed",
+          conclusion: "success",
+        }),
+      ]),
+    ).toBe(false)
+    // Only older publish runs: a real cancellation, not a superseded one.
+    expect(
+      isSupersededPublish(cancelled, [
+        publishRun(9, { conclusion: "success" }),
+      ]),
+    ).toBe(false)
+  })
+
+  it("never applies to a failed (not cancelled) publish or a non-publish run", () => {
+    const newer = publishRun(11, { conclusion: "success" })
+    expect(
+      isSupersededPublish(publishRun(10, { conclusion: "failure" }), [newer]),
+    ).toBe(false)
+    expect(
+      isSupersededPublish(
+        dispatchRun(10, "regrade.yaml", {
+          status: "completed",
+          conclusion: "cancelled",
+        }),
+        [newer],
+      ),
+    ).toBe(false)
+  })
+})
+
+describe("isTerminalPhase", () => {
+  it("is true for success, failed, and superseded only", () => {
+    expect(isTerminalPhase("success")).toBe(true)
+    expect(isTerminalPhase("failed")).toBe(true)
+    expect(isTerminalPhase("superseded")).toBe(true)
+    expect(isTerminalPhase("pending")).toBe(false)
+    expect(isTerminalPhase("running")).toBe(false)
+  })
+})
+
+describe("classifyPublishFailure", () => {
+  // Verbatim from issue #949: deploy-pages appends GitHub's 400 body.
+  const lockMessage =
+    "Failed to create deployment (status: 400) with build version 8f002501dc9b122a62c6bbebfa810de786430a71. Request ID 1C00:D9342:6FA1D4:966BBD:6AA2954D Responded with: Deployment request failed for 8f002501dc9b122a62c6bbebfa810de786430a71 due to in progress deployment. Please cancel 656e8d140b36230c9ccfe14584b9a81fa8c9c8d0 first or wait for it to complete."
+
+  it("reads GitHub's in-progress lock and extracts the blocking sha", () => {
+    expect(
+      classifyPublishFailure([{ level: "failure", message: lockMessage }]),
+    ).toEqual({
+      kind: "deployLocked",
+      blockerSha: "656e8d140b36230c9ccfe14584b9a81fa8c9c8d0",
+    })
+  })
+
+  it("maps deploy-pages' other refusals to their kinds", () => {
+    const cases: [string, string][] = [
+      [
+        "Failed to create deployment (status: 404) with build version abc. Ensure GitHub Pages has been enabled: https://github.com/acme/classroom50/settings/pages",
+        "pagesDisabled",
+      ],
+      [
+        'Failed to create deployment (status: 403) with build version abc. Ensure GITHUB_TOKEN has permission "pages: write".',
+        "permission",
+      ],
+      ["Timeout reached, aborting!", "timeout"],
+      [
+        "Failed to create deployment (status: 502) with build version abc. Server error, is githubstatus.com reporting a Pages outage? Please re-run the deployment at a later time.",
+        "outage",
+      ],
+    ]
+    for (const [message, kind] of cases) {
+      expect(classifyPublishFailure([{ level: "failure", message }])).toEqual({
+        kind,
+      })
+    }
+  })
+
+  it("ignores warnings and notices, and is undefined for an unknown failure", () => {
+    expect(
+      classifyPublishFailure([{ level: "warning", message: lockMessage }]),
+    ).toBeUndefined()
+    expect(
+      classifyPublishFailure([
+        { level: "failure", message: "Process completed with exit code 1." },
+      ]),
+    ).toBeUndefined()
+    expect(classifyPublishFailure([])).toBeUndefined()
+  })
 })
 
 describe("isRunning", () => {
@@ -311,7 +439,13 @@ describe("PHASE_LABEL_KEY", () => {
   })
 
   it("resolves every phase key to an en.json template carrying {{label}}", () => {
-    for (const phase of ["pending", "running", "success", "failed"] as const) {
+    for (const phase of [
+      "pending",
+      "running",
+      "success",
+      "failed",
+      "superseded",
+    ] as const) {
       const key = PHASE_LABEL_KEY[phase]
       // Guards the dynamic t(PHASE_LABEL_KEY[phase], { label }) call site the
       // static key audit skips: a rename/removal in en.json must fail here,

--- a/web/src/util/actionActivity.test.ts
+++ b/web/src/util/actionActivity.test.ts
@@ -153,6 +153,27 @@ describe("runMatchesOp", () => {
     ).toBe(false)
   })
 
+  it("never matches a dispatch op to a push run of the same workflow (publish-pages runs on both)", () => {
+    const dispatchOp = op({
+      anchor: {
+        kind: "sinceRunId",
+        workflow: "publish-pages.yaml",
+        sinceRunId: 100,
+      },
+    })
+    // The baseline is read from dispatch runs only, so a push run newer than
+    // it is not the dispatched run even though its id is past the baseline.
+    expect(
+      runMatchesOp(
+        dispatchRun(101, "publish-pages.yaml", { event: "push" }),
+        dispatchOp,
+      ),
+    ).toBe(false)
+    expect(
+      runMatchesOp(dispatchRun(102, "publish-pages.yaml"), dispatchOp),
+    ).toBe(true)
+  })
+
   it("null baseline matches a run started at/after the dispatch time", () => {
     const started = Date.now()
     const r = dispatchRun(5, "regrade.yaml", {
@@ -230,6 +251,21 @@ describe("resolveOpRun", () => {
     const claimed = new Set<number>([101])
     // 101 is taken by an earlier op, so this op binds to 102.
     expect(resolveOpRun(dispatchOp, runs, claimed)?.id).toBe(102)
+  })
+
+  it("skips a newer push publish and binds a Publish again op to the dispatch run", () => {
+    const dispatchOp = op({
+      anchor: {
+        kind: "sinceRunId",
+        workflow: "publish-pages.yaml",
+        sinceRunId: 100,
+      },
+    })
+    const runs = [
+      dispatchRun(103, "publish-pages.yaml"),
+      dispatchRun(101, "publish-pages.yaml", { event: "push" }),
+    ]
+    expect(resolveOpRun(dispatchOp, runs)?.id).toBe(103)
   })
 })
 
@@ -324,6 +360,35 @@ describe("isSupersededPublish", () => {
         [newer],
       ),
     ).toBe(false)
+  })
+
+  it("requires the newer publish to be running or to have succeeded", () => {
+    const cancelled = publishRun(10, { conclusion: "cancelled" })
+    // A successor that failed or was itself cancelled left the change
+    // unpublished, so the row stays failed and keeps Retry.
+    expect(
+      isSupersededPublish(cancelled, [
+        publishRun(11, { conclusion: "failure" }),
+      ]),
+    ).toBe(false)
+    expect(
+      isSupersededPublish(cancelled, [
+        publishRun(11, { conclusion: "cancelled" }),
+      ]),
+    ).toBe(false)
+    // Still running: it will carry the change, so the row reads superseded.
+    expect(
+      isSupersededPublish(cancelled, [
+        publishRun(11, { status: "in_progress", conclusion: null }),
+      ]),
+    ).toBe(true)
+    // One failed and one succeeded: the successful one counts.
+    expect(
+      isSupersededPublish(cancelled, [
+        publishRun(11, { conclusion: "failure" }),
+        publishRun(12, { conclusion: "success" }),
+      ]),
+    ).toBe(true)
   })
 })
 

--- a/web/src/util/actionActivity.ts
+++ b/web/src/util/actionActivity.ts
@@ -1,4 +1,5 @@
 import type { GitHubWorkflowRun } from "@/github-core/types"
+import { PUBLISH_PAGES_WORKFLOW } from "@/github-core/workflows"
 import { CONFIG_REPO } from "@/util/configRepo"
 
 // Pure helpers behind the activity banner, split out so run-attribution and
@@ -156,13 +157,42 @@ export function isFailureConclusion(
 }
 
 // A tracker's lifecycle phase, evaluated status-first: pending (no run bound),
-// running (in flight), failed / success (completed).
-export type TrackerPhase = "pending" | "running" | "success" | "failed"
+// running (in flight), superseded / failed / success (completed).
+export type TrackerPhase =
+  "pending" | "running" | "success" | "failed" | "superseded"
 
-export function trackerPhase(run: GitHubWorkflowRun | null): TrackerPhase {
+// A publish run GitHub cancelled because a newer publish run took its place.
+// The publish artifact is the whole site, so the newer run carries this run's
+// change too; reporting it as failed sends the teacher chasing a non-problem.
+// Older skeletons still queue one pending run (the default), which is where
+// these cancellations come from. A cancelled run with no newer publish run is
+// a real cancellation and stays failed.
+export function isSupersededPublish(
+  run: GitHubWorkflowRun,
+  runs: readonly GitHubWorkflowRun[],
+): boolean {
+  if (run.status !== "completed" || run.conclusion !== "cancelled") return false
+  if (workflowFile(run) !== PUBLISH_PAGES_WORKFLOW) return false
+  return runs.some(
+    (r) => r.id > run.id && workflowFile(r) === PUBLISH_PAGES_WORKFLOW,
+  )
+}
+
+// `runs` (the polled window) lets a cancelled publish read as superseded; a
+// caller without it gets the plain success/failed verdict.
+export function trackerPhase(
+  run: GitHubWorkflowRun | null,
+  runs?: readonly GitHubWorkflowRun[],
+): TrackerPhase {
   if (!run) return "pending"
   if (isRunning(run)) return "running"
+  if (runs && isSupersededPublish(run, runs)) return "superseded"
   return isFailureConclusion(run.conclusion) ? "failed" : "success"
+}
+
+// Whether a phase is final: the tracker is history, not something to wait on.
+export function isTerminalPhase(phase: TrackerPhase): boolean {
+  return phase === "success" || phase === "failed" || phase === "superseded"
 }
 
 // The i18n key that wraps a base action label for a given phase, so the banner
@@ -173,13 +203,55 @@ export const PHASE_LABEL_KEY: Record<TrackerPhase, string> = {
   running: "actionsBanner.state.running",
   success: "actionsBanner.state.success",
   failed: "actionsBanner.state.failed",
+  superseded: "actionsBanner.state.superseded",
 }
 
 // The i18n key for a workflow file's human label. Shared by the activity banner
 // (useActionActivity) and the org activity page so the mapping has one source.
 export const WORKFLOW_LABEL_KEY: Record<string, string> = {
-  "publish-pages.yaml": "actionsBanner.workflow.publishPages",
+  [PUBLISH_PAGES_WORKFLOW]: "actionsBanner.workflow.publishPages",
   "collect-scores.yaml": "actionsBanner.workflow.collectScores",
   "regrade.yaml": "actionsBanner.workflow.regrade",
   "probe-token.yaml": "actionsBanner.workflow.probeToken",
+}
+
+// Why a publish run's deploy failed, read from the annotations
+// actions/deploy-pages emits. Each kind maps to a different next step:
+//  - deployLocked:  GitHub Pages runs one deployment at a time and an earlier
+//                   one (`blockerSha`) is still marked in progress. Clears on
+//                   its own within about 10 minutes, or can be cancelled.
+//  - pagesDisabled: the config repo's Pages site is off (404 on deploy).
+//  - permission:    the workflow token lacks pages: write (403).
+//  - timeout:       the deployment never reported a final status.
+//  - outage:        GitHub returned a 5xx; nothing to fix locally.
+export type PublishFailure =
+  | { kind: "deployLocked"; blockerSha: string }
+  | { kind: "pagesDisabled" }
+  | { kind: "permission" }
+  | { kind: "timeout" }
+  | { kind: "outage" }
+
+// The wording comes from actions/deploy-pages (src/internal/deployment.js);
+// GitHub's own message supplies the "Please cancel <sha> first" part.
+const DEPLOY_LOCKED_RE = /in progress deployment.*?cancel\s+([0-9a-f]{7,40})/i
+
+export function classifyPublishFailure(
+  annotations: readonly { level: string; message: string }[],
+): PublishFailure | undefined {
+  for (const { level, message } of annotations) {
+    if (level !== "failure") continue
+    const locked = DEPLOY_LOCKED_RE.exec(message)
+    if (locked) return { kind: "deployLocked", blockerSha: locked[1] }
+    if (/Ensure GitHub Pages has been enabled/i.test(message)) {
+      return { kind: "pagesDisabled" }
+    }
+    if (/permission "pages: write"/i.test(message)) {
+      return { kind: "permission" }
+    }
+    if (/Timeout reached/i.test(message)) return { kind: "timeout" }
+    if (/Server error, is githubstatus\.com/i.test(message)) {
+      return { kind: "outage" }
+    }
+  }
+  return undefined
 }

--- a/web/src/util/actionActivity.ts
+++ b/web/src/util/actionActivity.ts
@@ -161,12 +161,10 @@ export function isFailureConclusion(
 export type TrackerPhase =
   "pending" | "running" | "success" | "failed" | "superseded"
 
-// A publish run GitHub cancelled because a newer publish run took its place.
-// The publish artifact is the whole site, so the newer run carries this run's
-// change too; reporting it as failed sends the teacher chasing a non-problem.
-// Older skeletons still queue one pending run (the default), which is where
-// these cancellations come from. A cancelled run with no newer publish run is
-// a real cancellation and stays failed.
+// A publish run GitHub cancelled because a newer publish run took its place
+// (skeletons before `queue: max` hold one pending run). The newer run carries
+// this run's change too, so it isn't a failure. A cancelled publish with no
+// newer publish run is a real cancellation and stays failed.
 export function isSupersededPublish(
   run: GitHubWorkflowRun,
   runs: readonly GitHubWorkflowRun[],
@@ -178,8 +176,7 @@ export function isSupersededPublish(
   )
 }
 
-// `runs` (the polled window) lets a cancelled publish read as superseded; a
-// caller without it gets the plain success/failed verdict.
+// Without `runs` (the polled window) a cancelled publish reads as failed.
 export function trackerPhase(
   run: GitHubWorkflowRun | null,
   runs?: readonly GitHubWorkflowRun[],
@@ -215,15 +212,15 @@ export const WORKFLOW_LABEL_KEY: Record<string, string> = {
   "probe-token.yaml": "actionsBanner.workflow.probeToken",
 }
 
-// Why a publish run's deploy failed, read from the annotations
-// actions/deploy-pages emits. Each kind maps to a different next step:
+// Why a publish run's deploy failed, from the annotations actions/deploy-pages
+// emits. Each kind has a different next step:
 //  - deployLocked:  GitHub Pages runs one deployment at a time and an earlier
-//                   one (`blockerSha`) is still marked in progress. Clears on
-//                   its own within about 10 minutes, or can be cancelled.
-//  - pagesDisabled: the config repo's Pages site is off (404 on deploy).
+//                   one (`blockerSha`) is still in progress. GitHub releases it
+//                   within about 10 minutes; it can also be cancelled.
+//  - pagesDisabled: the config repo's Pages site is off (404).
 //  - permission:    the workflow token lacks pages: write (403).
 //  - timeout:       the deployment never reported a final status.
-//  - outage:        GitHub returned a 5xx; nothing to fix locally.
+//  - outage:        GitHub returned a 5xx.
 export type PublishFailure =
   | { kind: "deployLocked"; blockerSha: string }
   | { kind: "pagesDisabled" }
@@ -231,8 +228,7 @@ export type PublishFailure =
   | { kind: "timeout" }
   | { kind: "outage" }
 
-// The wording comes from actions/deploy-pages (src/internal/deployment.js);
-// GitHub's own message supplies the "Please cancel <sha> first" part.
+// deploy-pages appends GitHub's 400 body, which names the blocking sha.
 const DEPLOY_LOCKED_RE = /in progress deployment.*?cancel\s+([0-9a-f]{7,40})/i
 
 export function classifyPublishFailure(

--- a/web/src/util/actionActivity.ts
+++ b/web/src/util/actionActivity.ts
@@ -90,8 +90,10 @@ export function workflowFile(run: GitHubWorkflowRun): string | undefined {
 const NULL_BASELINE_SKEW_MS = 60_000
 
 // Whether a run is the one an op triggered. A push run matches by head_sha; a
-// dispatch run matches by workflow file + a run id past the pre-dispatch
-// baseline.
+// dispatch run matches by workflow file + event + a run id past the
+// pre-dispatch baseline. The event check matters for publish-pages, which also
+// runs on push: the baseline is read from dispatch runs only, so a push run
+// newer than it would otherwise be claimed as the dispatch.
 //
 // Null-baseline (no prior dispatch runs at dispatch time): an id comparison
 // alone would match ANY future run, mis-attributing a later cron/other run — so
@@ -105,6 +107,7 @@ export function runMatchesOp(
     return Boolean(run.head_sha && run.head_sha === op.anchor.sha)
   }
   if (workflowFile(run) !== op.anchor.workflow) return false
+  if (run.event !== "workflow_dispatch") return false
   if (op.anchor.sinceRunId !== null) return run.id > op.anchor.sinceRunId
 
   // Null baseline: accept any run of the workflow that started no earlier than
@@ -163,8 +166,10 @@ export type TrackerPhase =
 
 // A publish run GitHub cancelled because a newer publish run took its place
 // (skeletons before `queue: max` hold one pending run). The newer run carries
-// this run's change too, so it isn't a failure. A cancelled publish with no
-// newer publish run is a real cancellation and stays failed.
+// this run's change too, so it isn't a failure, as long as that run is still
+// going or succeeded: a failed successor leaves the change unpublished, and the
+// cancelled row must stay failed so Retry is offered. A cancelled publish with
+// no newer publish run is a real cancellation and stays failed.
 export function isSupersededPublish(
   run: GitHubWorkflowRun,
   runs: readonly GitHubWorkflowRun[],
@@ -172,7 +177,10 @@ export function isSupersededPublish(
   if (run.status !== "completed" || run.conclusion !== "cancelled") return false
   if (workflowFile(run) !== PUBLISH_PAGES_WORKFLOW) return false
   return runs.some(
-    (r) => r.id > run.id && workflowFile(r) === PUBLISH_PAGES_WORKFLOW,
+    (r) =>
+      r.id > run.id &&
+      workflowFile(r) === PUBLISH_PAGES_WORKFLOW &&
+      (isRunning(r) || !isFailureConclusion(r.conclusion)),
   )
 }
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -693,6 +693,50 @@ workflow has run." Check in order:
    invite also blocks the accept flow (see the
    [accept error table](#common-gh-student-accept-errors)).
 
+### "Publishing … to the student site: failed" with `due to in progress deployment`
+
+The red banner appears after you create or edit an assignment or classroom,
+and the run's **deploy** step (the build step passed) reports:
+
+```text
+Failed to create deployment (status: 400) … Responded with: Deployment request
+failed for <sha> due to in progress deployment. Please cancel <other sha> first
+or wait for it to complete.
+```
+
+Nothing is misconfigured, and **your change is saved** in the `classroom50`
+repository. GitHub Pages deploys one version of a site at a time, and it is
+still marking an earlier publish (the `<other sha>`) as in progress, usually
+after a slow deploy or a cancelled run. The lock clears on its own within about
+10 minutes. Because every publish deploys the whole site, the next one that
+succeeds carries every change made in the meantime.
+
+In the web app the banner names this cause under the failed row and offers two
+ways out:
+
+- **Wait, then Retry.** The row flips to "the earlier publish has finished"
+  once GitHub releases it. Click **Retry**, which re-runs only the failed
+  deploy step against the artifact the run already built.
+- **Cancel the stuck publish and retry.** Cancels the blocking Pages deployment
+  through GitHub's API, then re-runs the failed step at once. Your sign-in
+  token needs write access to Pages, which the standard teacher sign-in has.
+
+From a terminal, the same two calls are:
+
+```sh
+gh api -X POST repos/YOUR-ORGANIZATION/classroom50/pages/deployments/OTHER-SHA/cancel
+gh run rerun RUN-ID --failed -R YOUR-ORGANIZATION/classroom50
+```
+
+Creating a new classroom doesn't help: the lock belongs to the
+`YOUR-ORGANIZATION/classroom50` repository, which every classroom shares.
+
+If several publishes queued at once and one shows "included in a newer publish"
+instead of failed, that isn't an error either: GitHub cancelled it in favor of
+the newer run, which published its change too. Updating the organization's
+workflow files (the update banner) stops this happening, since the current
+`publish-pages.yaml` lets publishes queue instead of cancelling each other.
+
 ### "Couldn't load the classroom's assignments" on the accept page
 
 The accept page shows this error card, listing the URLs it tried, when the


### PR DESCRIPTION
## Summary

A failed student-site publish now tells the teacher why it failed and gives them a way out, instead of a red "failed" with only a link to the run. The trigger was a GitHub Pages behavior: Pages deploys one version of a site at a time, and a deployment GitHub still marks as in progress makes every following deploy fail with `due to in progress deployment. Please cancel <sha> first`. Nothing in the app explained that or could clear it, so a teacher creating assignments saw every publish fail and concluded their organization was misconfigured.

What is different for a teacher:

- The banner reads the failed run's annotations and says what happened in plain terms: an earlier publish is still finishing (the common case), Pages is turned off, the workflow lacks Pages write, the deploy timed out, or GitHub returned a server error. Every message says the change itself is saved; only the student site is stale.
- For the in-progress case, the row polls the blocking deployment and flips to "the earlier publish has finished, retry now" on its own, or offers **Cancel the stuck publish and retry**, which cancels the blocking deployment through the Pages API and re-runs the failed deploy step.
- A publish GitHub cancelled because a newer publish took its place is shown as "included in a newer publish" rather than failed, as long as that newer publish is still running or succeeded. Previously three quick saves produced a false failure for the middle one.
- **Publish again** on the Published resources page (owners) redeploys the site from the repository without a commit, the missing recovery for a site that drifted from the repo.
- The skeleton's `publish-pages.yaml` uses `queue: max`, so queued publishes wait their turn instead of GitHub cancelling the pending one. Existing organizations pick this up through the usual "workflow files are out of date" banner.

Design notes for review:

- Dispatch trackers now match only `workflow_dispatch` runs. The baseline read was already dispatch-only, but publish-pages also runs on push, so without this Publish again could bind to an older push publish and report its outcome.
- The cancel-then-retry sequence lives in `useActionActivity` next to Retry, sharing one busy set. The banner body renders twice (a hidden height probe plus the visible bar), so the row component must stay a pure projection of hook state or the two copies diverge.
- The web app already requests Pages write on the teacher token, so no new scope is needed for the cancel.

Fixes #949

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [x] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass. (No contract changed.)
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README). (No CLI change; the wiki gains a Troubleshooting entry for the error text.)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).

## Validation

`npm run check` passes (431 files, 5646 tests, 15 new across the banner, the activity hook, the failure-detail hook, and the dispatch helpers). `go test ./...` and `golangci-lint run` pass in `cli/gh-teacher`; the skeleton manifest test now pins `queue: max` and `cancel-in-progress: false`. The cancel and status calls were verified against the REST docs for `POST /repos/{owner}/{repo}/pages/deployments/{id}/cancel` and `GET .../pages/deployments/{id}` (both accept the commit SHA GitHub names in its refusal); a live stuck deployment was not reproducible on demand, so the end-to-end unstick was exercised through the hook and component tests rather than against GitHub.
