### PR TITLE
feat(gh-teacher): re-issue an expired invitation and drop a dead pending row

### DIFF
--- a/cli/gh-teacher/internal/membership/membership.go
+++ b/cli/gh-teacher/internal/membership/membership.go
@@ -139,6 +139,32 @@ func ListPendingOrgInvitations(client githubapi.Client, org string) ([]PendingOr
 		func(path string, err error) error { return ClassifyMembershipReadError(path, subject, err) })
 }
 
+// FailedOrgInvitation is one GET /orgs/{org}/failed_invitations element: an
+// invitation nobody accepted within GitHub's 7 days, or one GitHub couldn't
+// deliver. Keyed by login or email exactly like a pending one.
+type FailedOrgInvitation struct {
+	ID           int64  `json:"id"`
+	Login        string `json:"login"`
+	Email        string `json:"email"`
+	FailedReason string `json:"failed_reason"`
+}
+
+// ListFailedOrgInvitations walks the org's failed-invitation list, the record
+// GitHub keeps of an expired invitation once it leaves the pending list. Owner
+// only. Dismissing a record is CancelOrgInvitation on its id (the same DELETE;
+// GitHub's UI calls it "dismiss"). The raw HTTP error is preserved (not
+// classified) so a caller can read a 403/404 as "no list to sweep": these
+// records are bookkeeping, and whether a failed read matters is the caller's
+// call.
+func ListFailedOrgInvitations(client githubapi.Client, org string) ([]FailedOrgInvitation, error) {
+	base := fmt.Sprintf("orgs/%s/failed_invitations", url.PathEscape(org))
+	return githubapi.PaginateAll[FailedOrgInvitation](client, githubapi.ListPerPage, githubapi.ListMaxPages,
+		func(page int) string {
+			return fmt.Sprintf("%s?per_page=%d&page=%d", base, githubapi.ListPerPage, page)
+		},
+		func(path string, err error) error { return fmt.Errorf("GET %s: %w", path, err) })
+}
+
 // InvitationTeamRef is one element of GET /orgs/{org}/invitations/{id}/teams:
 // the teams an invitation will add its invitee to on acceptance.
 type InvitationTeamRef struct {

--- a/cli/gh-teacher/internal/membership/membership.go
+++ b/cli/gh-teacher/internal/membership/membership.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strings"
 
 	"github.com/foundation50/gh-teacher/internal/cliutil"
 	"github.com/foundation50/gh-teacher/internal/githubapi"
@@ -46,9 +48,41 @@ func InviteOrgByID(client githubapi.Client, org, username string, userID int64, 
 // ErrEmailAlreadyInvitedOrMember is the 422 GitHub returns when the address is
 // already a member or already has a pending invitation. The username path
 // confirms which via a membership lookup; an email has no
-// `/orgs/{org}/memberships/{user}` to read, so the 422 itself is the answer —
+// `/orgs/{org}/memberships/{user}` to read, so the 422's text is the answer —
 // callers treat it as a skip, not a failed invite.
 var ErrEmailAlreadyInvitedOrMember = errors.New("already a member of the organization or already invited")
+
+// ErrInvitationLimit is the 422 GitHub returns when the org's invitation cap
+// (50 per day for a new or free org, 500 otherwise) or its spam throttle is hit.
+// Nothing covers the address afterwards, so callers treat it like a rate limit,
+// never as "already invited".
+var ErrInvitationLimit = errors.New("GitHub's invitation limit for the organization was reached; try again later")
+
+var (
+	invitation422Limit   = regexp.MustCompile(`(?i)rate limit|invitation limit|too many`)
+	invitation422Already = regexp.MustCompile(`(?i)already`)
+)
+
+// classifyInvitation422 reads a POST /orgs/{org}/invitations 422, which GitHub
+// uses for three answers ("Validation failed, or the endpoint has been
+// spammed"): already invited or a member, the invitation cap, or any other
+// validation failure. Mirrors the web's classifyInvitation422 so both tools
+// skip, defer, and fail on the same bodies.
+func classifyInvitation422(email string, httpErr *githubapi.HTTPError) error {
+	texts := []string{httpErr.Message}
+	for _, item := range httpErr.Errors {
+		texts = append(texts, item.Message)
+	}
+	joined := strings.TrimSpace(strings.Join(texts, " "))
+	switch {
+	case invitation422Limit.MatchString(joined):
+		return fmt.Errorf("%s: %w (%s)", email, ErrInvitationLimit, joined)
+	case invitation422Already.MatchString(joined):
+		return fmt.Errorf("%s: %w", email, ErrEmailAlreadyInvitedOrMember)
+	default:
+		return fmt.Errorf("%s: GitHub rejected the invitation (%s); check the address and try again", email, joined)
+	}
+}
 
 // InviteOrgByEmail posts an org invitation to an email address (the invitee has
 // no GitHub account to look up yet). teamIDs auto-add the invitee to those teams
@@ -71,8 +105,8 @@ func InviteOrgByEmail(client githubapi.Client, org, email string, teamIDs []int6
 	if err := client.Post(path, bytes.NewReader(body), nil); err != nil {
 		// Intercepted before ClassifyOrgInviteError, whose 422 branch issues a
 		// username-keyed membership GET this path has no username for.
-		if cliutil.IsHTTPStatus(err, http.StatusUnprocessableEntity) {
-			return fmt.Errorf("%s: %w", email, ErrEmailAlreadyInvitedOrMember)
+		if httpErr, ok := errors.AsType[*githubapi.HTTPError](err); ok && httpErr.StatusCode == http.StatusUnprocessableEntity {
+			return classifyInvitation422(email, httpErr)
 		}
 		return ClassifyOrgInviteError(client, org, "", path, err)
 	}

--- a/cli/gh-teacher/internal/membership/membership.go
+++ b/cli/gh-teacher/internal/membership/membership.go
@@ -143,19 +143,20 @@ func ListPendingOrgInvitations(client githubapi.Client, org string) ([]PendingOr
 // invitation nobody accepted within GitHub's 7 days, or one GitHub couldn't
 // deliver. Keyed by login or email exactly like a pending one.
 type FailedOrgInvitation struct {
-	ID           int64  `json:"id"`
-	Login        string `json:"login"`
-	Email        string `json:"email"`
-	FailedReason string `json:"failed_reason"`
+	ID    int64  `json:"id"`
+	Login string `json:"login"`
+	Email string `json:"email"`
 }
 
-// ListFailedOrgInvitations walks the org's failed-invitation list, the record
-// GitHub keeps of an expired invitation once it leaves the pending list. Owner
-// only. Dismissing a record is CancelOrgInvitation on its id (the same DELETE;
-// GitHub's UI calls it "dismiss"). The raw HTTP error is preserved (not
-// classified) so a caller can read a 403/404 as "no list to sweep": these
-// records are bookkeeping, and whether a failed read matters is the caller's
-// call.
+// IsEmailKeyed is PendingOrgInvitation.IsEmailKeyed for a failed record.
+func (inv FailedOrgInvitation) IsEmailKeyed() bool {
+	return inv.Login == "" && inv.Email != ""
+}
+
+// ListFailedOrgInvitations walks GET /orgs/{org}/failed_invitations, the
+// owner-only record GitHub keeps of expired invitations. The HTTP error is left
+// unclassified so a caller can treat 403/404 as an empty list; dismissing a
+// record is CancelOrgInvitation on its id.
 func ListFailedOrgInvitations(client githubapi.Client, org string) ([]FailedOrgInvitation, error) {
 	base := fmt.Sprintf("orgs/%s/failed_invitations", url.PathEscape(org))
 	return githubapi.PaginateAll[FailedOrgInvitation](client, githubapi.ListPerPage, githubapi.ListMaxPages,
@@ -217,8 +218,13 @@ type OrgMembershipKnownError struct {
 func (e *OrgMembershipKnownError) Error() string { return e.msg }
 
 // ClassifyOrgInviteError maps POST /orgs/{org}/invitations errors to
-// user-facing messages. Unrecognized errors wrap with request context.
+// user-facing messages. Unrecognized errors wrap with request context. A rate
+// limit is wrapped, not classified: GitHub sends secondary limits as a 403, and
+// a caller deciding whether to defer needs cliutil.IsRateLimited to still see it.
 func ClassifyOrgInviteError(client githubapi.Client, org, username, path string, err error) error {
+	if cliutil.IsRateLimited(err) {
+		return fmt.Errorf("POST %s: %w", path, err)
+	}
 	if httpErr, ok := errors.AsType[*githubapi.HTTPError](err); ok {
 		switch httpErr.StatusCode {
 		case http.StatusUnauthorized:
@@ -292,11 +298,12 @@ var ErrMissingOrgAdminScope = errors.New("missing admin:org OAuth scope; run `gh
 
 // ClassifyMembershipReadError maps the common failure statuses of the read-only
 // membership endpoints to actionable messages, mirroring ClassifyOrgInviteError's
-// 403/404 handling. `subject` is a human label for the thing being read. Other
+// 403/404 handling (and, like it, leaving a rate limit wrapped rather than
+// classified). `subject` is a human label for the thing being read. Other
 // statuses return the wrapped error.
 func ClassifyMembershipReadError(path, subject string, err error) error {
 	httpErr, ok := errors.AsType[*githubapi.HTTPError](err)
-	if !ok {
+	if !ok || cliutil.IsRateLimited(err) {
 		return fmt.Errorf("GET %s: %w", path, err)
 	}
 	switch httpErr.StatusCode {

--- a/cli/gh-teacher/internal/membership/membership_test.go
+++ b/cli/gh-teacher/internal/membership/membership_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/foundation50/gh-teacher/internal/cliutil"
 	"github.com/foundation50/gh-teacher/internal/githubtest"
 )
 
@@ -124,6 +125,14 @@ func TestClassifyOrgInviteError(t *testing.T) {
 // `/orgs/o/memberships/` and must never be attempted.
 func inviteByEmailServer(t *testing.T, status int, oauthScopes string, capture *map[string]any) *httptest.Server {
 	t.Helper()
+	return inviteByEmailServerWithBody(t, status, oauthScopes, `{"id":1}`, nil, capture)
+}
+
+// inviteByEmailServerWithBody is inviteByEmailServer with the response body and
+// extra headers chosen by the test: a 422's text and a throttle's Retry-After
+// are what the classifier reads.
+func inviteByEmailServerWithBody(t *testing.T, status int, oauthScopes, body string, headers map[string]string, capture *map[string]any) *httptest.Server {
+	t.Helper()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
 		if capture != nil {
@@ -132,9 +141,12 @@ func inviteByEmailServer(t *testing.T, status int, oauthScopes string, capture *
 		if oauthScopes != "" {
 			w.Header().Set("X-OAuth-Scopes", oauthScopes)
 		}
+		for k, v := range headers {
+			w.Header().Set(k, v)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
-		_, _ = w.Write([]byte(`{"id":1}`))
+		_, _ = w.Write([]byte(body))
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
@@ -182,10 +194,11 @@ func TestInviteOrgByEmail(t *testing.T) {
 		}
 	})
 
-	t.Run("422 → already-invited-or-member sentinel, no username follow-up", func(t *testing.T) {
+	t.Run("422 saying already → already-invited-or-member sentinel, no username follow-up", func(t *testing.T) {
 		// The mux fails the test on any non-/invitations route, so this also
 		// pins that ClassifyOrgInviteError's username-keyed 422 lookup is bypassed.
-		server := inviteByEmailServer(t, http.StatusUnprocessableEntity, "", nil)
+		server := inviteByEmailServerWithBody(t, http.StatusUnprocessableEntity, "",
+			`{"message":"Validation Failed","errors":[{"message":"Invitee is already a part of this org"}]}`, nil, nil)
 		client := githubtest.NewTestClient(t, server)
 
 		err := InviteOrgByEmail(client, "o", "alice@example.com", nil)
@@ -194,6 +207,50 @@ func TestInviteOrgByEmail(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "alice@example.com") {
 			t.Errorf("message = %q, want the invited address", err.Error())
+		}
+	})
+
+	t.Run("422 naming the invitation limit → limit sentinel, never a skip", func(t *testing.T) {
+		server := inviteByEmailServerWithBody(t, http.StatusUnprocessableEntity, "",
+			`{"message":"Over invitation rate limit. Try again later."}`, nil, nil)
+		client := githubtest.NewTestClient(t, server)
+
+		err := InviteOrgByEmail(client, "o", "alice@example.com", nil)
+		if !errors.Is(err, ErrInvitationLimit) {
+			t.Fatalf("err = %v, want ErrInvitationLimit", err)
+		}
+		if errors.Is(err, ErrEmailAlreadyInvitedOrMember) {
+			t.Errorf("a capped send must not read as already invited: %v", err)
+		}
+	})
+
+	t.Run("422 with any other text → failure carrying GitHub's reason", func(t *testing.T) {
+		server := inviteByEmailServerWithBody(t, http.StatusUnprocessableEntity, "",
+			`{"message":"Validation Failed","errors":[{"message":"Email is invalid"}]}`, nil, nil)
+		client := githubtest.NewTestClient(t, server)
+
+		err := InviteOrgByEmail(client, "o", "alice@example.com", nil)
+		if err == nil || errors.Is(err, ErrEmailAlreadyInvitedOrMember) || errors.Is(err, ErrInvitationLimit) {
+			t.Fatalf("err = %v, want a plain failure", err)
+		}
+		if !strings.Contains(err.Error(), "Email is invalid") {
+			t.Errorf("message = %q, want GitHub's reason", err.Error())
+		}
+	})
+
+	t.Run("403 shaped as a secondary rate limit → still a rate limit", func(t *testing.T) {
+		// GitHub sends secondary limits as a 403 too; the admin:org scope on the
+		// token would otherwise read it as "not an admin".
+		server := inviteByEmailServerWithBody(t, http.StatusForbidden, "repo, admin:org",
+			`{"message":"You have exceeded a secondary rate limit"}`, map[string]string{"Retry-After": "60"}, nil)
+		client := githubtest.NewTestClient(t, server)
+
+		err := InviteOrgByEmail(client, "o", "alice@example.com", nil)
+		if !cliutil.IsRateLimited(err) {
+			t.Fatalf("err = %v, want a rate limit IsRateLimited still recognizes", err)
+		}
+		if errors.Is(err, ErrMissingOrgAdminScope) || strings.Contains(err.Error(), "admin") {
+			t.Errorf("a throttle must not be reported as an admin problem: %v", err)
 		}
 	})
 

--- a/cli/gh-teacher/internal/roster/cancel_invite.go
+++ b/cli/gh-teacher/internal/roster/cancel_invite.go
@@ -28,8 +28,10 @@ func rosterCancelInviteCmd() *cobra.Command {
 			"for the address this reports and changes nothing: an invitation the\n" +
 			"student already accepted looks exactly the same from here, and the\n" +
 			"metadata team holds the only record of which address their account\n" +
-			"came from. Run `gh teacher roster sync` in that case: it records the\n" +
-			"student, and cleans up a genuine leftover under its own checks.\n\n" +
+			"came from. Run `gh teacher roster sync` in that case to record the\n" +
+			"student. If the invitation expired instead (GitHub invitations last\n" +
+			"7 days), `gh teacher roster invite` sends a new one against the\n" +
+			"same row.\n\n" +
 			"For a student already on the roster with a username, use\n" +
 			"`gh teacher roster remove` (and `gh teacher remove` for the org).\n\n" +
 			"Exits 0 when nothing was pending; returns non-zero if the pending\n" +
@@ -76,8 +78,11 @@ func runRosterCancelInvite(client githubapi.Client, out, errOut io.Writer, org, 
 	invitationID, found := pendingEmailInvitationID(pending, email)
 	if !found {
 		_, _ = fmt.Fprintf(out, "%s: no pending invitation for %s, nothing was cancelled\n", org, email)
-		_, _ = fmt.Fprintf(errOut, "If they already accepted, run `gh teacher roster sync %s %s` to record their username and github_id. It also collects a genuine leftover invite team or pending row under its own checks, which this command deliberately won't do without a pending invitation to revoke.\n",
-			org, classroom)
+		_, _ = fmt.Fprintf(errOut, "Nothing is touched without a pending invitation to revoke, since the metadata team may hold the only record of an accepted invitation's address.\n"+
+			"  - If they already accepted, run `gh teacher roster sync %s %s --write` to record their username and github_id.\n"+
+			"  - If the invitation expired (GitHub invitations last 7 days), run `gh teacher roster invite %s %s %s` to send a new one against the same row.\n"+
+			"  - To drop the row instead, edit %s.\n",
+			org, classroom, org, classroom, email, configrepo.RosterFilePath(classroom))
 		return nil
 	}
 

--- a/cli/gh-teacher/internal/roster/cancel_invite.go
+++ b/cli/gh-teacher/internal/roster/cancel_invite.go
@@ -111,8 +111,8 @@ func runRosterCancelInvite(client githubapi.Client, out, errOut io.Writer, org, 
 	if err := membership.CancelOrgInvitation(client, org, invitationID); err != nil {
 		if errors.Is(err, membership.ErrInvitationAlreadyGone) {
 			_, _ = fmt.Fprintf(out, "%s: the invitation for %s was already gone, nothing was cancelled\n", org, email)
-			_, _ = fmt.Fprintf(errOut, "Nothing else was touched: another invitation for %s may have replaced this one. Run `gh teacher roster sync %s %s` to refresh the roster.\n",
-				email, org, classroom)
+			_, _ = fmt.Fprintf(errOut, "Nothing else was touched: another invitation for %s may have replaced this one. Run %s to refresh the roster.\n",
+				email, syncWriteCommand(org, classroom))
 			return nil
 		}
 		return err
@@ -141,8 +141,8 @@ func runRosterCancelInvite(client githubapi.Client, out, errOut io.Writer, org, 
 
 	message := contract.PrefixCommit(fmt.Sprintf("roster: remove cancelled invite from %s (gh teacher roster cancel-invite)", classroom))
 	if _, err := configwrite.CommitTreeChange(client, org, configrepo.ConfigRepoName, branch, message, build); err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: the invitation to %s was cancelled, but dropping its pending row from %s failed; run `gh teacher roster sync %s %s` to refresh the roster.\n",
-			email, configrepo.RosterFilePath(classroom), org, classroom)
+		_, _ = fmt.Fprintf(errOut, "Warning: the invitation to %s was cancelled, but dropping its pending row from %s failed; the sync never removes a row, so edit the file to drop it.\n",
+			email, configrepo.RosterFilePath(classroom))
 		return fmt.Errorf("invitation cancelled, but the pending roster row was not removed: %w", err)
 	}
 	if !removed {

--- a/cli/gh-teacher/internal/roster/cancel_invite.go
+++ b/cli/gh-teacher/internal/roster/cancel_invite.go
@@ -81,8 +81,8 @@ func runRosterCancelInvite(client githubapi.Client, out, errOut io.Writer, org, 
 		_, _ = fmt.Fprintf(errOut, "Nothing is touched without a pending invitation to revoke, since the metadata team may hold the only record of an accepted invitation's address.\n"+
 			"  - If they already accepted, run %s to record their username and github_id.\n"+
 			"  - If the invitation expired (GitHub invitations last 7 days), run `gh teacher roster invite %s %s %s` to send a new one against the same row.\n"+
-			"  - To drop the row instead, edit %s.\n",
-			syncWriteCommand(org, classroom), org, classroom, email, configrepo.RosterFilePath(classroom))
+			"  - To drop the row instead, run `gh teacher roster remove %s %s %s`.\n",
+			syncWriteCommand(org, classroom), org, classroom, email, org, classroom, email)
 		return nil
 	}
 
@@ -141,8 +141,8 @@ func runRosterCancelInvite(client githubapi.Client, out, errOut io.Writer, org, 
 
 	message := contract.PrefixCommit(fmt.Sprintf("roster: remove cancelled invite from %s (gh teacher roster cancel-invite)", classroom))
 	if _, err := configwrite.CommitTreeChange(client, org, configrepo.ConfigRepoName, branch, message, build); err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: the invitation to %s was cancelled, but dropping its pending row from %s failed; the sync never removes a row, so edit the file to drop it.\n",
-			email, configrepo.RosterFilePath(classroom))
+		_, _ = fmt.Fprintf(errOut, "Warning: the invitation to %s was cancelled, but dropping its pending row from %s failed; run `gh teacher roster remove %s %s %s` to drop it.\n",
+			email, configrepo.RosterFilePath(classroom), org, classroom, email)
 		return fmt.Errorf("invitation cancelled, but the pending roster row was not removed: %w", err)
 	}
 	if !removed {

--- a/cli/gh-teacher/internal/roster/cancel_invite.go
+++ b/cli/gh-teacher/internal/roster/cancel_invite.go
@@ -79,10 +79,10 @@ func runRosterCancelInvite(client githubapi.Client, out, errOut io.Writer, org, 
 	if !found {
 		_, _ = fmt.Fprintf(out, "%s: no pending invitation for %s, nothing was cancelled\n", org, email)
 		_, _ = fmt.Fprintf(errOut, "Nothing is touched without a pending invitation to revoke, since the metadata team may hold the only record of an accepted invitation's address.\n"+
-			"  - If they already accepted, run `gh teacher roster sync %s %s --write` to record their username and github_id.\n"+
+			"  - If they already accepted, run %s to record their username and github_id.\n"+
 			"  - If the invitation expired (GitHub invitations last 7 days), run `gh teacher roster invite %s %s %s` to send a new one against the same row.\n"+
 			"  - To drop the row instead, edit %s.\n",
-			org, classroom, org, classroom, email, configrepo.RosterFilePath(classroom))
+			syncWriteCommand(org, classroom), org, classroom, email, configrepo.RosterFilePath(classroom))
 		return nil
 	}
 

--- a/cli/gh-teacher/internal/roster/cancel_invite_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/cancel_invite_cmd_test.go
@@ -352,7 +352,9 @@ func TestRunRosterCancelInvite_IgnoresLoginKeyedInvitation(t *testing.T) {
 
 // No pending invitation is report-only: an accepted-but-unsynced invitation
 // reads identically, and the invite team holds the only email→account mapping,
-// so deleting either artifact here could lose the address for good.
+// so deleting either artifact here could lose the address for good. The hint
+// must name BOTH ways out: the sync for an accepted one, and `roster invite` for
+// an expired one (#970), since neither this command nor the sync clears the row.
 func TestRunRosterCancelInvite_NoPendingInvitationIsReportOnly(t *testing.T) {
 	mock := newCancelMock(storedRosterHeader + ",,," + inviteTestEmail + ",,,student\n")
 	mock.pending = nil
@@ -367,8 +369,10 @@ func TestRunRosterCancelInvite_NoPendingInvitationIsReportOnly(t *testing.T) {
 	if len(mock.blobs) != 0 {
 		t.Errorf("committed %d blob(s) with nothing cancelled", len(mock.blobs))
 	}
-	if !strings.Contains(out+errOut, "roster sync") {
-		t.Errorf("output must point at `roster sync`:\n%s%s", out, errOut)
+	for _, want := range []string{"roster sync", "roster invite"} {
+		if !strings.Contains(out+errOut, want) {
+			t.Errorf("output must point at `%s`:\n%s%s", want, out, errOut)
+		}
 	}
 }
 

--- a/cli/gh-teacher/internal/roster/failed_invites.go
+++ b/cli/gh-teacher/internal/roster/failed_invites.go
@@ -1,0 +1,85 @@
+package roster
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+
+	"github.com/foundation50/gh-teacher/internal/cliutil"
+	"github.com/foundation50/gh-teacher/internal/configrepo"
+	"github.com/foundation50/gh-teacher/internal/githubapi"
+	"github.com/foundation50/gh-teacher/internal/membership"
+)
+
+// failedInviteRecords is the org's failed-invitation list indexed by address,
+// read once and only on first use. GitHub keeps a record of every invitation
+// that expired, and once the address has a fresh invitation (or accepted one)
+// that record is only noise on the org's People page. The web dismisses it
+// right after a confirmed send (dismissFailedInvitation); the CLI's re-invite
+// and sync do the same through this.
+//
+// Bookkeeping, never state: the list is owner-only, so a 403/404 reads as
+// "nothing to dismiss", any other failed read or DELETE is a warning, and none
+// of it can fail the send or the roster commit that came before.
+type failedInviteRecords struct {
+	client githubapi.Client
+	org    string
+	loaded bool
+	// byEmail is nil after an unreadable list; every lookup then finds nothing.
+	byEmail map[string][]int64
+}
+
+func (f *failedInviteRecords) load(errOut io.Writer) {
+	if f.loaded {
+		return
+	}
+	f.loaded = true
+	list, err := membership.ListFailedOrgInvitations(f.client, f.org)
+	if err != nil {
+		if !cliutil.IsHTTPStatus(err, http.StatusForbidden) && !cliutil.IsHTTPStatus(err, http.StatusNotFound) {
+			_, _ = fmt.Fprintf(errOut, "Warning: %s: reading the failed invitations failed (%v); any expired record is left for you to dismiss from https://github.com/orgs/%s/people/failed_invitations.\n", f.org, err, f.org)
+		}
+		return
+	}
+	f.byEmail = map[string][]int64{}
+	for _, inv := range list {
+		// Login-keyed records belong to account invitations, which never had
+		// an address to match a pending row on.
+		if inv.ID == 0 || inv.Login != "" || inv.Email == "" {
+			continue
+		}
+		key := configrepo.NormalizeInviteEmail(inv.Email)
+		f.byEmail[key] = append(f.byEmail[key], inv.ID)
+	}
+}
+
+// idsFor is the records an address still has, in id order so output is stable.
+func (f *failedInviteRecords) idsFor(errOut io.Writer, email string) []int64 {
+	f.load(errOut)
+	ids := f.byEmail[configrepo.NormalizeInviteEmail(email)]
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// dismiss deletes every failed record for email and reports how many went. A
+// record already gone counts as dismissed, since the outcome is the same.
+func (f *failedInviteRecords) dismiss(out, errOut io.Writer, email string) {
+	ids := f.idsFor(errOut, email)
+	if len(ids) == 0 {
+		return
+	}
+	dismissed := 0
+	for _, id := range ids {
+		if err := membership.CancelOrgInvitation(f.client, f.org, id); err != nil && !errors.Is(err, membership.ErrInvitationAlreadyGone) {
+			_, _ = fmt.Fprintf(errOut, "Warning: %s: dismissing the expired invitation record %d for %s failed (%v); dismiss it from https://github.com/orgs/%s/people/failed_invitations.\n", f.org, id, email, err, f.org)
+			continue
+		}
+		dismissed++
+	}
+	delete(f.byEmail, configrepo.NormalizeInviteEmail(email))
+	if dismissed > 0 {
+		_, _ = fmt.Fprintf(out, "%s: dismissed %d expired invitation record(s) for %s\n", f.org, dismissed, email)
+	}
+}

--- a/cli/gh-teacher/internal/roster/failed_invites.go
+++ b/cli/gh-teacher/internal/roster/failed_invites.go
@@ -14,15 +14,13 @@ import (
 )
 
 // failedInviteRecords is the org's failed-invitation list indexed by address,
-// read once and only on first use. GitHub keeps a record of every invitation
-// that expired, and once the address has a fresh invitation (or accepted one)
-// that record is only noise on the org's People page. The web dismisses it
-// right after a confirmed send (dismissFailedInvitation); the CLI's re-invite
-// and sync do the same through this.
+// read on first use. A fresh or accepted invitation makes the address's expired
+// record noise on the org's People page, so re-invite and sync dismiss it, as the
+// web's dismissFailedInvitation does.
 //
-// Bookkeeping, never state: the list is owner-only, so a 403/404 reads as
-// "nothing to dismiss", any other failed read or DELETE is a warning, and none
-// of it can fail the send or the roster commit that came before.
+// Bookkeeping, never state: a 403 (the list is owner-only) or 404 reads as
+// nothing to dismiss, any other failed read or DELETE only warns, and none of it
+// can fail the send or the roster commit that came before.
 type failedInviteRecords struct {
 	client githubapi.Client
 	org    string
@@ -38,16 +36,17 @@ func (f *failedInviteRecords) load(errOut io.Writer) {
 	f.loaded = true
 	list, err := membership.ListFailedOrgInvitations(f.client, f.org)
 	if err != nil {
-		if !cliutil.IsHTTPStatus(err, http.StatusForbidden) && !cliutil.IsHTTPStatus(err, http.StatusNotFound) {
+		// A secondary rate limit is also a 403, and that one is worth a warning.
+		silent := (cliutil.IsHTTPStatus(err, http.StatusForbidden) && !cliutil.IsRateLimited(err)) ||
+			cliutil.IsHTTPStatus(err, http.StatusNotFound)
+		if !silent {
 			_, _ = fmt.Fprintf(errOut, "Warning: %s: reading the failed invitations failed (%v); any expired record is left for you to dismiss from https://github.com/orgs/%s/people/failed_invitations.\n", f.org, err, f.org)
 		}
 		return
 	}
 	f.byEmail = map[string][]int64{}
 	for _, inv := range list {
-		// Login-keyed records belong to account invitations, which never had
-		// an address to match a pending row on.
-		if inv.ID == 0 || inv.Login != "" || inv.Email == "" {
+		if inv.ID == 0 || !inv.IsEmailKeyed() {
 			continue
 		}
 		key := configrepo.NormalizeInviteEmail(inv.Email)

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -281,42 +281,59 @@ const (
 	pendingDead
 )
 
-// classifyPendingRow resolves a pending row's state from GitHub's pending list
+// pendingRowInspection is what inspectPendingRow learned about a pending row:
+// its state, and the invite team it read to decide it (unread while the
+// invitation is live, so teamFound is false there).
+type pendingRowInspection struct {
+	state     pendingRowState
+	team      configrepo.InviteTeamState
+	teamFound bool
+}
+
+// classifyPendingRow is inspectPendingRow for callers that only need the state.
+func classifyPendingRow(client githubapi.Client, org, classroom, email string, live *liveInvitations) (pendingRowState, error) {
+	insp, err := inspectPendingRow(client, org, classroom, email, live)
+	return insp.state, err
+}
+
+// inspectPendingRow resolves a pending row's state from GitHub's pending list
 // and, only when the invitation is gone, the invite team. The team's record
 // decides what a member on it means: a valid record makes them the invitee; a
 // provisional description (an interrupted run) makes them the stranded teacher
 // the re-send's EnsureInviteTeam drops; any other unreadable record is the same
 // trust failure the sync reports, so the row is refused for a human to check.
-func classifyPendingRow(client githubapi.Client, org, classroom, email string, live *liveInvitations) (pendingRowState, error) {
+func inspectPendingRow(client githubapi.Client, org, classroom, email string, live *liveInvitations) (pendingRowInspection, error) {
 	isLive, err := live.has(email)
 	if err != nil {
-		return 0, err
+		return pendingRowInspection{}, err
 	}
 	if isLive {
-		return pendingLive, nil
+		return pendingRowInspection{state: pendingLive}, nil
 	}
 	slug := configrepo.InviteTeamName(classroom, email)
 	team, found, err := configrepo.ReadInviteTeam(client, org, slug)
 	if err != nil {
-		return 0, err
+		return pendingRowInspection{}, err
 	}
+	insp := pendingRowInspection{state: pendingDead, team: team, teamFound: found}
 	if !found {
-		return pendingDead, nil
+		return insp, nil
 	}
 	members, found, err := configrepo.FindTeamMembersWithIDs(client, org, slug)
 	if err != nil {
-		return 0, err
+		return pendingRowInspection{}, err
 	}
 	if !found || len(members) == 0 {
-		return pendingDead, nil
+		return insp, nil
 	}
 	switch {
 	case team.Record != nil:
-		return pendingAccepted, nil
+		insp.state = pendingAccepted
+		return insp, nil
 	case team.Provisional:
-		return pendingDead, nil
+		return insp, nil
 	default:
-		return 0, fmt.Errorf("the invite team %s for %s has a member but its description is no longer a readable invite record, so nothing was changed. Check the team at https://github.com/orgs/%s/teams/%s first, and delete it by hand if the member is not the invitee",
+		return pendingRowInspection{}, fmt.Errorf("the invite team %s for %s has a member but its description is no longer a readable invite record, so nothing was changed. Check the team at https://github.com/orgs/%s/teams/%s first, and delete it by hand if the member is not the invitee",
 			slug, email, org, slug)
 	}
 }

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -46,6 +46,11 @@ func rosterInviteCmd() *cobra.Command {
 			"can never grant org ownership from a mistyped address.\n\n" +
 			"Once the student accepts, run `gh teacher roster sync` to fill in\n" +
 			"their username and github_id (the web app does this on its own).\n\n" +
+			"An address already on the roster as a pending invitation is refused\n" +
+			"while GitHub still lists that invitation, and while someone who\n" +
+			"accepted it is waiting to be synced. Once the invitation is gone\n" +
+			"(GitHub invitations expire after 7 days) a new one is sent and the\n" +
+			"existing row is kept, the same as the web app's Re-invite.\n\n" +
 			"Bulk mode: pass --file <path> instead of an email to invite a whole\n" +
 			"list.\n" +
 			"  - The file is plaintext, one address per line; blank lines and\n" +
@@ -67,15 +72,13 @@ func rosterInviteCmd() *cobra.Command {
 			"     are skipped)\n" +
 			"  1  an address genuinely failed or the roster write failed\n\n" +
 			"A single address returns non-zero on: classroom missing a GitHub team,\n" +
-			"an address whose invitation is still outstanding, or a failed\n" +
-			"invitation. When the roster still lists an invite GitHub has since\n" +
-			"expired (they lapse after 7 days), the invitation is re-sent rather\n" +
-			"than refused, and the pending row is kept. With --file that same\n" +
-			"already-listed address is reported as skipped instead, and does not\n" +
-			"affect the exit code. An address that already belongs to a member (or\n" +
-			"already has a pending invitation) is reported as skipped and exits 0.\n" +
-			"An address some other row already carries is still invited, but gets\n" +
-			"no second row.",
+			"an address whose invitation is still pending (or accepted but not yet\n" +
+			"synced), or a failed invitation. With --file that same address is\n" +
+			"reported as skipped instead, and does not affect the exit code. An\n" +
+			"address that already belongs to a member (or already has a pending\n" +
+			"invitation GitHub knows of) is reported as skipped and exits 0. An\n" +
+			"address some other row already carries is still invited, but gets no\n" +
+			"second row.",
 		Example: "  gh teacher roster invite cs50-fall-2026 cs-principles ada@example.edu\n" +
 			"  gh teacher roster invite cs50-fall-2026 cs-principles ada@example.edu --first-name Ada --last-name Lovelace --section section-1\n" +
 			"  gh teacher roster invite cs50-fall-2026 cs-principles --file ./section-1-emails.txt",
@@ -205,9 +208,13 @@ const (
 	// outcomeSkippedAlready: GitHub's 422 — already a member or already invited.
 	// No row; a team this run created has already been torn down.
 	outcomeSkippedAlready
-	// outcomePendingBlocked: the stored roster already lists this address as a
-	// pending email invite, so nothing was sent (no API call was made).
+	// outcomePendingBlocked: the stored roster lists this address as a pending
+	// email invite AND GitHub still has that invitation, so nothing was sent.
 	outcomePendingBlocked
+	// outcomeAcceptedBlocked: the pending row's invitation is gone but its
+	// invite team has a member, so someone accepted and only a sync is missing.
+	// Nothing was sent.
+	outcomeAcceptedBlocked
 	// outcomeRateLimited: a secondary rate limit; the bulk caller stops issuing
 	// new sends and the single caller surfaces the error.
 	outcomeRateLimited
@@ -215,30 +222,114 @@ const (
 	outcomeFailed
 )
 
+// liveInvitations answers whether GitHub still lists a pending EMAIL invitation
+// for an address, reading the org's pending list once and only on first use.
+type liveInvitations struct {
+	client githubapi.Client
+	org    string
+	emails map[string]bool
+	err    error
+}
+
+func (l *liveInvitations) has(email string) (bool, error) {
+	if l.emails == nil && l.err == nil {
+		l.emails, l.err = pendingEmailInvitations(l.client, l.org)
+	}
+	if l.err != nil {
+		return false, l.err
+	}
+	return l.emails[email], nil
+}
+
+// orgInvitationLists is what a pending row is judged and cleaned up against:
+// GitHub's pending list (is the invitation live?) and its failed list (which
+// expired records to dismiss once a fresh one is out). Both are lazy, so a
+// fresh address touches neither and gains no new way to fail.
+type orgInvitationLists struct {
+	live   liveInvitations
+	failed failedInviteRecords
+}
+
+func newOrgInvitationLists(client githubapi.Client, org string) *orgInvitationLists {
+	return &orgInvitationLists{
+		live:   liveInvitations{client: client, org: org},
+		failed: failedInviteRecords{client: client, org: org},
+	}
+}
+
+// pendingRowState is what a pending roster row means once GitHub is consulted,
+// since the row's shape alone can't tell a live invitation from a dead one.
+type pendingRowState int
+
+const (
+	// pendingLive: GitHub still lists the invitation; the student can accept it.
+	pendingLive pendingRowState = iota + 1
+	// pendingAccepted: the invitation is gone but the invite team holds a
+	// member, so someone accepted and `roster sync` will record them. Sending
+	// again would only trip EnsureInviteTeam's not-empty check.
+	pendingAccepted
+	// pendingDead: nothing backs the row (expired after GitHub's 7 days, or
+	// revoked outside Classroom 50). The web renders this "unlinked" and
+	// offers Re-invite; here the address is simply invited again against the
+	// same row, with EnsureInviteTeam adopting or recreating the invite team.
+	pendingDead
+)
+
+// classifyPendingRow resolves a pending row's state from GitHub's pending list
+// and, only when the invitation is gone, the invite team's members.
+func classifyPendingRow(client githubapi.Client, org, classroom, email string, live *liveInvitations) (pendingRowState, error) {
+	isLive, err := live.has(email)
+	if err != nil {
+		return 0, err
+	}
+	if isLive {
+		return pendingLive, nil
+	}
+	members, found, err := configrepo.FindTeamMembersWithIDs(client, org, configrepo.InviteTeamName(classroom, email))
+	if err != nil {
+		return 0, err
+	}
+	if found && len(members) > 0 {
+		return pendingAccepted, nil
+	}
+	return pendingDead, nil
+}
+
 // sendOneEmailInvite runs the per-address invite sequence shared by the single
-// `roster invite` and the bulk `--file` path: pre-check the stored roster,
-// ensure the per-invite metadata team, send the org invitation carrying the
-// classroom and invite team ids, and classify the result. It never writes
+// `roster invite` and the bulk `--file` path: pre-check the stored roster (and,
+// for a pending row, GitHub), ensure the per-invite metadata team, send the org
+// invitation carrying the classroom and invite team ids, classify the result,
+// and for a re-invite dismiss the expired record GitHub kept. It never writes
 // roster.csv — the caller owns the commit — so a bulk run can append every
 // invited address in one batched commit.
 //
 // The order is load-bearing (mirrors the web's bulkInviteByEmail inviteOne):
-// every read that could refuse the send happens before the first write, and the
+// every read that could refuse the send happens before the first write, the
 // invite team's record is written before the invitation exists, so an accepted
-// invitation always has an address to recover.
-// reissue marks a deliberate re-send of an invitation the caller has confirmed
-// expired (GitHub holds no live one for the address, though its roster row lives
-// on). It suppresses both the pending-row block and the shared-address note: the
-// caller has already explained the re-send, and either message would only
-// contradict it. The bulk path passes false: it never reads the live-invitation
-// list, so it can't tell an expired invite from a live one and stays
-// conservative.
-func sendOneEmailInvite(client githubapi.Client, errOut io.Writer, org, classroom, email string, classroomTeam configrepo.TeamRef, actor string, rows []configrepo.RosterRow, reissue bool) (emailInviteOutcome, configrepo.TeamRef, error) {
+// invitation always has an address to recover, and the expired record is
+// dismissed only once GitHub confirms the address is covered again.
+func sendOneEmailInvite(client githubapi.Client, out, errOut io.Writer, org, classroom, email string, classroomTeam configrepo.TeamRef, actor string, rows []configrepo.RosterRow, lists *orgInvitationLists) (emailInviteOutcome, configrepo.TeamRef, error) {
 	holder, pending := rosterEmailClaim(rows, email)
-	if pending && !reissue {
-		return outcomePendingBlocked, configrepo.TeamRef{}, nil
+	reinvite := false
+	if pending {
+		state, err := classifyPendingRow(client, org, classroom, email, &lists.live)
+		if err != nil {
+			if cliutil.IsRateLimited(err) {
+				return outcomeRateLimited, configrepo.TeamRef{}, err
+			}
+			return outcomeFailed, configrepo.TeamRef{}, err
+		}
+		switch state {
+		case pendingLive:
+			return outcomePendingBlocked, configrepo.TeamRef{}, nil
+		case pendingAccepted:
+			return outcomeAcceptedBlocked, configrepo.TeamRef{}, nil
+		}
+		reinvite = true
+		_, _ = fmt.Fprintf(errOut, "Note: %s is on the %s roster as a pending invitation, but GitHub no longer lists one for the address (invitations expire after 7 days), so a new invitation is being sent. The existing row is kept.\n",
+			email, classroom)
 	}
-	if holder != "" && !reissue {
+	if holder != "" {
 		_, _ = fmt.Fprintf(errOut, "Note: %s already appears on the %s roster on %s's row. An address can be shared (a parent or a lab contact), so the invitation is still being sent, but no second row is written for it, matching the web app. If that row is the same person, cancel this invite and run `gh teacher roster update %s %s %s` instead.\n",
 			email, classroom, holder, org, classroom, holder)
 	}
@@ -272,9 +363,17 @@ func sendOneEmailInvite(client githubapi.Client, errOut io.Writer, org, classroo
 			return outcomeRateLimited, configrepo.TeamRef{}, err
 		}
 		if errors.Is(err, membership.ErrEmailAlreadyInvitedOrMember) {
+			// Something live already covers the address, so its expired record
+			// is noise either way (the web dismisses on this 422 too).
+			if reinvite {
+				lists.failed.dismiss(out, errOut, email)
+			}
 			return outcomeSkippedAlready, configrepo.TeamRef{}, nil
 		}
 		return outcomeFailed, configrepo.TeamRef{}, err
+	}
+	if reinvite {
+		lists.failed.dismiss(out, errOut, email)
 	}
 	return outcomeInvited, inviteTeam, nil
 }
@@ -302,54 +401,6 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 	if err != nil {
 		return err
 	}
-	// Decide up front whether an address the roster already knows should still be
-	// (re-)sent. GitHub expires an org invitation after 7 days and drops it while
-	// the roster row lives on, so the row alone can't tell a live invitation from a
-	// lapsed one; only the live-invitation list can. When it lapsed we re-issue
-	// rather than leave the teacher wedged, since cancel-invite won't clear a row
-	// it has no live invitation to revoke and invite would otherwise refuse off
-	// that same row.
-	holder, pending := rosterEmailClaim(rows, email)
-	var reissue bool
-	switch {
-	case pending:
-		// An email-only pending row (issue #970's shape). Refuse here rather than
-		// off outcomePendingBlocked so this path can name the sync/cancel remedies;
-		// the helper's own check stays authoritative for the bulk path.
-		live, err := pendingEmailInvitations(client, org)
-		if err != nil {
-			return err
-		}
-		if live[email] {
-			return fmt.Errorf("%s is already invited to %s and nothing was sent. Run `gh teacher roster sync %s %s` if they accepted, or `gh teacher roster cancel-invite %s %s %s` to revoke it",
-				email, classroom, org, classroom, org, classroom, email)
-		}
-		reissue = true
-		_, _ = fmt.Fprintf(errOut, "The earlier invitation to %s had expired; sending a fresh one and keeping its pending row.\n", email)
-	case holder != "":
-		// The address rides a row that already names a student. That happens two
-		// ways (this student's own invitation lapsed, or a different person
-		// genuinely shares the address), and roster state alone can't tell them
-		// apart. The metadata team can: it exists only because THIS classroom
-		// invited the address, so with that proof and no live invitation this is
-		// the student's lapsed invite and we re-issue with a plain message.
-		// Without it, fall through to the shared-address note sendOneEmailInvite
-		// prints, which stays right for a genuinely shared address.
-		invited, err := classroomInvitedByEmail(client, org, classroom, email)
-		if err != nil {
-			return err
-		}
-		if invited {
-			live, err := pendingEmailInvitations(client, org)
-			if err != nil {
-				return err
-			}
-			if !live[email] {
-				reissue = true
-				_, _ = fmt.Fprintf(errOut, "The invitation to %s had expired; re-issuing it on %s's row (no second row is written).\n", email, holder)
-			}
-		}
-	}
 
 	// EnsureInviteTeam drops the creator GitHub silently adds, so it needs to
 	// know who that is.
@@ -358,7 +409,8 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 		return fmt.Errorf("resolving your GitHub login (needed to keep the invite team free of teachers): %w", err)
 	}
 
-	outcome, inviteTeam, sendErr := sendOneEmailInvite(client, errOut, org, classroom, email, classroomTeam, actor, rows, reissue)
+	lists := newOrgInvitationLists(client, org)
+	outcome, inviteTeam, sendErr := sendOneEmailInvite(client, out, errOut, org, classroom, email, classroomTeam, actor, rows, lists)
 	switch outcome {
 	case outcomeInvited:
 		_, _ = fmt.Fprintf(out, "%s: invited %s as direct_member (teams %s, %s)\n",
@@ -367,11 +419,15 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 		_, _ = fmt.Fprintf(out, "%s: skipped %s (already a member of the org or already invited)\n", org, email)
 		_, _ = fmt.Fprintf(errOut, "If they accepted an earlier invitation, run `gh teacher roster sync %s %s` to record them on the roster.\n", org, classroom)
 		return nil
+	case outcomePendingBlocked:
+		return fmt.Errorf("%s already has a pending invitation to %s, so nothing was sent. Advise them to accept it, then run `gh teacher roster sync %s %s` to record them, or run `gh teacher roster cancel-invite %s %s %s` to revoke it",
+			email, classroom, org, classroom, org, classroom, email)
+	case outcomeAcceptedBlocked:
+		return fmt.Errorf("%s accepted an earlier invitation to %s but isn't recorded on the roster yet, so nothing was sent. Run `gh teacher roster sync %s %s --write` to record their username and github_id",
+			email, classroom, org, classroom)
 	case outcomeRateLimited, outcomeFailed:
 		return sendErr
 	default:
-		// Includes outcomePendingBlocked, which the pre-check above already
-		// refused with a better message, and the unset zero value.
 		return fmt.Errorf("internal error: unhandled invite outcome %d for %s (nothing was recorded)", outcome, email)
 	}
 
@@ -425,14 +481,14 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 }
 
 // rosterEmailClaim reports how the stored roster already holds this address:
-// `pending` for an identity-less email-invite row (a second invitation would
-// duplicate it, and RosterRow.IsPendingEmailInvite is the shared rule the write
-// helpers apply), and `holder` for the username of a row that merely carries the
-// address. Only `pending` may block a SEND: the web is explicit that a claimed
-// address does NOT filter the send list, since an address can belong to someone
-// else's row — a shared family address or a lab contact — and that real person
-// still needs inviting (see UploadRoster's claimedEmails). The ROW is a separate
-// question, answered by rosterHoldsEmail.
+// `pending` for an identity-less email-invite row (RosterRow.IsPendingEmailInvite
+// is the shared rule the write helpers apply; classifyPendingRow then asks GitHub
+// whether anything still backs it), and `holder` for the username of a row that
+// merely carries the address. Only `pending` may block a SEND: the web is
+// explicit that a claimed address does NOT filter the send list, since an
+// address can belong to someone else's row — a shared family address or a lab
+// contact — and that real person still needs inviting (see UploadRoster's
+// claimedEmails). The ROW is a separate question, answered by rosterHoldsEmail.
 func rosterEmailClaim(rows []configrepo.RosterRow, email string) (holder string, pending bool) {
 	key := configrepo.NormalizeInviteEmail(email)
 	if key == "" {
@@ -450,24 +506,6 @@ func rosterEmailClaim(rows []configrepo.RosterRow, email string) (holder string,
 		}
 	}
 	return holder, false
-}
-
-// classroomInvitedByEmail reports whether THIS classroom sent an email
-// invitation to this address, proven by its per-invite metadata team carrying a
-// record for the classroom, the same ownership proof cancel-invite trusts
-// (requireClassroomOwnsInvite). It tells a student whose own invitation lapsed
-// from a classmate who merely shares the address: only the former leaves a team.
-// A missing team (404) or a record-less one reads as "not invited here", and any
-// other read failure propagates rather than masquerading as absent.
-func classroomInvitedByEmail(client githubapi.Client, org, classroom, email string) (bool, error) {
-	state, ok, err := configrepo.ReadInviteTeam(client, org, configrepo.InviteTeamName(classroom, email))
-	if err != nil {
-		return false, err
-	}
-	if !ok || state.Record == nil {
-		return false, nil
-	}
-	return state.Record.Classroom == classroom, nil
 }
 
 // rosterHoldsEmail reports whether ANY row already carries the address, whatever

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -67,12 +67,15 @@ func rosterInviteCmd() *cobra.Command {
 			"     are skipped)\n" +
 			"  1  an address genuinely failed or the roster write failed\n\n" +
 			"A single address returns non-zero on: classroom missing a GitHub team,\n" +
-			"an address the roster already lists as invited, or a failed\n" +
-			"invitation. With --file that same already-listed address is reported\n" +
-			"as skipped instead, and does not affect the exit code. An address\n" +
-			"that already belongs to a member (or already has a pending\n" +
-			"invitation) is reported as skipped and exits 0. An address some other\n" +
-			"row already carries is still invited, but gets no second row.",
+			"an address whose invitation is still outstanding, or a failed\n" +
+			"invitation. When the roster still lists an invite GitHub has since\n" +
+			"expired (they lapse after 7 days), the invitation is re-sent rather\n" +
+			"than refused, and the pending row is kept. With --file that same\n" +
+			"already-listed address is reported as skipped instead, and does not\n" +
+			"affect the exit code. An address that already belongs to a member (or\n" +
+			"already has a pending invitation) is reported as skipped and exits 0.\n" +
+			"An address some other row already carries is still invited, but gets\n" +
+			"no second row.",
 		Example: "  gh teacher roster invite cs50-fall-2026 cs-principles ada@example.edu\n" +
 			"  gh teacher roster invite cs50-fall-2026 cs-principles ada@example.edu --first-name Ada --last-name Lovelace --section section-1\n" +
 			"  gh teacher roster invite cs50-fall-2026 cs-principles --file ./section-1-emails.txt",
@@ -223,9 +226,14 @@ const (
 // every read that could refuse the send happens before the first write, and the
 // invite team's record is written before the invitation exists, so an accepted
 // invitation always has an address to recover.
-func sendOneEmailInvite(client githubapi.Client, errOut io.Writer, org, classroom, email string, classroomTeam configrepo.TeamRef, actor string, rows []configrepo.RosterRow) (emailInviteOutcome, configrepo.TeamRef, error) {
+// reissue overrides the pending-row block: the caller has confirmed GitHub holds
+// no live invitation for the address, so the pending row is a leftover from one
+// that expired and re-sending is the recovery, not a duplicate. The bulk path
+// passes false: it never reads the live-invitation list, so it can't tell an
+// expired invite from a live one and stays conservative.
+func sendOneEmailInvite(client githubapi.Client, errOut io.Writer, org, classroom, email string, classroomTeam configrepo.TeamRef, actor string, rows []configrepo.RosterRow, reissue bool) (emailInviteOutcome, configrepo.TeamRef, error) {
 	holder, pending := rosterEmailClaim(rows, email)
-	if pending {
+	if pending && !reissue {
 		return outcomePendingBlocked, configrepo.TeamRef{}, nil
 	}
 	if holder != "" {
@@ -292,12 +300,29 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 	if err != nil {
 		return err
 	}
+	// A pending row usually means an invitation is still out, and re-sending would
+	// only duplicate it. But GitHub expires an org invitation after 7 days and
+	// drops it while the row lives on, and cancel-invite won't clear a row it has
+	// no live invitation to revoke. So a pending row alone can't decide this: check
+	// whether GitHub still holds the invitation, and only refuse when it does.
 	// Refuse here rather than off outcomePendingBlocked so this path's error can
 	// name the sync/cancel-invite remedies; the helper's own check stays
 	// authoritative for the bulk path.
+	var reissue bool
 	if _, pending := rosterEmailClaim(rows, email); pending {
-		return fmt.Errorf("%s is already invited to %s and nothing was sent. Run `gh teacher roster sync %s %s` if they accepted, or `gh teacher roster cancel-invite %s %s %s` to revoke it",
-			email, classroom, org, classroom, org, classroom, email)
+		live, err := pendingEmailInvitations(client, org)
+		if err != nil {
+			return err
+		}
+		if live[email] {
+			return fmt.Errorf("%s is already invited to %s and nothing was sent. Run `gh teacher roster sync %s %s` if they accepted, or `gh teacher roster cancel-invite %s %s %s` to revoke it",
+				email, classroom, org, classroom, org, classroom, email)
+		}
+		// The row outlived its invitation, so re-issue rather than leave the
+		// teacher wedged: invite refuses off the row, cancel-invite refuses off the
+		// absent invitation, and neither can act.
+		reissue = true
+		_, _ = fmt.Fprintf(errOut, "The earlier invitation to %s had expired; sending a fresh one and keeping its pending row.\n", email)
 	}
 
 	// EnsureInviteTeam drops the creator GitHub silently adds, so it needs to
@@ -307,7 +332,7 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 		return fmt.Errorf("resolving your GitHub login (needed to keep the invite team free of teachers): %w", err)
 	}
 
-	outcome, inviteTeam, sendErr := sendOneEmailInvite(client, errOut, org, classroom, email, classroomTeam, actor, rows)
+	outcome, inviteTeam, sendErr := sendOneEmailInvite(client, errOut, org, classroom, email, classroomTeam, actor, rows, reissue)
 	switch outcome {
 	case outcomeInvited:
 		_, _ = fmt.Fprintf(out, "%s: invited %s as direct_member (teams %s, %s)\n",

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -316,7 +316,7 @@ func classifyPendingRow(client githubapi.Client, org, classroom, email string, l
 	case team.Provisional:
 		return pendingDead, nil
 	default:
-		return 0, fmt.Errorf("the invite team %s for %s has a member but its description is no longer a readable invite record, so nothing was sent. Check the team at https://github.com/orgs/%s/teams/%s before re-inviting, and delete it by hand if the member is not the invitee",
+		return 0, fmt.Errorf("the invite team %s for %s has a member but its description is no longer a readable invite record, so nothing was changed. Check the team at https://github.com/orgs/%s/teams/%s first, and delete it by hand if the member is not the invitee",
 			slug, email, org, slug)
 	}
 }

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -257,9 +257,9 @@ func newOrgInvitationLists(client githubapi.Client, org string) *orgInvitationLi
 	}
 }
 
-// syncWriteCommand is the command every "they accepted, now record them" hint
-// names. The sync is a dry run by default, so a hint that omits --write sends
-// the teacher to a command that records nothing.
+// syncWriteCommand is the command every "now record them" hint names. The sync
+// is a dry run by default, so a hint that omits --write sends the teacher to a
+// command that records nothing.
 func syncWriteCommand(org, classroom string) string {
 	return fmt.Sprintf("`gh teacher roster sync %s %s --write`", org, classroom)
 }
@@ -282,10 +282,11 @@ const (
 )
 
 // classifyPendingRow resolves a pending row's state from GitHub's pending list
-// and, only when the invitation is gone, the invite team. A team without a
-// valid record (gone, or still provisional from an interrupted run) holds no
-// address, so any member on it is a stranded teacher, not an invitee: that row
-// is dead, and the re-send's EnsureInviteTeam adopts and heals the team.
+// and, only when the invitation is gone, the invite team. The team's record
+// decides what a member on it means: a valid record makes them the invitee; a
+// provisional description (an interrupted run) makes them the stranded teacher
+// the re-send's EnsureInviteTeam drops; any other unreadable record is the same
+// trust failure the sync reports, so the row is refused for a human to check.
 func classifyPendingRow(client githubapi.Client, org, classroom, email string, live *liveInvitations) (pendingRowState, error) {
 	isLive, err := live.has(email)
 	if err != nil {
@@ -299,17 +300,25 @@ func classifyPendingRow(client githubapi.Client, org, classroom, email string, l
 	if err != nil {
 		return 0, err
 	}
-	if !found || team.Record == nil {
+	if !found {
 		return pendingDead, nil
 	}
 	members, found, err := configrepo.FindTeamMembersWithIDs(client, org, slug)
 	if err != nil {
 		return 0, err
 	}
-	if found && len(members) > 0 {
-		return pendingAccepted, nil
+	if !found || len(members) == 0 {
+		return pendingDead, nil
 	}
-	return pendingDead, nil
+	switch {
+	case team.Record != nil:
+		return pendingAccepted, nil
+	case team.Provisional:
+		return pendingDead, nil
+	default:
+		return 0, fmt.Errorf("the invite team %s for %s has a member but its description is no longer a readable invite record, so nothing was sent. Check the team at https://github.com/orgs/%s/teams/%s before re-inviting, and delete it by hand if the member is not the invitee",
+			slug, email, org, slug)
+	}
 }
 
 // sendOneEmailInvite is the per-address invite sequence shared by `roster
@@ -365,14 +374,16 @@ func sendOneEmailInvite(client githubapi.Client, out, errOut io.Writer, org, cla
 		// A doomed invitation must not leave a fresh, member-less metadata team
 		// behind for the GC to reap — but an ADOPTED team may hold an earlier
 		// invite's still-unrecovered record, so only delete what this run made.
-		// A rate limit is not doomed: the team stays so a retry adopts it rather
-		// than re-creating one against the same limit (as the web does).
-		if created && !cliutil.IsRateLimited(err) {
+		// A rate limit or GitHub's invitation cap is not doomed: the team stays
+		// so a retry adopts it rather than re-creating one against the same
+		// limit (as the web does).
+		limited := cliutil.IsRateLimited(err) || errors.Is(err, membership.ErrInvitationLimit)
+		if created && !limited {
 			if delErr := configrepo.DeleteInviteTeam(client, org, inviteTeam.Slug); delErr != nil {
 				warnStrandedInviteTeam(errOut, "nothing was invited, but cleaning up", org, inviteTeam.Slug, delErr)
 			}
 		}
-		if cliutil.IsRateLimited(err) {
+		if limited {
 			return outcomeRateLimited, configrepo.TeamRef{}, err
 		}
 		if errors.Is(err, membership.ErrEmailAlreadyInvitedOrMember) {
@@ -430,7 +441,7 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 			org, email, classroomTeam.Slug, inviteTeam.Slug)
 	case outcomeSkippedAlready:
 		_, _ = fmt.Fprintf(out, "%s: skipped %s (already a member of the org or already invited)\n", org, email)
-		_, _ = fmt.Fprintf(errOut, "If they accepted an earlier invitation, run `gh teacher roster sync %s %s` to record them on the roster.\n", org, classroom)
+		_, _ = fmt.Fprintf(errOut, "If they accepted an earlier invitation, run %s to record them on the roster.\n", syncWriteCommand(org, classroom))
 		return nil
 	case outcomePendingBlocked:
 		return fmt.Errorf("GitHub still lists a pending invitation for %s (this classroom's, or another classroom's in %s), so nothing was sent. Advise them to accept it, then run %s to record them. To revoke this classroom's invitation, run `gh teacher roster cancel-invite %s %s %s`",
@@ -475,21 +486,21 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 		// Never a rollback: the invitation is the source of truth and the
 		// metadata team retains the address, so `roster sync` heals the row.
 		// Still non-zero, so a script sees the partial state.
-		_, _ = fmt.Fprintf(errOut, "Warning: the invitation to %s was sent, but recording it in %s failed; run `gh teacher roster sync %s %s` to add the pending row (the invitation itself is unaffected).\n",
-			email, configrepo.RosterFilePath(classroom), org, classroom)
+		_, _ = fmt.Fprintf(errOut, "Warning: the invitation to %s was sent, but recording it in %s failed; run %s to add the pending row (the invitation itself is unaffected).\n",
+			email, configrepo.RosterFilePath(classroom), syncWriteCommand(org, classroom))
 		return fmt.Errorf("invitation sent, but the roster row was not written: %w", err)
 	}
 	if !appended {
 		_, _ = fmt.Fprintf(out, "%s/%s/%s: %s is already on a row, roster unchanged (no second pending row)\n",
 			org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom), email)
-		_, _ = fmt.Fprintf(errOut, "Advise %s to accept the emailed invitation, then run `gh teacher roster sync %s %s` to record their username and github_id on the row that carries the address.\n",
-			email, org, classroom)
+		_, _ = fmt.Fprintf(errOut, "Advise %s to accept the emailed invitation, then run %s to record their username and github_id on the row that carries the address.\n",
+			email, syncWriteCommand(org, classroom))
 		return nil
 	}
 	_, _ = fmt.Fprintf(out, "%s/%s/%s: added pending row for %s\n",
 		org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom), email)
-	_, _ = fmt.Fprintf(errOut, "Advise %s to accept the emailed invitation, then run `gh teacher roster sync %s %s` to record their username and github_id.\n",
-		email, org, classroom)
+	_, _ = fmt.Fprintf(errOut, "Advise %s to accept the emailed invitation, then run %s to record their username and github_id.\n",
+		email, syncWriteCommand(org, classroom))
 	return nil
 }
 

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -208,12 +208,10 @@ const (
 	// outcomeSkippedAlready: GitHub's 422 — already a member or already invited.
 	// No row; a team this run created has already been torn down.
 	outcomeSkippedAlready
-	// outcomePendingBlocked: the stored roster lists this address as a pending
-	// email invite AND GitHub still has that invitation, so nothing was sent.
+	// outcomePendingBlocked: the row's invitation is pendingLive; nothing was sent.
 	outcomePendingBlocked
-	// outcomeAcceptedBlocked: the pending row's invitation is gone but its
-	// invite team has a member, so someone accepted and only a sync is missing.
-	// Nothing was sent.
+	// outcomeAcceptedBlocked: the row's invitation is pendingAccepted; nothing
+	// was sent.
 	outcomeAcceptedBlocked
 	// outcomeRateLimited: a secondary rate limit; the bulk caller stops issuing
 	// new sends and the single caller surfaces the error.
@@ -223,16 +221,18 @@ const (
 )
 
 // liveInvitations answers whether GitHub still lists a pending EMAIL invitation
-// for an address, reading the org's pending list once and only on first use.
+// for an address, reading the org's pending list on first use.
 type liveInvitations struct {
 	client githubapi.Client
 	org    string
+	loaded bool
 	emails map[string]bool
 	err    error
 }
 
 func (l *liveInvitations) has(email string) (bool, error) {
-	if l.emails == nil && l.err == nil {
+	if !l.loaded {
+		l.loaded = true
 		l.emails, l.err = pendingEmailInvitations(l.client, l.org)
 	}
 	if l.err != nil {
@@ -257,6 +257,13 @@ func newOrgInvitationLists(client githubapi.Client, org string) *orgInvitationLi
 	}
 }
 
+// syncWriteCommand is the command every "they accepted, now record them" hint
+// names. The sync is a dry run by default, so a hint that omits --write sends
+// the teacher to a command that records nothing.
+func syncWriteCommand(org, classroom string) string {
+	return fmt.Sprintf("`gh teacher roster sync %s %s --write`", org, classroom)
+}
+
 // pendingRowState is what a pending roster row means once GitHub is consulted,
 // since the row's shape alone can't tell a live invitation from a dead one.
 type pendingRowState int
@@ -264,19 +271,21 @@ type pendingRowState int
 const (
 	// pendingLive: GitHub still lists the invitation; the student can accept it.
 	pendingLive pendingRowState = iota + 1
-	// pendingAccepted: the invitation is gone but the invite team holds a
-	// member, so someone accepted and `roster sync` will record them. Sending
-	// again would only trip EnsureInviteTeam's not-empty check.
+	// pendingAccepted: the invitation is gone but the invite team holds a valid
+	// record and a member, so someone accepted and `roster sync` will record
+	// them. Sending again would only trip EnsureInviteTeam's not-empty check.
 	pendingAccepted
 	// pendingDead: nothing backs the row (expired after GitHub's 7 days, or
-	// revoked outside Classroom 50). The web renders this "unlinked" and
-	// offers Re-invite; here the address is simply invited again against the
-	// same row, with EnsureInviteTeam adopting or recreating the invite team.
+	// revoked outside Classroom 50). The web renders this "unlinked" and offers
+	// Re-invite; here the address is invited again against the same row.
 	pendingDead
 )
 
 // classifyPendingRow resolves a pending row's state from GitHub's pending list
-// and, only when the invitation is gone, the invite team's members.
+// and, only when the invitation is gone, the invite team. A team without a
+// valid record (gone, or still provisional from an interrupted run) holds no
+// address, so any member on it is a stranded teacher, not an invitee: that row
+// is dead, and the re-send's EnsureInviteTeam adopts and heals the team.
 func classifyPendingRow(client githubapi.Client, org, classroom, email string, live *liveInvitations) (pendingRowState, error) {
 	isLive, err := live.has(email)
 	if err != nil {
@@ -285,7 +294,15 @@ func classifyPendingRow(client githubapi.Client, org, classroom, email string, l
 	if isLive {
 		return pendingLive, nil
 	}
-	members, found, err := configrepo.FindTeamMembersWithIDs(client, org, configrepo.InviteTeamName(classroom, email))
+	slug := configrepo.InviteTeamName(classroom, email)
+	team, found, err := configrepo.ReadInviteTeam(client, org, slug)
+	if err != nil {
+		return 0, err
+	}
+	if !found || team.Record == nil {
+		return pendingDead, nil
+	}
+	members, found, err := configrepo.FindTeamMembersWithIDs(client, org, slug)
 	if err != nil {
 		return 0, err
 	}
@@ -295,13 +312,9 @@ func classifyPendingRow(client githubapi.Client, org, classroom, email string, l
 	return pendingDead, nil
 }
 
-// sendOneEmailInvite runs the per-address invite sequence shared by the single
-// `roster invite` and the bulk `--file` path: pre-check the stored roster (and,
-// for a pending row, GitHub), ensure the per-invite metadata team, send the org
-// invitation carrying the classroom and invite team ids, classify the result,
-// and for a re-invite dismiss the expired record GitHub kept. It never writes
-// roster.csv — the caller owns the commit — so a bulk run can append every
-// invited address in one batched commit.
+// sendOneEmailInvite is the per-address invite sequence shared by `roster
+// invite` and its `--file` path. It never writes roster.csv: the caller owns the
+// commit, so a bulk run appends every invited address at once.
 //
 // The order is load-bearing (mirrors the web's bulkInviteByEmail inviteOne):
 // every read that could refuse the send happens before the first write, the
@@ -420,11 +433,11 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 		_, _ = fmt.Fprintf(errOut, "If they accepted an earlier invitation, run `gh teacher roster sync %s %s` to record them on the roster.\n", org, classroom)
 		return nil
 	case outcomePendingBlocked:
-		return fmt.Errorf("%s already has a pending invitation to %s, so nothing was sent. Advise them to accept it, then run `gh teacher roster sync %s %s` to record them, or run `gh teacher roster cancel-invite %s %s %s` to revoke it",
-			email, classroom, org, classroom, org, classroom, email)
+		return fmt.Errorf("GitHub still lists a pending invitation for %s (this classroom's, or another classroom's in %s), so nothing was sent. Advise them to accept it, then run %s to record them. To revoke this classroom's invitation, run `gh teacher roster cancel-invite %s %s %s`",
+			email, org, syncWriteCommand(org, classroom), org, classroom, email)
 	case outcomeAcceptedBlocked:
-		return fmt.Errorf("%s accepted an earlier invitation to %s but isn't recorded on the roster yet, so nothing was sent. Run `gh teacher roster sync %s %s --write` to record their username and github_id",
-			email, classroom, org, classroom)
+		return fmt.Errorf("%s accepted an earlier invitation to %s but isn't recorded on the roster yet, so nothing was sent. Run %s to record their username and github_id",
+			email, classroom, syncWriteCommand(org, classroom))
 	case outcomeRateLimited, outcomeFailed:
 		return sendErr
 	default:

--- a/cli/gh-teacher/internal/roster/invite.go
+++ b/cli/gh-teacher/internal/roster/invite.go
@@ -226,17 +226,19 @@ const (
 // every read that could refuse the send happens before the first write, and the
 // invite team's record is written before the invitation exists, so an accepted
 // invitation always has an address to recover.
-// reissue overrides the pending-row block: the caller has confirmed GitHub holds
-// no live invitation for the address, so the pending row is a leftover from one
-// that expired and re-sending is the recovery, not a duplicate. The bulk path
-// passes false: it never reads the live-invitation list, so it can't tell an
-// expired invite from a live one and stays conservative.
+// reissue marks a deliberate re-send of an invitation the caller has confirmed
+// expired (GitHub holds no live one for the address, though its roster row lives
+// on). It suppresses both the pending-row block and the shared-address note: the
+// caller has already explained the re-send, and either message would only
+// contradict it. The bulk path passes false: it never reads the live-invitation
+// list, so it can't tell an expired invite from a live one and stays
+// conservative.
 func sendOneEmailInvite(client githubapi.Client, errOut io.Writer, org, classroom, email string, classroomTeam configrepo.TeamRef, actor string, rows []configrepo.RosterRow, reissue bool) (emailInviteOutcome, configrepo.TeamRef, error) {
 	holder, pending := rosterEmailClaim(rows, email)
 	if pending && !reissue {
 		return outcomePendingBlocked, configrepo.TeamRef{}, nil
 	}
-	if holder != "" {
+	if holder != "" && !reissue {
 		_, _ = fmt.Fprintf(errOut, "Note: %s already appears on the %s roster on %s's row. An address can be shared (a parent or a lab contact), so the invitation is still being sent, but no second row is written for it, matching the web app. If that row is the same person, cancel this invite and run `gh teacher roster update %s %s %s` instead.\n",
 			email, classroom, holder, org, classroom, holder)
 	}
@@ -300,16 +302,20 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 	if err != nil {
 		return err
 	}
-	// A pending row usually means an invitation is still out, and re-sending would
-	// only duplicate it. But GitHub expires an org invitation after 7 days and
-	// drops it while the row lives on, and cancel-invite won't clear a row it has
-	// no live invitation to revoke. So a pending row alone can't decide this: check
-	// whether GitHub still holds the invitation, and only refuse when it does.
-	// Refuse here rather than off outcomePendingBlocked so this path's error can
-	// name the sync/cancel-invite remedies; the helper's own check stays
-	// authoritative for the bulk path.
+	// Decide up front whether an address the roster already knows should still be
+	// (re-)sent. GitHub expires an org invitation after 7 days and drops it while
+	// the roster row lives on, so the row alone can't tell a live invitation from a
+	// lapsed one; only the live-invitation list can. When it lapsed we re-issue
+	// rather than leave the teacher wedged, since cancel-invite won't clear a row
+	// it has no live invitation to revoke and invite would otherwise refuse off
+	// that same row.
+	holder, pending := rosterEmailClaim(rows, email)
 	var reissue bool
-	if _, pending := rosterEmailClaim(rows, email); pending {
+	switch {
+	case pending:
+		// An email-only pending row (issue #970's shape). Refuse here rather than
+		// off outcomePendingBlocked so this path can name the sync/cancel remedies;
+		// the helper's own check stays authoritative for the bulk path.
 		live, err := pendingEmailInvitations(client, org)
 		if err != nil {
 			return err
@@ -318,11 +324,31 @@ func runRosterInvite(client githubapi.Client, out, errOut io.Writer, org, classr
 			return fmt.Errorf("%s is already invited to %s and nothing was sent. Run `gh teacher roster sync %s %s` if they accepted, or `gh teacher roster cancel-invite %s %s %s` to revoke it",
 				email, classroom, org, classroom, org, classroom, email)
 		}
-		// The row outlived its invitation, so re-issue rather than leave the
-		// teacher wedged: invite refuses off the row, cancel-invite refuses off the
-		// absent invitation, and neither can act.
 		reissue = true
 		_, _ = fmt.Fprintf(errOut, "The earlier invitation to %s had expired; sending a fresh one and keeping its pending row.\n", email)
+	case holder != "":
+		// The address rides a row that already names a student. That happens two
+		// ways (this student's own invitation lapsed, or a different person
+		// genuinely shares the address), and roster state alone can't tell them
+		// apart. The metadata team can: it exists only because THIS classroom
+		// invited the address, so with that proof and no live invitation this is
+		// the student's lapsed invite and we re-issue with a plain message.
+		// Without it, fall through to the shared-address note sendOneEmailInvite
+		// prints, which stays right for a genuinely shared address.
+		invited, err := classroomInvitedByEmail(client, org, classroom, email)
+		if err != nil {
+			return err
+		}
+		if invited {
+			live, err := pendingEmailInvitations(client, org)
+			if err != nil {
+				return err
+			}
+			if !live[email] {
+				reissue = true
+				_, _ = fmt.Fprintf(errOut, "The invitation to %s had expired; re-issuing it on %s's row (no second row is written).\n", email, holder)
+			}
+		}
 	}
 
 	// EnsureInviteTeam drops the creator GitHub silently adds, so it needs to
@@ -424,6 +450,24 @@ func rosterEmailClaim(rows []configrepo.RosterRow, email string) (holder string,
 		}
 	}
 	return holder, false
+}
+
+// classroomInvitedByEmail reports whether THIS classroom sent an email
+// invitation to this address, proven by its per-invite metadata team carrying a
+// record for the classroom, the same ownership proof cancel-invite trusts
+// (requireClassroomOwnsInvite). It tells a student whose own invitation lapsed
+// from a classmate who merely shares the address: only the former leaves a team.
+// A missing team (404) or a record-less one reads as "not invited here", and any
+// other read failure propagates rather than masquerading as absent.
+func classroomInvitedByEmail(client githubapi.Client, org, classroom, email string) (bool, error) {
+	state, ok, err := configrepo.ReadInviteTeam(client, org, configrepo.InviteTeamName(classroom, email))
+	if err != nil {
+		return false, err
+	}
+	if !ok || state.Record == nil {
+		return false, nil
+	}
+	return state.Record.Classroom == classroom, nil
 }
 
 // rosterHoldsEmail reports whether ANY row already carries the address, whatever

--- a/cli/gh-teacher/internal/roster/invite_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_cmd_test.go
@@ -45,9 +45,17 @@ type inviteMock struct {
 	// when a pending roster row makes the invite path check whether the invitation
 	// lapsed, so the happy path never touches it.
 	livePendingEmails []string
+	// inviteTeamDescription is what a GET of the metadata team serves. Empty (the
+	// default) reads as a record-less team, so classroomInvitedByEmail treats the
+	// address as not invited here; set it to a marshaled record to prove this
+	// classroom invited the address.
+	inviteTeamDescription string
 	// listInvitationsStatus is the GET /orgs/o/invitations status (0 → 200 with the
 	// livePendingEmails list); a 5xx drives the liveness read failure.
 	listInvitationsStatus int
+	// getInviteTeamStatus is the metadata-team GET status (0 → 200); a 5xx drives a
+	// degraded read that classroomInvitedByEmail must propagate, not read as absent.
+	getInviteTeamStatus int
 
 	calls           []inviteCall
 	invitationBody  map[string]any
@@ -80,6 +88,17 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 		if r.Method == http.MethodDelete {
 			m.deletedTeamSlug = m.inviteTeamSlug
 			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method == http.MethodGet {
+			if s := m.getInviteTeamStatus; s != 0 && s != http.StatusOK {
+				w.WriteHeader(s)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": inviteTestInviteTeamID, "slug": m.inviteTeamSlug,
+				"privacy": "secret", "description": m.inviteTeamDescription,
+			})
 			return
 		}
 		var body struct {
@@ -377,6 +396,12 @@ func TestRunRosterInvite_AddressOnAnAccountRowWarnsAndSends(t *testing.T) {
 	if !strings.Contains(errOut, "sibling") {
 		t.Errorf("stderr should name the account already holding the address:\n%s", errOut)
 	}
+	// No metadata team records this classroom invited the address (the mock serves
+	// a record-less team), so it reads as a genuinely shared address and keeps the
+	// parent/lab-contact note, the contrast with the expired-reissue case below.
+	if !strings.Contains(errOut, "parent or a lab contact") {
+		t.Errorf("a shared address should keep the shared-address note:\n%s", errOut)
+	}
 	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") < 0 {
 		t.Fatalf("the invitation was never sent; calls = %#v", mock.calls)
 	}
@@ -385,6 +410,41 @@ func TestRunRosterInvite_AddressOnAnAccountRowWarnsAndSends(t *testing.T) {
 	}
 	if !strings.Contains(out, "roster unchanged") {
 		t.Errorf("stdout should report the row was skipped:\n%s", out)
+	}
+}
+
+// A username-bearing row whose invitation lapsed is NOT the parent/lab-contact
+// case: the metadata team proves this classroom invited the address, so with no
+// live invitation the re-issue says so plainly rather than warning about a
+// shared address. This is the common real-world shape: the roster already knows
+// the student, their invite just expired.
+func TestRunRosterInvite_ExpiredInvitationOnUsernameRowIsReissued(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+"hopper,Grace,Hopper,"+inviteTestEmail+",,101,student\n")
+	desc, err := configrepo.MarshalInviteDescription(inviteTestClassroom, inviteTestEmail)
+	if err != nil {
+		t.Fatalf("MarshalInviteDescription: %v", err)
+	}
+	mock.inviteTeamDescription = desc // the metadata team still records the invite
+	mock.livePendingEmails = nil      // but GitHub no longer holds the invitation
+
+	out, errOut, err := runInvite(t, mock)
+	if err != nil {
+		t.Fatalf("an expired invitation on a username row must re-issue, not fail: %v", err)
+	}
+	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") < 0 {
+		t.Fatalf("the fresh invitation was never sent; calls = %#v", mock.calls)
+	}
+	if !strings.Contains(errOut, "expired") || !strings.Contains(errOut, "hopper") {
+		t.Errorf("stderr should say hopper's invitation expired and was re-issued:\n%s", errOut)
+	}
+	if strings.Contains(errOut, "parent or a lab contact") {
+		t.Errorf("the shared-address note must be suppressed for a proven re-issue:\n%s", errOut)
+	}
+	if len(mock.blobs) != 0 {
+		t.Errorf("re-issuing must not write a second row, got %d blob(s): %#v", len(mock.blobs), mock.blobs)
+	}
+	if !strings.Contains(out, "roster unchanged") {
+		t.Errorf("stdout should report the existing row was kept:\n%s", out)
 	}
 }
 
@@ -457,6 +517,56 @@ func TestRunRosterInvite_LivenessReadFailureRefusesUntouched(t *testing.T) {
 	}
 	if len(mock.blobs) != 0 {
 		t.Errorf("a failed liveness read must write no roster row, got %d blob(s)", len(mock.blobs))
+	}
+}
+
+// A degraded metadata-team read on the username-bearing path must propagate too:
+// reading it as absent would drop to the shared-address note and could re-send
+// against a team that actually proves this classroom's invite.
+func TestRunRosterInvite_MetadataTeamReadFailurePropagates(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+"hopper,Grace,Hopper,"+inviteTestEmail+",,101,student\n")
+	mock.getInviteTeamStatus = http.StatusInternalServerError
+
+	_, _, err := runInvite(t, mock)
+	if err == nil {
+		t.Fatal("err = nil, want the metadata-team read failure to propagate")
+	}
+	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") >= 0 {
+		t.Errorf("sent an invitation despite an unreadable metadata team; calls = %#v", mock.calls)
+	}
+	if len(mock.blobs) != 0 {
+		t.Errorf("a failed metadata-team read must write no roster row, got %d blob(s)", len(mock.blobs))
+	}
+}
+
+// A username-bearing row whose invitation GitHub still holds is not a re-issue:
+// with a live invitation the address keeps the shared-address note and the send
+// is left to skip on GitHub's 422, exactly as before this path existed.
+func TestRunRosterInvite_LiveInvitationOnUsernameRowKeepsSharedAddressNote(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+"hopper,Grace,Hopper,"+inviteTestEmail+",,101,student\n")
+	desc, err := configrepo.MarshalInviteDescription(inviteTestClassroom, inviteTestEmail)
+	if err != nil {
+		t.Fatalf("MarshalInviteDescription: %v", err)
+	}
+	mock.inviteTeamDescription = desc                      // this classroom did invite the address
+	mock.livePendingEmails = []string{inviteTestEmail}     // and GitHub still holds it
+	mock.invitationStatus = http.StatusUnprocessableEntity // so a resend 422-skips
+
+	out, errOut, err := runInvite(t, mock)
+	if err != nil {
+		t.Fatalf("a live invitation on a username row must skip, not fail: %v", err)
+	}
+	if !strings.Contains(errOut, "parent or a lab contact") {
+		t.Errorf("a live invitation must keep the shared-address note, not claim expiry:\n%s", errOut)
+	}
+	if strings.Contains(errOut, "expired") {
+		t.Errorf("nothing expired here, so the re-issue message must not appear:\n%s", errOut)
+	}
+	if !strings.Contains(out, "skipped") {
+		t.Errorf("stdout should report the 422 skip:\n%s", out)
+	}
+	if len(mock.blobs) != 0 {
+		t.Errorf("a skipped send must write no roster row, got %d blob(s)", len(mock.blobs))
 	}
 }
 

--- a/cli/gh-teacher/internal/roster/invite_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -34,8 +35,11 @@ type inviteMock struct {
 	// createStatus is the invite-team create status; 422 drives the adopt path
 	// (a pre-existing team a failed run must NOT delete).
 	createStatus int
-	// invitationStatus is the org-invitation POST status (0 → 201).
-	invitationStatus int
+	// invitationStatus is the org-invitation POST status (0 → 201). A 422 body
+	// says what GitHub rejected: invitation422Message, or the "already" text
+	// when empty.
+	invitationStatus     int
+	invitation422Message string
 	// invitationRateLimited makes the POST fail as a secondary rate limit, which
 	// the web deliberately treats differently from a hard failure.
 	invitationRateLimited bool
@@ -51,8 +55,12 @@ type inviteMock struct {
 	inviteTeamMembers []map[string]any
 	// inviteTeamStatus is the status of the invite team's GET and members read
 	// (0 → 200); 404 is a team the sync already garbage-collected, and lasts
-	// until this run recreates it.
-	inviteTeamStatus int
+	// until this run recreates it. inviteTeamMembersStatus overrides the members
+	// read alone, and inviteTeamRateLimited fails the team GET as a 403-shaped
+	// secondary rate limit.
+	inviteTeamStatus        int
+	inviteTeamMembersStatus int
+	inviteTeamRateLimited   bool
 	// inviteTeamDescription is what the team's GET reports before this run
 	// PATCHes it (empty → a plain record-less description).
 	inviteTeamDescription string
@@ -106,6 +114,10 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 			return
 		}
 		if r.Method == http.MethodGet {
+			if m.inviteTeamRateLimited {
+				writeSecondaryRateLimit403(w)
+				return
+			}
 			if status := m.teamStatus(); status != http.StatusOK {
 				w.WriteHeader(status)
 				return
@@ -129,14 +141,21 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 		})
 	})
 	base.HandleFunc(teamPath+"/memberships/"+inviteTestActor, func(w http.ResponseWriter, r *http.Request) {
-		// The drop is what removes a stranded teacher from an adopted team.
+		// The drop removes the acting teacher and nobody else, so a team that
+		// holds someone else stays not-empty.
 		if r.Method == http.MethodDelete {
-			m.inviteTeamMembers = nil
+			m.inviteTeamMembers = slices.DeleteFunc(m.inviteTeamMembers, func(member map[string]any) bool {
+				return member["login"] == inviteTestActor
+			})
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
 	base.HandleFunc(teamPath+"/members", func(w http.ResponseWriter, r *http.Request) {
-		if status := m.teamStatus(); status != http.StatusOK {
+		status := m.teamStatus()
+		if m.inviteTeamMembersStatus != 0 {
+			status = m.inviteTeamMembersStatus
+		}
+		if status != http.StatusOK {
 			w.WriteHeader(status)
 			return
 		}
@@ -175,6 +194,17 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 		status := m.invitationStatus
 		if status == 0 {
 			status = http.StatusCreated
+		}
+		if status == http.StatusUnprocessableEntity {
+			message := m.invitation422Message
+			if message == "" {
+				message = "Invitee is already a part of this org"
+			}
+			// go-gh only reads the message off a JSON content type.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": message})
+			return
 		}
 		w.WriteHeader(status)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
@@ -631,6 +661,31 @@ func TestRunRosterInvite_ReinviteAlreadyCoveredStillDismisses(t *testing.T) {
 	}
 }
 
+// GitHub uses the same 422 for its invitation cap. Nothing covers the address
+// after a capped send, so the expired record must stay, the fresh team must
+// stay for a retry to adopt, and the outcome is a deferral, not a skip.
+func TestRunRosterInvite_InvitationCapKeepsRecordAndTeam(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+	mock.pending = nil
+	mock.invitationStatus = http.StatusUnprocessableEntity
+	mock.invitation422Message = "Over invitation rate limit. Try again later."
+	mock.failed = []map[string]any{{"id": 70, "email": inviteTestEmail}}
+
+	_, _, err := runInvite(t, mock)
+	if err == nil || !strings.Contains(err.Error(), "invitation limit") {
+		t.Fatalf("err = %v, want the invitation limit reported", err)
+	}
+	if len(mock.dismissed) != 0 {
+		t.Errorf("dismissed %v although nothing covers the address", mock.dismissed)
+	}
+	if mock.deletedTeamSlug != "" {
+		t.Errorf("deleted the fresh team %q; a retry should adopt it", mock.deletedTeamSlug)
+	}
+	if len(mock.blobs) != 0 {
+		t.Errorf("wrote a roster row for an address that was not invited: %#v", mock.blobs)
+	}
+}
+
 // A GC'd team is the common expired shape, but a team the sync hasn't reaped yet
 // (younger than the GC age) is the same case: no invitation, no member. The send
 // must adopt that team rather than trip over the name collision.
@@ -675,6 +730,70 @@ func TestRunRosterInvite_StrandedProvisionalTeamIsReinvited(t *testing.T) {
 	}
 	if indexOfCall(mock.calls, http.MethodDelete, "/orgs/o/teams/"+mock.inviteTeamSlug+"/memberships/"+inviteTestActor) < 0 {
 		t.Errorf("the stranded teacher was not dropped from the adopted team; calls = %#v", mock.calls)
+	}
+}
+
+// A record-less team that is NOT provisional was edited by hand (the accepted
+// invitee owns their own team's description), so its member may well be the
+// student. The sync reports that shape as an anomaly and leaves it alone; the
+// re-invite must refuse the same way rather than adopt the team and tell the
+// teacher to remove the member.
+func TestRunRosterInvite_HandEditedTeamWithMemberRefused(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+	mock.pending = nil
+	mock.inviteTeamDescription = "not an invite record"
+	mock.inviteTeamMembers = []map[string]any{{"login": "ada", "id": 99}}
+
+	_, _, err := runInvite(t, mock)
+	if err == nil {
+		t.Fatal("err = nil, want a refusal naming the unreadable record")
+	}
+	for _, want := range []string{"readable invite record", mock.inviteTeamSlug} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "remove them") {
+		t.Errorf("must not tell the teacher to strip a member who may be the student: %v", err)
+	}
+	if writes := writeCalls(mock.calls); len(writes) != 0 {
+		t.Errorf("wrote %d request(s) for a team a human must check: %#v", len(writes), writes)
+	}
+}
+
+// A degraded read of the invite team (its GET or its members) refuses like a
+// degraded pending-list read: neither "dead" nor "accepted" can be proven, and
+// a rate limit must keep its shape so a bulk run defers instead of failing.
+func TestRunRosterInvite_DegradedTeamReadRefuses(t *testing.T) {
+	cases := []struct {
+		name          string
+		apply         func(*inviteMock)
+		wantRateLimit bool
+	}{
+		{"team GET 500", func(m *inviteMock) { m.inviteTeamStatus = http.StatusInternalServerError }, false},
+		{"team GET rate limited", func(m *inviteMock) { m.inviteTeamRateLimited = true }, true},
+		{"members GET 500 on a recorded team", func(m *inviteMock) {
+			m.inviteTeamDescription = inviteTestRecord(t)
+			m.inviteTeamMembersStatus = http.StatusInternalServerError
+		}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+			mock.pending = nil
+			tc.apply(mock)
+
+			_, _, err := runInvite(t, mock)
+			if err == nil {
+				t.Fatal("err = nil, want the degraded read to refuse")
+			}
+			if got := cliutil.IsRateLimited(err); got != tc.wantRateLimit {
+				t.Errorf("IsRateLimited = %v, want %v: %v", got, tc.wantRateLimit, err)
+			}
+			if writes := writeCalls(mock.calls); len(writes) != 0 {
+				t.Errorf("wrote %d request(s) after a degraded read: %#v", len(writes), writes)
+			}
+		})
 	}
 }
 

--- a/cli/gh-teacher/internal/roster/invite_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_cmd_test.go
@@ -73,9 +73,15 @@ type inviteMock struct {
 	failedRateLimited bool
 	// dismissStatus is the status of DELETE /orgs/o/invitations/{id} (0 → 204).
 	dismissStatus int
+	// inviteTeamDeleteStatus is the status of the invite team's DELETE (0 → 204).
+	inviteTeamDeleteStatus int
 	// commitFails fails the tree POST, simulating a roster write failure after a
 	// successful send.
 	commitFails bool
+	// afterCommit runs once the roster tree POST has been served, so a test can
+	// change what GitHub reports in the window between a commit and the
+	// teardown that follows it.
+	afterCommit func()
 
 	calls           []inviteCall
 	invitationBody  map[string]any
@@ -109,6 +115,10 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 
 	base.HandleFunc(teamPath, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodDelete {
+			if status := m.inviteTeamDeleteStatus; status != 0 && status != http.StatusNoContent {
+				w.WriteHeader(status)
+				return
+			}
 			m.deletedTeamSlug = m.inviteTeamSlug
 			w.WriteHeader(http.StatusNoContent)
 			return
@@ -234,15 +244,20 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	// commitFails intercepts before the mux so the tree POST never reaches it.
+	// commitFails intercepts before the mux so the tree POST never reaches it;
+	// afterCommit runs once the mux has served it.
 	failing := http.Handler(base)
-	if m.commitFails {
+	if m.commitFails || m.afterCommit != nil {
 		failing = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodPost && r.URL.Path == "/repos/o/classroom50/git/trees" {
+			isTreePost := r.Method == http.MethodPost && r.URL.Path == "/repos/o/classroom50/git/trees"
+			if isTreePost && m.commitFails {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
 			base.ServeHTTP(w, r)
+			if isTreePost && m.afterCommit != nil {
+				m.afterCommit()
+			}
 		})
 	}
 	return recordCalls(&m.calls, failing)

--- a/cli/gh-teacher/internal/roster/invite_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_cmd_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/foundation50/classroom50-cli-shared/contract"
+	"github.com/foundation50/gh-teacher/internal/cliutil"
 	"github.com/foundation50/gh-teacher/internal/configrepo"
 	"github.com/foundation50/gh-teacher/internal/githubtest"
 )
@@ -40,19 +42,27 @@ type inviteMock struct {
 	// pending is served as GET /orgs/o/invitations (nil → empty list), the
 	// liveness signal for a pending roster row.
 	pending []map[string]any
-	// pendingStatus is that GET's status (0 → 200).
-	pendingStatus int
+	// pendingStatus is that GET's status (0 → 200); pendingRateLimited makes it
+	// fail as a 403-shaped secondary rate limit instead.
+	pendingStatus      int
+	pendingRateLimited bool
 	// inviteTeamMembers is served as the invite team's members list; a member
 	// means someone accepted an earlier invitation.
 	inviteTeamMembers []map[string]any
-	// inviteTeamMembersStatus is that GET's status (0 → 200); 404 is a team the
-	// sync already garbage-collected, and lasts until this run recreates it.
-	inviteTeamMembersStatus int
+	// inviteTeamStatus is the status of the invite team's GET and members read
+	// (0 → 200); 404 is a team the sync already garbage-collected, and lasts
+	// until this run recreates it.
+	inviteTeamStatus int
+	// inviteTeamDescription is what the team's GET reports before this run
+	// PATCHes it (empty → a plain record-less description).
+	inviteTeamDescription string
 	// failed is served as GET /orgs/o/failed_invitations (nil → empty list),
 	// the expired records a re-invite dismisses; failedStatus overrides the
-	// read (403 is the owner-only refusal, tolerated silently).
-	failed       []map[string]any
-	failedStatus int
+	// read (403 is the owner-only refusal, tolerated silently) and
+	// failedRateLimited fails it as a 403-shaped secondary rate limit.
+	failed            []map[string]any
+	failedStatus      int
+	failedRateLimited bool
 	// dismissStatus is the status of DELETE /orgs/o/invitations/{id} (0 → 204).
 	dismissStatus int
 	// commitFails fails the tree POST, simulating a roster write failure after a
@@ -95,24 +105,38 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+		if r.Method == http.MethodGet {
+			if status := m.teamStatus(); status != http.StatusOK {
+				w.WriteHeader(status)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": inviteTestInviteTeamID, "slug": m.inviteTeamSlug,
+				"privacy": "secret", "description": m.inviteTeamDescription,
+			})
+			return
+		}
 		var body struct {
 			Description string `json:"description"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Description != "" {
+			m.inviteTeamDescription = body.Description
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id": inviteTestInviteTeamID, "slug": m.inviteTeamSlug,
 			"privacy": "secret", "description": body.Description,
 		})
 	})
 	base.HandleFunc(teamPath+"/memberships/"+inviteTestActor, func(w http.ResponseWriter, r *http.Request) {
+		// The drop is what removes a stranded teacher from an adopted team.
+		if r.Method == http.MethodDelete {
+			m.inviteTeamMembers = nil
+		}
 		w.WriteHeader(http.StatusNoContent)
 	})
 	base.HandleFunc(teamPath+"/members", func(w http.ResponseWriter, r *http.Request) {
-		status := m.inviteTeamMembersStatus
-		if status == http.StatusNotFound && m.teamCreated {
-			status = http.StatusOK
-		}
-		if status != 0 && status != http.StatusOK {
+		if status := m.teamStatus(); status != http.StatusOK {
 			w.WriteHeader(status)
 			return
 		}
@@ -125,6 +149,10 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 
 	base.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
+			if m.pendingRateLimited {
+				writeSecondaryRateLimit403(w)
+				return
+			}
 			if status := m.pendingStatus; status != 0 && status != http.StatusOK {
 				w.WriteHeader(status)
 				return
@@ -153,6 +181,10 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 	})
 
 	base.HandleFunc("/orgs/o/failed_invitations", func(w http.ResponseWriter, r *http.Request) {
+		if m.failedRateLimited {
+			writeSecondaryRateLimit403(w)
+			return
+		}
 		if status := m.failedStatus; status != 0 && status != http.StatusOK {
 			w.WriteHeader(status)
 			return
@@ -184,6 +216,35 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 		})
 	}
 	return recordCalls(&m.calls, failing)
+}
+
+// teamStatus is the invite team's current status: a 404 lasts only until this
+// run recreates the team.
+func (m *inviteMock) teamStatus() int {
+	if m.inviteTeamStatus == 0 || (m.inviteTeamStatus == http.StatusNotFound && m.teamCreated) {
+		return http.StatusOK
+	}
+	return m.inviteTeamStatus
+}
+
+// writeSecondaryRateLimit403 answers as GitHub does when a secondary limit
+// trips: a 403 that only Retry-After and the body distinguish from a denial.
+func writeSecondaryRateLimit403(w http.ResponseWriter) {
+	w.Header().Set("Retry-After", "60")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	_, _ = w.Write([]byte(`{"message":"You have exceeded a secondary rate limit"}`))
+}
+
+// inviteTestRecord is the valid v1 record an earlier run wrote onto the invite
+// team for inviteTestEmail.
+func inviteTestRecord(t *testing.T) string {
+	t.Helper()
+	record, err := configrepo.MarshalInviteDescription(inviteTestClassroom, inviteTestEmail)
+	if err != nil {
+		t.Fatalf("marshal invite record: %v", err)
+	}
+	return record
 }
 
 // inviteTestClassroomJSON records the classroom team the invitation must carry.
@@ -464,10 +525,10 @@ func TestRunRosterInvite_PendingRowWithLiveInvitationRefused(t *testing.T) {
 func TestRunRosterInvite_ExpiredInvitationIsReinvitedOnTheSameRow(t *testing.T) {
 	mock := newInviteMock(t, storedRosterHeader+",Ada,Lovelace,"+inviteTestEmail+",section-1,,student\n")
 	mock.pending = nil
-	mock.inviteTeamMembersStatus = http.StatusNotFound // the sync already GC'd the team
+	mock.inviteTeamStatus = http.StatusNotFound // the sync already GC'd the team
 	mock.failed = []map[string]any{
-		{"id": 70, "email": inviteTestEmail, "failed_reason": "Invitation expired. User did not accept this invite for 7 days"},
-		{"id": 71, "email": "someone-else@uni.edu", "failed_reason": "Invitation expired."},
+		{"id": 70, "email": inviteTestEmail},
+		{"id": 71, "email": "someone-else@uni.edu"},
 	}
 
 	out, errOut, err := runInvite(t, mock)
@@ -503,20 +564,29 @@ func TestRunRosterInvite_ExpiredInvitationIsReinvitedOnTheSameRow(t *testing.T) 
 }
 
 // The failed list is owner-only and the record is bookkeeping, so an unreadable
-// list or a failed DELETE can never fail a send that already went out: 403/404
-// are silent, anything else warns, and the exit code stays 0.
+// list or a failed DELETE can never fail a send that already went out: a plain
+// 403 or a 404 is silent, anything else (including a rate limit, which GitHub
+// also sends as a 403) warns, a record already gone counts as dismissed, and the
+// exit code stays 0.
 func TestRunRosterInvite_FailedRecordProblemsNeverFailTheSend(t *testing.T) {
 	cases := []struct {
-		name     string
-		apply    func(*inviteMock)
-		wantWarn bool
+		name          string
+		apply         func(*inviteMock)
+		wantWarn      bool
+		wantDismissed bool
 	}{
-		{"failed list 403 is silent", func(m *inviteMock) { m.failedStatus = http.StatusForbidden }, false},
-		{"failed list 500 warns", func(m *inviteMock) { m.failedStatus = http.StatusInternalServerError }, true},
+		{"failed list 403 is silent", func(m *inviteMock) { m.failedStatus = http.StatusForbidden }, false, false},
+		{"failed list 404 is silent", func(m *inviteMock) { m.failedStatus = http.StatusNotFound }, false, false},
+		{"failed list rate limit warns", func(m *inviteMock) { m.failedRateLimited = true }, true, false},
+		{"failed list 500 warns", func(m *inviteMock) { m.failedStatus = http.StatusInternalServerError }, true, false},
 		{"dismiss 500 warns", func(m *inviteMock) {
 			m.failed = []map[string]any{{"id": 70, "email": inviteTestEmail}}
 			m.dismissStatus = http.StatusInternalServerError
-		}, true},
+		}, true, false},
+		{"dismiss 404 counts as dismissed", func(m *inviteMock) {
+			m.failed = []map[string]any{{"id": 70, "email": inviteTestEmail}}
+			m.dismissStatus = http.StatusNotFound
+		}, false, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -524,15 +594,22 @@ func TestRunRosterInvite_FailedRecordProblemsNeverFailTheSend(t *testing.T) {
 			mock.pending = nil
 			tc.apply(mock)
 
-			_, errOut, err := runInvite(t, mock)
+			out, errOut, err := runInvite(t, mock)
 			if err != nil {
 				t.Fatalf("bookkeeping must not fail the send: %v", err)
 			}
 			if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") < 0 {
 				t.Fatal("the invitation itself was never sent")
 			}
+			// Silence must come from tolerating the read, not from skipping it.
+			if n := countCalls(mock.calls, http.MethodGet, "/orgs/o/failed_invitations"); n != 1 {
+				t.Errorf("failed-list reads = %d, want 1", n)
+			}
 			if got := strings.Contains(errOut, "failed_invitations"); got != tc.wantWarn {
 				t.Errorf("warning pointing at GitHub's failed-invitations page = %v, want %v:\n%s", got, tc.wantWarn, errOut)
+			}
+			if got := strings.Contains(out, "dismissed 1 expired invitation record"); got != tc.wantDismissed {
+				t.Errorf("dismissed report = %v, want %v:\n%s", got, tc.wantDismissed, out)
 			}
 		})
 	}
@@ -560,6 +637,7 @@ func TestRunRosterInvite_ReinviteAlreadyCoveredStillDismisses(t *testing.T) {
 func TestRunRosterInvite_ExpiredInvitationAdoptsSurvivingTeam(t *testing.T) {
 	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
 	mock.pending = nil
+	mock.inviteTeamDescription = inviteTestRecord(t)
 	mock.createStatus = http.StatusUnprocessableEntity // name taken → adopt
 
 	_, _, err := runInvite(t, mock)
@@ -574,21 +652,49 @@ func TestRunRosterInvite_ExpiredInvitationAdoptsSurvivingTeam(t *testing.T) {
 	}
 }
 
-// No pending invitation plus a member on the invite team means the student
-// ACCEPTED and only the sync is missing (common in the CLI, where the sync is
-// manual). Sending again would only trip EnsureInviteTeam's not-empty check with
-// a message telling the teacher to remove the invitee from the team, which would
-// destroy the only email→account mapping. Refuse, and point at the sync.
+// A re-invite interrupted after the team create (a rate limit, a 5xx) strands a
+// provisional team with the acting teacher on it: GitHub adds the creator, and
+// the drop is a later request. That member is not an invitee (the team holds no
+// record, so no invitation ever carried it), and the sync skips a provisional
+// team rather than repairing it. Reading it as "accepted" would refuse this
+// row forever; it must be re-sent, with EnsureInviteTeam adopting and healing
+// the team.
+func TestRunRosterInvite_StrandedProvisionalTeamIsReinvited(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+	mock.pending = nil
+	mock.inviteTeamDescription = contract.InviteProvisionalDescription
+	mock.inviteTeamMembers = []map[string]any{{"login": inviteTestActor, "id": 1}}
+	mock.createStatus = http.StatusUnprocessableEntity // the stranded team's name
+
+	_, _, err := runInvite(t, mock)
+	if err != nil {
+		t.Fatalf("a stranded provisional team must be adopted, not read as accepted: %v", err)
+	}
+	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") < 0 {
+		t.Fatalf("no invitation was sent; calls = %#v", mock.calls)
+	}
+	if indexOfCall(mock.calls, http.MethodDelete, "/orgs/o/teams/"+mock.inviteTeamSlug+"/memberships/"+inviteTestActor) < 0 {
+		t.Errorf("the stranded teacher was not dropped from the adopted team; calls = %#v", mock.calls)
+	}
+}
+
+// No pending invitation plus a member on a recorded invite team means the
+// student ACCEPTED and only the sync is missing (common in the CLI, where the
+// sync is manual). Sending again would only trip EnsureInviteTeam's not-empty
+// check with a message telling the teacher to remove the invitee from the team,
+// which would destroy the only email→account mapping. Refuse, and point at the
+// sync with --write, since a dry run records nothing.
 func TestRunRosterInvite_AcceptedButUnsyncedRefused(t *testing.T) {
 	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
 	mock.pending = nil
+	mock.inviteTeamDescription = inviteTestRecord(t)
 	mock.inviteTeamMembers = []map[string]any{{"login": "ada", "id": 99}}
 
 	_, _, err := runInvite(t, mock)
 	if err == nil {
 		t.Fatal("err = nil, want a refusal pointing at `roster sync`")
 	}
-	for _, want := range []string{"accepted", "roster sync"} {
+	for _, want := range []string{"accepted", "roster sync", "--write"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error should mention %q: %v", want, err)
 		}
@@ -600,7 +706,10 @@ func TestRunRosterInvite_AcceptedButUnsyncedRefused(t *testing.T) {
 
 // Liveness is only knowable from GitHub, so a failed pending-list read refuses
 // rather than guessing either way: re-sending could duplicate a live invitation,
-// and refusing forever is the deadlock this path exists to break.
+// and refusing forever is the deadlock this path exists to break. A rate limit
+// on that read is the one failure that must keep its shape: GitHub sends
+// secondary limits as a 403, and the classifier's admin-access message for a
+// 403 would send the teacher to `gh teacher login` for a throttle.
 func TestRunRosterInvite_PendingListReadFailureRefuses(t *testing.T) {
 	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
 	mock.pendingStatus = http.StatusInternalServerError
@@ -611,6 +720,19 @@ func TestRunRosterInvite_PendingListReadFailureRefuses(t *testing.T) {
 	}
 	if writes := writeCalls(mock.calls); len(writes) != 0 {
 		t.Errorf("wrote %d request(s) after a degraded read: %#v", len(writes), writes)
+	}
+
+	throttled := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+	throttled.pendingRateLimited = true
+	_, _, err = runInvite(t, throttled)
+	if err == nil {
+		t.Fatal("err = nil, want the rate limit to propagate")
+	}
+	if !cliutil.IsRateLimited(err) {
+		t.Errorf("a throttled pending-list read must still read as a rate limit, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "admin") {
+		t.Errorf("a throttle must not be reported as an admin-access problem: %v", err)
 	}
 }
 

--- a/cli/gh-teacher/internal/roster/invite_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_cmd_test.go
@@ -25,8 +25,8 @@ const (
 
 // inviteMock is the roster-write mock plus every endpoint `roster invite`
 // touches: /user (the acting teacher), the invite team
-// create/patch/membership/members/delete, and the org invitation. classroom.json
-// is served from rosterWriteMock.files.
+// create/patch/membership/members/delete, the org pending-invitation list, and
+// the org invitation POST. classroom.json is served from rosterWriteMock.files.
 type inviteMock struct {
 	*rosterWriteMock
 	// createStatus is the invite-team create status; 422 drives the adopt path
@@ -37,30 +37,34 @@ type inviteMock struct {
 	// invitationRateLimited makes the POST fail as a secondary rate limit, which
 	// the web deliberately treats differently from a hard failure.
 	invitationRateLimited bool
+	// pending is served as GET /orgs/o/invitations (nil → empty list), the
+	// liveness signal for a pending roster row.
+	pending []map[string]any
+	// pendingStatus is that GET's status (0 → 200).
+	pendingStatus int
+	// inviteTeamMembers is served as the invite team's members list; a member
+	// means someone accepted an earlier invitation.
+	inviteTeamMembers []map[string]any
+	// inviteTeamMembersStatus is that GET's status (0 → 200); 404 is a team the
+	// sync already garbage-collected, and lasts until this run recreates it.
+	inviteTeamMembersStatus int
+	// failed is served as GET /orgs/o/failed_invitations (nil → empty list),
+	// the expired records a re-invite dismisses; failedStatus overrides the
+	// read (403 is the owner-only refusal, tolerated silently).
+	failed       []map[string]any
+	failedStatus int
+	// dismissStatus is the status of DELETE /orgs/o/invitations/{id} (0 → 204).
+	dismissStatus int
 	// commitFails fails the tree POST, simulating a roster write failure after a
 	// successful send.
 	commitFails bool
-	// livePendingEmails is served as the GET /orgs/o/invitations liveness list:
-	// the addresses GitHub still holds an outstanding invitation for. Only read
-	// when a pending roster row makes the invite path check whether the invitation
-	// lapsed, so the happy path never touches it.
-	livePendingEmails []string
-	// inviteTeamDescription is what a GET of the metadata team serves. Empty (the
-	// default) reads as a record-less team, so classroomInvitedByEmail treats the
-	// address as not invited here; set it to a marshaled record to prove this
-	// classroom invited the address.
-	inviteTeamDescription string
-	// listInvitationsStatus is the GET /orgs/o/invitations status (0 → 200 with the
-	// livePendingEmails list); a 5xx drives the liveness read failure.
-	listInvitationsStatus int
-	// getInviteTeamStatus is the metadata-team GET status (0 → 200); a 5xx drives a
-	// degraded read that classroomInvitedByEmail must propagate, not read as absent.
-	getInviteTeamStatus int
 
 	calls           []inviteCall
 	invitationBody  map[string]any
 	inviteTeamSlug  string
 	deletedTeamSlug string
+	teamCreated     bool
+	dismissed       []string
 }
 
 func (m *inviteMock) handler(t *testing.T) http.Handler {
@@ -79,6 +83,7 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 			_, _ = w.Write([]byte(`{"message":"Name must be unique for this org"}`))
 			return
 		}
+		m.teamCreated = true
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id": inviteTestInviteTeamID, "slug": m.inviteTeamSlug, "privacy": "secret",
 		})
@@ -88,17 +93,6 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 		if r.Method == http.MethodDelete {
 			m.deletedTeamSlug = m.inviteTeamSlug
 			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-		if r.Method == http.MethodGet {
-			if s := m.getInviteTeamStatus; s != 0 && s != http.StatusOK {
-				w.WriteHeader(s)
-				return
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"id": inviteTestInviteTeamID, "slug": m.inviteTeamSlug,
-				"privacy": "secret", "description": m.inviteTeamDescription,
-			})
 			return
 		}
 		var body struct {
@@ -114,20 +108,32 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 		w.WriteHeader(http.StatusNoContent)
 	})
 	base.HandleFunc(teamPath+"/members", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode([]map[string]any{})
+		status := m.inviteTeamMembersStatus
+		if status == http.StatusNotFound && m.teamCreated {
+			status = http.StatusOK
+		}
+		if status != 0 && status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		members := m.inviteTeamMembers
+		if members == nil {
+			members = []map[string]any{}
+		}
+		_ = json.NewEncoder(w).Encode(members)
 	})
 
 	base.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			if s := m.listInvitationsStatus; s != 0 && s != http.StatusOK {
-				w.WriteHeader(s)
+			if status := m.pendingStatus; status != 0 && status != http.StatusOK {
+				w.WriteHeader(status)
 				return
 			}
-			list := make([]map[string]any, 0, len(m.livePendingEmails))
-			for i, email := range m.livePendingEmails {
-				list = append(list, map[string]any{"id": 100 + i, "email": email})
+			pending := m.pending
+			if pending == nil {
+				pending = []map[string]any{}
 			}
-			_ = json.NewEncoder(w).Encode(list)
+			_ = json.NewEncoder(w).Encode(pending)
 			return
 		}
 		_ = json.NewDecoder(r.Body).Decode(&m.invitationBody)
@@ -144,6 +150,26 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 		}
 		w.WriteHeader(status)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	base.HandleFunc("/orgs/o/failed_invitations", func(w http.ResponseWriter, r *http.Request) {
+		if status := m.failedStatus; status != 0 && status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		failed := m.failed
+		if failed == nil {
+			failed = []map[string]any{}
+		}
+		_ = json.NewEncoder(w).Encode(failed)
+	})
+	base.HandleFunc("/orgs/o/invitations/", func(w http.ResponseWriter, r *http.Request) {
+		if status := m.dismissStatus; status != 0 && status != http.StatusNoContent {
+			w.WriteHeader(status)
+			return
+		}
+		m.dismissed = append(m.dismissed, strings.TrimPrefix(r.URL.Path, "/orgs/o/invitations/"))
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	// commitFails intercepts before the mux so the tree POST never reaches it.
@@ -396,12 +422,6 @@ func TestRunRosterInvite_AddressOnAnAccountRowWarnsAndSends(t *testing.T) {
 	if !strings.Contains(errOut, "sibling") {
 		t.Errorf("stderr should name the account already holding the address:\n%s", errOut)
 	}
-	// No metadata team records this classroom invited the address (the mock serves
-	// a record-less team), so it reads as a genuinely shared address and keeps the
-	// parent/lab-contact note, the contrast with the expired-reissue case below.
-	if !strings.Contains(errOut, "parent or a lab contact") {
-		t.Errorf("a shared address should keep the shared-address note:\n%s", errOut)
-	}
 	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") < 0 {
 		t.Fatalf("the invitation was never sent; calls = %#v", mock.calls)
 	}
@@ -413,160 +433,204 @@ func TestRunRosterInvite_AddressOnAnAccountRowWarnsAndSends(t *testing.T) {
 	}
 }
 
-// A username-bearing row whose invitation lapsed is NOT the parent/lab-contact
-// case: the metadata team proves this classroom invited the address, so with no
-// live invitation the re-issue says so plainly rather than warning about a
-// shared address. This is the common real-world shape: the roster already knows
-// the student, their invite just expired.
-func TestRunRosterInvite_ExpiredInvitationOnUsernameRowIsReissued(t *testing.T) {
-	mock := newInviteMock(t, storedRosterHeader+"hopper,Grace,Hopper,"+inviteTestEmail+",,101,student\n")
-	desc, err := configrepo.MarshalInviteDescription(inviteTestClassroom, inviteTestEmail)
-	if err != nil {
-		t.Fatalf("MarshalInviteDescription: %v", err)
-	}
-	mock.inviteTeamDescription = desc // the metadata team still records the invite
-	mock.livePendingEmails = nil      // but GitHub no longer holds the invitation
-
-	out, errOut, err := runInvite(t, mock)
-	if err != nil {
-		t.Fatalf("an expired invitation on a username row must re-issue, not fail: %v", err)
-	}
-	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") < 0 {
-		t.Fatalf("the fresh invitation was never sent; calls = %#v", mock.calls)
-	}
-	if !strings.Contains(errOut, "expired") || !strings.Contains(errOut, "hopper") {
-		t.Errorf("stderr should say hopper's invitation expired and was re-issued:\n%s", errOut)
-	}
-	if strings.Contains(errOut, "parent or a lab contact") {
-		t.Errorf("the shared-address note must be suppressed for a proven re-issue:\n%s", errOut)
-	}
-	if len(mock.blobs) != 0 {
-		t.Errorf("re-issuing must not write a second row, got %d blob(s): %#v", len(mock.blobs), mock.blobs)
-	}
-	if !strings.Contains(out, "roster unchanged") {
-		t.Errorf("stdout should report the existing row was kept:\n%s", out)
-	}
-}
-
-// A pending row whose invitation GitHub still holds means re-sending would only
-// duplicate a live invite, so refuse before any API write.
-func TestRunRosterInvite_ExistingPendingRowWithLiveInvitationRefusedUpFront(t *testing.T) {
+// A pending row is only a reason to refuse while GitHub still lists its
+// invitation: then a second send would be a no-op on GitHub and a duplicate on
+// the roster, so refuse before any API write and name both remedies.
+func TestRunRosterInvite_PendingRowWithLiveInvitationRefused(t *testing.T) {
 	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
-	mock.livePendingEmails = []string{inviteTestEmail} // GitHub still holds it
+	mock.pending = []map[string]any{{"id": 42, "email": inviteTestEmail, "role": "direct_member"}}
 
 	_, _, err := runInvite(t, mock)
 	if err == nil {
 		t.Fatal("err = nil, want a refusal naming the existing pending invitation")
 	}
-	for _, want := range []string{"already invited", "roster sync", "cancel-invite"} {
+	for _, want := range []string{"pending invitation", "roster sync", "cancel-invite"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error should mention %q: %v", want, err)
 		}
 	}
-	for _, c := range mock.calls {
-		switch c.Method {
-		case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
-			t.Errorf("wrote %s %s before the refusal", c.Method, c.Path)
-		}
+	if writes := writeCalls(mock.calls); len(writes) != 0 {
+		t.Errorf("wrote %d request(s) before the refusal: %#v", len(writes), writes)
 	}
 }
 
-// A pending row GitHub no longer backs is the expired-invitation deadlock (issue
-// #970): invite refused off the row, cancel-invite refused off the absent
-// invitation, and neither could act. Now the send is re-issued instead, and the
-// existing pending row is kept rather than duplicated.
-func TestRunRosterInvite_ExpiredPendingRowIsReissued(t *testing.T) {
-	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
-	mock.livePendingEmails = nil // the invitation lapsed; GitHub holds nothing
+// The issue #970 deadlock: an org invitation expires after 7 days, GitHub drops
+// it from the pending list, the sync reaps the empty invite team, and the
+// pending row is left with nothing backing it. The web offers Re-invite for
+// exactly this row, so `roster invite` sends again against the same row: a
+// fresh team, a fresh invitation, NO second row, and GitHub's expired record
+// dismissed once the new invitation is confirmed (the web's
+// dismissFailedInvitation ordering).
+func TestRunRosterInvite_ExpiredInvitationIsReinvitedOnTheSameRow(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+",Ada,Lovelace,"+inviteTestEmail+",section-1,,student\n")
+	mock.pending = nil
+	mock.inviteTeamMembersStatus = http.StatusNotFound // the sync already GC'd the team
+	mock.failed = []map[string]any{
+		{"id": 70, "email": inviteTestEmail, "failed_reason": "Invitation expired. User did not accept this invite for 7 days"},
+		{"id": 71, "email": "someone-else@uni.edu", "failed_reason": "Invitation expired."},
+	}
 
 	out, errOut, err := runInvite(t, mock)
 	if err != nil {
-		t.Fatalf("an expired pending row must re-issue, not fail: %v", err)
+		t.Fatalf("an expired invitation must be re-sent, not refused: %v", err)
 	}
-	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") < 0 {
-		t.Fatalf("the fresh invitation was never sent; calls = %#v", mock.calls)
+	inviteIdx := indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations")
+	if inviteIdx < 0 {
+		t.Fatalf("no invitation was sent; calls = %#v", mock.calls)
 	}
-	if !strings.Contains(errOut, "expired") {
-		t.Errorf("stderr should explain the invitation was re-issued:\n%s", errOut)
+	if got := mock.invitationBody["email"]; got != inviteTestEmail {
+		t.Errorf("invitation email = %v, want %s", got, inviteTestEmail)
 	}
-	// The row already carries the address, so no second row is written.
 	if len(mock.blobs) != 0 {
-		t.Errorf("re-issuing must not duplicate the pending row, got %d blob(s): %#v", len(mock.blobs), mock.blobs)
+		t.Errorf("wrote a second row for an address the pending row already carries: %#v", mock.blobs)
+	}
+	if !strings.Contains(errOut, "expire") {
+		t.Errorf("stderr should explain that the earlier invitation expired:\n%s", errOut)
 	}
 	if !strings.Contains(out, "roster unchanged") {
-		t.Errorf("stdout should report the pending row was kept:\n%s", out)
+		t.Errorf("stdout should report the existing row was kept:\n%s", out)
+	}
+	// Only this address's record goes, and only after the send is confirmed.
+	if len(mock.dismissed) != 1 || mock.dismissed[0] != "70" {
+		t.Errorf("dismissed = %v, want exactly record 70 (not someone else's 71)", mock.dismissed)
+	}
+	if dismissIdx := indexOfCall(mock.calls, http.MethodDelete, "/orgs/o/invitations/70"); dismissIdx < inviteIdx {
+		t.Errorf("record dismissed (call %d) before the new invitation was sent (call %d)", dismissIdx, inviteIdx)
+	}
+	if !strings.Contains(out, "dismissed 1 expired invitation record") {
+		t.Errorf("stdout should report the dismissed record:\n%s", out)
 	}
 }
 
-// A degraded liveness read must not be mistaken for "no live invitation": if the
-// pending row can't be checked against GitHub, the send is refused with the read
-// error intact rather than re-issuing blind.
-func TestRunRosterInvite_LivenessReadFailureRefusesUntouched(t *testing.T) {
+// The failed list is owner-only and the record is bookkeeping, so an unreadable
+// list or a failed DELETE can never fail a send that already went out: 403/404
+// are silent, anything else warns, and the exit code stays 0.
+func TestRunRosterInvite_FailedRecordProblemsNeverFailTheSend(t *testing.T) {
+	cases := []struct {
+		name     string
+		apply    func(*inviteMock)
+		wantWarn bool
+	}{
+		{"failed list 403 is silent", func(m *inviteMock) { m.failedStatus = http.StatusForbidden }, false},
+		{"failed list 500 warns", func(m *inviteMock) { m.failedStatus = http.StatusInternalServerError }, true},
+		{"dismiss 500 warns", func(m *inviteMock) {
+			m.failed = []map[string]any{{"id": 70, "email": inviteTestEmail}}
+			m.dismissStatus = http.StatusInternalServerError
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+			mock.pending = nil
+			tc.apply(mock)
+
+			_, errOut, err := runInvite(t, mock)
+			if err != nil {
+				t.Fatalf("bookkeeping must not fail the send: %v", err)
+			}
+			if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") < 0 {
+				t.Fatal("the invitation itself was never sent")
+			}
+			if got := strings.Contains(errOut, "failed_invitations"); got != tc.wantWarn {
+				t.Errorf("warning pointing at GitHub's failed-invitations page = %v, want %v:\n%s", got, tc.wantWarn, errOut)
+			}
+		})
+	}
+}
+
+// GitHub's "already invited or a member" 422 on a re-invite means something live
+// now covers the address, so the expired record is noise here too.
+func TestRunRosterInvite_ReinviteAlreadyCoveredStillDismisses(t *testing.T) {
 	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
-	mock.listInvitationsStatus = http.StatusInternalServerError
+	mock.pending = nil
+	mock.invitationStatus = http.StatusUnprocessableEntity
+	mock.failed = []map[string]any{{"id": 70, "email": inviteTestEmail}}
+
+	if _, _, err := runInvite(t, mock); err != nil {
+		t.Fatalf("a 422 is a skip: %v", err)
+	}
+	if len(mock.dismissed) != 1 || mock.dismissed[0] != "70" {
+		t.Errorf("dismissed = %v, want record 70", mock.dismissed)
+	}
+}
+
+// A GC'd team is the common expired shape, but a team the sync hasn't reaped yet
+// (younger than the GC age) is the same case: no invitation, no member. The send
+// must adopt that team rather than trip over the name collision.
+func TestRunRosterInvite_ExpiredInvitationAdoptsSurvivingTeam(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+	mock.pending = nil
+	mock.createStatus = http.StatusUnprocessableEntity // name taken → adopt
+
+	_, _, err := runInvite(t, mock)
+	if err != nil {
+		t.Fatalf("a surviving empty team must be adopted: %v", err)
+	}
+	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") < 0 {
+		t.Fatalf("no invitation was sent; calls = %#v", mock.calls)
+	}
+	if mock.deletedTeamSlug != "" {
+		t.Errorf("deleted the adopted team %q", mock.deletedTeamSlug)
+	}
+}
+
+// No pending invitation plus a member on the invite team means the student
+// ACCEPTED and only the sync is missing (common in the CLI, where the sync is
+// manual). Sending again would only trip EnsureInviteTeam's not-empty check with
+// a message telling the teacher to remove the invitee from the team, which would
+// destroy the only email→account mapping. Refuse, and point at the sync.
+func TestRunRosterInvite_AcceptedButUnsyncedRefused(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+	mock.pending = nil
+	mock.inviteTeamMembers = []map[string]any{{"login": "ada", "id": 99}}
 
 	_, _, err := runInvite(t, mock)
 	if err == nil {
-		t.Fatal("err = nil, want the liveness read failure to propagate")
+		t.Fatal("err = nil, want a refusal pointing at `roster sync`")
 	}
-	for _, c := range mock.calls {
-		switch c.Method {
-		case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
-			t.Errorf("wrote %s %s despite an unreadable invitation list", c.Method, c.Path)
+	for _, want := range []string{"accepted", "roster sync"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q: %v", want, err)
 		}
 	}
-	if len(mock.blobs) != 0 {
-		t.Errorf("a failed liveness read must write no roster row, got %d blob(s)", len(mock.blobs))
+	if writes := writeCalls(mock.calls); len(writes) != 0 {
+		t.Errorf("wrote %d request(s) for an accepted invitation: %#v", len(writes), writes)
 	}
 }
 
-// A degraded metadata-team read on the username-bearing path must propagate too:
-// reading it as absent would drop to the shared-address note and could re-send
-// against a team that actually proves this classroom's invite.
-func TestRunRosterInvite_MetadataTeamReadFailurePropagates(t *testing.T) {
-	mock := newInviteMock(t, storedRosterHeader+"hopper,Grace,Hopper,"+inviteTestEmail+",,101,student\n")
-	mock.getInviteTeamStatus = http.StatusInternalServerError
+// Liveness is only knowable from GitHub, so a failed pending-list read refuses
+// rather than guessing either way: re-sending could duplicate a live invitation,
+// and refusing forever is the deadlock this path exists to break.
+func TestRunRosterInvite_PendingListReadFailureRefuses(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+	mock.pendingStatus = http.StatusInternalServerError
 
 	_, _, err := runInvite(t, mock)
 	if err == nil {
-		t.Fatal("err = nil, want the metadata-team read failure to propagate")
+		t.Fatal("err = nil, want the pending-list read failure to propagate")
 	}
-	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") >= 0 {
-		t.Errorf("sent an invitation despite an unreadable metadata team; calls = %#v", mock.calls)
-	}
-	if len(mock.blobs) != 0 {
-		t.Errorf("a failed metadata-team read must write no roster row, got %d blob(s)", len(mock.blobs))
+	if writes := writeCalls(mock.calls); len(writes) != 0 {
+		t.Errorf("wrote %d request(s) after a degraded read: %#v", len(writes), writes)
 	}
 }
 
-// A username-bearing row whose invitation GitHub still holds is not a re-issue:
-// with a live invitation the address keeps the shared-address note and the send
-// is left to skip on GitHub's 422, exactly as before this path existed.
-func TestRunRosterInvite_LiveInvitationOnUsernameRowKeepsSharedAddressNote(t *testing.T) {
-	mock := newInviteMock(t, storedRosterHeader+"hopper,Grace,Hopper,"+inviteTestEmail+",,101,student\n")
-	desc, err := configrepo.MarshalInviteDescription(inviteTestClassroom, inviteTestEmail)
-	if err != nil {
-		t.Fatalf("MarshalInviteDescription: %v", err)
-	}
-	mock.inviteTeamDescription = desc                      // this classroom did invite the address
-	mock.livePendingEmails = []string{inviteTestEmail}     // and GitHub still holds it
-	mock.invitationStatus = http.StatusUnprocessableEntity // so a resend 422-skips
+// A fresh address never needs either invitation list, so it must read neither:
+// both are owner-scoped and paginated, and a fresh invite must not gain a new way
+// to fail.
+func TestRunRosterInvite_FreshAddressSkipsTheInvitationListReads(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader)
+	mock.pendingStatus = http.StatusInternalServerError // would fail if read
+	mock.failedStatus = http.StatusInternalServerError  // would warn if read
 
-	out, errOut, err := runInvite(t, mock)
-	if err != nil {
-		t.Fatalf("a live invitation on a username row must skip, not fail: %v", err)
+	if _, errOut, err := runInvite(t, mock); err != nil {
+		t.Fatalf("a fresh address must not depend on the invitation lists: %v", err)
+	} else if strings.Contains(errOut, "Warning") {
+		t.Errorf("a fresh address read the failed list:\n%s", errOut)
 	}
-	if !strings.Contains(errOut, "parent or a lab contact") {
-		t.Errorf("a live invitation must keep the shared-address note, not claim expiry:\n%s", errOut)
-	}
-	if strings.Contains(errOut, "expired") {
-		t.Errorf("nothing expired here, so the re-issue message must not appear:\n%s", errOut)
-	}
-	if !strings.Contains(out, "skipped") {
-		t.Errorf("stdout should report the 422 skip:\n%s", out)
-	}
-	if len(mock.blobs) != 0 {
-		t.Errorf("a skipped send must write no roster row, got %d blob(s)", len(mock.blobs))
+	for _, path := range []string{"/orgs/o/invitations", "/orgs/o/failed_invitations"} {
+		if n := countCalls(mock.calls, http.MethodGet, path); n != 0 {
+			t.Errorf("read %s %d time(s) for a fresh address", path, n)
+		}
 	}
 }
 

--- a/cli/gh-teacher/internal/roster/invite_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_cmd_test.go
@@ -40,6 +40,14 @@ type inviteMock struct {
 	// commitFails fails the tree POST, simulating a roster write failure after a
 	// successful send.
 	commitFails bool
+	// livePendingEmails is served as the GET /orgs/o/invitations liveness list:
+	// the addresses GitHub still holds an outstanding invitation for. Only read
+	// when a pending roster row makes the invite path check whether the invitation
+	// lapsed, so the happy path never touches it.
+	livePendingEmails []string
+	// listInvitationsStatus is the GET /orgs/o/invitations status (0 → 200 with the
+	// livePendingEmails list); a 5xx drives the liveness read failure.
+	listInvitationsStatus int
 
 	calls           []inviteCall
 	invitationBody  map[string]any
@@ -91,6 +99,18 @@ func (m *inviteMock) handler(t *testing.T) http.Handler {
 	})
 
 	base.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			if s := m.listInvitationsStatus; s != 0 && s != http.StatusOK {
+				w.WriteHeader(s)
+				return
+			}
+			list := make([]map[string]any, 0, len(m.livePendingEmails))
+			for i, email := range m.livePendingEmails {
+				list = append(list, map[string]any{"id": 100 + i, "email": email})
+			}
+			_ = json.NewEncoder(w).Encode(list)
+			return
+		}
 		_ = json.NewDecoder(r.Body).Decode(&m.invitationBody)
 		if m.invitationRateLimited {
 			w.Header().Set("Retry-After", "60")
@@ -368,10 +388,11 @@ func TestRunRosterInvite_AddressOnAnAccountRowWarnsAndSends(t *testing.T) {
 	}
 }
 
-// A pending row already claims this address: re-sending would duplicate the row
-// (or resurrect one sync is about to fold), so refuse before any API write.
-func TestRunRosterInvite_ExistingPendingRowRefusedUpFront(t *testing.T) {
+// A pending row whose invitation GitHub still holds means re-sending would only
+// duplicate a live invite, so refuse before any API write.
+func TestRunRosterInvite_ExistingPendingRowWithLiveInvitationRefusedUpFront(t *testing.T) {
 	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+	mock.livePendingEmails = []string{inviteTestEmail} // GitHub still holds it
 
 	_, _, err := runInvite(t, mock)
 	if err == nil {
@@ -387,6 +408,55 @@ func TestRunRosterInvite_ExistingPendingRowRefusedUpFront(t *testing.T) {
 		case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
 			t.Errorf("wrote %s %s before the refusal", c.Method, c.Path)
 		}
+	}
+}
+
+// A pending row GitHub no longer backs is the expired-invitation deadlock (issue
+// #970): invite refused off the row, cancel-invite refused off the absent
+// invitation, and neither could act. Now the send is re-issued instead, and the
+// existing pending row is kept rather than duplicated.
+func TestRunRosterInvite_ExpiredPendingRowIsReissued(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+	mock.livePendingEmails = nil // the invitation lapsed; GitHub holds nothing
+
+	out, errOut, err := runInvite(t, mock)
+	if err != nil {
+		t.Fatalf("an expired pending row must re-issue, not fail: %v", err)
+	}
+	if indexOfCall(mock.calls, http.MethodPost, "/orgs/o/invitations") < 0 {
+		t.Fatalf("the fresh invitation was never sent; calls = %#v", mock.calls)
+	}
+	if !strings.Contains(errOut, "expired") {
+		t.Errorf("stderr should explain the invitation was re-issued:\n%s", errOut)
+	}
+	// The row already carries the address, so no second row is written.
+	if len(mock.blobs) != 0 {
+		t.Errorf("re-issuing must not duplicate the pending row, got %d blob(s): %#v", len(mock.blobs), mock.blobs)
+	}
+	if !strings.Contains(out, "roster unchanged") {
+		t.Errorf("stdout should report the pending row was kept:\n%s", out)
+	}
+}
+
+// A degraded liveness read must not be mistaken for "no live invitation": if the
+// pending row can't be checked against GitHub, the send is refused with the read
+// error intact rather than re-issuing blind.
+func TestRunRosterInvite_LivenessReadFailureRefusesUntouched(t *testing.T) {
+	mock := newInviteMock(t, storedRosterHeader+",,,"+inviteTestEmail+",,,student\n")
+	mock.listInvitationsStatus = http.StatusInternalServerError
+
+	_, _, err := runInvite(t, mock)
+	if err == nil {
+		t.Fatal("err = nil, want the liveness read failure to propagate")
+	}
+	for _, c := range mock.calls {
+		switch c.Method {
+		case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
+			t.Errorf("wrote %s %s despite an unreadable invitation list", c.Method, c.Path)
+		}
+	}
+	if len(mock.blobs) != 0 {
+		t.Errorf("a failed liveness read must write no roster row, got %d blob(s)", len(mock.blobs))
 	}
 }
 

--- a/cli/gh-teacher/internal/roster/invite_file.go
+++ b/cli/gh-teacher/internal/roster/invite_file.go
@@ -101,8 +101,8 @@ var inviteFileSleep = time.Sleep
 // rate limit appears (hammering a throttled endpoint only extends the window),
 // and append every successfully-invited address in one CommitTreeChange whose
 // closure re-checks the roster under the rebase. A rate-limited or failed run is
-// safe to re-run: an already-invited address 422-skips and an already-rowed one
-// appends nothing.
+// safe to re-run: an already-invited address 422-skips (or is skipped up front
+// as still pending) and an already-rowed one appends nothing.
 //
 // Exit codes follow `roster sync`'s convention so a script can tell a retryable
 // partial run from a broken one: 0 all done, 2 nothing failed but addresses
@@ -140,20 +140,22 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 	}
 
 	var (
-		invited        []string
-		skipped        []addressEntry
-		pendingBlocked []addressEntry
-		deferredList   []addressEntry
-		failedErrs     []error
-		rateLimitErr   error
+		invited         []string
+		skipped         []addressEntry
+		pendingBlocked  []addressEntry
+		acceptedBlocked []addressEntry
+		deferredList    []addressEntry
+		failedErrs      []error
+		rateLimitErr    error
 	)
+	lists := newOrgInvitationLists(client, org)
 	for _, entry := range entries {
 		if rateLimitErr != nil {
 			// Once throttled, every remaining address is deferred without a call.
 			deferredList = append(deferredList, entry)
 			continue
 		}
-		outcome, _, sendErr := sendOneEmailInvite(client, errOut, org, classroom, entry.email, classroomTeam, actor, rows, false)
+		outcome, _, sendErr := sendOneEmailInvite(client, out, errOut, org, classroom, entry.email, classroomTeam, actor, rows, lists)
 		// Report each address as it resolves: a few hundred addresses take
 		// minutes, and a silent run is indistinguishable from a hang.
 		switch outcome {
@@ -165,7 +167,10 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 			_, _ = fmt.Fprintf(out, "  skipped %s (line %d): already a member of the org or already invited\n", entry.email, entry.line)
 		case outcomePendingBlocked:
 			pendingBlocked = append(pendingBlocked, entry)
-			_, _ = fmt.Fprintf(out, "  skipped %s (line %d): already a pending invitation on this roster\n", entry.email, entry.line)
+			_, _ = fmt.Fprintf(out, "  skipped %s (line %d): already has a pending invitation\n", entry.email, entry.line)
+		case outcomeAcceptedBlocked:
+			acceptedBlocked = append(acceptedBlocked, entry)
+			_, _ = fmt.Fprintf(out, "  skipped %s (line %d): accepted an earlier invitation, not yet recorded\n", entry.email, entry.line)
 		case outcomeRateLimited:
 			rateLimitErr = sendErr
 			deferredList = append(deferredList, entry)
@@ -193,14 +198,18 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 
 	_, _ = fmt.Fprintf(out, "%s/%s/%s: %d invited, %d appended as pending rows, %d already member/invited, %d already on the roster, %d failed, %d deferred (rate limit)\n",
 		org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom),
-		len(invited), appended, len(skipped), len(pendingBlocked), len(failedErrs), len(deferredList))
+		len(invited), appended, len(skipped), len(pendingBlocked)+len(acceptedBlocked), len(failedErrs), len(deferredList))
 
 	for _, entry := range skipped {
 		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already a member of the org or already invited. Run `gh teacher roster sync %s %s` if they accepted an earlier invitation.\n",
 			entry.email, entry.line, org, classroom)
 	}
 	for _, entry := range pendingBlocked {
-		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already a pending invitation on the roster. Run `gh teacher roster sync %s %s` if they accepted.\n",
+		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already has a pending invitation. Advise them to accept it, then run `gh teacher roster sync %s %s` to record them.\n",
+			entry.email, entry.line, org, classroom)
+	}
+	for _, entry := range acceptedBlocked {
+		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): accepted an earlier invitation but isn't recorded on the roster yet. Run `gh teacher roster sync %s %s --write` to record them.\n",
 			entry.email, entry.line, org, classroom)
 	}
 	for _, addr := range alreadyHeld {

--- a/cli/gh-teacher/internal/roster/invite_file.go
+++ b/cli/gh-teacher/internal/roster/invite_file.go
@@ -201,8 +201,8 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 		len(invited), appended, len(skipped), len(pendingBlocked)+len(acceptedBlocked), len(failedErrs), len(deferredList))
 
 	for _, entry := range skipped {
-		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already a member of the org or already invited. Run `gh teacher roster sync %s %s` if they accepted an earlier invitation.\n",
-			entry.email, entry.line, org, classroom)
+		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already a member of the org or already invited. Run %s if they accepted an earlier invitation.\n",
+			entry.email, entry.line, syncWriteCommand(org, classroom))
 	}
 	for _, entry := range pendingBlocked {
 		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): GitHub still lists a pending invitation for the address (this classroom's, or another classroom's in %s). Advise them to accept it, then run %s to record them.\n",
@@ -223,15 +223,15 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 			rateLimitErr, joinEntryEmails(deferredList))
 	}
 	if len(invited) > 0 {
-		_, _ = fmt.Fprintf(errOut, "Advise the newly-invited students to accept the emailed invitation, then run `gh teacher roster sync %s %s` to record their username and github_id.\n", org, classroom)
+		_, _ = fmt.Fprintf(errOut, "Advise the newly-invited students to accept the emailed invitation, then run %s to record their username and github_id.\n", syncWriteCommand(org, classroom))
 	}
 
 	if commitErr != nil {
 		// Never a rollback: the invitations are the source of truth and each
 		// metadata team retains its address, so a sync heals the rows once the
 		// students accept.
-		_, _ = fmt.Fprintf(errOut, "Warning: %d invitation(s) were sent, but recording them in %s failed; the invitations are unaffected. Re-run this command to record them, or `gh teacher roster sync %s %s` once the students accept.\n",
-			len(invited), configrepo.RosterFilePath(classroom), org, classroom)
+		_, _ = fmt.Fprintf(errOut, "Warning: %d invitation(s) were sent, but recording them in %s failed; the invitations are unaffected. Re-run this command to record them, or run %s once the students accept.\n",
+			len(invited), configrepo.RosterFilePath(classroom), syncWriteCommand(org, classroom))
 		return fmt.Errorf("invitations sent, but the roster rows were not written: %w", commitErr)
 	}
 	if len(failedErrs) > 0 {

--- a/cli/gh-teacher/internal/roster/invite_file.go
+++ b/cli/gh-teacher/internal/roster/invite_file.go
@@ -153,7 +153,7 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 			deferredList = append(deferredList, entry)
 			continue
 		}
-		outcome, _, sendErr := sendOneEmailInvite(client, errOut, org, classroom, entry.email, classroomTeam, actor, rows)
+		outcome, _, sendErr := sendOneEmailInvite(client, errOut, org, classroom, entry.email, classroomTeam, actor, rows, false)
 		// Report each address as it resolves: a few hundred addresses take
 		// minutes, and a silent run is indistinguishable from a hang.
 		switch outcome {

--- a/cli/gh-teacher/internal/roster/invite_file.go
+++ b/cli/gh-teacher/internal/roster/invite_file.go
@@ -167,7 +167,7 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 			_, _ = fmt.Fprintf(out, "  skipped %s (line %d): already a member of the org or already invited\n", entry.email, entry.line)
 		case outcomePendingBlocked:
 			pendingBlocked = append(pendingBlocked, entry)
-			_, _ = fmt.Fprintf(out, "  skipped %s (line %d): already has a pending invitation\n", entry.email, entry.line)
+			_, _ = fmt.Fprintf(out, "  skipped %s (line %d): GitHub still lists a pending invitation for the address\n", entry.email, entry.line)
 		case outcomeAcceptedBlocked:
 			acceptedBlocked = append(acceptedBlocked, entry)
 			_, _ = fmt.Fprintf(out, "  skipped %s (line %d): accepted an earlier invitation, not yet recorded\n", entry.email, entry.line)
@@ -205,12 +205,12 @@ func runRosterInviteFile(client githubapi.Client, out, errOut io.Writer, org, cl
 			entry.email, entry.line, org, classroom)
 	}
 	for _, entry := range pendingBlocked {
-		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): already has a pending invitation. Advise them to accept it, then run `gh teacher roster sync %s %s` to record them.\n",
-			entry.email, entry.line, org, classroom)
+		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): GitHub still lists a pending invitation for the address (this classroom's, or another classroom's in %s). Advise them to accept it, then run %s to record them.\n",
+			entry.email, entry.line, org, syncWriteCommand(org, classroom))
 	}
 	for _, entry := range acceptedBlocked {
-		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): accepted an earlier invitation but isn't recorded on the roster yet. Run `gh teacher roster sync %s %s --write` to record them.\n",
-			entry.email, entry.line, org, classroom)
+		_, _ = fmt.Fprintf(errOut, "Skipped %s (line %d): accepted an earlier invitation but isn't recorded on the roster yet. Run %s to record them.\n",
+			entry.email, entry.line, syncWriteCommand(org, classroom))
 	}
 	for _, addr := range alreadyHeld {
 		_, _ = fmt.Fprintf(errOut, "Invited %s, but a roster row already carries that address, so no second pending row was written.\n", addr)

--- a/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
@@ -33,6 +33,13 @@ type bulkInviteMock struct {
 	teamCreateRateLimitAfter int
 	// commitFails fails the tree POST after sends succeed.
 	commitFails bool
+	// pending is served as GET /orgs/o/invitations (nil → empty list).
+	pending []map[string]any
+	// failed is served as GET /orgs/o/failed_invitations (nil → empty list).
+	failed []map[string]any
+	// teamMembers holds, per email, the members its invite team's list serves;
+	// an address absent here serves an empty list.
+	teamMembers map[string][]map[string]any
 	// onAfterInvitation runs after each invitation POST is served — strictly
 	// before the commit's rebase read — so a test can make the roster the
 	// closure re-reads differ from the pre-send snapshot.
@@ -41,6 +48,7 @@ type bulkInviteMock struct {
 	calls          []inviteCall
 	invitedEmails  []string
 	deletedTeams   []string
+	dismissed      []string
 	teamRecords    map[string]string
 	invitationsPos int
 	teamCreatePos  int
@@ -104,13 +112,27 @@ func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
 		case strings.HasPrefix(sub, "memberships/"):
 			w.WriteHeader(http.StatusNoContent)
 		case sub == "members":
-			_ = json.NewEncoder(w).Encode([]map[string]any{})
+			members := []map[string]any{}
+			for email, list := range m.teamMembers {
+				if configrepo.InviteTeamName(inviteTestClassroom, email) == slug {
+					members = list
+				}
+			}
+			_ = json.NewEncoder(w).Encode(members)
 		default:
 			http.NotFound(w, r)
 		}
 	})
 
 	base.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			pending := m.pending
+			if pending == nil {
+				pending = []map[string]any{}
+			}
+			_ = json.NewEncoder(w).Encode(pending)
+			return
+		}
 		var body struct {
 			Email string `json:"email"`
 		}
@@ -133,6 +155,17 @@ func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
 		if m.onAfterInvitation != nil {
 			m.onAfterInvitation()
 		}
+	})
+	base.HandleFunc("/orgs/o/failed_invitations", func(w http.ResponseWriter, r *http.Request) {
+		failed := m.failed
+		if failed == nil {
+			failed = []map[string]any{}
+		}
+		_ = json.NewEncoder(w).Encode(failed)
+	})
+	base.HandleFunc("/orgs/o/invitations/", func(w http.ResponseWriter, r *http.Request) {
+		m.dismissed = append(m.dismissed, strings.TrimPrefix(r.URL.Path, "/orgs/o/invitations/"))
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	failing := http.Handler(base)
@@ -261,9 +294,11 @@ func TestRunRosterInviteFile_HappyPath(t *testing.T) {
 	}
 }
 
-// A pending-blocked address costs no API call; a fresh one beside it still goes.
+// A pending row whose invitation GitHub still lists costs no send; a fresh one
+// beside it still goes.
 func TestRunRosterInviteFile_PendingSkippedSecondInvited(t *testing.T) {
 	mock := newBulkMock(t, storedRosterHeader+",,,ada@uni.edu,,,student\n")
+	mock.pending = []map[string]any{{"id": 42, "email": "ada@uni.edu", "role": "direct_member"}}
 	out, errOut, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\n"))
 	if err != nil {
 		t.Fatalf("runRosterInviteFile: %v", err)
@@ -283,6 +318,74 @@ func TestRunRosterInviteFile_PendingSkippedSecondInvited(t *testing.T) {
 	}
 	if !strings.Contains(errOut, "roster sync") {
 		t.Errorf("the skip notice should point at `roster sync`:\n%s", errOut)
+	}
+	// One list read serves the whole batch.
+	if n := countCalls(mock.calls, http.MethodGet, "/orgs/o/invitations"); n != 1 {
+		t.Errorf("pending-list reads = %d, want 1 for the whole batch", n)
+	}
+}
+
+// Re-uploading a list after invitations expired (#970) is the bulk shape of the
+// web's "Send invitations" on expired rows: each dead pending row is re-sent
+// against its own row, so the batch invites all three addresses but appends only
+// the genuinely new one, and dismisses each re-sent address's expired record off
+// ONE read of the failed list.
+func TestRunRosterInviteFile_ExpiredPendingRowsAreReinvited(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader+",,,ada@uni.edu,,,student\n,,,cam@uni.edu,,,student\n")
+	mock.pending = nil
+	mock.failed = []map[string]any{
+		{"id": 70, "email": "ada@uni.edu"},
+		{"id": 71, "email": "cam@uni.edu"},
+		{"id": 72, "email": "unrelated@uni.edu"},
+	}
+	out, _, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\ncam@uni.edu\n"))
+	if err != nil {
+		t.Fatalf("runRosterInviteFile: %v", err)
+	}
+	if len(mock.invitedEmails) != 3 {
+		t.Fatalf("invited = %v, want ada and cam re-invited plus bea", mock.invitedEmails)
+	}
+	if len(mock.blobs) != 1 {
+		t.Fatalf("want one roster commit, got %d blobs", len(mock.blobs))
+	}
+	rows, err := configrepo.ParseRoster([]byte(mock.blobs[0]))
+	if err != nil {
+		t.Fatalf("parse committed roster: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("committed %d rows, want 3 (two existing plus bea's): %#v", len(rows), rows)
+	}
+	if !strings.Contains(out, "3 invited, 1 appended as pending rows") {
+		t.Errorf("summary should show the re-sends without second rows:\n%s", out)
+	}
+	if strings.Join(mock.dismissed, ",") != "70,71" {
+		t.Errorf("dismissed = %v, want ada's 70 and cam's 71 only", mock.dismissed)
+	}
+	if n := countCalls(mock.calls, http.MethodGet, "/orgs/o/failed_invitations"); n != 1 {
+		t.Errorf("failed-list reads = %d, want 1 for the whole batch", n)
+	}
+}
+
+// An accepted-but-unsynced address in the list is a skip pointing at the sync,
+// not a send: its invite team holds the invitee, whom a re-send would strip.
+func TestRunRosterInviteFile_AcceptedUnsyncedSkipped(t *testing.T) {
+	mock := newBulkMock(t, storedRosterHeader+",,,ada@uni.edu,,,student\n")
+	mock.pending = nil
+	mock.teamMembers = map[string][]map[string]any{
+		"ada@uni.edu": {{"login": "ada", "id": 99}},
+	}
+	out, errOut, err := runInviteFile(t, mock, []byte("ada@uni.edu\nbea@uni.edu\n"))
+	if err != nil {
+		t.Fatalf("an accepted invitation is a clean skip: %v", err)
+	}
+	if len(mock.invitedEmails) != 1 || mock.invitedEmails[0] != "bea@uni.edu" {
+		t.Errorf("invited = %v, want only bea", mock.invitedEmails)
+	}
+	if !strings.Contains(out, "1 already on the roster") {
+		t.Errorf("summary should count ada as already on the roster:\n%s", out)
+	}
+	if !strings.Contains(errOut, "ada@uni.edu (line 1)") || !strings.Contains(errOut, "accepted") || !strings.Contains(errOut, "roster sync") {
+		t.Errorf("stderr should name ada, say they accepted, and point at the sync:\n%s", errOut)
 	}
 }
 

--- a/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
@@ -96,6 +96,17 @@ func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
 		case sub == "" && r.Method == http.MethodDelete:
 			m.deletedTeams = append(m.deletedTeams, slug)
 			w.WriteHeader(http.StatusNoContent)
+		case sub == "" && r.Method == http.MethodGet:
+			// A team with members from an earlier run holds that run's record;
+			// any other team not yet PATCHed by this run is record-less.
+			description := m.teamRecords[slug]
+			if description == "" && len(m.membersFor(slug)) > 0 {
+				description = m.recordFor(t, slug)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": inviteTestInviteTeamID, "slug": slug,
+				"privacy": "secret", "description": description,
+			})
 		case sub == "":
 			var body struct {
 				Description string `json:"description"`
@@ -112,13 +123,7 @@ func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
 		case strings.HasPrefix(sub, "memberships/"):
 			w.WriteHeader(http.StatusNoContent)
 		case sub == "members":
-			members := []map[string]any{}
-			for email, list := range m.teamMembers {
-				if configrepo.InviteTeamName(inviteTestClassroom, email) == slug {
-					members = list
-				}
-			}
-			_ = json.NewEncoder(w).Encode(members)
+			_ = json.NewEncoder(w).Encode(m.membersFor(slug))
 		default:
 			http.NotFound(w, r)
 		}
@@ -190,6 +195,31 @@ func (m *bulkInviteMock) slugMatchesAny(slug string, set map[string]bool) bool {
 		}
 	}
 	return false
+}
+
+// membersFor is the members list served for a team slug, from teamMembers.
+func (m *bulkInviteMock) membersFor(slug string) []map[string]any {
+	for email, list := range m.teamMembers {
+		if configrepo.InviteTeamName(inviteTestClassroom, email) == slug {
+			return list
+		}
+	}
+	return []map[string]any{}
+}
+
+// recordFor is the valid v1 record for the email whose invite team is slug.
+func (m *bulkInviteMock) recordFor(t *testing.T, slug string) string {
+	t.Helper()
+	for email := range m.teamMembers {
+		if configrepo.InviteTeamName(inviteTestClassroom, email) == slug {
+			record, err := configrepo.MarshalInviteDescription(inviteTestClassroom, email)
+			if err != nil {
+				t.Fatalf("marshal invite record: %v", err)
+			}
+			return record
+		}
+	}
+	return ""
 }
 
 func newBulkMock(t *testing.T, rosterCSV string) *bulkInviteMock {
@@ -361,8 +391,12 @@ func TestRunRosterInviteFile_ExpiredPendingRowsAreReinvited(t *testing.T) {
 	if strings.Join(mock.dismissed, ",") != "70,71" {
 		t.Errorf("dismissed = %v, want ada's 70 and cam's 71 only", mock.dismissed)
 	}
-	if n := countCalls(mock.calls, http.MethodGet, "/orgs/o/failed_invitations"); n != 1 {
-		t.Errorf("failed-list reads = %d, want 1 for the whole batch", n)
+	// One read of each list serves the whole batch, even when the pending list
+	// comes back empty.
+	for _, path := range []string{"/orgs/o/invitations", "/orgs/o/failed_invitations"} {
+		if n := countCalls(mock.calls, http.MethodGet, path); n != 1 {
+			t.Errorf("reads of %s = %d, want 1 for the whole batch", path, n)
+		}
 	}
 }
 

--- a/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/invite_file_cmd_test.go
@@ -150,8 +150,9 @@ func (m *bulkInviteMock) handler(t *testing.T) http.Handler {
 			return
 		}
 		if m.status422[body.Email] {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnprocessableEntity)
-			_, _ = w.Write([]byte(`{"message":"already a member"}`))
+			_, _ = w.Write([]byte(`{"message":"Invitee is already a part of this org"}`))
 			return
 		}
 		m.invitedEmails = append(m.invitedEmails, body.Email)

--- a/cli/gh-teacher/internal/roster/remove_pending.go
+++ b/cli/gh-teacher/internal/roster/remove_pending.go
@@ -1,0 +1,110 @@
+package roster
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/foundation50/classroom50-cli-shared/contract"
+	"github.com/foundation50/gh-teacher/internal/configrepo"
+	"github.com/foundation50/gh-teacher/internal/configwrite"
+	"github.com/foundation50/gh-teacher/internal/githubapi"
+)
+
+// runRosterRemovePendingRow drops the pending row for an address once GitHub
+// confirms nothing backs it: the web's Remove row for an "unlinked" row, plus
+// the one check the CLI needs because its sync is manual (a team holding an
+// accepted student must refuse, not drop). The row is the primary action and
+// the only one that can fail the command; the invite team and GitHub's expired
+// record are cleared afterwards with warnings, since the sync's GC and the
+// People page are the backstops for both.
+func runRosterRemovePendingRow(client githubapi.Client, out, errOut io.Writer, org, classroom, email string) error {
+	email = configrepo.NormalizeInviteEmail(email)
+	path := fmt.Sprintf("%s/%s/%s", org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom))
+
+	branch, err := configrepo.ResolveConfigRepoBranch(client, org)
+	if err != nil {
+		return err
+	}
+	rows, err := configrepo.LoadRosterLenient(client, org, classroom, branch)
+	if err != nil {
+		return err
+	}
+	holder, pending := rosterEmailClaim(rows, email)
+	if !pending {
+		if holder != "" {
+			return fmt.Errorf("%s is the address on %s's row, which has an account, so nothing was changed. To remove that student, run `gh teacher roster remove %s %s %s`",
+				email, holder, org, classroom, holder)
+		}
+		_, _ = fmt.Fprintf(out, "%s: no pending row for %s, nothing to do\n", path, email)
+		return nil
+	}
+
+	live := &liveInvitations{client: client, org: org}
+	state, err := classifyPendingRow(client, org, classroom, email, live)
+	if err != nil {
+		return err
+	}
+	switch state {
+	case pendingLive:
+		return fmt.Errorf("GitHub still lists a pending invitation for %s, so the row was kept: dropping it would leave an invitation whose acceptance nothing records. Run `gh teacher roster cancel-invite %s %s %s` to revoke the invitation and drop the row together",
+			email, org, classroom, email)
+	case pendingAccepted:
+		return fmt.Errorf("%s accepted an earlier invitation to %s but isn't recorded on the roster yet, so the row was kept. Run %s to record their username and github_id, then remove them by username if they should not be on the roster",
+			email, classroom, syncWriteCommand(org, classroom))
+	}
+
+	// Every pending row carrying the address goes (identical duplicates are
+	// indistinguishable). A row that gained an identity under the rebase is no
+	// longer a pending row, so RemovePendingEmailRow leaves it alone.
+	removed := 0
+	build := func(parentSHA string) (configwrite.CommitChange, error) {
+		removed = 0
+		current, err := configrepo.LoadRosterLenient(client, org, classroom, parentSHA)
+		if err != nil {
+			return configwrite.CommitChange{}, err
+		}
+		for {
+			next, ok := configrepo.RemovePendingEmailRow(current, email)
+			if !ok {
+				break
+			}
+			current = next
+			removed++
+		}
+		if removed == 0 {
+			return configwrite.CommitChange{}, nil
+		}
+		return configrepo.RosterWriteChange(classroom, current)
+	}
+	message := contract.PrefixCommit(fmt.Sprintf("roster: remove the expired pending row for %s from %s (gh teacher roster remove)", email, classroom))
+	if _, err := configwrite.CommitTreeChange(client, org, configrepo.ConfigRepoName, branch, message, build); err != nil {
+		return err
+	}
+	if removed == 0 {
+		_, _ = fmt.Fprintf(out, "%s: no pending row for %s, nothing to do\n", path, email)
+		return nil
+	}
+	_, _ = fmt.Fprintf(out, "%s: removed the pending row for %s (no invitation was pending)\n", path, email)
+
+	// The team was just proven record-less or member-less for this address, so
+	// it maps nothing; only a record naming another classroom is not ours to
+	// delete (the slug hashes (classroom, email), so that should never happen).
+	slug := configrepo.InviteTeamName(classroom, email)
+	team, found, err := configrepo.ReadInviteTeam(client, org, slug)
+	switch {
+	case err != nil:
+		warnStrandedInviteTeam(errOut, "the row was removed, but reading", org, slug, err)
+	case found && team.Record != nil && team.Record.Classroom != classroom:
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: left the metadata team %s alone: its record names classroom %s, not %s.\n", org, slug, team.Record.Classroom, classroom)
+	case found:
+		if err := configrepo.DeleteInviteTeam(client, org, slug); err != nil {
+			warnStrandedInviteTeam(errOut, "the row was removed, but deleting", org, slug, err)
+		} else {
+			_, _ = fmt.Fprintf(out, "%s: deleted metadata team %s\n", org, slug)
+		}
+	}
+
+	failed := &failedInviteRecords{client: client, org: org}
+	failed.dismiss(out, errOut, email)
+	return nil
+}

--- a/cli/gh-teacher/internal/roster/remove_pending.go
+++ b/cli/gh-teacher/internal/roster/remove_pending.go
@@ -46,8 +46,8 @@ func runRosterRemovePendingRow(client githubapi.Client, out, errOut io.Writer, o
 	}
 	switch state {
 	case pendingLive:
-		return fmt.Errorf("GitHub still lists a pending invitation for %s, so the row was kept: dropping it would leave an invitation whose acceptance nothing records. Run `gh teacher roster cancel-invite %s %s %s` to revoke the invitation and drop the row together",
-			email, org, classroom, email)
+		return fmt.Errorf("GitHub still lists a pending invitation for %s (this classroom's, or another classroom's in %s), so the row was kept: dropping it would leave an invitation whose acceptance nothing records. If it is this classroom's, run `gh teacher roster cancel-invite %s %s %s` to revoke it and drop the row together. If another classroom sent it, cancel it there or wait for it to be accepted or expire, then re-run this command",
+			email, org, org, classroom, email)
 	case pendingAccepted:
 		return fmt.Errorf("%s accepted an earlier invitation to %s but isn't recorded on the roster yet, so the row was kept. Run %s to record their username and github_id, then remove them by username if they should not be on the roster",
 			email, classroom, syncWriteCommand(org, classroom))
@@ -86,17 +86,22 @@ func runRosterRemovePendingRow(client githubapi.Client, out, errOut io.Writer, o
 	}
 	_, _ = fmt.Fprintf(out, "%s: removed the pending row for %s (no invitation was pending)\n", path, email)
 
-	// The team was just proven record-less or member-less for this address, so
-	// it maps nothing; only a record naming another classroom is not ours to
-	// delete (the slug hashes (classroom, email), so that should never happen).
+	// The commit round-trip is a window in which the web's Re-invite can adopt
+	// this same team for a fresh invitation, or a student can accept one, so the
+	// team is deleted only on a FRESH proof that it still maps nothing (the
+	// sync's teardown re-checks at delete time for the same reason). A record
+	// naming another classroom or address is not ours to delete either.
 	slug := configrepo.InviteTeamName(classroom, email)
-	team, found, err := configrepo.ReadInviteTeam(client, org, slug)
+	insp, err := inspectPendingRow(client, org, classroom, email, &liveInvitations{client: client, org: org})
 	switch {
 	case err != nil:
-		warnStrandedInviteTeam(errOut, "the row was removed, but reading", org, slug, err)
-	case found && team.Record != nil && team.Record.Classroom != classroom:
-		_, _ = fmt.Fprintf(errOut, "Warning: %s: left the metadata team %s alone: its record names classroom %s, not %s.\n", org, slug, team.Record.Classroom, classroom)
-	case found:
+		warnStrandedInviteTeam(errOut, "the row was removed, but re-checking", org, slug, err)
+	case insp.state != pendingDead:
+		_, _ = fmt.Fprintf(errOut, "Note: %s: kept metadata team %s: a same-email re-invite or acceptance now maps to it, so deleting it would strip a live invitation.\n", org, slug)
+	case !insp.teamFound:
+	case insp.team.Record != nil && (insp.team.Record.Classroom != classroom || configrepo.NormalizeInviteEmail(insp.team.Record.Email) != email):
+		_, _ = fmt.Fprintf(errOut, "Warning: %s: left the metadata team %s alone: its record names %s in classroom %s, not this row.\n", org, slug, insp.team.Record.Email, insp.team.Record.Classroom)
+	default:
 		if err := configrepo.DeleteInviteTeam(client, org, slug); err != nil {
 			warnStrandedInviteTeam(errOut, "the row was removed, but deleting", org, slug, err)
 		} else {

--- a/cli/gh-teacher/internal/roster/remove_pending_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/remove_pending_cmd_test.go
@@ -1,0 +1,179 @@
+package roster
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/foundation50/classroom50-cli-shared/contract"
+	"github.com/foundation50/gh-teacher/internal/configrepo"
+	"github.com/foundation50/gh-teacher/internal/githubtest"
+)
+
+// runRemovePending drives the email form of `roster remove` against inviteMock,
+// which serves every endpoint the drop consults: the roster, the pending list,
+// the invite team and its members, the failed list, and both DELETEs.
+func runRemovePending(t *testing.T, mock *inviteMock, email string) (string, string, error) {
+	t.Helper()
+	server := httptest.NewServer(mock.handler(t))
+	t.Cleanup(server.Close)
+	client := githubtest.NewTestClient(t, server)
+
+	var out, errOut bytes.Buffer
+	err := runRosterRemovePendingRow(client, &out, &errOut, inviteTestOrg, inviteTestClassroom, email)
+	return out.String(), errOut.String(), err
+}
+
+const removeTestPendingRoster = storedRosterHeader + ",Ada,Lovelace," + inviteTestEmail + ",section-1,,student\n" +
+	"bea,Bea,Byte,bea@uni.edu,section-1,202,student\n"
+
+// The #970 leftover: the invitation expired, the sync reaped the team, and only
+// the row remains. Dropping it is the one thing no command could do; the row
+// goes, nothing else on the roster moves, and GitHub's expired record is
+// dismissed so the People page stops showing it.
+func TestRunRosterRemovePendingRow_DeadRowDropped(t *testing.T) {
+	mock := newInviteMock(t, removeTestPendingRoster)
+	mock.pending = nil
+	mock.inviteTeamStatus = http.StatusNotFound
+	mock.failed = []map[string]any{
+		{"id": 70, "email": inviteTestEmail},
+		{"id": 71, "email": "someone-else@uni.edu"},
+	}
+
+	out, _, err := runRemovePending(t, mock, inviteTestEmail)
+	if err != nil {
+		t.Fatalf("a dead pending row must be removable: %v", err)
+	}
+	if len(mock.blobs) != 1 {
+		t.Fatalf("want one roster commit, got %d blobs", len(mock.blobs))
+	}
+	rows, err := configrepo.ParseRoster([]byte(mock.blobs[0]))
+	if err != nil {
+		t.Fatalf("parse committed roster: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Username != "bea" {
+		t.Errorf("committed rows = %#v, want only bea's", rows)
+	}
+	if !strings.Contains(out, "removed the pending row for "+inviteTestEmail) {
+		t.Errorf("stdout should report the removed row:\n%s", out)
+	}
+	if mock.deletedTeamSlug != "" {
+		t.Errorf("deleted a team GitHub no longer had: %q", mock.deletedTeamSlug)
+	}
+	if len(mock.dismissed) != 1 || mock.dismissed[0] != "70" {
+		t.Errorf("dismissed = %v, want exactly record 70", mock.dismissed)
+	}
+}
+
+// A team the sync hasn't reaped yet (recorded, empty) and a provisional team
+// stranded with the acting teacher both map nothing once the row goes, so both
+// are deleted with it.
+func TestRunRosterRemovePendingRow_LeftoverTeamDeleted(t *testing.T) {
+	cases := []struct {
+		name  string
+		apply func(*inviteMock)
+	}{
+		{"recorded empty team", func(m *inviteMock) { m.inviteTeamDescription = inviteTestRecord(t) }},
+		{"provisional team with the teacher on it", func(m *inviteMock) {
+			m.inviteTeamDescription = contract.InviteProvisionalDescription
+			m.inviteTeamMembers = []map[string]any{{"login": inviteTestActor, "id": 1}}
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := newInviteMock(t, removeTestPendingRoster)
+			mock.pending = nil
+			tc.apply(mock)
+
+			out, _, err := runRemovePending(t, mock, inviteTestEmail)
+			if err != nil {
+				t.Fatalf("runRosterRemovePendingRow: %v", err)
+			}
+			if len(mock.blobs) != 1 {
+				t.Errorf("want one roster commit, got %d", len(mock.blobs))
+			}
+			if mock.deletedTeamSlug != mock.inviteTeamSlug {
+				t.Errorf("deleted team = %q, want %q", mock.deletedTeamSlug, mock.inviteTeamSlug)
+			}
+			if !strings.Contains(out, "deleted metadata team") {
+				t.Errorf("stdout should report the deleted team:\n%s", out)
+			}
+		})
+	}
+}
+
+// Only a row nothing backs may go. A live invitation is cancel-invite's job, an
+// accepted student is the sync's, and a hand-edited team is a human's; each
+// refusal names its remedy and changes nothing.
+func TestRunRosterRemovePendingRow_BackedRowRefused(t *testing.T) {
+	cases := []struct {
+		name  string
+		apply func(*inviteMock)
+		want  []string
+	}{
+		{"live invitation", func(m *inviteMock) {
+			m.pending = []map[string]any{{"id": 42, "email": inviteTestEmail, "role": "direct_member"}}
+		}, []string{"still lists a pending invitation", "cancel-invite"}},
+		{"accepted but unsynced", func(m *inviteMock) {
+			m.pending = nil
+			m.inviteTeamDescription = inviteTestRecord(t)
+			m.inviteTeamMembers = []map[string]any{{"login": "ada", "id": 99}}
+		}, []string{"accepted", "roster sync", "--write"}},
+		{"hand-edited team with a member", func(m *inviteMock) {
+			m.pending = nil
+			m.inviteTeamDescription = "not an invite record"
+			m.inviteTeamMembers = []map[string]any{{"login": "ada", "id": 99}}
+		}, []string{"readable invite record"}},
+		{"pending-list read failed", func(m *inviteMock) {
+			m.pendingStatus = http.StatusInternalServerError
+		}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := newInviteMock(t, removeTestPendingRoster)
+			tc.apply(mock)
+
+			_, _, err := runRemovePending(t, mock, inviteTestEmail)
+			if err == nil {
+				t.Fatal("err = nil, want a refusal")
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error should mention %q: %v", want, err)
+				}
+			}
+			if writes := writeCalls(mock.calls); len(writes) != 0 {
+				t.Errorf("refusal issued %d write(s): %#v", len(writes), writes)
+			}
+		})
+	}
+}
+
+// An address with no pending row is a no-op, like removing an absent username,
+// and reads neither GitHub list. An address that sits on an account row is a
+// different request (remove that student), so it is refused by name.
+func TestRunRosterRemovePendingRow_NoPendingRow(t *testing.T) {
+	absent := newInviteMock(t, removeTestPendingRoster)
+	absent.pendingStatus = http.StatusInternalServerError // would fail if read
+	out, _, err := runRemovePending(t, absent, "nobody@uni.edu")
+	if err != nil {
+		t.Fatalf("an absent row is a clean no-op: %v", err)
+	}
+	if !strings.Contains(out, "nothing to do") {
+		t.Errorf("stdout should say there was nothing to do:\n%s", out)
+	}
+	if n := len(absent.calls); countCalls(absent.calls, http.MethodGet, "/orgs/o/invitations") != 0 || writeCalls(absent.calls) != nil {
+		t.Errorf("an absent row touched GitHub's lists or wrote (%d calls): %#v", n, absent.calls)
+	}
+
+	onAccount := newInviteMock(t, removeTestPendingRoster)
+	_, _, err = runRemovePending(t, onAccount, "bea@uni.edu")
+	if err == nil || !strings.Contains(err.Error(), "roster remove o cs-principles bea") {
+		t.Errorf("err = %v, want a refusal naming the username form", err)
+	}
+	if writes := writeCalls(onAccount.calls); len(writes) != 0 {
+		t.Errorf("refusal issued %d write(s): %#v", len(writes), writes)
+	}
+}

--- a/cli/gh-teacher/internal/roster/remove_pending_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/remove_pending_cmd_test.go
@@ -115,7 +115,7 @@ func TestRunRosterRemovePendingRow_BackedRowRefused(t *testing.T) {
 	}{
 		{"live invitation", func(m *inviteMock) {
 			m.pending = []map[string]any{{"id": 42, "email": inviteTestEmail, "role": "direct_member"}}
-		}, []string{"still lists a pending invitation", "cancel-invite"}},
+		}, []string{"still lists a pending invitation", "another classroom's", "cancel-invite"}},
 		{"accepted but unsynced", func(m *inviteMock) {
 			m.pending = nil
 			m.inviteTeamDescription = inviteTestRecord(t)
@@ -175,5 +175,139 @@ func TestRunRosterRemovePendingRow_NoPendingRow(t *testing.T) {
 	}
 	if writes := writeCalls(onAccount.calls); len(writes) != 0 {
 		t.Errorf("refusal issued %d write(s): %#v", len(writes), writes)
+	}
+}
+
+// Two pending rows can carry one address (an import re-run, a hand edit); they
+// are indistinguishable by construction, so the drop takes both in one commit
+// and reports once.
+func TestRunRosterRemovePendingRow_DuplicateRowsDroppedTogether(t *testing.T) {
+	roster := storedRosterHeader +
+		",Ada,Lovelace," + inviteTestEmail + ",section-1,,student\n" +
+		",Ada,L.," + strings.ToUpper(inviteTestEmail) + ",section-2,,student\n" +
+		"bea,Bea,Byte,bea@uni.edu,section-1,202,student\n"
+	mock := newInviteMock(t, roster)
+	mock.pending = nil
+	mock.inviteTeamStatus = http.StatusNotFound
+
+	out, _, err := runRemovePending(t, mock, inviteTestEmail)
+	if err != nil {
+		t.Fatalf("runRosterRemovePendingRow: %v", err)
+	}
+	if len(mock.blobs) != 1 {
+		t.Fatalf("want one roster commit, got %d blobs", len(mock.blobs))
+	}
+	rows, err := configrepo.ParseRoster([]byte(mock.blobs[0]))
+	if err != nil {
+		t.Fatalf("parse committed roster: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Username != "bea" {
+		t.Errorf("committed rows = %#v, want only bea's", rows)
+	}
+	if n := strings.Count(out, "removed the pending row"); n != 1 {
+		t.Errorf("removal reported %d times, want once:\n%s", n, out)
+	}
+}
+
+// The roster commit is a round-trip in which the web's Re-invite can adopt the
+// same team for a fresh invitation, or a student can accept one. The team is
+// deleted only on a fresh proof taken after the commit, so either event keeps
+// it; the row is already gone, and the sync appends one when they accept.
+func TestRunRosterRemovePendingRow_TeamKeptWhenBackedAgainAfterCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		flip func(*inviteMock)
+	}{
+		{"re-invited from the web", func(m *inviteMock) {
+			m.pending = []map[string]any{{"id": 43, "email": inviteTestEmail, "role": "direct_member"}}
+		}},
+		{"accepted", func(m *inviteMock) {
+			m.inviteTeamMembers = []map[string]any{{"login": "ada", "id": 99}}
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := newInviteMock(t, removeTestPendingRoster)
+			mock.pending = nil
+			mock.inviteTeamDescription = inviteTestRecord(t)
+			mock.afterCommit = func() { tc.flip(mock) }
+
+			_, errOut, err := runRemovePending(t, mock, inviteTestEmail)
+			if err != nil {
+				t.Fatalf("a re-backed team is a note, not a failure: %v", err)
+			}
+			if len(mock.blobs) != 1 {
+				t.Errorf("want the row commit to have landed, got %d blobs", len(mock.blobs))
+			}
+			if mock.deletedTeamSlug != "" {
+				t.Errorf("deleted team %q that a fresh invitation or member now maps to", mock.deletedTeamSlug)
+			}
+			if !strings.Contains(errOut, "kept metadata team") {
+				t.Errorf("stderr should say the team was kept and why:\n%s", errOut)
+			}
+			// The two pending-list reads prove the delete decision was fresh.
+			if n := countCalls(mock.calls, http.MethodGet, "/orgs/o/invitations"); n != 2 {
+				t.Errorf("pending-list reads = %d, want 2 (classify, then re-check at delete time)", n)
+			}
+		})
+	}
+}
+
+// Once the row is gone, a team or record that can't be cleared is a warning,
+// never a failure: the sync's GC and the People page are the backstops.
+func TestRunRosterRemovePendingRow_TeardownProblemsOnlyWarn(t *testing.T) {
+	cases := []struct {
+		name     string
+		apply    func(*inviteMock)
+		wantWarn string
+	}{
+		{"team DELETE 500", func(m *inviteMock) {
+			m.inviteTeamDescription = inviteTestRecord(t)
+			m.inviteTeamDeleteStatus = http.StatusInternalServerError
+		}, "the row was removed, but deleting"},
+		{"team re-check 500 after the commit", func(m *inviteMock) {
+			m.inviteTeamDescription = inviteTestRecord(t)
+			m.afterCommit = func() { m.inviteTeamStatus = http.StatusInternalServerError }
+		}, "the row was removed, but re-checking"},
+		{"record names another address", func(m *inviteMock) {
+			record, err := configrepo.MarshalInviteDescription(inviteTestClassroom, "someone-else@uni.edu")
+			if err != nil {
+				t.Fatalf("marshal record: %v", err)
+			}
+			m.inviteTeamDescription = record
+		}, "left the metadata team"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := newInviteMock(t, removeTestPendingRoster)
+			mock.pending = nil
+			tc.apply(mock)
+
+			_, errOut, err := runRemovePending(t, mock, inviteTestEmail)
+			if err != nil {
+				t.Fatalf("teardown trouble must not fail a drop that landed: %v", err)
+			}
+			if len(mock.blobs) != 1 {
+				t.Errorf("want one roster commit, got %d", len(mock.blobs))
+			}
+			if mock.deletedTeamSlug != "" {
+				t.Errorf("deleted team %q", mock.deletedTeamSlug)
+			}
+			if !strings.Contains(errOut, tc.wantWarn) {
+				t.Errorf("stderr should contain %q:\n%s", tc.wantWarn, errOut)
+			}
+		})
+	}
+}
+
+// The email form is chosen by the @ in the argument and canonicalized before
+// auth, like the invite paths: a form GitHub rejects must fail here rather than
+// match no row and exit 0.
+func TestRosterRemoveCmd_EmailFormValidated(t *testing.T) {
+	for _, arg := range []string{"<ada@uni.edu>", "@alice", "Ada <ada@uni.edu>"} {
+		err := runRosterSubcommand(t, rosterRemoveCmd(), "o", "cs-principles", arg)
+		if err == nil {
+			t.Errorf("%q: err = nil, want the address rejected before any auth or network", arg)
+		}
 	}
 }

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -215,8 +215,8 @@ func rosterUpdateCmd() *cobra.Command {
 
 func rosterRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "remove <org> <classroom> <username>",
-		Short: "Remove one student from roster.csv",
+		Use:   "remove <org> <classroom> <username-or-email>",
+		Short: "Remove one student or one dead pending row from roster.csv",
 		Long: "Drop the row whose username matches <username> (case-insensitive)\n" +
 			"from <org>/classroom50/<classroom>/roster.csv.\n\n" +
 			"Does not remove the student from the org. Use\n" +
@@ -224,16 +224,27 @@ func rosterRemoveCmd() *cobra.Command {
 			"deliberate two-step process so an off-by-one roster edit\n" +
 			"can't accidentally revoke a student's access to every repo\n" +
 			"in the org.\n\n" +
+			"Pass an email address instead to drop the pending row a lapsed\n" +
+			"invitation left behind (GitHub invitations expire after 7 days),\n" +
+			"the same as the web app's Remove row. The row is dropped only once\n" +
+			"GitHub confirms nothing backs it: an invitation still pending is\n" +
+			"left for `gh teacher roster cancel-invite`, and a student who\n" +
+			"accepted but isn't recorded yet is left for `gh teacher roster\n" +
+			"sync --write`, so a row can never be dropped out from under an\n" +
+			"invitation someone could still accept. The invitation's leftover\n" +
+			"metadata team and GitHub's expired record for the address are\n" +
+			"cleared too.\n\n" +
 			"Idempotent: if the row is absent, exits 0 with a note.",
-		Example: "  gh teacher roster remove cs50-fall-2026 cs-principles alice",
-		Args:    cobra.ExactArgs(3),
+		Example: "  gh teacher roster remove cs50-fall-2026 cs-principles alice\n" +
+			"  gh teacher roster remove cs50-fall-2026 cs-principles ada@example.edu",
+		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			org := strings.TrimSpace(args[0])
 			classroom := strings.TrimSpace(args[1])
-			username := strings.TrimSpace(args[2])
-			if org == "" || classroom == "" || username == "" {
-				return errors.New("org, classroom, and username must all be non-empty")
+			subject := strings.TrimSpace(args[2])
+			if org == "" || classroom == "" || subject == "" {
+				return errors.New("org, classroom, and username or email must all be non-empty")
 			}
 			if err := validate.ShortName(classroom, "classroom"); err != nil {
 				return err
@@ -242,7 +253,11 @@ func rosterRemoveCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runRosterRemove(client, cmd.OutOrStdout(), org, classroom, username)
+			// A username can't contain @, so the argument's shape picks the path.
+			if strings.Contains(subject, "@") {
+				return runRosterRemovePendingRow(client, cmd.OutOrStdout(), cmd.ErrOrStderr(), org, classroom, subject)
+			}
+			return runRosterRemove(client, cmd.OutOrStdout(), org, classroom, subject)
 		},
 	}
 	return cmd

--- a/cli/gh-teacher/internal/roster/roster.go
+++ b/cli/gh-teacher/internal/roster/roster.go
@@ -217,7 +217,7 @@ func rosterRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove <org> <classroom> <username-or-email>",
 		Short: "Remove one student or one dead pending row from roster.csv",
-		Long: "Drop the row whose username matches <username> (case-insensitive)\n" +
+		Long: "Pass a username to drop that student's row (matched case-insensitively)\n" +
 			"from <org>/classroom50/<classroom>/roster.csv.\n\n" +
 			"Does not remove the student from the org. Use\n" +
 			"`gh teacher remove <org> <username>` for that: it's a\n" +
@@ -249,13 +249,24 @@ func rosterRemoveCmd() *cobra.Command {
 			if err := validate.ShortName(classroom, "classroom"); err != nil {
 				return err
 			}
+			// A username can't contain @, so the argument's shape picks the path.
+			// The address is canonicalized before auth, as the invite paths do, so
+			// a form GitHub rejects (`<a@b.edu>`, `@handle`) fails here instead of
+			// matching no row and exiting 0.
+			email := ""
+			if strings.Contains(subject, "@") {
+				canonical, err := configrepo.CanonicalRosterEmail(subject)
+				if err != nil {
+					return err
+				}
+				email = canonical
+			}
 			client, err := githubapi.RequireAuthClient(cmd)
 			if err != nil {
 				return err
 			}
-			// A username can't contain @, so the argument's shape picks the path.
-			if strings.Contains(subject, "@") {
-				return runRosterRemovePendingRow(client, cmd.OutOrStdout(), cmd.ErrOrStderr(), org, classroom, subject)
+			if email != "" {
+				return runRosterRemovePendingRow(client, cmd.OutOrStdout(), cmd.ErrOrStderr(), org, classroom, email)
 			}
 			return runRosterRemove(client, cmd.OutOrStdout(), org, classroom, subject)
 		},

--- a/cli/gh-teacher/internal/roster/sync.go
+++ b/cli/gh-teacher/internal/roster/sync.go
@@ -95,7 +95,9 @@ func rosterSyncCmd() *cobra.Command {
 			"per-invite `secret` metadata team holds the only record of which\n" +
 			"address the new account came from. This folds that mapping onto the\n" +
 			"pending row and then retires the team, in that order, so a failed\n" +
-			"cleanup never loses the address.\n\n" +
+			"cleanup never loses the address. Any expired-invitation record\n" +
+			"GitHub still keeps for that address is dismissed too, since they\n" +
+			"got in.\n\n" +
 			"The sync never REMOVES a roster row. An email row nothing backs\n" +
 			"stays on the roster for the teacher to link or delete by hand (the\n" +
 			"web app shows it as \"unlinked\").\n\n" +
@@ -664,7 +666,8 @@ func runRosterSync(client githubapi.Client, out, errOut io.Writer, org, classroo
 		scan.staleSlugs = nil
 		retirable = nil
 	}
-	reportSyncPlan(out, errOut, org, classroom, scan, plan, retirable)
+	failed := &failedInviteRecords{client: client, org: org}
+	reportSyncPlan(out, errOut, org, classroom, scan, plan, retirable, failed)
 
 	pending := !plan.empty() || len(scan.staleSlugs) > 0 || len(retirable) > 0
 	if !write {
@@ -686,6 +689,13 @@ func runRosterSync(client githubapi.Client, out, errOut io.Writer, org, classroo
 	retired, err := applyRosterSync(client, out, org, classroom, branch, scan, idx)
 	if err != nil {
 		return err
+	}
+	// Every recovered address belongs to someone now enrolled, so any expired
+	// record GitHub still keeps for it is noise (the web drops it from view for
+	// a member). Dismissed after the commit, and regardless of trust: a
+	// recovery is proven per team, and this touches no metadata team.
+	for _, rec := range scan.recovered {
+		failed.dismiss(out, errOut, rec.Email)
 	}
 	if !scan.trusted {
 		_, _ = fmt.Fprintf(errOut, "Note: %s: no metadata team was deleted; this pass could not read enough to prove one is redundant.\n", org)
@@ -747,8 +757,11 @@ func syncDegradedError(org, classroom string) error {
 // reportSyncPlan prints the planned edits on stdout (the result a script reads)
 // and the report-only findings needing a human on stderr. `retirable` is the
 // recovered metadata teams a --write pass would delete: reported here so a dry
-// run whose roster plan is empty still says so rather than "up to date".
-func reportSyncPlan(out, errOut io.Writer, org, classroom string, scan inviteScan, plan rosterPlan, retirable []string) {
+// run whose roster plan is empty still says so rather than "up to date". The
+// expired records a --write pass would dismiss are read only when there is a
+// recovery to dismiss them for, and never decide the exit code on their own: a
+// recovery always already counts as pending through its fold or its team.
+func reportSyncPlan(out, errOut io.Writer, org, classroom string, scan inviteScan, plan rosterPlan, retirable []string, failed *failedInviteRecords) {
 	path := fmt.Sprintf("%s/%s/%s", org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom))
 	if plan.empty() && len(scan.staleSlugs) == 0 && len(retirable) == 0 {
 		_, _ = fmt.Fprintf(out, "%s: up to date (no invites to record, no ids to fill)\n", path)
@@ -773,6 +786,11 @@ func reportSyncPlan(out, errOut io.Writer, org, classroom string, scan inviteSca
 	}
 	for _, slug := range retirable {
 		_, _ = fmt.Fprintf(out, "%s: retire the metadata team %s (the roster already records its address)\n", org, slug)
+	}
+	for _, rec := range scan.recovered {
+		if ids := failed.idsFor(errOut, rec.Email); len(ids) > 0 {
+			_, _ = fmt.Fprintf(out, "%s: dismiss %d expired invitation record(s) for %s (they accepted a later one)\n", org, len(ids), rec.Email)
+		}
 	}
 	for _, username := range plan.findings.dupLogins {
 		_, _ = fmt.Fprintf(errOut, "Warning: %s: left a second row for %q alone: more than one row carries that username, and only the first can be filled in, so which student the id belongs to is not this pass's guess. Remove the duplicate row (or give it its own username) to let the sync finish it.\n",

--- a/cli/gh-teacher/internal/roster/sync.go
+++ b/cli/gh-teacher/internal/roster/sync.go
@@ -669,6 +669,8 @@ func runRosterSync(client githubapi.Client, out, errOut io.Writer, org, classroo
 	failed := &failedInviteRecords{client: client, org: org}
 	reportSyncPlan(out, errOut, org, classroom, scan, plan, retirable, failed)
 
+	// Dismissals are not counted: a recovery already counts through its fold or
+	// its team.
 	pending := !plan.empty() || len(scan.staleSlugs) > 0 || len(retirable) > 0
 	if !write {
 		if pending {
@@ -690,10 +692,8 @@ func runRosterSync(client githubapi.Client, out, errOut io.Writer, org, classroo
 	if err != nil {
 		return err
 	}
-	// Every recovered address belongs to someone now enrolled, so any expired
-	// record GitHub still keeps for it is noise (the web drops it from view for
-	// a member). Dismissed after the commit, and regardless of trust: a
-	// recovery is proven per team, and this touches no metadata team.
+	// Runs before the trust check: a recovery is proven per team, and this
+	// touches no metadata team.
 	for _, rec := range scan.recovered {
 		failed.dismiss(out, errOut, rec.Email)
 	}
@@ -757,10 +757,7 @@ func syncDegradedError(org, classroom string) error {
 // reportSyncPlan prints the planned edits on stdout (the result a script reads)
 // and the report-only findings needing a human on stderr. `retirable` is the
 // recovered metadata teams a --write pass would delete: reported here so a dry
-// run whose roster plan is empty still says so rather than "up to date". The
-// expired records a --write pass would dismiss are read only when there is a
-// recovery to dismiss them for, and never decide the exit code on their own: a
-// recovery always already counts as pending through its fold or its team.
+// run whose roster plan is empty still says so rather than "up to date".
 func reportSyncPlan(out, errOut io.Writer, org, classroom string, scan inviteScan, plan rosterPlan, retirable []string, failed *failedInviteRecords) {
 	path := fmt.Sprintf("%s/%s/%s", org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom))
 	if plan.empty() && len(scan.staleSlugs) == 0 && len(retirable) == 0 {

--- a/cli/gh-teacher/internal/roster/sync.go
+++ b/cli/gh-teacher/internal/roster/sync.go
@@ -667,11 +667,9 @@ func runRosterSync(client githubapi.Client, out, errOut io.Writer, org, classroo
 		retirable = nil
 	}
 	failed := &failedInviteRecords{client: client, org: org}
-	reportSyncPlan(out, errOut, org, classroom, scan, plan, retirable, failed)
+	dismissals := reportSyncPlan(out, errOut, org, classroom, scan, plan, retirable, failed)
 
-	// Dismissals are not counted: a recovery already counts through its fold or
-	// its team.
-	pending := !plan.empty() || len(scan.staleSlugs) > 0 || len(retirable) > 0
+	pending := !plan.empty() || len(scan.staleSlugs) > 0 || len(retirable) > 0 || dismissals > 0
 	if !write {
 		if pending {
 			_, _ = fmt.Fprintf(errOut, "Nothing was changed. Re-run with --write to apply this.\n")
@@ -756,11 +754,17 @@ func syncDegradedError(org, classroom string) error {
 
 // reportSyncPlan prints the planned edits on stdout (the result a script reads)
 // and the report-only findings needing a human on stderr. `retirable` is the
-// recovered metadata teams a --write pass would delete: reported here so a dry
-// run whose roster plan is empty still says so rather than "up to date".
-func reportSyncPlan(out, errOut io.Writer, org, classroom string, scan inviteScan, plan rosterPlan, retirable []string, failed *failedInviteRecords) {
+// recovered metadata teams a --write pass would delete, and the returned count
+// is the expired records it would dismiss: both are reported here so a dry run
+// whose roster plan is empty still says so rather than "up to date". The failed
+// list is read only when there is a recovery to dismiss for.
+func reportSyncPlan(out, errOut io.Writer, org, classroom string, scan inviteScan, plan rosterPlan, retirable []string, failed *failedInviteRecords) int {
 	path := fmt.Sprintf("%s/%s/%s", org, configrepo.ConfigRepoName, configrepo.RosterFilePath(classroom))
-	if plan.empty() && len(scan.staleSlugs) == 0 && len(retirable) == 0 {
+	dismissals := 0
+	for _, rec := range scan.recovered {
+		dismissals += len(failed.idsFor(errOut, rec.Email))
+	}
+	if plan.empty() && len(scan.staleSlugs) == 0 && len(retirable) == 0 && dismissals == 0 {
 		_, _ = fmt.Fprintf(out, "%s: up to date (no invites to record, no ids to fill)\n", path)
 	}
 	for _, rec := range plan.folds {
@@ -800,6 +804,7 @@ func reportSyncPlan(out, errOut io.Writer, org, classroom string, scan inviteSca
 	for _, anomaly := range scan.anomalies {
 		_, _ = fmt.Fprintf(errOut, "Warning: %s: kept %s\n", org, anomaly)
 	}
+	return dismissals
 }
 
 // applyRosterSync is phase 3: ONE rebase-retried commit that folds every

--- a/cli/gh-teacher/internal/roster/sync_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/sync_cmd_test.go
@@ -50,6 +50,11 @@ type syncMock struct {
 
 	pending       []map[string]any
 	pendingStatus int
+	// failed is served as GET /orgs/o/failed_invitations (nil → empty list):
+	// the expired records a recovered address gets dismissed. failedStatus
+	// overrides the read.
+	failed       []map[string]any
+	failedStatus int
 	// pendingFailAfterScan fails the invitation read only AFTER the scan's, so
 	// the teardown's delete-time liveness re-check is the read that degrades.
 	pendingFailAfterScan bool
@@ -84,6 +89,7 @@ type syncMock struct {
 
 	calls        []inviteCall
 	deletedTeams []string
+	dismissed    []string
 	committed    bool
 }
 
@@ -188,6 +194,21 @@ func (m *syncMock) handler(t *testing.T) http.Handler {
 			pending = []map[string]any{}
 		}
 		_ = json.NewEncoder(w).Encode(pending)
+	})
+	base.HandleFunc("/orgs/o/failed_invitations", func(w http.ResponseWriter, r *http.Request) {
+		if m.failedStatus != 0 {
+			w.WriteHeader(m.failedStatus)
+			return
+		}
+		failed := m.failed
+		if failed == nil {
+			failed = []map[string]any{}
+		}
+		_ = json.NewEncoder(w).Encode(failed)
+	})
+	base.HandleFunc("/orgs/o/invitations/", func(w http.ResponseWriter, r *http.Request) {
+		m.dismissed = append(m.dismissed, strings.TrimPrefix(r.URL.Path, "/orgs/o/invitations/"))
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	// committed latches on the roster write so a same-email re-invite can be
@@ -341,6 +362,79 @@ func TestRunRosterSync_AcceptedInviteRecoveredThenClean(t *testing.T) {
 	}
 	if !strings.Contains(cleanOut, "up to date") {
 		t.Errorf("a clean pass should say so:\n%s", cleanOut)
+	}
+}
+
+// An accepted invitation whose address still carries an EXPIRED record (an
+// earlier invitation lapsed, and a re-invite from GitHub's UI or an older CLI
+// didn't dismiss it) is noise once they're in, so the sync clears it: the dry run
+// reports it as pending work, and --write dismisses it after the roster commit
+// lands (the web's dismiss-after-confirmation ordering).
+func TestRunRosterSync_RecoveredAddressDismissesExpiredRecords(t *testing.T) {
+	roster := storedRosterHeader + ",Ada,Lovelace," + inviteTestEmail + ",section-1,,student\n"
+	failed := []map[string]any{
+		{"id": 70, "email": inviteTestEmail, "failed_reason": "Invitation expired."},
+		{"id": 71, "email": "someone-else@uni.edu", "failed_reason": "Invitation expired."},
+	}
+
+	dry := newSyncMock(t, roster)
+	dry.teams = []syncTeam{acceptedInviteTeam(t)}
+	dry.failed = failed
+	out, _, err := runSync(t, dry, false)
+	if got := exitCode(err); got != 2 {
+		t.Fatalf("dry-run exit code = %d (err %v), want 2", got, err)
+	}
+	if !strings.Contains(out, "dismiss 1 expired invitation record") {
+		t.Errorf("dry run should report the record it would dismiss:\n%s", out)
+	}
+	if writes := writeCalls(dry.calls); len(writes) != 0 {
+		t.Errorf("dry run issued %d write request(s): %#v", len(writes), writes)
+	}
+
+	apply := newSyncMock(t, roster)
+	apply.teams = []syncTeam{acceptedInviteTeam(t)}
+	apply.failed = failed
+	out, _, err = runSync(t, apply, true)
+	if err != nil {
+		t.Fatalf("--write: %v", err)
+	}
+	if len(apply.dismissed) != 1 || apply.dismissed[0] != "70" {
+		t.Errorf("dismissed = %v, want exactly record 70 (not someone else's 71)", apply.dismissed)
+	}
+	treeIdx := indexOfCall(apply.calls, http.MethodPost, "/repos/o/classroom50/git/trees")
+	dismissIdx := indexOfCall(apply.calls, http.MethodDelete, "/orgs/o/invitations/70")
+	if treeIdx < 0 || dismissIdx < treeIdx {
+		t.Errorf("the dismiss (call %d) must follow the roster commit (call %d)", dismissIdx, treeIdx)
+	}
+	if !strings.Contains(out, "dismissed 1 expired invitation record") {
+		t.Errorf("--write should report the dismissed record:\n%s", out)
+	}
+}
+
+// The failed list is owner-only bookkeeping: a pass with nothing recovered never
+// reads it, and an unreadable list (403) neither warns nor changes the outcome.
+func TestRunRosterSync_FailedListIsReadOnlyForRecoveries(t *testing.T) {
+	quiet := newSyncMock(t, storedRosterHeader+",,,gone@uni.edu,,,student\n")
+	quiet.failedStatus = http.StatusInternalServerError // would warn if read
+	if _, errOut, err := runSync(t, quiet, true); err != nil {
+		t.Fatalf("--write with nothing to recover: %v", err)
+	} else if strings.Contains(errOut, "failed invitations") {
+		t.Errorf("read the failed list with nothing recovered:\n%s", errOut)
+	}
+	if n := countCalls(quiet.calls, http.MethodGet, "/orgs/o/failed_invitations"); n != 0 {
+		t.Errorf("failed-list reads = %d, want 0 with nothing recovered", n)
+	}
+
+	forbidden := newSyncMock(t, storedRosterHeader+",Ada,Lovelace,"+inviteTestEmail+",section-1,,student\n")
+	forbidden.teams = []syncTeam{acceptedInviteTeam(t)}
+	forbidden.failedStatus = http.StatusForbidden
+	if _, errOut, err := runSync(t, forbidden, true); err != nil {
+		t.Fatalf("an owner-only 403 on the failed list must not fail the sync: %v", err)
+	} else if strings.Contains(errOut, "Warning") {
+		t.Errorf("a 403 on the owner-only list should be silent:\n%s", errOut)
+	}
+	if len(forbidden.dismissed) != 0 {
+		t.Errorf("dismissed %v with an unreadable list", forbidden.dismissed)
 	}
 }
 

--- a/cli/gh-teacher/internal/roster/sync_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/sync_cmd_test.go
@@ -373,8 +373,8 @@ func TestRunRosterSync_AcceptedInviteRecoveredThenClean(t *testing.T) {
 func TestRunRosterSync_RecoveredAddressDismissesExpiredRecords(t *testing.T) {
 	roster := storedRosterHeader + ",Ada,Lovelace," + inviteTestEmail + ",section-1,,student\n"
 	failed := []map[string]any{
-		{"id": 70, "email": inviteTestEmail, "failed_reason": "Invitation expired."},
-		{"id": 71, "email": "someone-else@uni.edu", "failed_reason": "Invitation expired."},
+		{"id": 70, "email": inviteTestEmail},
+		{"id": 71, "email": "someone-else@uni.edu"},
 	}
 
 	dry := newSyncMock(t, roster)

--- a/cli/gh-teacher/internal/roster/sync_cmd_test.go
+++ b/cli/gh-teacher/internal/roster/sync_cmd_test.go
@@ -411,6 +411,32 @@ func TestRunRosterSync_RecoveredAddressDismissesExpiredRecords(t *testing.T) {
 	}
 }
 
+// A recovery can leave the roster untouched and its team standing (the row
+// already names the account under a different address, so there is nothing to
+// fold and the team is not proven redundant) while an expired record for the
+// address still waits to be dismissed. That dismissal is work --write would do,
+// so the dry run must count it as pending rather than report "up to date".
+func TestRunRosterSync_DismissalAloneCountsAsPending(t *testing.T) {
+	roster := storedRosterHeader + syncTestAcceptedLogin + ",Ada,Lovelace,ada.personal@uni.edu,section-1,101,student\n"
+	mock := newSyncMock(t, roster)
+	mock.teams = []syncTeam{acceptedInviteTeam(t)}
+	mock.failed = []map[string]any{{"id": 70, "email": inviteTestEmail}}
+
+	out, _, err := runSync(t, mock, false)
+	if got := exitCode(err); got != 2 {
+		t.Fatalf("dry-run exit code = %d (err %v), want 2 for a planned dismissal", got, err)
+	}
+	if strings.Contains(out, "up to date") {
+		t.Errorf("dry run claimed up to date while planning a dismissal:\n%s", out)
+	}
+	if !strings.Contains(out, "dismiss 1 expired invitation record") {
+		t.Errorf("dry run should report the record it would dismiss:\n%s", out)
+	}
+	if writes := writeCalls(mock.calls); len(writes) != 0 {
+		t.Errorf("dry run issued %d write request(s): %#v", len(writes), writes)
+	}
+}
+
 // The failed list is owner-only bookkeeping: a pass with nothing recovered never
 // reads it, and an unreadable list (403) neither warns nor changes the outcome.
 func TestRunRosterSync_FailedListIsReadOnlyForRecoveries(t *testing.T) {

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -509,7 +509,8 @@ is the rest of that work without a browser. For every trigger, see
 
 **Dry run unless you pass `--write`**: without it, no write request is issued at
 all. A dry run also flags an invite team whose address the roster *already*
-records, since `--write` would retire it. That counts as changes pending, so the
+records, since `--write` would retire it, and any expired-invitation record it
+would dismiss. Both count as changes pending, so the
 run exits `2` rather than reporting the classroom up to date. On an **archived**
 classroom `--write` is refused (the roster is frozen), while a dry run still
 reports what's outstanding.

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -395,12 +395,13 @@ account. An address that's already an organization member, or that already has a
 pending invitation, is reported as skipped and the command exits 0.
 
 It refuses to send in two cases: the classroom has no usable team recorded in
-`classroom.json`, or the roster lists the address as a **pending invitation** that
-GitHub still holds. If that invitation has since **expired** (GitHub drops one
-after 7 days), a single `roster invite` re-sends it and keeps the row instead of
-refusing, the same re-invite the web app offers on an expired row. (With `--file`
-a pending address is always a skip rather than a refusal or a re-send, so one
-already-listed address doesn't stop the batch.) An address some *other* row
+`classroom.json`, or the roster already lists the address as a **pending
+invitation** that GitHub still has open (or that someone accepted but you haven't
+synced yet). (With `--file` that second case is a skip rather than a refusal, so
+one already-invited address doesn't stop the batch.) A pending row whose
+invitation has since **expired** (GitHub invitations last 7 days) doesn't block:
+a new invitation is sent and the existing row is kept, the same as the web app's
+**Re-invite**. An address some *other* row
 merely carries is a shared address (a
 parent, a lab contact), so the real person still gets invited: the invitation is
 sent, a note on stderr names that row, and **no second row is written**. If the
@@ -485,7 +486,9 @@ gh teacher roster sync <org> <classroom> --write    # apply it
 It records the students who accepted an email invitation (username and
 `github_id`, onto their own pending row), fills in a missing `github_id` from the
 classroom team's membership (and a blank or outdated username from the member's
-`github_id`), and deletes the invite teams that are done. If no
+`github_id`), deletes the invite teams that are done, and dismisses any
+expired-invitation record GitHub still keeps for an address that accepted a later
+one. If no
 row claims an accepted invitation (the pending row was deleted, or the invite's
 roster commit never landed), it appends one so the address isn't lost; that row
 records the role of the classroom team the account was found on, so a staff
@@ -495,10 +498,9 @@ than as a student. A role already recorded is never rewritten.
 The sync **never removes a row**. A pending row whose invitation expired or was
 canceled stays on the roster for you to re-invite, link, or delete by hand: the
 web app shows it as unlinked with an **Invitation expired** badge and offers
-**Re-invite**, **Link account**, and **Remove row**. From the CLI, re-invite with
-`roster invite <org> <classroom> <email>`: it notices the invitation is gone and
-re-sends it, leaving the row in place. To remove it instead, drop the row by
-editing `roster.csv`.
+**Re-invite**, **Link account**, and **Remove row**; from the CLI, re-invite it
+with [`roster invite`](#inviting-a-student-by-email), which sends a new
+invitation against the same row, or drop it by editing `roster.csv`.
 
 The web app runs this same sync when a teacher opens the roster, and
 additionally refreshes each row's recorded `role` from live team membership; this

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -395,9 +395,12 @@ account. An address that's already an organization member, or that already has a
 pending invitation, is reported as skipped and the command exits 0.
 
 It refuses to send in two cases: the classroom has no usable team recorded in
-`classroom.json`, or the roster already lists the address as a **pending
-invitation**. (With `--file` that second case is a skip rather than a refusal, so
-one already-invited address doesn't stop the batch.) An address some *other* row
+`classroom.json`, or the roster lists the address as a **pending invitation** that
+GitHub still holds. If that invitation has since **expired** (GitHub drops one
+after 7 days), a single `roster invite` re-sends it and keeps the row instead of
+refusing, the same re-invite the web app offers on an expired row. (With `--file`
+a pending address is always a skip rather than a refusal or a re-send, so one
+already-listed address doesn't stop the batch.) An address some *other* row
 merely carries is a shared address (a
 parent, a lab contact), so the real person still gets invited: the invitation is
 sent, a note on stderr names that row, and **no second row is written**. If the
@@ -492,7 +495,9 @@ than as a student. A role already recorded is never rewritten.
 The sync **never removes a row**. A pending row whose invitation expired or was
 canceled stays on the roster for you to re-invite, link, or delete by hand: the
 web app shows it as unlinked with an **Invitation expired** badge and offers
-**Re-invite**, **Link account**, and **Remove row**; from the CLI, drop it by
+**Re-invite**, **Link account**, and **Remove row**. From the CLI, re-invite with
+`roster invite <org> <classroom> <email>`: it notices the invitation is gone and
+re-sends it, leaving the row in place. To remove it instead, drop the row by
 editing `roster.csv`.
 
 The web app runs this same sync when a teacher opens the roster, and

--- a/wiki/CLI-Teacher-Guide.md
+++ b/wiki/CLI-Teacher-Guide.md
@@ -362,12 +362,18 @@ argument.
 
 ```sh
 gh teacher roster remove <org> <classroom> <username>
+gh teacher roster remove <org> <classroom> <email>     # drop a dead pending row
 ```
 
 > [!NOTE]
 > This does **not** remove organization membership; use `gh teacher remove`
 > (step 8) for that. Splitting the two is deliberate: a roster edit shouldn't be
 > able to revoke a student's access to every repo in the organization.
+
+The email form is for the pending row a lapsed invitation leaves behind (see
+[Syncing the roster](#syncing-the-roster-with-github)). It refuses while GitHub
+still lists the invitation (use `roster cancel-invite`) or while an accepted
+student is waiting to be synced (use `roster sync --write`).
 
 Roster writes retry on top of each other, so two teachers editing at once can't
 lose each other's work. If you see `lost the rebase race`, retry.
@@ -496,11 +502,13 @@ member who accepted an email invitation is recorded with their staff role rather
 than as a student. A role already recorded is never rewritten.
 
 The sync **never removes a row**. A pending row whose invitation expired or was
-canceled stays on the roster for you to re-invite, link, or delete by hand: the
+canceled stays on the roster for you to re-invite, link, or remove: the
 web app shows it as unlinked with an **Invitation expired** badge and offers
 **Re-invite**, **Link account**, and **Remove row**; from the CLI, re-invite it
 with [`roster invite`](#inviting-a-student-by-email), which sends a new
-invitation against the same row, or drop it by editing `roster.csv`.
+invitation against the same row, or drop it with `roster remove <org> <classroom>
+<email>`, which checks with GitHub first so it never drops a row an invitation
+someone could still accept is backing.
 
 The web app runs this same sync when a teacher opens the roster, and
 additionally refreshes each row's recorded `role` from live team membership; this

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -290,6 +290,12 @@ and the **Members** page shows the same badge. To recover:
 - **A whole class.** Upload the roster file again. Each expired address is
   marked **Resend invitation (expired)** in the preview and re-sent on import;
   addresses with a live invitation are skipped.
+- **From the CLI.** Run `gh teacher roster invite <org> <classroom> <email>`
+  again (or `--file` with the original list). A pending row whose invitation
+  GitHub no longer lists is re-sent against the same row, nothing else is
+  written, and GitHub's expired record for the address is dismissed once the
+  new invitation is confirmed. An address whose invitation is still open, or
+  that was accepted but not yet synced, is skipped with a note saying which.
 
 A failed invitation whose roster row was already removed shows up on the
 **Members** page as a **failed invitation that isn't on any roster**. Nothing
@@ -531,7 +537,12 @@ collect a record-less team for you: it skips one for the same reason.
 A fifth outcome isn't a refusal. With no pending invitation for the address at all,
 `cancel-invite` reports that and exits 0, because a student who already accepted
 looks identical from here. Run `gh teacher roster sync cs50-fall-2026
-cs-principles --write` in that case.
+cs-principles --write` in that case. If the invitation expired instead, run
+`gh teacher roster invite` for the address again: it sends a new invitation
+against the same row (see
+[A student's invitation expired before they accepted](#a-students-invitation-expired-before-they-accepted)).
+To drop the row without re-inviting, edit `roster.csv`; neither `cancel-invite`
+nor the sync removes a row nothing backs.
 
 ### A pending row shows a `github_id` that can't be an account
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -296,7 +296,9 @@ and the **Members** page shows the same badge. To recover:
   written, and GitHub's expired record for the address is dismissed once the
   new invitation is confirmed. An address whose invitation is still open, or
   that was accepted but not yet synced, is refused with a message saying which
-  (with `--file` it is skipped instead and the rest of the list still goes).
+  (with `--file` it is skipped instead and the rest of the list still goes). To
+  drop the row instead of re-inviting, run `gh teacher roster remove <org>
+  <classroom> <email>`; it applies the same checks before removing anything.
 
 A failed invitation whose roster row was already removed shows up on the
 **Members** page as a **failed invitation that isn't on any roster**. Nothing
@@ -542,8 +544,10 @@ cs-principles --write` in that case. If the invitation expired instead, run
 `gh teacher roster invite` for the address again: it sends a new invitation
 against the same row (see
 [A student's invitation expired before they accepted](#a-students-invitation-expired-before-they-accepted)).
-To drop the row without re-inviting, edit `roster.csv`; neither `cancel-invite`
-nor the sync removes a row nothing backs.
+To drop the row without re-inviting, run `gh teacher roster remove cs50-fall-2026
+cs-principles ada@example.edu`: it drops the row only once GitHub confirms
+nothing backs it, and clears the leftover metadata team and expired record with
+it. Neither `cancel-invite` nor the sync removes a row nothing backs.
 
 ### A pending row shows a `github_id` that can't be an account
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -295,7 +295,8 @@ and the **Members** page shows the same badge. To recover:
   GitHub no longer lists is re-sent against the same row, nothing else is
   written, and GitHub's expired record for the address is dismissed once the
   new invitation is confirmed. An address whose invitation is still open, or
-  that was accepted but not yet synced, is skipped with a note saying which.
+  that was accepted but not yet synced, is refused with a message saying which
+  (with `--file` it is skipped instead and the rest of the list still goes).
 
 A failed invitation whose roster row was already removed shows up on the
 **Members** page as a **failed invitation that isn't on any roster**. Nothing

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -334,9 +334,18 @@ Once the student accepts, `roster sync` fills in their username and `github_id`.
 
 A single address is non-zero on: a classroom with no usable team recorded in
 `classroom.json` (nothing is sent), an address the roster already lists **as a
-pending invitation**, or a failed invitation. An address that already belongs to an
+pending invitation** that GitHub still has open (or that was accepted but not yet
+synced), or a failed invitation. An address that already belongs to an
 organization member, or that already has a pending invitation, is reported as
 skipped and exits **0**.
+
+A pending row whose invitation has **expired** (GitHub invitations last 7 days)
+doesn't block: a new invitation is sent, the existing row is kept, and GitHub's
+expired record for the address is dismissed once the send is confirmed, the same
+as the web app's **Re-invite**. `roster invite` tells the cases apart by asking
+GitHub, never from the row's shape: an invitation still on the pending list is
+live, an invite team that already holds a member was accepted, and neither means
+the invitation died.
 
 An address that some *other* row merely carries is a shared address (a parent, a
 lab contact), so the invitation is still sent and the command exits **0**: a note
@@ -369,7 +378,9 @@ those columns are yours, and are never derived from a GitHub profile.
 Exit codes follow [`roster sync`](#roster-sync): **0** all invited or cleanly
 skipped, **2** nothing failed but a rate limit left addresses uninvited, **1** an
 address failed or the roster write failed. An address the roster already lists as
-pending is a skip here, not a failure, so it doesn't change the exit code. On a
+pending (and GitHub still has open, or that was accepted but not yet synced) is a
+skip here, not a failure, so it doesn't change the exit code; an expired one is
+re-sent against its existing row. On a
 rate limit the run stops sending, waits out `Retry-After` before recording what it
 already sent, and reports the rest; re-running is safe, since already-invited
 addresses skip.
@@ -386,8 +397,9 @@ performs, so either tool can revoke either tool's invitation.
 
 Acts only on a **pending** invitation. With none for the address it reports and
 changes nothing, exiting 0: an invitation the student already accepted looks
-identical from here. Run `roster sync` in that case. It records the student, and
-collects a genuine leftover under its own checks. For a student already on the
+identical from here. Run `roster sync` in that case to record the student. If the
+invitation expired instead (GitHub invitations last 7 days), `roster invite` sends
+a new one against the same row. For a student already on the
 roster with a username, use `roster remove` (and `gh teacher remove` for the
 organization).
 
@@ -411,8 +423,9 @@ gh teacher roster sync <org> <classroom> --write    # apply
 Catches `roster.csv` up with GitHub: records the students who accepted an email
 invitation (username and `github_id`, onto their own pending row), fills in a
 missing `github_id` from the classroom team's membership (and a blank or
-outdated username from the member's `github_id`), and deletes the
-invite teams that are done. If no row claims a recovered invitation (the
+outdated username from the member's `github_id`), deletes the
+invite teams that are done, and dismisses any expired-invitation record GitHub
+still keeps for an address that accepted a later one. If no row claims a recovered invitation (the
 pending row was deleted, or `roster invite`'s commit never landed), it appends
 a row so the address isn't lost. The web app runs this same sync when a teacher
 opens the roster; here it's explicit and script-callable. The web app's pass
@@ -423,7 +436,8 @@ missing.
 The sync **never removes a roster row**. An email-only row nothing backs (an
 expired or canceled invitation) stays on the roster for you to re-invite, link,
 or delete by hand; the web app shows it as unlinked with an **Invitation
-expired** badge and offers **Re-invite**. Its scope is the email-invite
+expired** badge and offers **Re-invite**, and [`roster invite`](#roster-invite)
+re-sends against the same row. Its scope is the email-invite
 lifecycle and `github_id`. It never rewrites a `role` already recorded on a
 row, and it doesn't add rows for organization members who were never invited
 through Classroom 50; see

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -346,6 +346,11 @@ as the web app's **Re-invite**. `roster invite` tells the cases apart by asking
 GitHub, never from the row's shape: an invitation still on the organization's
 pending list is live (whichever classroom sent it), an invite team that holds a
 valid record and a member was accepted, and neither means the invitation died.
+An invite team whose record was edited by hand and still holds a member is
+refused for you to check, the same anomaly `roster sync` reports. If GitHub
+answers the send with its daily invitation limit, nothing was sent: the row and
+GitHub's expired record are left as they were, and the command exits as it does
+for a rate limit.
 
 An address that some *other* row merely carries is a shared address (a parent, a
 lab contact), so the invitation is still sent and the command exits **0**: a note
@@ -449,7 +454,8 @@ rather than as a student. If no team names them, the stored role is left as it i
 
 **Dry run by default**: without `--write` it issues no write request at all. A dry
 run also reports an invite team whose address the roster *already* records, since
-that team is redundant and `--write` would retire it. It counts as changes
+that team is redundant and `--write` would retire it, and any expired-invitation
+record `--write` would dismiss. Both count as changes
 pending, so a pass with nothing to fold exits `2` rather than claiming the
 classroom is up to date. `--write` is refused outright on an **archived**
 classroom (`active: false` in `classroom.json`), whose roster is frozen; a dry run

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -404,7 +404,8 @@ Acts only on a **pending** invitation. With none for the address it reports and
 changes nothing, exiting 0: an invitation the student already accepted looks
 identical from here. Run `roster sync` in that case to record the student. If the
 invitation expired instead (GitHub invitations last 7 days), `roster invite` sends
-a new one against the same row. For a student already on the
+a new one against the same row, and `roster remove <email>` drops the row. For a
+student already on the
 roster with a username, use `roster remove` (and `gh teacher remove` for the
 organization).
 
@@ -440,9 +441,10 @@ missing.
 
 The sync **never removes a roster row**. An email-only row nothing backs (an
 expired or canceled invitation) stays on the roster for you to re-invite, link,
-or delete by hand; the web app shows it as unlinked with an **Invitation
-expired** badge and offers **Re-invite**, and [`roster invite`](#roster-invite)
-re-sends against the same row. Its scope is the email-invite
+or remove; the web app shows it as unlinked with an **Invitation
+expired** badge and offers **Re-invite** and **Remove row**, and from the CLI
+[`roster invite`](#roster-invite) re-sends against the same row while
+[`roster remove <email>`](#roster-remove) drops it. Its scope is the email-invite
 lifecycle and `github_id`. It never rewrites a `role` already recorded on a
 row, and it doesn't add rows for organization members who were never invited
 through Classroom 50; see
@@ -493,10 +495,23 @@ required; an unknown username is an error.
 
 ```sh
 gh teacher roster remove <org> <classroom> <username>
+gh teacher roster remove <org> <classroom> <email>
 ```
 
 Drops the row (idempotent). Does **not** remove organization membership; use
 `gh teacher remove <org> <username>` for that.
+
+Passing an **email** drops the pending row a lapsed invitation left behind, the
+same as the web app's **Remove row**. It asks GitHub first and drops the row only
+when nothing backs it: an invitation still on the organization's pending list is
+refused and left for [`roster cancel-invite`](#roster-cancel-invite), a student
+who accepted but isn't recorded yet is refused and left for
+[`roster sync --write`](#roster-sync), and an invite team whose record was edited
+by hand and still holds a member is refused for you to check. Once the row is
+dropped, the invitation's leftover metadata team is deleted and GitHub's expired
+record for the address is dismissed, each as a warning if it fails. An address
+that sits on a row with an account is refused with the username form to run
+instead.
 
 ### `roster import`
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -508,8 +508,9 @@ refused and left for [`roster cancel-invite`](#roster-cancel-invite), a student
 who accepted but isn't recorded yet is refused and left for
 [`roster sync --write`](#roster-sync), and an invite team whose record was edited
 by hand and still holds a member is refused for you to check. Once the row is
-dropped, the invitation's leftover metadata team is deleted and GitHub's expired
-record for the address is dismissed, each as a warning if it fails. An address
+dropped, the invitation's leftover metadata team is deleted (after a fresh check,
+so a re-invitation sent meanwhile keeps its team) and GitHub's expired record for
+the address is dismissed, each as a warning if it fails. An address
 that sits on a row with an account is refused with the username form to run
 instead.
 

--- a/wiki/gh-teacher.md
+++ b/wiki/gh-teacher.md
@@ -343,9 +343,9 @@ A pending row whose invitation has **expired** (GitHub invitations last 7 days)
 doesn't block: a new invitation is sent, the existing row is kept, and GitHub's
 expired record for the address is dismissed once the send is confirmed, the same
 as the web app's **Re-invite**. `roster invite` tells the cases apart by asking
-GitHub, never from the row's shape: an invitation still on the pending list is
-live, an invite team that already holds a member was accepted, and neither means
-the invitation died.
+GitHub, never from the row's shape: an invitation still on the organization's
+pending list is live (whichever classroom sent it), an invite team that holds a
+valid record and a member was accepted, and neither means the invitation died.
 
 An address that some *other* row merely carries is a shared address (a parent, a
 lab contact), so the invitation is still sent and the command exits **0**: a note


### PR DESCRIPTION
## Summary

GitHub drops an organization invitation after 7 days. The roster row it left behind survives, but `roster invite` refused the address because the row looked pending, and `cancel-invite` refused because there was no live invitation to revoke, so the CLI had no way to re-invite the student.

`roster invite` (single address and `--file`) now judges a pending row by asking GitHub instead of by the row's shape:

- The invitation is still on the org's pending list: refuse as before. The list is org-wide, so the message says the invitation may be another classroom's, and names `roster sync --write` and `cancel-invite` as the ways forward.
- The invitation is gone but the per-invite metadata team holds a valid record and a member: the student accepted and only a sync is missing, so refuse and point at `roster sync --write`. Sending again would trip the team's not-empty check with a message telling the teacher to remove the invitee, which would destroy the only email-to-account mapping.
- The team is gone, empty, or still carries the provisional description an interrupted run leaves behind (with the teacher GitHub added on create as its only member): nothing backs the row, so send a new invitation against the same row. The metadata team is adopted and healed if it survived or recreated if the sync already collected it, no second row is written, and GitHub's expired record for the address is dismissed once the send is confirmed (or once GitHub answers that the address is already covered). This is the web app's Re-invite.
- The team's record was edited by hand and it holds a member: that member may be the student, so the send is refused for the teacher to check, the same anomaly `roster sync` reports.

GitHub uses one 422 for three answers on the invitation POST. `InviteOrgByEmail` now reads the body the way the web's `classifyInvitation422` does: "already" is a skip, the organization's invitation limit is treated like a rate limit (the fresh team is kept for a retry, nothing is dismissed, bulk defers the rest and exits 2), and any other validation failure is reported with GitHub's reason instead of being read as "already invited".

A 403-shaped secondary rate limit used to be stripped by the membership classifiers before the invite path could see it, so a throttled read reported an admin-access problem and a bulk run counted the row as failed. Both classifiers now leave a rate limit wrapped so `IsRateLimited` still recognizes it.

Both GitHub lists are read lazily, so an address with no pending row touches neither and gains no new way to fail. The failed-invitation list is owner-only: a plain 403 or a 404 reads as nothing to dismiss, a rate-limited 403 or any other read or DELETE failure is a warning, and none of it can fail a send that already went out.

`roster sync` also dismisses expired records for the addresses it recovers as accepted. A dry run reports them and counts them as pending work (exit 2), and `--write` dismisses them after the roster commit lands.

`roster remove <org> <classroom> <email>` drops the pending row a lapsed invitation left behind, the web app's Remove row. It reuses the same classification: a live invitation is refused and left for `cancel-invite` (the message notes it may be another classroom's, since the pending list is org-wide), an accepted-but-unsynced student is refused and left for `roster sync --write`, a hand-edited team with a member is refused for a human, and only a dead row is dropped (every duplicate pending row for the address, in one rebase-retried commit). The leftover metadata team is then deleted, but only on a fresh check taken after the commit, as the sync's teardown does: a web Re-invite or an acceptance in that window keeps the team, since it now maps a live invitation. GitHub's expired record is dismissed last. Both teardown steps warn rather than fail. The address is canonicalized before auth like the invite paths, so a form GitHub rejects fails up front instead of matching no row; an address that sits on a row with an account is refused with the username form to run instead; an absent row is a no-op that reads neither GitHub list. This is the issue's second suggested fix, and without it the only way to drop such a row was to edit `roster.csv` by hand.

`cancel-invite` still acts only on a live invitation. Its no-pending hint lists the three ways out (sync if they accepted, `roster invite` if it expired, `roster remove <email>` to drop the row). Every "record them" hint across the commands now names `roster sync --write`, since a dry run records nothing.

New `membership.ListFailedOrgInvitations` reads `GET /orgs/{org}/failed_invitations`; dismissal reuses the existing invitation DELETE. The CLI teacher guide, command reference, and troubleshooting pages are updated to match.

Closes #970

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / maintenance

## Checklist

- [x] I built, tested, and linted the module(s) I touched:
  - CLI (Go): `go build ./... && go test ./... && golangci-lint run` in the module dir (`cli/gh-teacher`, `cli/gh-student`, or `cli/shared`)
  - Web: `cd web && npm run check`
  - Skeleton scripts (Python): `python3 -m pytest cli/gh-teacher/skeleton_tests -q`
- [ ] If I changed a cross-binary contract, I updated `schemas/*.schema.json` **and** every mirror (Go / Python / TypeScript), and the parity tests pass.
- [x] If I added or changed a CLI command or flag, I documented it in the [wiki](https://github.com/foundation50/classroom50/wiki) (not in a README).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(web): ...`, `fix(gh-teacher): ...`).
