### PR TITLE
fix(web): credit collected push-mode submitters in the not-submitted filter

### DIFF
--- a/web/src/domain/submissions/dashboard.test.ts
+++ b/web/src/domain/submissions/dashboard.test.ts
@@ -24,6 +24,7 @@ import {
   existingGroupRepos,
   existingTeamRepos,
   filterAndSortRows,
+  filterDisplayList,
   filterNonSubmitters,
   hasAccepted,
   latestAssignmentPush,
@@ -54,8 +55,10 @@ import {
   assignmentRepoCandidateLogins,
   assignmentFunnelCounts,
   orgReposReadEnabled,
+  unsubmittedGroupRepos,
   withSnapshotDetected,
   type SubmissionFilters,
+  type SubmissionSort,
 } from "./dashboard"
 import type { DetectedSubmitter } from "./scores"
 import type { GroupTeamRef } from "@/domain/teams/groupTeams"
@@ -2170,6 +2173,184 @@ describe("withSnapshotDetected", () => {
   })
 })
 
+describe("unsubmittedGroupRepos", () => {
+  it("drops repos a row credits, case-insensitively", () => {
+    const repos = [
+      { owner: "alice", repoName: "cs101-hw1-alice" },
+      { owner: "bob", repoName: "cs101-hw1-bob" },
+    ]
+    expect(
+      unsubmittedGroupRepos(repos, [row({ owner: "Alice" })]).map(
+        (r) => r.owner,
+      ),
+    ).toEqual(["bob"])
+  })
+})
+
+describe("filterDisplayList", () => {
+  const students = [
+    student({ username: "alice", first_name: "Alice", last_name: "Adams" }),
+    student({ username: "bob", first_name: "Bob", last_name: "Brown" }),
+    student({ username: "cara", first_name: "Cara", last_name: "Cole" }),
+    student({ username: "dan", first_name: "Dan", last_name: "Dean" }),
+  ]
+  // alice passed on time, bob failed late; cara accepted but never pushed; dan
+  // never accepted.
+  const rows = [
+    row({ owner: "alice", usernames: ["alice"], score: 9, late: false }),
+    row({ owner: "bob", usernames: ["bob"], score: 2, late: true }),
+  ]
+  const accepted = new Set(["alice", "bob", "cara"])
+  const groupRepos = [
+    { owner: "alice", repoName: "cs101-hw1-alice" },
+    { owner: "cara", repoName: "cs101-hw1-cara" },
+  ]
+  const teams: GroupTeamRef[] = [
+    { n: 1, id: 1, slug: "cs101-hw1-group-1", name: "Group 1" },
+    { n: 2, id: 2, slug: "cs101-hw1-group-2", name: "Night owls" },
+  ]
+  const base = {
+    rows,
+    nonSubmitters: reconcileNonSubmitters(students, rows, new Set()),
+    groupRepos,
+    teamsWithoutRepos: teams,
+    query: "",
+    filters: filters(),
+    sort: "name-first" as const,
+    students,
+    sectionByUsername: new Map<string, string>(),
+    thresholdFraction: 0.5,
+    acceptedSet: accepted,
+    groupDisplayNames: new Map([["group-2", "night owls"]]),
+  }
+  const owners = (out: { rows: { owner: string }[] }) =>
+    out.rows.map((r) => r.owner)
+  const logins = (out: { nonSubmitters: { username: string }[] }) =>
+    out.nonSubmitters.map((s) => s.username)
+
+  it("passes everything through unfiltered", () => {
+    const out = filterDisplayList(base)
+    expect(owners(out)).toEqual(["alice", "bob"])
+    expect(logins(out)).toEqual(["cara", "dan"])
+    expect(out.groupRepos).toBe(groupRepos)
+    expect(out.teamsWithoutRepos).toBe(teams)
+  })
+
+  it.each(["submitted", "on-time", "late"] as const)(
+    "hides every no-submission item under %s",
+    (submission) => {
+      const out = filterDisplayList({
+        ...base,
+        filters: filters({ submission }),
+      })
+      expect(out.nonSubmitters).toEqual([])
+      expect(out.groupRepos).toEqual([])
+      expect(out.teamsWithoutRepos).toEqual([])
+    },
+  )
+
+  it("applies the real passing threshold to rows and hides non-submitters", () => {
+    const passing = filterDisplayList({
+      ...base,
+      filters: filters({ passing: "passing" }),
+    })
+    expect(owners(passing)).toEqual(["alice"])
+    expect(passing.nonSubmitters).toEqual([])
+    const failing = filterDisplayList({
+      ...base,
+      filters: filters({ passing: "failing" }),
+    })
+    expect(owners(failing)).toEqual(["bob"])
+  })
+
+  it("hides every row under not-submitted and keeps both non-submitter kinds", () => {
+    const out = filterDisplayList({
+      ...base,
+      filters: filters({ submission: "not-submitted" }),
+    })
+    expect(out.rows).toEqual([])
+    expect(logins(out)).toEqual(["cara", "dan"])
+    expect(out.groupRepos).toBe(groupRepos)
+  })
+
+  it("splits non-submitters on the accepted axis", () => {
+    const acceptedOnly = filterDisplayList({
+      ...base,
+      filters: filters({ accepted: "accepted" }),
+    })
+    expect(owners(acceptedOnly)).toEqual(["alice", "bob"])
+    expect(logins(acceptedOnly)).toEqual(["cara"])
+    const notAccepted = filterDisplayList({
+      ...base,
+      filters: filters({ accepted: "not-accepted" }),
+    })
+    expect(notAccepted.rows).toEqual([])
+    expect(logins(notAccepted)).toEqual(["dan"])
+  })
+
+  it("matches group repos and repo-less teams against the search", () => {
+    const byName = filterDisplayList({ ...base, query: "cole" })
+    expect(byName.groupRepos.map((r) => r.owner)).toEqual(["cara"])
+    expect(byName.teamsWithoutRepos).toEqual([])
+    const byOwner = filterDisplayList({ ...base, query: "group-1" })
+    expect(byOwner.teamsWithoutRepos.map((t) => t.n)).toEqual([1])
+    const byTeamName = filterDisplayList({ ...base, query: "night" })
+    expect(byTeamName.teamsWithoutRepos.map((t) => t.n)).toEqual([2])
+    expect(byTeamName.groupRepos).toEqual([])
+  })
+
+  it("pages the spine and the table over the same owners on every axis", () => {
+    // The alignment property #954 depends on: given the same row source, the
+    // fan-out's page names exactly the owners the table renders, whatever the
+    // filter, so any drift between the two recipes is caught here.
+    const scenarios: Partial<SubmissionFilters>[] = [
+      {},
+      { submission: "submitted" },
+      { submission: "late" },
+      { submission: "on-time" },
+      { submission: "not-submitted" },
+      { accepted: "accepted" },
+      { accepted: "not-accepted" },
+      { passing: "passing" },
+      { passing: "failing" },
+    ]
+    for (const over of scenarios) {
+      for (const sort of ["name-first", "name-last", "recent"] as const) {
+        const args = { ...base, filters: filters(over), sort }
+        const spine = displayPageOwners({
+          ...filterDisplayList(args),
+          isGroup: false,
+          sort,
+          students,
+          page: 0,
+          pageSize: 10,
+        })
+        const table = paginateDisplayItems(
+          buildDisplayItems(filterDisplayList(args), students, sort),
+          10,
+          0,
+        )
+          .map(displayItemOwner)
+          .filter(Boolean)
+        expect(spine, JSON.stringify({ over, sort })).toEqual(table)
+      }
+    }
+  })
+})
+
+// The table's own display-list assembly (SubmissionsTable.displayItems) for an
+// individual assignment, so the property test above compares against what the
+// table actually renders rather than against displayPageOwners' own builders.
+function buildDisplayItems(
+  inputs: { rows: SubmissionRow[]; nonSubmitters: Student[] },
+  students: Student[],
+  sort: SubmissionSort,
+) {
+  return sort === "name-first" || sort === "name-last"
+    ? buildRosterDisplayItems(students, inputs.rows, inputs.nonSubmitters)
+    : buildSortedDisplayItems(inputs.rows, inputs.nonSubmitters)
+}
+
 describe("displayPageOwners", () => {
   const students = [
     student({ username: "alice", first_name: "Alice", last_name: "Adams" }),
@@ -2200,29 +2381,25 @@ describe("displayPageOwners", () => {
       [row({ owner: "alice", usernames: ["alice"] })],
       [{ owner: "bob", usernames: ["bob"], count: 1 }],
     )
-    const notSubmitted = filters({ submission: "not-submitted" })
-    const rows = filterAndSortRows(snapshot, {
+    const spine = filterDisplayList({
+      rows: snapshot,
+      nonSubmitters: reconcileNonSubmitters(students, snapshot, new Set()),
+      groupRepos: [],
+      teamsWithoutRepos: [],
       query: "",
-      filters: notSubmitted,
+      filters: filters({ submission: "not-submitted" }),
       sort: "name-first",
       students,
       sectionByUsername: new Map(),
       thresholdFraction: null,
+      acceptedSet: new Set(["alice", "bob", "cara"]),
     })
-    expect(rows).toEqual([])
-    const pool = filterNonSubmitters(
-      reconcileNonSubmitters(students, snapshot, new Set()),
-      "",
-      notSubmitted,
-      new Set(),
-    )
+    expect(spine.rows).toEqual([])
     const owners = displayPageOwners({
+      ...spine,
       isGroup: false,
       sort: "name-first",
       students,
-      rows,
-      nonSubmitters: pool,
-      groupRepos: [],
       page: 0,
       pageSize: 2,
     })

--- a/web/src/domain/submissions/dashboard.test.ts
+++ b/web/src/domain/submissions/dashboard.test.ts
@@ -57,6 +57,7 @@ import {
   orgReposReadEnabled,
   unsubmittedGroupRepos,
   withSnapshotDetected,
+  type DisplayListInputs,
   type SubmissionFilters,
   type SubmissionSort,
 } from "./dashboard"
@@ -2325,30 +2326,87 @@ describe("filterDisplayList", () => {
           page: 0,
           pageSize: 10,
         })
-        const table = paginateDisplayItems(
-          buildDisplayItems(filterDisplayList(args), students, sort),
-          10,
-          0,
+        const table = tableOwners(
+          filterDisplayList(args),
+          false,
+          students,
+          sort,
         )
-          .map(displayItemOwner)
-          .filter(Boolean)
         expect(spine, JSON.stringify({ over, sort })).toEqual(table)
+      }
+    }
+  })
+
+  it("pages a group assignment the same way, with a submitted founder in one slot", () => {
+    // The page hands both sides the unsubmitted repos only; a founder who
+    // submitted must not also occupy a group-repo slot and shift the page.
+    const allRepos = [
+      { owner: "alice", repoName: "cs101-hw1-alice" },
+      { owner: "bob", repoName: "cs101-hw1-bob" },
+      { owner: "cara", repoName: "cs101-hw1-cara" },
+    ]
+    const groupRows = [row({ owner: "alice", usernames: ["alice", "dan"] })]
+    for (const over of [
+      {},
+      { submission: "submitted" as const },
+      { submission: "not-submitted" as const },
+    ]) {
+      for (const sort of ["name-first", "recent"] as const) {
+        const args = {
+          ...base,
+          rows: groupRows,
+          nonSubmitters: [],
+          groupRepos: unsubmittedGroupRepos(allRepos, groupRows),
+          filters: filters(over),
+          sort,
+        }
+        const spine = displayPageOwners({
+          ...filterDisplayList(args),
+          isGroup: true,
+          sort,
+          students,
+          page: 0,
+          pageSize: 10,
+        })
+        const table = tableOwners(filterDisplayList(args), true, students, sort)
+        expect(spine, JSON.stringify({ over, sort })).toEqual(table)
+        expect(spine.filter((o) => o === "alice").length).toBeLessThanOrEqual(1)
       }
     }
   })
 })
 
-// The table's own display-list assembly (SubmissionsTable.displayItems) for an
-// individual assignment, so the property test above compares against what the
-// table actually renders rather than against displayPageOwners' own builders.
-function buildDisplayItems(
-  inputs: { rows: SubmissionRow[]; nonSubmitters: Student[] },
+// The table's own display-list assembly (SubmissionsTable.displayItems), so the
+// property tests above compare against what the table actually renders rather
+// than against displayPageOwners' own builders.
+function tableOwners(
+  inputs: DisplayListInputs,
+  isGroup: boolean,
   students: Student[],
   sort: SubmissionSort,
-) {
-  return sort === "name-first" || sort === "name-last"
-    ? buildRosterDisplayItems(students, inputs.rows, inputs.nonSubmitters)
-    : buildSortedDisplayItems(inputs.rows, inputs.nonSubmitters)
+): string[] {
+  const nameSort = sort === "name-first" || sort === "name-last"
+  const items = isGroup
+    ? nameSort
+      ? buildGroupRosterDisplayItems(
+          inputs.rows,
+          inputs.groupRepos,
+          students,
+          sort === "name-last" ? "last" : "first",
+          inputs.teamsWithoutRepos,
+        )
+      : buildGroupDisplayItems(
+          inputs.rows,
+          inputs.groupRepos,
+          inputs.teamsWithoutRepos,
+        )
+    : nameSort
+      ? buildRosterDisplayItems(students, inputs.rows, inputs.nonSubmitters)
+      : buildSortedDisplayItems(inputs.rows, inputs.nonSubmitters)
+  return paginateDisplayItems(items, 10, 0)
+    .filter((item) => item.kind !== "teamNoRepo")
+    .map(displayItemOwner)
+    .filter(Boolean)
 }
 
 describe("displayPageOwners", () => {

--- a/web/src/domain/submissions/dashboard.test.ts
+++ b/web/src/domain/submissions/dashboard.test.ts
@@ -54,8 +54,10 @@ import {
   assignmentRepoCandidateLogins,
   assignmentFunnelCounts,
   orgReposReadEnabled,
+  withSnapshotDetected,
   type SubmissionFilters,
 } from "./dashboard"
+import type { DetectedSubmitter } from "./scores"
 import type { GroupTeamRef } from "@/domain/teams/groupTeams"
 
 // Minimal row factory — only the fields the dashboard logic reads.
@@ -2083,6 +2085,91 @@ describe("mergeDetectedSubmissions", () => {
   })
 })
 
+describe("withSnapshotDetected", () => {
+  const detected = (
+    over: Partial<DetectedSubmitter> = {},
+  ): DetectedSubmitter => ({
+    owner: "bob",
+    usernames: ["bob"],
+    count: 2,
+    datetime: "2026-06-21T10:00:00Z",
+    late: false,
+    ...over,
+  })
+
+  it("returns the rows untouched when the bucket carries no detected list", () => {
+    const rows = [row({ owner: "alice" })]
+    expect(withSnapshotDetected(rows, undefined)).toBe(rows)
+    expect(withSnapshotDetected(rows, [])).toBe(rows)
+  })
+
+  it("appends a pending, grade-free row per detected submitter", () => {
+    const graded = row({ owner: "alice", score: 8 })
+    const merged = withSnapshotDetected(
+      [graded],
+      [detected({ owner: "bob", count: 3, late: true })],
+    )
+    expect(merged.map((r) => r.owner)).toEqual(["alice", "bob"])
+    const bob = merged[1]
+    expect(bob.pending).toBe(true)
+    expect(bob.score).toBe(0)
+    expect(bob["max-score"]).toBe(0)
+    expect(bob.submissionCount).toBe(3)
+    expect(bob.datetime).toBe("2026-06-21T10:00:00Z")
+    expect(bob.late).toBe(true)
+    expect(merged[0]).toBe(graded)
+  })
+
+  it("credits every group member", () => {
+    const [team] = withSnapshotDetected(
+      [],
+      [detected({ owner: "group-1", usernames: ["bob", "cara"] })],
+    )
+    expect(team.usernames).toEqual(["bob", "cara"])
+  })
+
+  it("leaves datetime and late unknown when the collector recorded none", () => {
+    const [pending] = withSnapshotDetected(
+      [],
+      [detected({ datetime: undefined, late: undefined })],
+    )
+    expect(pending.datetime).toBe("")
+    expect(pending.late).toBeUndefined()
+  })
+
+  it("skips a zero count and an owner the graded entries already cover", () => {
+    const merged = withSnapshotDetected(
+      [row({ owner: "alice" })],
+      [
+        detected({ owner: "Alice", usernames: ["Alice"] }),
+        detected({ owner: "bob", count: 0 }),
+      ],
+    )
+    expect(merged.map((r) => r.owner)).toEqual(["alice"])
+  })
+
+  it("makes the snapshot credit push-mode submitters so they leave the non-submitter list", () => {
+    // The #954 shape: no graded entries, only the collector's detected list.
+    const students = [
+      student({ username: "alice" }),
+      student({ username: "bob" }),
+      student({ username: "cara" }),
+    ]
+    const snapshot = withSnapshotDetected(
+      [],
+      [
+        detected({ owner: "alice", usernames: ["alice"] }),
+        detected({ owner: "bob", usernames: ["bob"] }),
+      ],
+    )
+    expect(
+      reconcileNonSubmitters(students, snapshot, new Set()).map(
+        (s) => s.username,
+      ),
+    ).toEqual(["cara"])
+  })
+})
+
 describe("displayPageOwners", () => {
   const students = [
     student({ username: "alice", first_name: "Alice", last_name: "Adams" }),
@@ -2104,6 +2191,44 @@ describe("displayPageOwners", () => {
     })
     // Name order: alice (non-sub), bob (row) — page of 2.
     expect(owners).toEqual(["alice", "bob"])
+  })
+
+  it("under the not-submitted filter, pages over the snapshot's non-submitters only", () => {
+    // #954: with every submitted row filtered out, the non-submitter pool alone
+    // decides the fan-out window, so it must exclude snapshot-credited students.
+    const snapshot = withSnapshotDetected(
+      [row({ owner: "alice", usernames: ["alice"] })],
+      [{ owner: "bob", usernames: ["bob"], count: 1 }],
+    )
+    const notSubmitted = filters({ submission: "not-submitted" })
+    const rows = filterAndSortRows(snapshot, {
+      query: "",
+      filters: notSubmitted,
+      sort: "name-first",
+      students,
+      sectionByUsername: new Map(),
+      thresholdFraction: null,
+    })
+    expect(rows).toEqual([])
+    const pool = filterNonSubmitters(
+      reconcileNonSubmitters(students, snapshot, new Set()),
+      "",
+      notSubmitted,
+      new Set(),
+    )
+    const owners = displayPageOwners({
+      isGroup: false,
+      sort: "name-first",
+      students,
+      rows,
+      nonSubmitters: pool,
+      groupRepos: [],
+      page: 0,
+      pageSize: 2,
+    })
+    // alice (graded) and bob (collector-detected) are credited; only cara's
+    // repo is read.
+    expect(owners).toEqual(["cara"])
   })
 
   it("only names owners from the (pre-filtered) non-submitter pool it is given", () => {

--- a/web/src/domain/submissions/dashboard.ts
+++ b/web/src/domain/submissions/dashboard.ts
@@ -1523,6 +1523,108 @@ function ownerSortKey(owner: string, names: Map<string, string>): string {
   return names.get(owner.trim().toLowerCase()) || owner.toLowerCase()
 }
 
+// Group repos that exist but that no row credits: the "team formed, nobody
+// pushed yet" items. Owner match is case-insensitive like every other join.
+export function unsubmittedGroupRepos(
+  groupRepos: GroupRepo[],
+  rows: SubmissionRow[],
+): GroupRepo[] {
+  const submitted = new Set(rows.map((row) => row.owner.trim().toLowerCase()))
+  return groupRepos.filter(
+    (repo) => !submitted.has(repo.owner.trim().toLowerCase()),
+  )
+}
+
+// The four inputs the display-list builders take, after the search, filters,
+// and sort have been applied.
+export type DisplayListInputs = {
+  rows: SubmissionRow[]
+  nonSubmitters: Student[]
+  groupRepos: GroupRepo[]
+  teamsWithoutRepos: GroupTeamRef[]
+}
+
+// Apply the toolbar's search, filters, and sort to a row source and its
+// companions. The ONE recipe for the rendered table (over the live-merged rows)
+// and the fan-out spine (over the snapshot rows): the fan-out reads only the
+// repos on the current page, so any axis the spine applied differently would
+// have it page over different people than the table shows (#954). Any state
+// that implies a submission (a late/on-time/submitted or passing filter) hides
+// every no-submission item; "not submitted" hides every row; the accepted
+// axis splits the non-submitters. Group repos and repo-less teams match the
+// search by owner segment or display name and carry no section.
+export function filterDisplayList({
+  rows,
+  nonSubmitters,
+  groupRepos,
+  teamsWithoutRepos,
+  query,
+  filters,
+  sort,
+  students,
+  sectionByUsername,
+  thresholdFraction,
+  acceptedSet,
+  groupDisplayNames,
+}: {
+  rows: SubmissionRow[]
+  // Roster students `rows` doesn't credit (see reconcileNonSubmitters).
+  nonSubmitters: Student[]
+  // Existing group repos `rows` doesn't cover (see unsubmittedGroupRepos).
+  groupRepos: GroupRepo[]
+  teamsWithoutRepos: GroupTeamRef[]
+  query: string
+  filters: SubmissionFilters
+  sort: SubmissionSort
+  students: Student[]
+  sectionByUsername: Map<string, string>
+  thresholdFraction: number | null
+  acceptedSet: Set<string>
+  groupDisplayNames?: Map<string, string>
+}): DisplayListInputs {
+  const filteredRows = filterAndSortRows(rows, {
+    query,
+    filters,
+    sort,
+    students,
+    sectionByUsername,
+    thresholdFraction,
+  })
+  if (!showsNonSubmitters(filters)) {
+    return {
+      rows: filteredRows,
+      nonSubmitters: [],
+      groupRepos: [],
+      teamsWithoutRepos: [],
+    }
+  }
+  const q = query.trim().toLowerCase()
+  return {
+    rows: filteredRows,
+    nonSubmitters: filterNonSubmitters(
+      nonSubmitters,
+      query,
+      filters,
+      acceptedSet,
+    ),
+    groupRepos: q
+      ? groupRepos.filter((repo) => {
+          if (repo.owner.toLowerCase().includes(q)) return true
+          const name = getName(repo.owner, students).toLowerCase()
+          return name.length > 0 && name.includes(q)
+        })
+      : groupRepos,
+    teamsWithoutRepos: q
+      ? teamsWithoutRepos.filter((team) => {
+          const owner = `${GROUP_REPO_SEGMENT}${team.n}`
+          if (owner.includes(q)) return true
+          const name = groupDisplayNames?.get(owner)?.toLowerCase() ?? ""
+          return name.includes(q)
+        })
+      : teamsWithoutRepos,
+  }
+}
+
 // The repo owners on the CURRENTLY RENDERED page, in display order under the
 // active sort, so the live fan-out reads exactly the repos the user sees. Built
 // from the SNAPSHOT display list (same builders SubmissionsTable uses) — it must

--- a/web/src/domain/submissions/dashboard.ts
+++ b/web/src/domain/submissions/dashboard.ts
@@ -2,7 +2,11 @@
 // over already-loaded scores/roster data — no fetches, no React, so the
 // classification is reusable and testable.
 
-import type { NormalizedScores, SubmissionRow } from "./scores"
+import type {
+  DetectedSubmitter,
+  NormalizedScores,
+  SubmissionRow,
+} from "./scores"
 import type { GitHubRepo } from "@/github-core/types"
 import { latestDetectedAt } from "@/domain/assignments/submissionDetection"
 import { existingAssignmentRepos } from "@/domain/assignments/assignmentRepoPresence"
@@ -307,6 +311,38 @@ export function mergeDetectedSubmissions(
     })
 
   return [...merged, ...detectedOnly]
+}
+
+// Fold the collector's detected submitters (pushes or tags with no graded
+// entry) into the snapshot as pending rows. Without them a never-autograding
+// assignment's snapshot has no rows, so only the page-scoped detection overlay
+// credits submitters and everyone off-page reads "Not submitted" (#954).
+export function withSnapshotDetected(
+  rows: SubmissionRow[],
+  detected: DetectedSubmitter[] | undefined,
+): SubmissionRow[] {
+  if (!detected || detected.length === 0) return rows
+  // The collector never lists an owner in both entries and detected; defensive.
+  const knownOwners = new Set(rows.map((row) => row.owner.trim().toLowerCase()))
+  const pendingRows = detected
+    .filter(
+      (d) => d.count > 0 && !knownOwners.has(d.owner.trim().toLowerCase()),
+    )
+    .map<SubmissionRow>((d) => ({
+      usernames: d.usernames,
+      owner: d.owner,
+      datetime: d.datetime ?? "",
+      commit: "",
+      release: "",
+      review: "",
+      score: 0,
+      "max-score": 0,
+      submissionCount: d.count,
+      pending: true,
+      late: d.late,
+      submissions: [],
+    }))
+  return [...rows, ...pendingRows]
 }
 
 // The newest detected time when it's strictly newer than BOTH reference

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -93,6 +93,7 @@ import {
   studentInSection,
   submissionRosterStudents,
   teamsWithoutRepos,
+  withSnapshotDetected,
   type SubmissionFilters,
   type SubmissionSort,
 } from "@/domain/submissions/dashboard"
@@ -476,8 +477,14 @@ const SubmissionsPageContent = () => {
   // rather than blanking a populated gradebook (discussion #677: every row
   // filtered out against a roster the viewer couldn't read).
   const rosterReady = !rosterLoading && !rosterError && studentRosterKnown
+  // Graded entries plus the collector's detected submitters, so a push-mode
+  // submitter is credited on every page, not only the one being read (#954).
   const snapshotRows = useMemo(() => {
-    return scoresData?.submissions?.[assignment ?? ""] || []
+    const slug = assignment ?? ""
+    return withSnapshotDetected(
+      scoresData?.submissions?.[slug] ?? [],
+      scoresData?.detected?.[slug],
+    )
   }, [scoresData, assignment])
 
   // Dashboard controls — all client-side over already-loaded data. Declared
@@ -620,23 +627,23 @@ const SubmissionsPageContent = () => {
       new Set(snapshotScoped.map((row) => row.owner.toLowerCase())),
     )
   }, [teamsSettled, orgRepos, groupTeams, groupRepoList, snapshotScoped])
-  // Non-submitter pool for the fan-out's display list, filtered by the SAME
-  // query + section + submission axes the rendered table applies — so the
-  // fanned page lines up with the visible page. The ACCEPTED axis is neutralized
-  // here: this pool is deliberately snapshot-independent (empty accepted set) so
-  // it can't loop on live results, and `filterNonSubmitters` would otherwise
-  // test acceptance against that empty set and wrongly drop every owner. The
-  // rendered non-submitter list (visibleNonSubmitters) applies the real
-  // acceptedSet.
+  // Non-submitter pool for the fan-out's display list: roster students the
+  // snapshot doesn't credit, under the same query/section/submission filters
+  // as the rendered table, so the fanned page names the students the table
+  // shows. Under "not submitted" `rows` is empty, so this pool alone decides
+  // the window; paging the whole roster here would read the wrong repos.
+  // Snapshot-derived, never live-derived, so it can't loop on its own output.
+  // The accepted axis is neutralized: the empty set would drop every owner.
+  // visibleNonSubmitters applies the real acceptedSet.
   const liveNonSubmitterPool = useMemo(
     () =>
       filterNonSubmitters(
-        students,
+        reconcileNonSubmitters(students, snapshotScoped, groupRepoFounders),
         query,
         { ...filters, accepted: "all" },
         EMPTY_SET,
       ),
-    [students, query, filters],
+    [students, snapshotScoped, groupRepoFounders, query, filters],
   )
   const liveOwnerArgs = useMemo(
     () => ({
@@ -963,13 +970,10 @@ const SubmissionsPageContent = () => {
     ? orgRepos != null && groupRepoList.length > 0
     : acceptedAvailable
 
-  // The progress bar's one-click jump to who hasn't submitted. On this page a
-  // "not submitted" row implies the student accepted (no repo, nothing to
-  // submit), so the set is just the not-submitted filter: a single axis the
-  // Status select represents exactly, so switching away from it never silently
-  // drops a hidden acceptance filter. The other axes reset so the surfaced set
-  // matches the label.
-  const showAcceptedNotSubmitted = () =>
+  // The progress bar's jump to everyone without a submission, never-accepted
+  // students included (their rows say "Not accepted"). One axis the Status
+  // select represents exactly, so switching away never leaves a hidden filter.
+  const showNotSubmitted = () =>
     setFilters({ ...DEFAULT_FILTERS, submission: "not-submitted" })
 
   // Rows actually rendered. When acceptance data isn't loaded, neutralize the
@@ -1259,7 +1263,7 @@ const SubmissionsPageContent = () => {
               showSubmissionProgress && (
                 <button
                   type="button"
-                  onClick={showAcceptedNotSubmitted}
+                  onClick={showNotSubmitted}
                   title={t("submissions.funnel.showNotSubmitted")}
                   className="-m-1 cursor-pointer rounded-btn p-1 hover:bg-base-200"
                 >

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -472,6 +472,8 @@ const SubmissionsPageContent = () => {
   // rather than blanking a populated gradebook (discussion #677: every row
   // filtered out against a roster the viewer couldn't read).
   const rosterReady = !rosterLoading && !rosterError && studentRosterKnown
+  // A background refetch keeps this true, so Refresh never blanks the table.
+  const scoresLoaded = scoresData !== undefined
   // Graded entries plus the collector's detected submitters, so a push-mode
   // submitter is credited on every page, not only the one being read (#954).
   const snapshotRows = useMemo(() => {
@@ -696,17 +698,21 @@ const SubmissionsPageContent = () => {
       missingRepoTeams,
     ],
   )
+  // The spine is the snapshot's display list, so paging it before the snapshot
+  // exists would read the first N roster repos and then the real page again.
   const livePageOwners = useMemo(
     () =>
-      displayPageOwners({
-        ...spineInputs,
-        isGroup: isGroupFlavor,
-        sort,
-        students,
-        page,
-        pageSize,
-      }),
-    [spineInputs, isGroupFlavor, sort, students, page, pageSize],
+      scoresLoaded
+        ? displayPageOwners({
+            ...spineInputs,
+            isGroup: isGroupFlavor,
+            sort,
+            students,
+            page,
+            pageSize,
+          })
+        : [],
+    [scoresLoaded, spineInputs, isGroupFlavor, sort, students, page, pageSize],
   )
   const {
     submissions: liveSubmissions,
@@ -802,7 +808,6 @@ const SubmissionsPageContent = () => {
   // reconciliation) — else a submitter flashes "not submitted" before its row
   // resolves. detectedPending matters on its own for a no_autograder
   // assignment, where detection is the ONLY thing that can credit a submitter.
-  const scoresLoaded = scoresData !== undefined
   // Empty rows before the snapshot+roster land mean "loading", not "empty" —
   // gate the empty state on this so it doesn't flash on first paint. A
   // background refetch keeps scoresLoaded true, so Refresh never blanks the table.

--- a/web/src/pages/SubmissionsPage.tsx
+++ b/web/src/pages/SubmissionsPage.tsx
@@ -72,8 +72,7 @@ import {
   distinctSections,
   existingGroupRepos,
   existingTeamRepos,
-  filterAndSortRows,
-  filterNonSubmitters,
+  filterDisplayList,
   latestAssignmentPush,
   effectiveCollectedAt,
   mergeDetectedSubmissions,
@@ -93,6 +92,7 @@ import {
   studentInSection,
   submissionRosterStudents,
   teamsWithoutRepos,
+  unsubmittedGroupRepos,
   withSnapshotDetected,
   type SubmissionFilters,
   type SubmissionSort,
@@ -104,7 +104,7 @@ import { useSubmissionAssignment } from "@/hooks/useSubmissionAssignment"
 import useGetClassroom from "@/hooks/useGetClassroom"
 import useGetStudents from "@/hooks/useGetStudents"
 import { useTeamRoster } from "@/hooks/useTeamRoster"
-import { getName, sortStudentsByName } from "@/util/students"
+import { sortStudentsByName } from "@/util/students"
 import { studentRepoName, GROUP_REPO_SEGMENT } from "@/util/studentRepo"
 import { groupDisplayName } from "@/util/groupTeam"
 import useGroupTeams from "@/hooks/useGroupTeams"
@@ -147,11 +147,6 @@ import { githubTemplateRepoUrl } from "@/util/orgUrl"
 import { acceptLinkCli, acceptLinkUrl } from "@/util/acceptLink"
 import { CONFIG_REPO } from "@/util/configRepo"
 import { GitHubLink } from "@/components/GitHubLink"
-
-// Stable empty set for the live non-submitter filter (accepted axis is "all"
-// when live, so no accepted-set membership is consulted). Module-level so its
-// identity is stable across renders and doesn't churn the memo.
-const EMPTY_SET: Set<string> = new Set()
 
 // Stable empty list for the disabled legacy collaborators fan-out (team mode).
 const EMPTY_GROUP_REPOS: { owner: string; repoName: string }[] = []
@@ -627,57 +622,91 @@ const SubmissionsPageContent = () => {
       new Set(snapshotScoped.map((row) => row.owner.toLowerCase())),
     )
   }, [teamsSettled, orgRepos, groupTeams, groupRepoList, snapshotScoped])
-  // Non-submitter pool for the fan-out's display list: roster students the
-  // snapshot doesn't credit, under the same query/section/submission filters
-  // as the rendered table, so the fanned page names the students the table
-  // shows. Under "not submitted" `rows` is empty, so this pool alone decides
-  // the window; paging the whole roster here would read the wrong repos.
-  // Snapshot-derived, never live-derived, so it can't loop on its own output.
-  // The accepted axis is neutralized: the empty set would drop every owner.
-  // visibleNonSubmitters applies the real acceptedSet.
-  const liveNonSubmitterPool = useMemo(
+  // Deterministic acceptance from the org repo list (see acceptedUsernames);
+  // individual assignments only, so gated on acceptedAvailable.
+  const acceptedSet = useMemo(
     () =>
-      filterNonSubmitters(
-        reconcileNonSubmitters(students, snapshotScoped, groupRepoFounders),
-        query,
-        { ...filters, accepted: "all" },
-        EMPTY_SET,
-      ),
-    [students, snapshotScoped, groupRepoFounders, query, filters],
+      acceptedUsernames(orgRepos, classroom ?? "", assignment ?? "", students),
+    [orgRepos, classroom, assignment, students],
   )
-  const liveOwnerArgs = useMemo(
+  const acceptedAvailable = !isGroupFlavor && orgRepos != null
+  // The filters actually applied. When acceptance data isn't loaded, neutralize
+  // the accepted axis so a transient empty repo list can't flip the visible set.
+  const effectiveFilters = useMemo(
+    () =>
+      acceptedAvailable ? filters : { ...filters, accepted: "all" as const },
+    [acceptedAvailable, filters],
+  )
+  // Passing bar as a fraction of max, or null when the teacher didn't opt in
+  // (off by default) — then no Passing rollup/filter, neutral badges.
+  const passThresholdPct = assignmentInfo?.pass_threshold
+  const passingEnabled =
+    typeof passThresholdPct === "number" && Number.isFinite(passThresholdPct)
+  const thresholdFraction = passingEnabled ? passThresholdPct / 100 : null
+
+  // Everything the display list depends on besides its row source. Shared by
+  // the fan-out spine (snapshot rows) and the rendered table (live-merged rows)
+  // so the two can only differ in rows, never in how they're filtered.
+  const displayListArgs = useMemo(
     () => ({
-      isGroup: isGroupFlavor,
+      query,
+      filters: effectiveFilters,
       sort,
       students,
-      rows: filterAndSortRows(snapshotScoped, {
-        query,
-        filters,
-        sort,
-        students,
-        sectionByUsername,
-        thresholdFraction: null,
-      }),
-      nonSubmitters: liveNonSubmitterPool,
-      groupRepos: groupRepoList,
-      teamsWithoutRepos: missingRepoTeams,
+      sectionByUsername,
+      thresholdFraction,
+      acceptedSet,
+      groupDisplayNames,
     }),
     [
-      isGroupFlavor,
+      query,
+      effectiveFilters,
       sort,
       students,
-      snapshotScoped,
-      query,
-      filters,
       sectionByUsername,
+      thresholdFraction,
+      acceptedSet,
+      groupDisplayNames,
+    ],
+  )
+
+  // The fan-out spine: the snapshot's display list under the real filters, so
+  // the fanned page names exactly the students the table shows. Everything here
+  // is snapshot- or org-repo-derived, never live-derived, so it can't loop on
+  // the fan-out's own output.
+  const spineInputs = useMemo(
+    () =>
+      filterDisplayList({
+        ...displayListArgs,
+        rows: snapshotScoped,
+        nonSubmitters: reconcileNonSubmitters(
+          students,
+          snapshotScoped,
+          groupRepoFounders,
+        ),
+        groupRepos: unsubmittedGroupRepos(groupRepoList, snapshotScoped),
+        teamsWithoutRepos: missingRepoTeams,
+      }),
+    [
+      displayListArgs,
+      snapshotScoped,
+      students,
+      groupRepoFounders,
       groupRepoList,
-      liveNonSubmitterPool,
       missingRepoTeams,
     ],
   )
   const livePageOwners = useMemo(
-    () => displayPageOwners({ ...liveOwnerArgs, page, pageSize }),
-    [liveOwnerArgs, page, pageSize],
+    () =>
+      displayPageOwners({
+        ...spineInputs,
+        isGroup: isGroupFlavor,
+        sort,
+        students,
+        page,
+        pageSize,
+      }),
+    [spineInputs, isGroupFlavor, sort, students, page, pageSize],
   )
   const {
     submissions: liveSubmissions,
@@ -823,15 +852,6 @@ const SubmissionsPageContent = () => {
   // live and surface this instead of hiding Sort + Status.
   const showPendingHiddenHint = pendingMayHide(sort, filters)
 
-  // Deterministic acceptance from the org repo list (see acceptedUsernames);
-  // individual assignments only, so gated on acceptedAvailable.
-  const acceptedSet = useMemo(
-    () =>
-      acceptedUsernames(orgRepos, classroom ?? "", assignment ?? "", students),
-    [orgRepos, classroom, assignment, students],
-  )
-  const acceptedAvailable = !isGroupFlavor && orgRepos != null
-
   // Every existing assignment repo name (individual + group), for the bulk
   // "Open all Feedback PRs" action. Derived from the already-loaded org repo
   // list, so no extra reads. Only meaningful for a live-capable owner on a
@@ -900,13 +920,9 @@ const SubmissionsPageContent = () => {
   // derived per student — instead surface every group repo from the org list
   // (#245) so teachers can see teams that formed before anyone pushes. Submitted
   // groups already show as score rows, so drop them here.
-  const submittedGroupOwners = useMemo(
-    () => new Set(scoresInfo.map((row) => row.owner.toLowerCase())),
-    [scoresInfo],
-  )
-  const unsubmittedGroupRepos = useMemo(
-    () => groupRepoList.filter((repo) => !submittedGroupOwners.has(repo.owner)),
-    [groupRepoList, submittedGroupOwners],
+  const liveUnsubmittedGroupRepos = useMemo(
+    () => unsubmittedGroupRepos(groupRepoList, scoresInfo),
+    [groupRepoList, scoresInfo],
   )
 
   // With a section filter active, scope roster and rows to it so the stat cards
@@ -939,13 +955,6 @@ const SubmissionsPageContent = () => {
   )
   const acceptedOwners = useMemo(() => [...acceptedSet], [acceptedSet])
 
-  // Passing bar as a fraction of max, or null when the teacher didn't opt in
-  // (off by default) — then no Passing rollup/filter, neutral badges.
-  const passThresholdPct = assignmentInfo?.pass_threshold
-  const passingEnabled =
-    typeof passThresholdPct === "number" && Number.isFinite(passThresholdPct)
-  const thresholdFraction = passingEnabled ? passThresholdPct / 100 : null
-
   // Top-line counts over the (section-scoped) submitted set + roster size.
   const stats = useMemo(
     () => computeStats(scopedScores, scopedStudents.length, thresholdFraction),
@@ -963,7 +972,8 @@ const SubmissionsPageContent = () => {
   // (KTD4-style) so a staff/extra repo can't push the share past 100%.
   const funnelTotal = stats.rostered
   const submittedShare = Math.min(submittedPresenceCount, funnelTotal)
-  const submittedGroups = groupRepoList.length - unsubmittedGroupRepos.length
+  const submittedGroups =
+    groupRepoList.length - liveUnsubmittedGroupRepos.length
   // Show the bar once its denominator is real: repo list resolved, and (for
   // groups) at least one group repo exists.
   const showSubmissionProgress = isGroupFlavor
@@ -976,77 +986,31 @@ const SubmissionsPageContent = () => {
   const showNotSubmitted = () =>
     setFilters({ ...DEFAULT_FILTERS, submission: "not-submitted" })
 
-  // Rows actually rendered. When acceptance data isn't loaded, neutralize the
-  // accepted axis so a transient empty repo list can't flip the visible set.
-  // This acceptance neutralization is independent of live mode — the sort and
-  // status/passing axes always reflect the user's real selection.
-  const effectiveFilters = useMemo(
+  // What the table renders: the live-merged rows and their companions under the
+  // same recipe as the fan-out spine (see displayListArgs). Non-submitters are
+  // gated on their readiness upstream, so they can't flash while sources settle.
+  const {
+    rows: visibleRows,
+    nonSubmitters: visibleNonSubmitters,
+    groupRepos: visibleGroupRepos,
+    teamsWithoutRepos: visibleMissingRepoTeams,
+  } = useMemo(
     () =>
-      acceptedAvailable ? filters : { ...filters, accepted: "all" as const },
-    [acceptedAvailable, filters],
-  )
-  const visibleRows = useMemo(
-    () =>
-      filterAndSortRows(scoresInfo, {
-        query,
-        filters: effectiveFilters,
-        sort,
-        students,
-        sectionByUsername,
-        thresholdFraction,
+      filterDisplayList({
+        ...displayListArgs,
+        rows: scoresInfo,
+        nonSubmitters,
+        groupRepos: liveUnsubmittedGroupRepos,
+        teamsWithoutRepos: missingRepoTeams,
       }),
     [
+      displayListArgs,
       scoresInfo,
-      query,
-      effectiveFilters,
-      sort,
-      students,
-      sectionByUsername,
-      thresholdFraction,
+      nonSubmitters,
+      liveUnsubmittedGroupRepos,
+      missingRepoTeams,
     ],
   )
-  const visibleNonSubmitters = useMemo(
-    () =>
-      showsNonSubmitters(effectiveFilters)
-        ? filterNonSubmitters(
-            nonSubmitters,
-            query,
-            effectiveFilters,
-            acceptedSet,
-          )
-        : [],
-    [effectiveFilters, nonSubmitters, query, acceptedSet],
-  )
-
-  // Group repos without a submission, gated like non-submitters (hidden while a
-  // narrowing filter other than "not submitted" is active) and matched against
-  // the search by founder login or roster name. Section isn't filtered — a group
-  // repo carries no single section.
-  const visibleGroupRepos = useMemo(() => {
-    if (!showsNonSubmitters(effectiveFilters)) return []
-    const q = query.trim().toLowerCase()
-    if (!q) return unsubmittedGroupRepos
-    return unsubmittedGroupRepos.filter((repo) => {
-      if (repo.owner.includes(q)) return true
-      const name = getName(repo.owner, students).toLowerCase()
-      return name.length > 0 && name.includes(q)
-    })
-  }, [effectiveFilters, query, unsubmittedGroupRepos, students])
-
-  // Repo-less teams, gated like the unsubmitted group repos (hidden while a
-  // narrowing filter other than "not submitted" is active) and matched against
-  // the search by display name or `group-<n>` owner segment.
-  const visibleMissingRepoTeams = useMemo(() => {
-    if (!showsNonSubmitters(effectiveFilters)) return []
-    const q = query.trim().toLowerCase()
-    if (!q) return missingRepoTeams
-    return missingRepoTeams.filter((team) => {
-      const owner = `${GROUP_REPO_SEGMENT}${team.n}`
-      if (owner.includes(q)) return true
-      const name = groupDisplayNames?.get(owner)?.toLowerCase() ?? ""
-      return name.includes(q)
-    })
-  }, [effectiveFilters, query, missingRepoTeams, groupDisplayNames])
 
   // The read-only Refresh's own re-reads, for its spinner and latch (a viewer
   // who dispatches is gated by the collect itself).

--- a/web/src/pages/submissions/SubmissionsTable.test.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.test.tsx
@@ -312,6 +312,28 @@ describe("SubmissionsTable per-row feedback PR shortcut", () => {
   })
 })
 
+describe("SubmissionsTable stale-count hint", () => {
+  const stale = () =>
+    scoreRow({
+      score: 0,
+      "max-score": 0,
+      submissionCount: 3,
+      pending: true,
+      staleCount: true,
+    })
+
+  it("shows the New hint on an autograded assignment", () => {
+    render(<SubmissionsTable {...baseProps} scores={[stale()]} />)
+    expect(screen.getByText("submissions.table.staleCount")).toBeTruthy()
+  })
+
+  it("omits it when the assignment never autogrades", () => {
+    // The hint promises a grade on re-collect, which never arrives here.
+    render(<SubmissionsTable {...baseProps} scores={[stale()]} skipsGrading />)
+    expect(screen.queryByText("submissions.table.staleCount")).toBeNull()
+  })
+})
+
 describe("SubmissionsTable initial loading", () => {
   it("shows skeleton rows and not the empty state while core data loads", () => {
     render(<SubmissionsTable {...baseProps} initialLoading />)

--- a/web/src/pages/submissions/SubmissionsTable.tsx
+++ b/web/src/pages/submissions/SubmissionsTable.tsx
@@ -762,7 +762,9 @@ const SubmissionsTable = ({
             mode={assignmentMode}
             count={submissionCount}
             onOpen={openDetails}
-            staleCount={rest.staleCount}
+            // The hint promises a grade on re-collect, which a never-autograding
+            // assignment can't deliver; the raised count alone says what's new.
+            staleCount={rest.staleCount && !skipsGrading}
             settling={settling}
           />
         </td>


### PR DESCRIPTION
Fixes #954

## What went wrong

The Submissions page built its rows from `scores.json` graded entries only. On a "submits on every push" assignment those entries never exist, so the only thing crediting submitters was the client-side detection overlay, which reads just the repos on the current table page. Under the "Not submitted" filter every submitted row is hidden, so the table filled with students the overlay had never looked at, and a 60-student roster with 52 submissions read as "50-something not submitted". Collect all changed nothing because the page ignored the `detected` list the collector writes.

## What this changes

- **The snapshot now credits push-mode submitters.** The collector's `detected` list (pushes or tags with no graded entry) is folded into the snapshot as pending rows. The filter, the header count, the non-submitter list, and the CSV export are now correct across the whole roster, and Collect now is the refresh path a teacher expects. This also brings the Submissions page into agreement with the assignments table, which already read `detected`.
- **The fan-out spine and the rendered table share one recipe.** `filterDisplayList` applies search, filters, sort, passing threshold, and acceptance to a row source and its companions (non-submitters, unsubmitted group repos, repo-less teams). The spine runs it over the snapshot rows and the table over the live-merged rows, so they can only differ in row source. Before, the spine used raw filters instead of effective ones, hard-coded a null passing threshold, and never gated or acceptance-filtered non-submitters and group repos, so under most filters it read repos the table didn't show and skipped ones it did.
- **The fan-out waits for the snapshot.** Paging the spine before `scores.json` loaded read the first N roster repos and then the real page again once the snapshot changed the page's composition (any filter or time sort, including the assignments table's `?status=not-submitted` deep link).
- The "New" count hint is omitted on never-autograding assignments, where its "run Collect now to grade" promise can't be kept. It became reachable there once collector pending rows exist.

## Behavior changes worth knowing

- The CSV export now writes a blank score, the commit count, and the push time for each collector-detected submitter. Previously these students were exported as non-submitters with score 0, which for a no-autograder assignment recorded a zero for someone who submitted.
- Under a "Late", "On time", "Submitted", or passing filter the fan-out no longer scans non-submitters' repos, so a student who pushed since the last collect and has no snapshot row appears under those filters only after a collect. Before, they appeared only if they happened to land in the misaligned window. The existing hint on those filters already says to run Collect now.
- "Not submitted" intentionally includes never-accepted students; their rows say "Not accepted".

## Verification

- `npm run check` passes: 5648 tests, 0 lint errors, prettier and dependency-cruiser clean. New coverage: `withSnapshotDetected`, `filterDisplayList` per axis, and a property test that pages the spine and the table over 9 filter states and 3 sorts for both individual and group assignments and asserts they name the same owners.
- Live against `classroom50-summer-dev`, on an every-push assignment with zero graded entries and one collector-detected submitter: the unfiltered view credits the submitter, "Not submitted" lists exactly the 4 real non-submitters, and the header agrees with the assignments table. Recording GitHub requests per filter, the fan-out read exactly the rendered students' repos under Submitted, Late, Accepted, Not accepted, and a search query. An autograded assignment and a bucket written by an older collector (no `detected` key) behave as before.
- Not reproduced live: a roster larger than one page (the dev org has none); that path is covered by the pagination property test.
