### PR TITLE
feat(web): offer HTTPS, SSH, and GitHub CLI clone commands to students

### DIFF
--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -1288,7 +1288,7 @@ func forkParentRestrictedError(parentOwner string, tmpl assignments.TemplateRef,
 // human-channel progress, so this doesn't duplicate the headline onto stderr.
 func reportAccepted(u *ui.UI, out io.Writer, fullName, htmlURL string) error {
 	_, _ = fmt.Fprintf(out, "Assignment accepted: %s\n\n", fullName)
-	return printCloneInstructions(u, out, htmlURL)
+	return printCloneInstructions(u, out, fullName, htmlURL)
 }
 
 // reportBareAccepted is reportAccepted's empty_repo variant: the repo has no
@@ -1300,7 +1300,7 @@ func reportBareAccepted(u *ui.UI, out io.Writer, fullName, htmlURL string) error
 	_, _ = fmt.Fprintln(out, "This assignment uses an empty repository: it has no starter files, and")
 	_, _ = fmt.Fprintln(out, "autograding is disabled. Clone it, then create and push your own work.")
 	_, _ = fmt.Fprintln(out)
-	return printCloneInstructions(u, out, htmlURL)
+	return printCloneInstructions(u, out, fullName, htmlURL)
 }
 
 // reportAlreadyAccepted writes the re-run message; the existing repo is never
@@ -1309,25 +1309,30 @@ func reportAlreadyAccepted(u *ui.UI, out io.Writer, fullName, htmlURL string) er
 	_, _ = fmt.Fprintf(out, "Assignment already accepted: %s\n\n", fullName)
 	_, _ = fmt.Fprintln(out, "Your existing repository contains your latest submissions and commits.")
 	_, _ = fmt.Fprintln(out)
-	return printCloneInstructions(u, out, htmlURL)
+	return printCloneInstructions(u, out, fullName, htmlURL)
 }
 
 // printCloneInstructions writes the clone block on stdout (scriptable) and
 // warns on the human channel if cwd is inside a Git repo (nested clones are
-// confusing).
-func printCloneInstructions(u *ui.UI, out io.Writer, htmlURL string) error {
+// confusing). Both HTTPS and SSH forms are printed: teachers differ on which
+// they teach (discussion #966), and nothing downstream depends on the choice.
+func printCloneInstructions(u *ui.UI, out io.Writer, fullName, htmlURL string) error {
 	root, insideRepo, err := localgit.CurrentGitRoot()
 	if err != nil {
 		return err
 	}
 	if insideRepo {
 		u.Warn("you are currently inside a Git repository (%s); clone from a parent or workspace directory to avoid nesting repositories", root)
-		_, _ = fmt.Fprintln(out, "Clone from a parent or workspace directory to avoid nesting repositories:")
-	} else {
-		_, _ = fmt.Fprintln(out, "Clone it with:")
+		_, _ = fmt.Fprintln(out, "Clone from a parent or workspace directory to avoid nesting repositories.")
+		_, _ = fmt.Fprintln(out)
 	}
+	_, _ = fmt.Fprintln(out, "Clone it with HTTPS:")
 	_, _ = fmt.Fprintln(out)
 	_, _ = fmt.Fprintf(out, "  git clone %s.git\n\n", htmlURL)
+	_, _ = fmt.Fprintln(out, "Or with SSH:")
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintf(out, "  git clone git@github.com:%s.git\n\n", fullName)
+	_, _ = fmt.Fprintln(out, "Use the option your teacher told you to use.")
 	return nil
 }
 

--- a/cli/gh-student/accept.go
+++ b/cli/gh-student/accept.go
@@ -1332,7 +1332,7 @@ func printCloneInstructions(u *ui.UI, out io.Writer, fullName, htmlURL string) e
 	_, _ = fmt.Fprintln(out, "Or with SSH:")
 	_, _ = fmt.Fprintln(out)
 	_, _ = fmt.Fprintf(out, "  git clone git@github.com:%s.git\n\n", fullName)
-	_, _ = fmt.Fprintln(out, "Use the option your teacher told you to use.")
+	_, _ = fmt.Fprintln(out, "Your teacher may ask you to clone or submit in a specific way. If so, follow their instructions.")
 	return nil
 }
 

--- a/web/src/components/SubmitGuidance.test.tsx
+++ b/web/src/components/SubmitGuidance.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { cleanup, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
@@ -23,6 +23,36 @@ describe("SubmitGuidance", () => {
       screen.getByText("git clone https://github.com/acme/cs-hw1-student1.git"),
     ).toBeTruthy()
     expect(screen.getByText("gh student submit")).toBeTruthy()
+  })
+
+  it("switches the clone command between HTTPS, SSH, and GitHub CLI", () => {
+    render(
+      <SubmitGuidance repoHtmlUrl="https://github.com/acme/cs-hw1-student1" />,
+    )
+    const https = screen.getByRole("button", {
+      name: "submissions.student.submitGuide.cloneMethod.https",
+    })
+    const ssh = screen.getByRole("button", {
+      name: "submissions.student.submitGuide.cloneMethod.ssh",
+    })
+    const cli = screen.getByRole("button", {
+      name: "submissions.student.submitGuide.cloneMethod.cli",
+    })
+    expect(https.getAttribute("aria-pressed")).toBe("true")
+
+    fireEvent.click(ssh)
+    expect(
+      screen.getByText("git clone git@github.com:acme/cs-hw1-student1.git"),
+    ).toBeTruthy()
+    expect(ssh.getAttribute("aria-pressed")).toBe("true")
+    expect(https.getAttribute("aria-pressed")).toBe("false")
+
+    fireEvent.click(cli)
+    expect(screen.getByText("gh repo clone acme/cs-hw1-student1")).toBeTruthy()
+    expect(cli.getAttribute("aria-pressed")).toBe("true")
+    expect(
+      screen.queryByText("git clone git@github.com:acme/cs-hw1-student1.git"),
+    ).toBeNull()
   })
 
   it("renders both copy buttons", () => {

--- a/web/src/components/SubmitGuidance.test.tsx
+++ b/web/src/components/SubmitGuidance.test.tsx
@@ -75,6 +75,9 @@ describe("SubmitGuidance", () => {
       screen.getByText("submissions.student.submitGuide.intro"),
     ).toBeTruthy()
     expect(
+      screen.getByText("submissions.student.submitGuide.teacherNote"),
+    ).toBeTruthy()
+    expect(
       screen.queryByLabelText("submissions.student.submitGuide.copyMilestone"),
     ).toBeNull()
   })

--- a/web/src/components/SubmitGuidance.tsx
+++ b/web/src/components/SubmitGuidance.tsx
@@ -107,6 +107,9 @@ export function SubmitGuidance({
           ? t("submissions.student.submitGuide.tagIntro")
           : t("submissions.student.submitGuide.intro")}
       </p>
+      <p className="mt-1 text-sm text-base-content/70">
+        {t("submissions.student.submitGuide.teacherNote")}
+      </p>
       <ol className="mt-3 space-y-3">
         <li className="space-y-1.5">
           <p className="text-sm text-base-content/70">

--- a/web/src/components/SubmitGuidance.tsx
+++ b/web/src/components/SubmitGuidance.tsx
@@ -1,7 +1,8 @@
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { Ref } from "react"
 
-import { CopyableCode } from "@/components/ui"
+import { Button, CopyableCode } from "@/components/ui"
 import { isGlobPattern } from "@/domain/assignments/submissionDetection"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import type { SubmissionMode } from "@/types/classroom"
@@ -12,6 +13,34 @@ import type { SubmissionMode } from "@/types/classroom"
 const exampleMilestoneTag = (submissionTags?: string[]): string => {
   const literal = submissionTags?.find((p) => !isGlobPattern(p))
   return literal ?? "milestone"
+}
+
+// Same three clone options GitHub's own Code dropdown offers. Teachers differ
+// on which they teach (discussion #966), so the student picks; nothing else in
+// the app depends on how the repo was cloned.
+type CloneMethod = "https" | "ssh" | "cli"
+const CLONE_METHODS: CloneMethod[] = ["https", "ssh", "cli"]
+
+// "owner/repo" from the API's html_url; the API only ever returns github.com
+// URLs, so a parse failure falls back to the raw string rather than throwing.
+const repoFullName = (repoHtmlUrl: string): string => {
+  try {
+    return new URL(repoHtmlUrl).pathname.replace(/^\/+|\/+$/g, "")
+  } catch {
+    return repoHtmlUrl
+  }
+}
+
+const cloneCommand = (method: CloneMethod, repoHtmlUrl: string): string => {
+  const fullName = repoFullName(repoHtmlUrl)
+  switch (method) {
+    case "https":
+      return `git clone ${repoHtmlUrl}.git`
+    case "ssh":
+      return `git clone git@github.com:${fullName}.git`
+    case "cli":
+      return `gh repo clone ${fullName}`
+  }
 }
 
 // How a student submits from a terminal. Mode-aware:
@@ -42,16 +71,17 @@ export function SubmitGuidance({
 }) {
   const { t } = useTranslation()
   const isTagMode = submissionMode === "tag"
-  const cloneUrl = `${repoHtmlUrl}.git`
-  const cloneCmd = `git clone ${cloneUrl}`
+  const [cloneMethod, setCloneMethod] = useState<CloneMethod>("https")
+  const cloneCmd = cloneCommand(cloneMethod, repoHtmlUrl)
   const submitCmd = "gh student submit"
   const milestoneTag = exampleMilestoneTag(submissionTags)
   const milestoneCmd = `git tag ${milestoneTag} && git push origin ${milestoneTag}`
 
-  const { copied: cloneCopied, copy: copyClone } = useCopyToClipboard(
-    cloneCmd,
-    1500,
-  )
+  const {
+    copied: cloneCopied,
+    copy: copyClone,
+    reset: resetCloneCopied,
+  } = useCopyToClipboard(cloneCmd, 1500)
   const { copied: submitCopied, copy: copySubmit } = useCopyToClipboard(
     submitCmd,
     1500,
@@ -82,12 +112,38 @@ export function SubmitGuidance({
           <p className="text-sm text-base-content/70">
             {t("submissions.student.submitGuide.step1")}
           </p>
+          <div
+            role="group"
+            aria-label={t("submissions.student.submitGuide.cloneMethodAria")}
+            className="join"
+          >
+            {CLONE_METHODS.map((method) => (
+              <Button
+                key={method}
+                size="xs"
+                active={cloneMethod === method}
+                aria-pressed={cloneMethod === method}
+                className="join-item"
+                onClick={() => {
+                  // Drop a lingering "copied" check so it can't read as if
+                  // the newly selected command were already on the clipboard.
+                  resetCloneCopied()
+                  setCloneMethod(method)
+                }}
+              >
+                {t(`submissions.student.submitGuide.cloneMethod.${method}`)}
+              </Button>
+            ))}
+          </div>
           <CopyableCode
             value={cloneCmd}
             copied={cloneCopied}
             onCopy={copyClone}
             label={t("submissions.student.submitGuide.copyClone")}
           />
+          <p className="text-xs text-base-content/60">
+            {t("submissions.student.submitGuide.cloneHint")}
+          </p>
         </li>
         <li className="space-y-1.5">
           <p className="text-sm text-base-content/70">

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -3595,6 +3595,13 @@
         "step1": "Clone your assignment repository (once):",
         "step2": "From inside the repository, submit your work for grading:",
         "copyClone": "Copy clone command",
+        "cloneMethodAria": "Clone method",
+        "cloneMethod": {
+          "https": "HTTPS",
+          "ssh": "SSH",
+          "cli": "GitHub CLI"
+        },
+        "cloneHint": "Use the option your teacher told you to use. SSH needs an SSH key added to your GitHub account. GitHub CLI needs the gh command installed.",
         "copySubmit": "Copy submit command",
         "tagIntro": "Your teacher grades tagged snapshots of your work. Commit and push as usual, then run the submit command below. It tags your latest work for grading.",
         "tagStep2": "From inside the repository, submit your work. This pushes a submission tag that triggers grading:",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -3592,6 +3592,7 @@
       "submitGuide": {
         "title": "Submit from the command line",
         "intro": "Submit your work for grading from a terminal.",
+        "teacherNote": "Your teacher may ask you to clone or submit in a specific way. If so, follow their instructions.",
         "step1": "Clone your assignment repository (once):",
         "step2": "From inside the repository, submit your work for grading:",
         "copyClone": "Copy clone command",
@@ -3601,7 +3602,7 @@
           "ssh": "SSH",
           "cli": "GitHub CLI"
         },
-        "cloneHint": "Use the option your teacher told you to use. SSH needs an SSH key added to your GitHub account. GitHub CLI needs the gh command installed.",
+        "cloneHint": "SSH needs an SSH key added to your GitHub account. GitHub CLI needs the gh command installed.",
         "copySubmit": "Copy submit command",
         "tagIntro": "Your teacher grades tagged snapshots of your work. Commit and push as usual, then run the submit command below. It tags your latest work for grading.",
         "tagStep2": "From inside the repository, submit your work. This pushes a submission tag that triggers grading:",


### PR DESCRIPTION
Resolves discussion #966. Teachers differ on which clone form they teach, and the app only ever showed the HTTPS command.

## Web

The student submission page's "Submit from the command line" guide now has a GitHub-style HTTPS / SSH / GitHub CLI switcher above the clone command (HTTPS stays the default). It derives `owner/repo` from the repo's `html_url` and offers `git clone https://github.com/owner/repo.git`, `git clone git@github.com:owner/repo.git`, or `gh repo clone owner/repo`. Switching resets the "copied" state so it can't imply the new command is already on the clipboard.

Two short notes were added: one under the intro telling students to follow their teacher's instructions if they were asked to clone or submit in a specific way, and one under the clone box noting that SSH needs a key on the GitHub account and GitHub CLI needs `gh` installed.

Built from existing primitives (`Button` in a `join` with `aria-pressed`, the same pattern as `ListViewToggle`), so no new class recipe.

## CLI

`gh student accept` now prints both the HTTPS and SSH clone lines, plus the same teacher note, for fresh, empty-repo, and already-accepted outcomes.

## Testing

- `npm run check` in `web/` and `audit_i18n.py --strict` pass. Added a test that clicks through SSH and GitHub CLI and checks the rendered command and pressed state.
- `go build`, `golangci-lint fmt --diff`, `golangci-lint run`, `go test ./...` in `cli/gh-student` pass.